### PR TITLE
Preserve view mode when opening new tabs

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -649,6 +649,13 @@ void CMainWindow::CommandNewTab(CPanelSide side, bool addAtEnd)
         return;
     }
 
+    if (previous != NULL && previous != panel)
+    {
+        int templateIndex = previous->GetViewTemplateIndex();
+        if (panel->IsViewTemplateValid(templateIndex))
+            panel->SelectViewTemplate(templateIndex, TRUE, FALSE);
+    }
+
     const char* targetPath = (previous != NULL && previous != panel) ? previous->GetPath() : panel->GetPath();
     if (targetPath != NULL)
         panel->ChangeDir(targetPath);


### PR DESCRIPTION
## Summary
- ensure new panel tabs inherit the view template from the current tab on the same side so that the view mode matches the user's current choice when a tab is created

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d44e65bd5883299fb67a60637310c9