### PR TITLE
Update window title when switching panel tabs

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -135,7 +135,11 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
 
     CFilesWindow* active = GetActivePanel();
     if (active == NULL || active->GetPanelSide() == side)
+    {
         SetActivePanel(panel);
+        if (Created)
+            EditWindowSetDirectory();
+    }
 
     CTabWindow* tabWnd = GetPanelTabWindow(side);
     if (tabWnd != NULL && tabWnd->HWindow != NULL)


### PR DESCRIPTION
## Summary
- update the active panel handling so that switching tabs refreshes the command line directory and window title

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2c5f5089c8329b265c69b810e9151