### PR TITLE
Ensure tab panels refresh when activated

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -160,6 +160,14 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
         LayoutWindows();
         FocusPanel(panel);
     }
+
+    if (Created && panel->HWindow != NULL)
+    {
+        HANDLES(EnterCriticalSection(&TimeCounterSection));
+        int t1 = MyTimeCounter++;
+        HANDLES(LeaveCriticalSection(&TimeCounterSection));
+        PostMessage(panel->HWindow, WM_USER_REFRESH_DIR, 0, t1);
+    }
 }
 
 void CMainWindow::ClosePanelTab(CFilesWindow* panel)


### PR DESCRIPTION
## Summary
- schedule a directory refresh when switching to a different panel tab so the listing stays current

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3f96679808329bacb0e8e5ad8751d