### PR TITLE
Add panel side tracking and tab helpers

### DIFF
--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -1665,7 +1665,7 @@ BOOL CFilesWindow::OnSysKeyDown(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT
             if (controlPressed && shiftPressed && !altPressed)
             {
                 // focusing the focused directory/file in the second panel
-                BOOL leftPanel = this == MainWindow->LeftPanel;
+                BOOL leftPanel = IsLeftPanel();
                 if (wParam == VK_LEFT)
                 {
                     SendMessage(MainWindow->HWindow, WM_COMMAND, leftPanel ? CM_OPEN_IN_OTHER_PANEL : CM_OPEN_IN_OTHER_PANEL_ACT, 0);
@@ -2257,7 +2257,7 @@ void CFilesWindow::RefreshDirectory(BOOL probablyUselessRefresh, BOOL forceReloa
 #ifdef _DEBUG
     char t_path[2 * MAX_PATH];
     GetGeneralPath(t_path, 2 * MAX_PATH);
-    TRACE_I("RefreshDirectory: " << (MainWindow->LeftPanel == this ? "left" : "right") << ": " << t_path);
+    TRACE_I("RefreshDirectory: " << (IsLeftPanel() ? "left" : "right") << ": " << t_path);
 #endif // _DEBUG
 
     // show wait cursor

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -1306,7 +1306,7 @@ DWORD WINAPI IconThreadThreadF(void* param)
     return IconThreadThreadFEH(param);
 }
 
-CFilesWindow::CFilesWindow(CMainWindow* parent)
+CFilesWindow::CFilesWindow(CMainWindow* parent, CPanelSide side)
     : Columns(20, 10), ColumnsTemplate(20, 10), VisibleItemsArray(FALSE), VisibleItemsArraySurround(TRUE)
 {
     CALL_STACK_MESSAGE1("CFilesWindow::CFilesWindow()");
@@ -1357,6 +1357,7 @@ CFilesWindow::CFilesWindow(CMainWindow* parent)
     OpenedDrivesList = NULL;
 
     Parent = parent;
+    PanelSide = side;
     ViewTemplate = &parent->ViewTemplates.Items[2]; // detailed view
     BuildColumnsTemplate();
     CopyColumnsTemplateToColumns();

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -294,7 +294,7 @@ void CFilesWindow::Execute(int index)
                                 s++;
                             if (*s == '\\')
                                 *s = 0;
-                            nethoodPlugin->EnsureShareExistsOnServer(HWindow, this == MainWindow->LeftPanel ? PANEL_LEFT : PANEL_RIGHT,
+                            nethoodPlugin->EnsureShareExistsOnServer(HWindow, IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT,
                                                                      path + 2, focusName);
                             ChangePathToPluginFS(doublePath, path, -1, focusName);
                             if (Is(ptPluginFS))
@@ -502,7 +502,7 @@ void CFilesWindow::Execute(int index)
                 CPluginInterfaceForFSEncapsulation* ifaceForFS = GetPluginFS()->GetPluginInterfaceForFS();
                 char fsNameBuf[MAX_PATH]; // GetPluginFS() muze prestt existovat, radsi dame fsName do lokalniho bufferu
                 lstrcpyn(fsNameBuf, GetPluginFS()->GetPluginFSName(), MAX_PATH);
-                ifaceForFS->ExecuteOnFS(MainWindow->LeftPanel == this ? PANEL_LEFT : PANEL_RIGHT,
+                ifaceForFS->ExecuteOnFS(IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT,
                                         GetPluginFS()->GetInterface(), fsNameBuf,
                                         GetPluginFS()->GetPluginFSNameIndex(), *file, isDir);
             }
@@ -906,6 +906,8 @@ void CFilesWindow::ToggleDirectoryLine()
                                    HInstance,
                                    DirectoryLine))
             TRACE_E("Unable to create directory-line.");
+        else
+            DirectoryLine->SetLeftPanel(IsLeftPanel());
         IdleForceRefresh = TRUE;  // forcneme update
         IdleRefreshStates = TRUE; // pri pristim Idle vynutime kontrolu stavovych promennych
     }
@@ -945,6 +947,8 @@ void CFilesWindow::ToggleStatusLine()
                                 HInstance,
                                 StatusLine))
             TRACE_E("Unable to create information-line.");
+        else
+            StatusLine->SetLeftPanel(IsLeftPanel());
     }
     RECT r;
     GetClientRect(HWindow, &r);
@@ -1075,7 +1079,7 @@ BOOL CFilesWindow::SelectViewTemplate(int templateIndex, BOOL canRefreshPath,
         if (PluginData.NotEmpty())
         {
             CSalamanderView view(this);
-            PluginData.SetupView(this == MainWindow->LeftPanel,
+            PluginData.SetupView(IsLeftPanel(),
                                  &view, Is(ptZIPArchive) ? GetZIPPath() : NULL,
                                  Is(ptZIPArchive) ? GetArchiveDir()->GetUpperDir(GetZIPPath()) : NULL);
         }
@@ -1152,7 +1156,7 @@ void CFilesWindow::ItemFocused(int index)
         {
             if (PluginData.NotEmpty())
             {
-                if (PluginData.GetInfoLineContent(MainWindow->LeftPanel == this ? PANEL_LEFT : PANEL_RIGHT,
+                if (PluginData.GetInfoLineContent(IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT,
                                                   f, index < Dirs->Count, 0, 0, TRUE, CQuadWord(0, 0), buff,
                                                   varPlacements, varPlacementsCount))
                 {
@@ -1251,7 +1255,7 @@ BOOL CFilesWindow::PrepareCloseCurrentPath(HWND parent, BOOL canForce, BOOL canD
             // pokud muzou byt v diskcache editovane soubory nebo tento archiv neni otevren
             // i v druhem panelu, vyhodime jeho cachovane soubory, pri dalsim otevreni se bude
             // znovu vypakovavat (archiv muze byt mezitim editovan)
-            CFilesWindow* another = (MainWindow->LeftPanel == this) ? MainWindow->RightPanel : MainWindow->LeftPanel;
+            CFilesWindow* another = MainWindow->GetOtherPanel(this);
             if (someFilesChanged || !another->Is(ptZIPArchive) || StrICmp(another->GetZIPArchive(), GetZIPArchive()) != 0)
             {
                 StrICpy(buf, GetZIPArchive()); // v disk-cache je jmeno archivu malymi pismeny (umozni case-insensitive porovnani jmena z Windows file systemu)
@@ -3441,7 +3445,7 @@ void CFilesWindow::RefreshDiskFreeSpace(BOOL check, BOOL doNotRefreshOtherPanel)
                 // disk-free-space i ve vedlejsim panelu (neni dokonale - idealni by bylo
                 // testovat, jestli jsou cesty na stejnem svazku, ale to by bylo moc pomale,
                 // toto zjednoduseni bude pro obycejne pouziti bohate stacit)
-                CFilesWindow* otherPanel = (MainWindow->LeftPanel == this) ? MainWindow->RightPanel : MainWindow->LeftPanel;
+                CFilesWindow* otherPanel = MainWindow->GetOtherPanel(this);
                 if (otherPanel->Is(ptDisk) && HasTheSameRootPath(GetPath(), otherPanel->GetPath()))
                     otherPanel->RefreshDiskFreeSpace(TRUE, TRUE /* jinak nekonecna rekurze */);
             }
@@ -4029,7 +4033,7 @@ void CFilesWindow::RefreshListBox(int suggestedXOffset,
         }
 
         // osetrime Smart Mode sloupce Name
-        BOOL leftPanel = (MainWindow->LeftPanel == this);
+        BOOL leftPanel = IsLeftPanel();
         if (Columns[0].FixedWidth == 0 &&
             (leftPanel && ViewTemplate->LeftSmartMode || !leftPanel && ViewTemplate->RightSmartMode) &&
             ListBox->FilesRect.right - ListBox->FilesRect.left > 0) // jen pokud uz je files-box inicializovany

--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -973,7 +973,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
             if (PluginData.NotEmpty())
             {
                 CSalamanderView view(this);
-                PluginData.SetupView(this == MainWindow->LeftPanel, &view, GetZIPPath(),
+                PluginData.SetupView(IsLeftPanel(), &view, GetZIPPath(),
                                      GetArchiveDir()->GetUpperDir(GetZIPPath()));
             }
 
@@ -1238,7 +1238,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                 if (PluginData.NotEmpty())
                 {
                     CSalamanderView view(this);
-                    PluginData.SetupView(this == MainWindow->LeftPanel, &view, NULL, NULL);
+                    PluginData.SetupView(IsLeftPanel(), &view, NULL, NULL);
                 }
 
                 // setting of icon size for IconCache
@@ -1339,7 +1339,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                     DWORD varPlacements[100];
                     int varPlacementsCount = 100;
                     if (PluginData.NotEmpty() &&
-                        PluginData.GetInfoLineContent(MainWindow->LeftPanel == this ? PANEL_LEFT : PANEL_RIGHT,
+                        PluginData.GetInfoLineContent(IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT,
                                                       NULL, FALSE, 0, 0, TRUE, CQuadWord(0, 0), buff,
                                                       varPlacements, varPlacementsCount))
                     {
@@ -2521,7 +2521,7 @@ void CFilesWindow::ChangeDrive(char drive)
     //--- DefaultDire refresh
     MainWindow->UpdateDefaultDir(MainWindow->GetActivePanel() != this);
     //---  possible disk selection from the dialog
-    CFilesWindow* anotherPanel = (Parent->LeftPanel == this ? Parent->RightPanel : Parent->LeftPanel);
+    CFilesWindow* anotherPanel = Parent->GetOtherPanel(this);
     if (drive == 0)
     {
         CDriveTypeEnum driveType = drvtUnknow; // dummy

--- a/src/fileswn5.cpp
+++ b/src/fileswn5.cpp
@@ -627,7 +627,7 @@ void CFilesWindow::ChangeAttr(BOOL setCompress, BOOL compressed, BOOL setEncrypt
             // snizime prioritu threadu na "normal" (aby operace prilis nezatezovaly stroj)
             SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
 
-            int panel = MainWindow->LeftPanel == this ? PANEL_LEFT : PANEL_RIGHT;
+            int panel = IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT;
 
             int count = GetSelCount();
             int selectedDirs = 0;
@@ -675,7 +675,7 @@ void CFilesWindow::FindFile()
     { // zkusime otevrit Find pro FS v panelu, pokud se povede, nema uz smysl otevirat standardni Find
         SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
         BOOL done = GetPluginFS()->OpenFindDialog(GetPluginFS()->GetPluginFSName(),
-                                                  this == MainWindow->LeftPanel ? PANEL_LEFT : PANEL_RIGHT);
+                                                  IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT);
         SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
         if (done)
             return;

--- a/src/fileswn6.cpp
+++ b/src/fileswn6.cpp
@@ -56,7 +56,7 @@ void CFilesWindow::Activate(BOOL shares)
             {
                 if (checkPathRet == ERROR_USER_TERMINATED) // user dal ESC -> zmena na fixed drive
                 {
-                    if (MainWindow->LeftPanel == this)
+                    if (IsLeftPanel())
                     {
                         if (!ChangeLeftPanelToFixedWhenIdleInProgress)
                             ChangeLeftPanelToFixedWhenIdle = TRUE;

--- a/src/fileswn8.cpp
+++ b/src/fileswn8.cpp
@@ -1371,7 +1371,7 @@ void CFilesWindow::EmailFiles()
 
 BOOL CFilesWindow::OpenFocusedInOtherPanel(BOOL activate)
 {
-    CFilesWindow* otherPanel = (this == MainWindow->LeftPanel) ? MainWindow->RightPanel : MainWindow->LeftPanel;
+    CFilesWindow* otherPanel = MainWindow->GetOtherPanel(this);
     if (otherPanel == NULL)
         return FALSE;
 
@@ -1450,7 +1450,7 @@ BOOL CFilesWindow::OpenFocusedInOtherPanel(BOOL activate)
 
 void CFilesWindow::ChangePathToOtherPanelPath()
 {
-    CFilesWindow* panel = (this == MainWindow->LeftPanel) ? MainWindow->RightPanel : MainWindow->LeftPanel;
+    CFilesWindow* panel = MainWindow->GetOtherPanel(this);
     if (panel == NULL)
         return;
 

--- a/src/fileswn9.cpp
+++ b/src/fileswn9.cpp
@@ -68,10 +68,20 @@ BOOL CFilesWindow::ParsePath(char* path, int& type, BOOL& isDir, char*& secondPa
                         Is(ptDisk) || Is(ptZIPArchive), curPath, curArchivePath, error, pathBufSize);
 }
 
+void CFilesWindow::SetPanelSide(CPanelSide side)
+{
+    CALL_STACK_MESSAGE_NONE
+    PanelSide = side;
+    if (StatusLine != NULL)
+        StatusLine->SetLeftPanel(IsLeftPanel());
+    if (DirectoryLine != NULL)
+        DirectoryLine->SetLeftPanel(IsLeftPanel());
+}
+
 int CFilesWindow::GetPanelCode()
 {
     CALL_STACK_MESSAGE_NONE
-    return (MainWindow != NULL && MainWindow->LeftPanel == this) ? PANEL_LEFT : PANEL_RIGHT;
+    return IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT;
 }
 
 void CFilesWindow::ClearPluginFSFromHistory(CPluginFSInterfaceAbstract* fs)
@@ -1143,7 +1153,7 @@ void CFilesWindow::OfferArchiveUpdateIfNeeded(HWND parent, int textID, BOOL* arc
 
     OfferArchiveUpdateIfNeededAux(parent, textID, archMaybeUpdated);
 
-    CFilesWindow* otherPanel = MainWindow->LeftPanel == this ? MainWindow->RightPanel : MainWindow->LeftPanel;
+    CFilesWindow* otherPanel = MainWindow->GetOtherPanel(this);
     BOOL otherPanelArchMaybeUpdated = FALSE;
     if (otherPanel->Is(ptZIPArchive) && StrICmp(GetZIPArchive(), otherPanel->GetZIPArchive()) == 0)
     { // stejny archiv je i v druhem panelu, musime provest i jeho update
@@ -2005,7 +2015,7 @@ BOOL CFilesWindow::BuildColumnsTemplate()
     column.CustomData = 0;
     CColumDataItem* item;
 
-    BOOL leftPanel = (this == MainWindow->LeftPanel);
+    BOOL leftPanel = IsLeftPanel();
 
     // vyberu s sablony pohledy odpovidajici konfiguracni pole
     CColumnConfig* colCfg = ViewTemplate->Columns;
@@ -2121,7 +2131,7 @@ void CFilesWindow::OnHeaderLineColWidthChanged()
     CALL_STACK_MESSAGE1("CFilesWindow::OnHeaderLineColWidthChanged()");
     // prenesu data z panelu do sablony
     BOOL pluginColMaybeChanged = FALSE;
-    BOOL leftPanel = (this == MainWindow->LeftPanel);
+    BOOL leftPanel = IsLeftPanel();
     int i;
     for (i = 0; i < Columns.Count; i++)
     {

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -22,8 +22,8 @@ void CFilesWindow::PluginFSFilesAction(CPluginFSActionType type)
         return;
     if (!Is(ptPluginFS) || !GetPluginFS()->NotEmpty())
         return;
-    int panel = MainWindow->LeftPanel == this ? PANEL_LEFT : PANEL_RIGHT;
-    CFilesWindow* target = (MainWindow->LeftPanel == this ? MainWindow->RightPanel : MainWindow->LeftPanel);
+    int panel = IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT;
+    CFilesWindow* target = MainWindow->GetOtherPanel(this);
     BOOL unselect = FALSE;
 
     BeginSuspendMode(); // the snooper takes a break

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -177,7 +177,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             //          if (wParam == DBT_DEVICEREMOVEPENDING) TRACE_I("WM_DEVICECHANGE: DBT_DEVICEREMOVEPENDING");
             //          else TRACE_I("WM_DEVICECHANGE: DBT_DEVICEREMOVECOMPLETE");
             DetachDirectory((CFilesWindow*)this, TRUE); // zavreme DeviceNotification
-            if (MainWindow->LeftPanel == this)
+            if (IsLeftPanel())
             {
                 if (!ChangeLeftPanelToFixedWhenIdleInProgress)
                     ChangeLeftPanelToFixedWhenIdle = TRUE;
@@ -247,7 +247,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 else
                     count = 0;
 
-                int panel = MainWindow->LeftPanel == this ? PANEL_LEFT : PANEL_RIGHT;
+                int panel = IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT;
                 BOOL copy = (operation == SALSHEXT_COPY);
                 BOOL operationMask = FALSE;
                 BOOL cancelOrHandlePath = FALSE;
@@ -940,7 +940,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                     if (PluginData.NotEmpty())
                     {
-                        if (PluginData.GetInfoLineContent(MainWindow->LeftPanel == this ? PANEL_LEFT : PANEL_RIGHT,
+                        if (PluginData.GetInfoLineContent(IsLeftPanel() ? PANEL_LEFT : PANEL_RIGHT,
                                                           NULL, FALSE, files, dirs,
                                                           displaySize, selectedSize, buff,
                                                           varPlacements, varPlacementsCount))
@@ -1001,6 +1001,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             TRACE_E(LOW_MEMORY);
             return -1;
         }
+        StatusLine->SetLeftPanel(IsLeftPanel());
         ToggleStatusLine();
         //---  vytvoreni statusliny s informacemi o akt. adresari
         DirectoryLine = new CStatusWindow(this, blTop, ooStatic);
@@ -1009,7 +1010,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             TRACE_E(LOW_MEMORY);
             return -1;
         }
-        DirectoryLine->SetLeftPanel(MainWindow->LeftPanel == this);
+        DirectoryLine->SetLeftPanel(IsLeftPanel());
         ToggleDirectoryLine();
         //---  nahozeni typu viewu + nacteni obsahu adresare
         SetThumbnailSize(Configuration.ThumbnailSize); // musi existovat ListBox
@@ -1456,7 +1457,7 @@ MENU_TEMPLATE_ITEM SortByMenu[] =
     int leftCmdID[5] = {CM_LEFTNAME, CM_LEFTEXT, CM_LEFTTIME, CM_LEFTSIZE, CM_LEFTATTR};
     int rightCmdID[5] = {CM_RIGHTNAME, CM_RIGHTEXT, CM_RIGHTTIME, CM_RIGHTSIZE, CM_RIGHTATTR};
     int imgIndex[5] = {IDX_TB_SORTBYNAME, IDX_TB_SORTBYEXT, IDX_TB_SORTBYDATE, IDX_TB_SORTBYSIZE, -1};
-    int* cmdID = MainWindow->LeftPanel == this ? leftCmdID : rightCmdID;
+    int* cmdID = IsLeftPanel() ? leftCmdID : rightCmdID;
     MENU_ITEM_INFO mii;
     int i;
     for (i = 0; i < 5; i++)

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -36,6 +36,12 @@ enum CPanelType
     ptPluginFS,   // aktualni cesta je na plug-inovy file-system (obsluhuje plug-in)
 };
 
+enum CPanelSide
+{
+    cpsLeft,
+    cpsRight,
+};
+
 struct CAttrsData // data pro atChangeAttrs
 {
     DWORD AttrAnd, AttrOr;
@@ -757,6 +763,8 @@ public:
     CStatusWindow *StatusLine,
         *DirectoryLine;
 
+    CPanelSide PanelSide;
+
     BOOL StatusLineVisible;
     BOOL DirectoryLineVisible;
     BOOL HeaderLineVisible;
@@ -896,8 +904,13 @@ public:
     DWORD NextIconOvrRefreshTime;             // cas, kdy ma smysl zase zacit sledovat notifikace o zmenach icon-overlays v tomto panelu (viz IconOverlaysChangedOnPath())
 
 public:
-    CFilesWindow(CMainWindow* parent);
+    CFilesWindow(CMainWindow* parent, CPanelSide side);
     ~CFilesWindow();
+
+    CPanelSide GetPanelSide() const { return PanelSide; }
+    BOOL IsLeftPanel() const { return PanelSide == cpsLeft; }
+    BOOL IsRightPanel() const { return PanelSide == cpsRight; }
+    void SetPanelSide(CPanelSide side);
 
     BOOL IsGood() { return DirectoryLine != NULL &&
                            StatusLine != NULL && ListBox != NULL && Files != NULL && Dirs != NULL &&

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -3,6 +3,10 @@
 
 #pragma once
 
+class CFilesWindow;
+
+#include "plugins.h"
+
 #define NUM_OF_CHECKTHREADS 30                   // max. pocet threadu pro "neblokujici" testy pristupnosti cest
 #define ICONOVR_REFRESH_PERIOD 2000              // minimalni odstup refreshu icon-overlays v panelu (viz IconOverlaysChangedOnPath)
 #define MIN_DELAY_BETWEENINACTIVEREFRESHES 2000  // minimalni odstup refreshu pri neaktivnim hl. okne

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "fileswnd.h"
+
 #define HOT_PATHS_COUNT 30
 
 #define TASKBAR_ICON_ID 0x0000
@@ -14,8 +16,6 @@ struct CCommandLineParams;
 
 // pokud uzivatel nechce vic instanci, pouze aktivujeme predchozi
 BOOL CheckOnlyOneInstance(const CCommandLineParams* cmdLineParams);
-
-enum CPanelSide : int;
 
 // otevrenym oknum interniho vieweru a findu rozesle zpravu WM_USER_CFGCHANGED
 void BroadcastConfigChanged();
@@ -379,8 +379,8 @@ public:
 
     CFilesWindow *LeftPanel,
         *RightPanel;
-    TIndirectArray<CFilesWindow*> LeftPanelTabs;
-    TIndirectArray<CFilesWindow*> RightPanelTabs;
+    TIndirectArray<CFilesWindow> LeftPanelTabs;
+    TIndirectArray<CFilesWindow> RightPanelTabs;
     CEditWindow* EditWindow;
     CMainToolBar* TopToolBar;
     CPluginsBar* PluginsBar;

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -15,6 +15,8 @@ struct CCommandLineParams;
 // pokud uzivatel nechce vic instanci, pouze aktivujeme predchozi
 BOOL CheckOnlyOneInstance(const CCommandLineParams* cmdLineParams);
 
+enum CPanelSide : int;
+
 // otevrenym oknum interniho vieweru a findu rozesle zpravu WM_USER_CFGCHANGED
 void BroadcastConfigChanged();
 
@@ -377,6 +379,8 @@ public:
 
     CFilesWindow *LeftPanel,
         *RightPanel;
+    TIndirectArray<CFilesWindow*> LeftPanelTabs;
+    TIndirectArray<CFilesWindow*> RightPanelTabs;
     CEditWindow* EditWindow;
     CMainToolBar* TopToolBar;
     CPluginsBar* PluginsBar;
@@ -504,6 +508,10 @@ public:
     void FocusPanel(CFilesWindow* focus, BOOL testIfMainWndActive = FALSE); // sejme EditMode, protoze do panelu umisti focus
     void FocusLeftPanel();                                                  // vola FocusPanel pro levy panel
 
+    CFilesWindow* AddPanelTab(CPanelSide side);
+    void SwitchPanelTab(CFilesWindow* panel);
+    void ClosePanelTab(CFilesWindow* panel);
+
     // porovna adresare v levem a pravem panelu
     void CompareDirectories(DWORD flags); // flags je kombinaci COMPARE_DIRECTORIES_xxx
 
@@ -563,10 +571,7 @@ public:
     HWND GetActivePanelHWND();
     int GetDirectoryLineHeight();
 
-    CFilesWindow* GetOtherPanel(CFilesWindow* panel)
-    {
-        return panel == LeftPanel ? RightPanel : LeftPanel;
-    }
+    CFilesWindow* GetOtherPanel(CFilesWindow* panel);
 
     BOOL EditWindowKnowHWND(HWND hwnd);
     void EditWindowSetDirectory(); // nastavi text pred command-line a zaroven ji enabluje/disabluje

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -280,7 +280,8 @@ BOOL CHotPathItems::Load1_52(HKEY hKey)
 // CMainWindow
 //
 
-CMainWindow::CMainWindow() : ChangeNotifArray(3, 5)
+CMainWindow::CMainWindow()
+    : ChangeNotifArray(3, 5), LeftPanelTabs(1, 1, dtNoDelete), RightPanelTabs(1, 1, dtNoDelete)
 {
     HANDLES(InitializeCriticalSection(&DispachChangeNotifCS));
     LastDispachChangeNotifTime = 0;
@@ -454,7 +455,20 @@ CMainWindow::~CMainWindow()
         delete ContextMenuNew;
     if (ToolTip != NULL)
         delete ToolTip;
+    for (int i = 0; i < LeftPanelTabs.Count; i++)
+        if (LeftPanelTabs[i] != NULL)
+            delete LeftPanelTabs[i];
+    for (int i = 0; i < RightPanelTabs.Count; i++)
+        if (RightPanelTabs[i] != NULL)
+            delete RightPanelTabs[i];
     MainWindow = NULL;
+}
+
+CFilesWindow* CMainWindow::GetOtherPanel(CFilesWindow* panel)
+{
+    if (panel == NULL)
+        return NULL;
+    return panel->IsLeftPanel() ? RightPanel : LeftPanel;
 }
 
 void CMainWindow::ClearHistory()

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -80,7 +80,7 @@ CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side)
     CFilesWindow* panel = new CFilesWindow(this, side);
     if (panel == NULL)
         return NULL;
-    TIndirectArray<CFilesWindow*>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
+    TIndirectArray<CFilesWindow>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
     tabs.Add(panel);
     SwitchPanelTab(panel);
     return panel;
@@ -92,7 +92,7 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
     if (panel == NULL)
         return;
     CPanelSide side = panel->GetPanelSide();
-    TIndirectArray<CFilesWindow*>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
+    TIndirectArray<CFilesWindow>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
     BOOL found = FALSE;
     for (int i = 0; i < tabs.Count; i++)
     {
@@ -121,7 +121,7 @@ void CMainWindow::ClosePanelTab(CFilesWindow* panel)
     if (panel == NULL)
         return;
     CPanelSide side = panel->GetPanelSide();
-    TIndirectArray<CFilesWindow*>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
+    TIndirectArray<CFilesWindow>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
     for (int i = 0; i < tabs.Count; i++)
     {
         if (tabs[i] == panel)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -74,6 +74,83 @@ const int MIN_WIN_WIDTH = 2; // minimalni sirka panelu
 
 extern BOOL CacheNextSetFocus;
 
+CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side)
+{
+    CALL_STACK_MESSAGE2("CMainWindow::AddPanelTab(%d)", side);
+    CFilesWindow* panel = new CFilesWindow(this, side);
+    if (panel == NULL)
+        return NULL;
+    TIndirectArray<CFilesWindow*>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
+    tabs.Add(panel);
+    SwitchPanelTab(panel);
+    return panel;
+}
+
+void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
+{
+    CALL_STACK_MESSAGE1("CMainWindow::SwitchPanelTab()");
+    if (panel == NULL)
+        return;
+    CPanelSide side = panel->GetPanelSide();
+    TIndirectArray<CFilesWindow*>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
+    BOOL found = FALSE;
+    for (int i = 0; i < tabs.Count; i++)
+    {
+        if (tabs[i] == panel)
+        {
+            found = TRUE;
+            break;
+        }
+    }
+    if (!found)
+        return;
+
+    if (side == cpsLeft)
+        LeftPanel = panel;
+    else
+        RightPanel = panel;
+
+    CFilesWindow* active = GetActivePanel();
+    if (active == NULL || active->GetPanelSide() == side)
+        SetActivePanel(panel);
+}
+
+void CMainWindow::ClosePanelTab(CFilesWindow* panel)
+{
+    CALL_STACK_MESSAGE1("CMainWindow::ClosePanelTab()");
+    if (panel == NULL)
+        return;
+    CPanelSide side = panel->GetPanelSide();
+    TIndirectArray<CFilesWindow*>& tabs = (side == cpsLeft) ? LeftPanelTabs : RightPanelTabs;
+    for (int i = 0; i < tabs.Count; i++)
+    {
+        if (tabs[i] == panel)
+        {
+            tabs.Delete(i);
+            break;
+        }
+    }
+
+    CFilesWindow* newActive = NULL;
+    if (side == cpsLeft)
+    {
+        if (LeftPanel == panel)
+            newActive = (tabs.Count > 0) ? tabs[0] : NULL;
+        LeftPanel = newActive;
+    }
+    else
+    {
+        if (RightPanel == panel)
+            newActive = (tabs.Count > 0) ? tabs[0] : NULL;
+        RightPanel = newActive;
+    }
+
+    if (GetActivePanel() == panel)
+        SetActivePanel(newActive);
+
+    delete panel;
+}
+
 BOOL MainFrameIsActive = FALSE;
 
 // kod pro testovani casovych ztrat
@@ -1075,42 +1152,46 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (!MenuBar->CreateWnd(HTopRebar))
             return -1;
 
-        LeftPanel = new CFilesWindow(this);
-        if (LeftPanel == NULL)
+        CFilesWindow* leftPanel = AddPanelTab(cpsLeft);
+        if (leftPanel == NULL)
         {
             TRACE_E(LOW_MEMORY);
             return -1;
         }
-        if (!LeftPanel->Create(CWINDOW_CLASSNAME2, "",
+        if (!leftPanel->Create(CWINDOW_CLASSNAME2, "",
                                WS_VISIBLE | WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
                                0, 0, 0, 0,
                                HWindow,
                                NULL,
                                HInstance,
-                               LeftPanel))
+                               leftPanel))
         {
             TRACE_E("LeftPanel->Create failed");
+            ClosePanelTab(leftPanel);
             return -1;
         }
-        SetActivePanel(LeftPanel);
+        SetActivePanel(leftPanel);
         //      ReleaseMenuNew();
-        RightPanel = new CFilesWindow(this);
-        if (RightPanel == NULL)
+        CFilesWindow* rightPanel = AddPanelTab(cpsRight);
+        if (rightPanel == NULL)
         {
             TRACE_E(LOW_MEMORY);
             return -1;
         }
-        if (!RightPanel->Create(CWINDOW_CLASSNAME2, "",
+        if (!rightPanel->Create(CWINDOW_CLASSNAME2, "",
                                 WS_VISIBLE | WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN,
                                 0, 0, 0, 0,
                                 HWindow,
                                 NULL,
                                 HInstance,
-                                RightPanel))
+                                rightPanel))
         {
             TRACE_E("RightPanel->Create failed");
+            ClosePanelTab(rightPanel);
             return -1;
         }
+        LeftPanel = leftPanel;
+        RightPanel = rightPanel;
 
         EditWindow = new CEditWindow;
         if (EditWindow == NULL || !EditWindow->IsGood())
@@ -4237,21 +4318,55 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
 
         case CM_SWAPPANELS:
         {
-            // prohodime panely
-            CFilesWindow* swap = LeftPanel;
-            LeftPanel = RightPanel;
-            RightPanel = swap;
+            CFilesWindow* oldLeftPanel = LeftPanel;
+            CFilesWindow* oldRightPanel = RightPanel;
+
+            int leftTabsCount = LeftPanelTabs.Count;
+            int rightTabsCount = RightPanelTabs.Count;
+            TDirectArray<CFilesWindow*> oldLeftTabs(leftTabsCount > 0 ? leftTabsCount : 1,
+                                                   leftTabsCount > 0 ? leftTabsCount : 1);
+            for (int i = 0; i < leftTabsCount; i++)
+                oldLeftTabs.Add(LeftPanelTabs[i]);
+            TDirectArray<CFilesWindow*> oldRightTabs(rightTabsCount > 0 ? rightTabsCount : 1,
+                                                    rightTabsCount > 0 ? rightTabsCount : 1);
+            for (int i = 0; i < rightTabsCount; i++)
+                oldRightTabs.Add(RightPanelTabs[i]);
+
+            if (leftTabsCount > 0)
+                LeftPanelTabs.Delete(0, leftTabsCount);
+            if (rightTabsCount > 0)
+                RightPanelTabs.Delete(0, rightTabsCount);
+
+            for (int i = 0; i < oldRightTabs.Count; i++)
+            {
+                CFilesWindow* panel = oldRightTabs[i];
+                panel->SetPanelSide(cpsLeft);
+                LeftPanelTabs.Add(panel);
+            }
+            for (int i = 0; i < oldLeftTabs.Count; i++)
+            {
+                CFilesWindow* panel = oldLeftTabs[i];
+                panel->SetPanelSide(cpsRight);
+                RightPanelTabs.Add(panel);
+            }
+
+            LeftPanel = oldRightPanel;
+            RightPanel = oldLeftPanel;
             // prohodime zaznamy toolbar
             char buff[1024];
             lstrcpy(buff, Configuration.LeftToolBar);
             lstrcpy(Configuration.LeftToolBar, Configuration.RightToolBar);
             lstrcpy(Configuration.RightToolBar, buff);
             // nastavime panelum promenne a nechame nacist toolbary
-            LeftPanel->DirectoryLine->SetLeftPanel(TRUE);
-            RightPanel->DirectoryLine->SetLeftPanel(FALSE);
+            if (LeftPanel != NULL)
+                LeftPanel->SetPanelSide(cpsLeft);
+            if (RightPanel != NULL)
+                RightPanel->SetPanelSide(cpsRight);
             // ikonka se musi zmenit v imagelistu
-            LeftPanel->UpdateDriveIcon(FALSE);
-            RightPanel->UpdateDriveIcon(FALSE);
+            if (LeftPanel != NULL)
+                LeftPanel->UpdateDriveIcon(FALSE);
+            if (RightPanel != NULL)
+                RightPanel->UpdateDriveIcon(FALSE);
 
             // pokud byl aktivni panel ZOOMed, po Ctrl+U by zustal aktivni minimalizovany panel
             if (GetActivePanel() == LeftPanel && IsPanelZoomed(FALSE) ||
@@ -4260,6 +4375,12 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 // aktivujeme tedy ten viditelny
                 ChangePanel(TRUE);
             }
+
+            CFilesWindow* activePanel = GetActivePanel();
+            if (activePanel == oldLeftPanel)
+                SetActivePanel(RightPanel);
+            else if (activePanel == oldRightPanel)
+                SetActivePanel(LeftPanel);
 
             LockWindowUpdate(HWindow);
             LayoutWindows();
@@ -6629,50 +6750,60 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         CALL_STACK_MESSAGE1("WM_USER_CLOSE_MAINWND::3");
 
         // optame se panelu, jestli muzeme koncit
-        if (LeftPanel != NULL && RightPanel != NULL)
+        int totalPanels = LeftPanelTabs.Count + RightPanelTabs.Count;
+        if (totalPanels > 0)
         {
-            BOOL canClose = FALSE;
-            BOOL detachFS1, detachFS2;
-            if (LeftPanel->PrepareCloseCurrentPath(shutdown ? analysing.HWindow : LeftPanel->HWindow, TRUE, FALSE, detachFS1, FSTRYCLOSE_UNLOADCLOSEFS /* zbytecne - pluginy (i FS) uz jsou unloadle */))
+            TDirectArray<CFilesWindow*> panels(totalPanels, totalPanels);
+            TDirectArray<BOOL> detachFlags(totalPanels, totalPanels);
+            for (int i = 0; i < LeftPanelTabs.Count; i++)
             {
-                if (RightPanel->PrepareCloseCurrentPath(shutdown ? analysing.HWindow : RightPanel->HWindow, TRUE, FALSE, detachFS2, FSTRYCLOSE_UNLOADCLOSEFS /* zbytecne - pluginy (i FS) uz jsou unloadle */))
-                {
-                    canClose = TRUE; // jen oba najednou, jinak nezavirame ani jeden
-                    if (RightPanel->UseSystemIcons || RightPanel->UseThumbnails)
-                        RightPanel->SleepIconCacheThread();
-                    RightPanel->CloseCurrentPath(shutdown ? analysing.HWindow : RightPanel->HWindow, FALSE, detachFS2, FALSE, FALSE, TRUE); // zavreme pravy panel
-
-                    // zabezpecime listbox proti chybam vzniklym zadosti o prekresleni (prave jsme podrizli data)
-                    RightPanel->ListBox->SetItemsCount(0, 0, 0, TRUE);
-                    RightPanel->SelectedCount = 0;
-                    // Pokud se doruci WM_USER_UPDATEPANEL, dojde k prekreslnei obsahu panelu a nastaveni
-                    // scrollbary. Dorucit ji muze message loopa pri vytvoreni message boxu.
-                    // Jinak se panel bude tvarit jako nezmeneny a message bude vyjmuta z fronty.
-                    PostMessage(RightPanel->HWindow, WM_USER_UPDATEPANEL, 0, 0);
-                }
-                if (canClose)
-                {
-                    if (LeftPanel->UseSystemIcons || LeftPanel->UseThumbnails)
-                        LeftPanel->SleepIconCacheThread();
-                    LeftPanel->CloseCurrentPath(shutdown ? analysing.HWindow : LeftPanel->HWindow, FALSE, detachFS1, FALSE, FALSE, TRUE); // zavreme levy panel
-
-                    // zabezpecime listbox proti chybam vzniklym zadosti o prekresleni (prave jsme podrizli data)
-                    LeftPanel->ListBox->SetItemsCount(0, 0, 0, TRUE);
-                    LeftPanel->SelectedCount = 0;
-                    // Pokud se doruci WM_USER_UPDATEPANEL, dojde k prekreslnei obsahu panelu a nastaveni
-                    // scrollbary. Dorucit ji muze message loopa pri vytvoreni message boxu.
-                    // Jinak se panel bude tvarit jako nezmeneny a message bude vyjmuta z fronty.
-                    PostMessage(LeftPanel->HWindow, WM_USER_UPDATEPANEL, 0, 0);
-                }
-                else
-                    LeftPanel->CloseCurrentPath(shutdown ? analysing.HWindow : LeftPanel->HWindow, TRUE, detachFS1, FALSE, FALSE, TRUE); // cancel na close leveho panelu
+                panels.Add(LeftPanelTabs[i]);
+                detachFlags.Add(FALSE);
             }
+            for (int i = 0; i < RightPanelTabs.Count; i++)
+            {
+                panels.Add(RightPanelTabs[i]);
+                detachFlags.Add(FALSE);
+            }
+
+            BOOL canClose = TRUE;
+            for (int i = 0; i < panels.Count; i++)
+            {
+                CFilesWindow* panel = panels[i];
+                BOOL detachFS;
+                if (!panel->PrepareCloseCurrentPath(shutdown ? analysing.HWindow : panel->HWindow, TRUE, FALSE, detachFS,
+                                                    FSTRYCLOSE_UNLOADCLOSEFS /* zbytecne - pluginy (i FS) uz jsou unloadle */))
+                {
+                    canClose = FALSE;
+                    for (int j = i - 1; j >= 0; j--)
+                    {
+                        CFilesWindow* preparedPanel = panels[j];
+                        preparedPanel->CloseCurrentPath(shutdown ? analysing.HWindow : preparedPanel->HWindow, TRUE,
+                                                        detachFlags[j], FALSE, FALSE, TRUE);
+                    }
+                    break;
+                }
+                detachFlags[i] = detachFS;
+            }
+
             if (!canClose)
             {
                 SetDoNotLoadAnyPlugins(FALSE);
                 if (uMsg == WM_QUERYENDSESSION)
                     TRACE_I("WM_QUERYENDSESSION: cancelling shutdown: unable to close paths in panels");
                 goto EXIT_WM_USER_CLOSE_MAINWND; // panely nejdou uzavrit
+            }
+
+            for (int i = 0; i < panels.Count; i++)
+            {
+                CFilesWindow* panel = panels[i];
+                if (panel->UseSystemIcons || panel->UseThumbnails)
+                    panel->SleepIconCacheThread();
+                panel->CloseCurrentPath(shutdown ? analysing.HWindow : panel->HWindow, FALSE, detachFlags[i], FALSE, FALSE, TRUE);
+
+                panel->ListBox->SetItemsCount(0, 0, 0, TRUE);
+                panel->SelectedCount = 0;
+                PostMessage(panel->HWindow, WM_USER_UPDATEPANEL, 0, 0);
             }
         }
 

--- a/src/plugins/pictview/exif/config.h
+++ b/src/plugins/pictview/exif/config.h
@@ -89,8 +89,8 @@
 
 #define ssize_t int
 
-// static inline not supported by MSVC and not usefull here -> define it out
-#define inline
+// make the generic inline keyword available even for C sources built by MSVC
+#define inline __inline
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846


### PR DESCRIPTION
## Summary
- add the CPanelSide property to CFilesWindow and update orientation logic for status and directory lines
- introduce CMainWindow tab collections with helpers and use them during initialization and panel swaps
- iterate all panel tabs during shutdown and replace pointer comparisons with side-aware accessors throughout the files window code

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf98ea05c83299567f4b52ffae087