### PR TITLE
Ensure reactivating tabs restores change monitoring

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -155,6 +155,20 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
 
     UpdatePanelTabTitle(panel);
 
+    if (panel->GetMonitorChanges() && !panel->AutomaticRefresh &&
+        (panel->Is(ptDisk) || panel->Is(ptZIPArchive)))
+    {
+        const char* path = panel->GetPath();
+        if (path != NULL && path[0] != 0)
+        {
+            BOOL registerDevNotification = panel->GetPathDriveType() == DRIVE_REMOVABLE ||
+                                           panel->GetPathDriveType() == DRIVE_FIXED;
+            ChangeDirectory(panel, path, registerDevNotification);
+            if (!panel->AutomaticRefresh)
+                AddDirectory(panel, path, registerDevNotification);
+        }
+    }
+
     if (canFocusNow)
     {
         LayoutWindows();


### PR DESCRIPTION
## Summary
- restore automatic change monitoring when a hidden panel tab becomes active again by re-registering directory notifications if needed

## Testing
- Not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d40ef7e9448329837f801fbef3b180