### PR TITLE
Fix change notification handling for tabbed panels

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -5290,13 +5290,91 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                         // send the message to all loaded plugins
                         Plugins.AcceptChangeOnPathNotification(path, includingSubdirs);
 
-                        if (GetNonActivePanel() != NULL) // non-active panel first (due to timestamps of subdirectory changes on NTFS)
+                        BOOL notifiedLeft = FALSE;
+                        BOOL notifiedRight = FALSE;
+
+                        CFilesWindow* nonActivePanel = GetNonActivePanel();
+                        if (nonActivePanel != NULL) // non-active panel first (due to timestamps of subdirectory changes on NTFS)
                         {
-                            GetNonActivePanel()->AcceptChangeOnPathNotification(path, includingSubdirs);
+                            CPanelSide side = nonActivePanel->GetPanelSide();
+                            if (side == cpsLeft)
+                            {
+                                notifiedLeft = TRUE;
+                                TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsLeft);
+                                for (int i = 0; i < tabs.Count; i++)
+                                {
+                                    CFilesWindow* panel = tabs[i];
+                                    if (panel != NULL)
+                                        panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                                }
+                            }
+                            else if (side == cpsRight)
+                            {
+                                notifiedRight = TRUE;
+                                TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsRight);
+                                for (int i = 0; i < tabs.Count; i++)
+                                {
+                                    CFilesWindow* panel = tabs[i];
+                                    if (panel != NULL)
+                                        panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                                }
+                            }
                         }
-                        if (GetActivePanel() != NULL) // then the active panel
+
+                        CFilesWindow* activePanel = GetActivePanel();
+                        if (activePanel != NULL) // then the active panel
                         {
-                            GetActivePanel()->AcceptChangeOnPathNotification(path, includingSubdirs);
+                            CPanelSide side = activePanel->GetPanelSide();
+                            if (side == cpsLeft)
+                            {
+                                if (!notifiedLeft)
+                                {
+                                    notifiedLeft = TRUE;
+                                    TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsLeft);
+                                    for (int i = 0; i < tabs.Count; i++)
+                                    {
+                                        CFilesWindow* panel = tabs[i];
+                                        if (panel != NULL)
+                                            panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                                    }
+                                }
+                            }
+                            else if (side == cpsRight)
+                            {
+                                if (!notifiedRight)
+                                {
+                                    notifiedRight = TRUE;
+                                    TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsRight);
+                                    for (int i = 0; i < tabs.Count; i++)
+                                    {
+                                        CFilesWindow* panel = tabs[i];
+                                        if (panel != NULL)
+                                            panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                                    }
+                                }
+                            }
+                        }
+
+                        if (!notifiedLeft)
+                        {
+                            TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsLeft);
+                            for (int i = 0; i < tabs.Count; i++)
+                            {
+                                CFilesWindow* panel = tabs[i];
+                                if (panel != NULL)
+                                    panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                            }
+                        }
+
+                        if (!notifiedRight)
+                        {
+                            TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsRight);
+                            for (int i = 0; i < tabs.Count; i++)
+                            {
+                                CFilesWindow* panel = tabs[i];
+                                if (panel != NULL)
+                                    panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                            }
                         }
 
                         if (DetachedFSList->Count > 0)

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -2261,15 +2261,27 @@ BOOL CSalamanderGeneral::PostRefreshPanelFS2(CPluginFSInterfaceAbstract* modifie
         // neni synchronizacni problem, protoze PluginFS se nuluje az po CloseFS, ktere by
         // melo zrusit thread monitorujici zmeny na FS (po CloseFS by nemelo dojit k volani
         // PostRefreshPanelFS2)
-        if (MainWindow->LeftPanel != NULL && MainWindow->LeftPanel->Is(ptPluginFS) &&
-            MainWindow->LeftPanel->GetPluginFS()->Contains(modifiedFS))
+        TIndirectArray<CFilesWindow>& leftTabs = MainWindow->GetPanelTabs(cpsLeft);
+        int i;
+        for (i = 0; i < leftTabs.Count && p == NULL; i++)
         {
-            p = MainWindow->LeftPanel;
+            CFilesWindow* panel = leftTabs[i];
+            if (panel != NULL && panel->Is(ptPluginFS) && panel->GetPluginFS()->Contains(modifiedFS))
+            {
+                p = panel;
+            }
         }
-        if (MainWindow->RightPanel != NULL && MainWindow->RightPanel->Is(ptPluginFS) &&
-            MainWindow->RightPanel->GetPluginFS()->Contains(modifiedFS))
+        if (p == NULL)
         {
-            p = MainWindow->RightPanel;
+            TIndirectArray<CFilesWindow>& rightTabs = MainWindow->GetPanelTabs(cpsRight);
+            for (i = 0; i < rightTabs.Count && p == NULL; i++)
+            {
+                CFilesWindow* panel = rightTabs[i];
+                if (panel != NULL && panel->Is(ptPluginFS) && panel->GetPluginFS()->Contains(modifiedFS))
+                {
+                    p = panel;
+                }
+            }
         }
     }
     if (p != NULL)


### PR DESCRIPTION
## Summary
- ensure change notifications are delivered to every panel tab so hidden tabs refresh after file operations
- locate plugin filesystem panels across all tabs before posting refresh requests

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2f5cd52d08329833ca59ef4bd3f69