### PR TITLE
Include tab window definition for deletion

### DIFF
--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -10,6 +10,7 @@
 #include "fileswnd.h"
 #include "filesbox.h"
 #include "mainwnd.h"
+#include "tabwnd.h"
 #include "editwnd.h"
 #include "cfgdlg.h"
 #include "dialogs.h"


### PR DESCRIPTION
## Summary
- include tab window header in main window implementation so the destructor sees the full CTabWindow type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d29ebc61a88329aa958ade2ac03054