### PR TITLE
Fix toolbar state refresh when switching panel tabs

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -134,7 +134,9 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
         UpdateDirectoryLineHistoryState(panel);
 
     CFilesWindow* active = GetActivePanel();
-    if (active == NULL || active->GetPanelSide() == side)
+    bool activateSameSide = (active == NULL || active->GetPanelSide() == side);
+    bool canFocusNow = (Created && panel->HWindow != NULL);
+    if (activateSameSide && !canFocusNow)
     {
         SetActivePanel(panel);
         if (Created)
@@ -153,7 +155,7 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
 
     UpdatePanelTabTitle(panel);
 
-    if (Created && panel->HWindow != NULL)
+    if (canFocusNow)
     {
         LayoutWindows();
         FocusPanel(panel);


### PR DESCRIPTION
## Summary
- ensure `SwitchPanelTab` keeps the previous active panel until focus is applied when the panel window is ready
- allow `FocusPanel` to detect the active panel change and refresh command states on tab switches

## Testing
- not run (Windows-specific build)

------
https://chatgpt.com/codex/tasks/task_e_68d3f27c00548329b7ab9208b558b844