### PR TITLE
Fix change notification handling for tabbed panels

### DIFF
--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -529,6 +529,7 @@ public:
     void OnPanelTabReordered(CPanelSide side, int from, int to);
     int GetPanelTabIndex(CPanelSide side, CFilesWindow* panel) const;
     int GetPanelTabCount(CPanelSide side) const;
+    CFilesWindow* GetPanelTabAt(CPanelSide side, int index) const;
     void CommandNewTab(CPanelSide side, bool addAtEnd = false);
     void CommandCloseTab(CPanelSide side);
     void CommandNextTab(CPanelSide side);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -365,6 +365,14 @@ int CMainWindow::GetPanelTabCount(CPanelSide side) const
     return const_cast<CMainWindow*>(this)->GetPanelTabs(side).Count;
 }
 
+CFilesWindow* CMainWindow::GetPanelTabAt(CPanelSide side, int index) const
+{
+    TIndirectArray<CFilesWindow>& tabs = const_cast<CMainWindow*>(this)->GetPanelTabs(side);
+    if (index < 0 || index >= tabs.Count)
+        return NULL;
+    return tabs[index];
+}
+
 void CMainWindow::UpdatePanelTabTitle(CFilesWindow* panel)
 {
     if (panel == NULL)
@@ -5290,13 +5298,91 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                         // send the message to all loaded plugins
                         Plugins.AcceptChangeOnPathNotification(path, includingSubdirs);
 
-                        if (GetNonActivePanel() != NULL) // non-active panel first (due to timestamps of subdirectory changes on NTFS)
+                        BOOL notifiedLeft = FALSE;
+                        BOOL notifiedRight = FALSE;
+
+                        CFilesWindow* nonActivePanel = GetNonActivePanel();
+                        if (nonActivePanel != NULL) // non-active panel first (due to timestamps of subdirectory changes on NTFS)
                         {
-                            GetNonActivePanel()->AcceptChangeOnPathNotification(path, includingSubdirs);
+                            CPanelSide side = nonActivePanel->GetPanelSide();
+                            if (side == cpsLeft)
+                            {
+                                notifiedLeft = TRUE;
+                                TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsLeft);
+                                for (int i = 0; i < tabs.Count; i++)
+                                {
+                                    CFilesWindow* panel = tabs[i];
+                                    if (panel != NULL)
+                                        panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                                }
+                            }
+                            else if (side == cpsRight)
+                            {
+                                notifiedRight = TRUE;
+                                TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsRight);
+                                for (int i = 0; i < tabs.Count; i++)
+                                {
+                                    CFilesWindow* panel = tabs[i];
+                                    if (panel != NULL)
+                                        panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                                }
+                            }
                         }
-                        if (GetActivePanel() != NULL) // then the active panel
+
+                        CFilesWindow* activePanel = GetActivePanel();
+                        if (activePanel != NULL) // then the active panel
                         {
-                            GetActivePanel()->AcceptChangeOnPathNotification(path, includingSubdirs);
+                            CPanelSide side = activePanel->GetPanelSide();
+                            if (side == cpsLeft)
+                            {
+                                if (!notifiedLeft)
+                                {
+                                    notifiedLeft = TRUE;
+                                    TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsLeft);
+                                    for (int i = 0; i < tabs.Count; i++)
+                                    {
+                                        CFilesWindow* panel = tabs[i];
+                                        if (panel != NULL)
+                                            panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                                    }
+                                }
+                            }
+                            else if (side == cpsRight)
+                            {
+                                if (!notifiedRight)
+                                {
+                                    notifiedRight = TRUE;
+                                    TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsRight);
+                                    for (int i = 0; i < tabs.Count; i++)
+                                    {
+                                        CFilesWindow* panel = tabs[i];
+                                        if (panel != NULL)
+                                            panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                                    }
+                                }
+                            }
+                        }
+
+                        if (!notifiedLeft)
+                        {
+                            TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsLeft);
+                            for (int i = 0; i < tabs.Count; i++)
+                            {
+                                CFilesWindow* panel = tabs[i];
+                                if (panel != NULL)
+                                    panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                            }
+                        }
+
+                        if (!notifiedRight)
+                        {
+                            TIndirectArray<CFilesWindow>& tabs = GetPanelTabs(cpsRight);
+                            for (int i = 0; i < tabs.Count; i++)
+                            {
+                                CFilesWindow* panel = tabs[i];
+                                if (panel != NULL)
+                                    panel->AcceptChangeOnPathNotification(path, includingSubdirs);
+                            }
                         }
 
                         if (DetachedFSList->Count > 0)


### PR DESCRIPTION
## Summary
- add a safe panel-tab accessor so other components can enumerate tabs without relying on private containers
- refresh plugin-backed panels by iterating tabs on each side, ensuring hidden tabs receive filesystem change notifications

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d2f5cd52d08329833ca59ef4bd3f69