### PR TITLE
Allow loading Altap 4.0 plugins

### DIFF
--- a/src/plugins.h
+++ b/src/plugins.h
@@ -4,7 +4,7 @@
 #pragma once
 
 // pri zmene hledat "BuiltForVersion" - testy na starsi verze pluginu uz nebudou mit smysl, zahodit je
-#define PLUGIN_REQVER 103 // ("5.0") loadit jen pluginy, ktere vraci alespon tuto pozadovanou verzi Salamandera
+#define PLUGIN_REQVER 102 // ("4.0") loadit jen pluginy, ktere vraci alespon tuto pozadovanou verzi Salamandera (zpetna kompatibilita s Altap Salamander 4.0 pluginy)
 
 //
 // ****************************************************************************


### PR DESCRIPTION
## Summary
- lower the required plugin interface version so Open Salamander 5.0 will accept Altap Salamander 4.0 plugins
- document the compatibility change directly in the constant comment

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8f231e95c8329a2f39988138b2f84