### PR TITLE
Add FlaUI-based UI automation test project

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,8 @@
 
 This folder contains the Visual Studio solution `Salamander.AutomationTests.sln` with a C# project for
 running automated UI tests against Salamander using [FlaUI](https://github.com/FlaUI/FlaUI)
-and [Reqnroll](https://github.com/reqnroll/Reqnroll).
+(with the UIA2 automation backend suitable for Win32/WinForms applications) and
+[Reqnroll](https://github.com/reqnroll/Reqnroll).
 
 ## Getting started
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,16 @@
+# UI automation tests
+
+This folder contains the Visual Studio solution `Salamander.AutomationTests.sln` with a C# project for
+running automated UI tests against Salamander using [FlaUI](https://github.com/FlaUI/FlaUI)
+and [Reqnroll](https://github.com/reqnroll/Reqnroll).
+
+## Getting started
+
+1. Build the Salamander application (`Salamand.exe`).
+2. Optionally set the `SALAMANDER_APP_PATH` environment variable to the full path of the built executable.
+   If the variable is not set, the tests try a few common relative locations under the repository root.
+3. Open the solution in Visual Studio and restore NuGet packages.
+4. Run the tests using the Test Explorer.
+
+The sample scenario opens Salamander, launches the **About** dialog from the **Help** menu,
+closes the dialog, and then exits the application.

--- a/tests/Salamander.AutomationTests.sln
+++ b/tests/Salamander.AutomationTests.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34310.174
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Salamander.AutomationTests", "Salamander.AutomationTests\\Salamander.AutomationTests.csproj", "{56AC1D92-F9D8-4DD8-899E-43A276DB53C3}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{56AC1D92-F9D8-4DD8-899E-43A276DB53C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{56AC1D92-F9D8-4DD8-899E-43A276DB53C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{56AC1D92-F9D8-4DD8-899E-43A276DB53C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{56AC1D92-F9D8-4DD8-899E-43A276DB53C3}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/tests/Salamander.AutomationTests/Features/AboutDialog.feature
+++ b/tests/Salamander.AutomationTests/Features/AboutDialog.feature
@@ -1,0 +1,14 @@
+Feature: About dialog
+  In order to verify that the Salamander application displays product information
+  As a Salamander user
+  I want to open the About dialog and close it again
+
+  Scenario: User can open and close the About dialog
+    Given Salamander is running
+    When I open the About dialog from the Help menu
+    Then the About dialog is displayed
+    When I close the About dialog
+    Then the About dialog is closed
+    And Salamander remains running
+    When I exit Salamander
+    Then Salamander is not running

--- a/tests/Salamander.AutomationTests/Hooks/TestHooks.cs
+++ b/tests/Salamander.AutomationTests/Hooks/TestHooks.cs
@@ -1,0 +1,13 @@
+using Reqnroll;
+
+namespace Salamander.AutomationTests.Hooks;
+
+[Binding]
+public sealed class TestHooks
+{
+    [BeforeScenario(Order = 0)]
+    public void StartApplication() => TestSession.Start();
+
+    [AfterScenario(Order = 100)]
+    public void StopApplication() => TestSession.Shutdown();
+}

--- a/tests/Salamander.AutomationTests/NativeCommandIds.cs
+++ b/tests/Salamander.AutomationTests/NativeCommandIds.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Salamander.AutomationTests;
+
+internal static class NativeCommandIds
+{
+    private static readonly Lazy<int> HelpAboutLazy = new(() => ResourceHeaderIds.GetValue("CM_HELP_ABOUT"));
+
+    public static int HelpAbout => HelpAboutLazy.Value;
+}

--- a/tests/Salamander.AutomationTests/NativeMethods.cs
+++ b/tests/Salamander.AutomationTests/NativeMethods.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Salamander.AutomationTests;
+
+internal static class NativeMethods
+{
+    public const int WM_COMMAND = 0x0111;
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+}

--- a/tests/Salamander.AutomationTests/NativeMethods.cs
+++ b/tests/Salamander.AutomationTests/NativeMethods.cs
@@ -6,7 +6,11 @@ namespace Salamander.AutomationTests;
 internal static class NativeMethods
 {
     public const int WM_COMMAND = 0x0111;
+    public const uint GW_OWNER = 4;
 
     [DllImport("user32.dll", CharSet = CharSet.Auto)]
     public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
+    public static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);
 }

--- a/tests/Salamander.AutomationTests/ResourceHeaderIds.cs
+++ b/tests/Salamander.AutomationTests/ResourceHeaderIds.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Salamander.AutomationTests;
+
+internal static class ResourceHeaderIds
+{
+    private static readonly Regex DefineRegex = new(
+        @"^#define\s+(?<name>\w+)\s+(?<value>0x[0-9A-Fa-f]+|\d+)",
+        RegexOptions.Compiled);
+
+    public static int GetValue(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("A symbol name must be provided.", nameof(symbol));
+        }
+
+        var headerPath = Path.Combine(TestConfiguration.RepositoryRoot, "src", "resource.rh2");
+        if (!File.Exists(headerPath))
+        {
+            throw new FileNotFoundException("The resource header could not be located.", headerPath);
+        }
+
+        foreach (var line in File.ReadLines(headerPath))
+        {
+            var match = DefineRegex.Match(line);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            if (!string.Equals(match.Groups["name"].Value, symbol, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var valueText = match.Groups["value"].Value;
+            return valueText.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                ? int.Parse(valueText[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture)
+                : int.Parse(valueText, NumberStyles.Integer, CultureInfo.InvariantCulture);
+        }
+
+        throw new InvalidOperationException($"Symbol '{symbol}' was not found in {headerPath}.");
+    }
+}

--- a/tests/Salamander.AutomationTests/Salamander.AutomationTests.csproj
+++ b/tests/Salamander.AutomationTests/Salamander.AutomationTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FlaUI.Core" Version="4.0.0" />
+    <PackageReference Include="FlaUI.UIA3" Version="4.0.0" />
+    <PackageReference Include="Reqnroll.NUnit" Version="1.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ReqnrollFeature Include="Features\**\*.feature" />
+  </ItemGroup>
+</Project>

--- a/tests/Salamander.AutomationTests/Salamander.AutomationTests.csproj
+++ b/tests/Salamander.AutomationTests/Salamander.AutomationTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FlaUI.Core" Version="4.0.0" />
-    <PackageReference Include="FlaUI.UIA3" Version="4.0.0" />
+    <PackageReference Include="FlaUI.UIA2" Version="4.0.0" />
     <PackageReference Include="Reqnroll.NUnit" Version="1.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
+++ b/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
 using FlaUI.Core.Tools;
 using NUnit.Framework;
 using Reqnroll;
@@ -23,17 +24,17 @@ public sealed class AboutDialogSteps
     public void WhenIOpenTheAboutDialogFromTheHelpMenu()
     {
         var mainWindow = TestSession.MainWindow;
-        var menuBar = mainWindow.MenuBar ?? throw new InvalidOperationException("The main window does not contain a menu bar.");
-        var helpMenu = menuBar.Items.FirstOrDefault(item => item.Name.Contains("Help", StringComparison.OrdinalIgnoreCase))
-                       ?? throw new InvalidOperationException("The Help menu could not be located.");
+        var menuBar = mainWindow.FindFirstDescendant(cf => cf.ByControlType(ControlType.MenuBar))?.AsMenu()
+                       ?? throw new InvalidOperationException("The main window does not contain a menu bar.");
+        var helpMenuItem = menuBar.Items.FirstOrDefault(item => item.Name.Contains("Help", StringComparison.OrdinalIgnoreCase))
+                           ?? throw new InvalidOperationException("The Help menu could not be located.");
 
-        var helpMenuItem = helpMenu.AsMenuItem();
         helpMenuItem.Click();
 
-        var aboutMenu = helpMenuItem.SubMenu.Items.FirstOrDefault(item => item.Name.Contains("About", StringComparison.OrdinalIgnoreCase))
-                         ?? throw new InvalidOperationException("The About menu item could not be located.");
+        var aboutMenuItem = helpMenuItem.Items.FirstOrDefault(item => item.Name.Contains("About", StringComparison.OrdinalIgnoreCase))
+                             ?? throw new InvalidOperationException("The About menu item could not be located.");
 
-        aboutMenu.Click();
+        aboutMenuItem.Click();
 
         _aboutWindow = Retry.WhileNull(
                 () => mainWindow.ModalWindows.FirstOrDefault(window => window.Title.Contains("About", StringComparison.OrdinalIgnoreCase)),

--- a/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
+++ b/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Tools;
+using NUnit.Framework;
+using Reqnroll;
+
+namespace Salamander.AutomationTests.StepDefinitions;
+
+[Binding]
+public sealed class AboutDialogSteps
+{
+    private Window? _aboutWindow;
+
+    [Given("Salamander is running")]
+    public void GivenSalamanderIsRunning()
+    {
+        Assert.That(TestSession.IsRunning, Is.True, "The Salamander application failed to start.");
+        Assert.That(TestSession.MainWindow, Is.Not.Null, "The main window is not available.");
+    }
+
+    [When("I open the About dialog from the Help menu")]
+    public void WhenIOpenTheAboutDialogFromTheHelpMenu()
+    {
+        var mainWindow = TestSession.MainWindow;
+        var menuBar = mainWindow.MenuBar ?? throw new InvalidOperationException("The main window does not contain a menu bar.");
+        var helpMenu = menuBar.Items.FirstOrDefault(item => item.Name.Contains("Help", StringComparison.OrdinalIgnoreCase))
+                       ?? throw new InvalidOperationException("The Help menu could not be located.");
+
+        var helpMenuItem = helpMenu.AsMenuItem();
+        helpMenuItem.Click();
+
+        var aboutMenu = helpMenuItem.SubMenu.Items.FirstOrDefault(item => item.Name.Contains("About", StringComparison.OrdinalIgnoreCase))
+                         ?? throw new InvalidOperationException("The About menu item could not be located.");
+
+        aboutMenu.Click();
+
+        _aboutWindow = Retry.WhileNull(
+                () => mainWindow.ModalWindows.FirstOrDefault(window => window.Title.Contains("About", StringComparison.OrdinalIgnoreCase)),
+                timeout: TimeSpan.FromSeconds(5))
+            .Result ?? throw new InvalidOperationException("The About dialog did not appear within the expected time.");
+    }
+
+    [Then("the About dialog is displayed")]
+    public void ThenTheAboutDialogIsDisplayed()
+    {
+        Assert.That(_aboutWindow, Is.Not.Null, "The About dialog is not available.");
+        Assert.That(_aboutWindow!.IsAvailable, Is.True, "The About dialog is not visible.");
+    }
+
+    [When("I close the About dialog")]
+    public void WhenICloseTheAboutDialog()
+    {
+        Assert.That(_aboutWindow, Is.Not.Null, "No About dialog is currently open.");
+        _aboutWindow!.Close();
+
+        Retry.WhileTrue(() => _aboutWindow!.IsAvailable, timeout: TimeSpan.FromSeconds(5));
+    }
+
+    [Then("the About dialog is closed")]
+    public void ThenTheAboutDialogIsClosed()
+    {
+        Assert.That(_aboutWindow, Is.Not.Null, "The About dialog reference has not been captured.");
+        Assert.That(_aboutWindow!.IsOffscreen || !_aboutWindow.IsAvailable, Is.True, "The About dialog is still visible.");
+    }
+
+    [Then("Salamander remains running")]
+    public void ThenSalamanderRemainsRunning()
+    {
+        Assert.That(TestSession.IsRunning, Is.True, "The Salamander application closed unexpectedly.");
+    }
+
+    [When("I exit Salamander")]
+    public void WhenIExitSalamander() => TestSession.Shutdown();
+
+    [Then("Salamander is not running")]
+    public void ThenSalamanderIsNotRunning()
+    {
+        Assert.That(TestSession.IsRunning, Is.False, "The Salamander application is still running.");
+    }
+}

--- a/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
+++ b/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
@@ -24,6 +24,9 @@ public sealed class AboutDialogSteps
     public void WhenIOpenTheAboutDialogFromTheHelpMenu()
     {
         var mainWindow = TestSession.MainWindow;
+        mainWindow.Focus();
+        Retry.WhileFalse(() => mainWindow.IsEnabled && mainWindow.IsAvailable, timeout: TimeSpan.FromSeconds(5));
+
         var menuBar = mainWindow.FindMainMenu();
 
         var helpMenuItem = menuBar.FindMenuItem("Help")
@@ -153,13 +156,24 @@ internal static class MenuElementExtensions
             throw new ArgumentNullException(nameof(menuItem));
         }
 
+        Retry.WhileFalse(() => menuItem.IsEnabled, timeout: TimeSpan.FromSeconds(5));
+
         var expandCollapse = menuItem.Patterns.ExpandCollapse?.PatternOrDefault;
         if (expandCollapse != null && expandCollapse.ExpandCollapseState != ExpandCollapseState.Expanded)
         {
-            expandCollapse.Expand();
+            try
+            {
+                expandCollapse.Expand();
+            }
+            catch (System.Windows.Automation.ElementNotEnabledException)
+            {
+                menuItem.Focus();
+                menuItem.Click();
+            }
         }
         else
         {
+            menuItem.Focus();
             menuItem.Click();
         }
     }

--- a/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
+++ b/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
@@ -187,14 +187,12 @@ public sealed class AboutDialogSteps
 
     private static MenuItem? FindMenuItem(Menu menu, string nameFragment)
     {
-        var items = menu.Items ?? Array.Empty<MenuItem>();
-        return items.FirstOrDefault(item => MatchesName(item, nameFragment));
+        return menu.Items.FirstOrDefault(item => MatchesName(item, nameFragment));
     }
 
     private static MenuItem? FindMenuItem(MenuItem parent, string nameFragment)
     {
-        var items = parent.Items ?? Array.Empty<MenuItem>();
-        return items.FirstOrDefault(item => MatchesName(item, nameFragment));
+        return parent.Items.FirstOrDefault(item => MatchesName(item, nameFragment));
     }
 
     private static bool MatchesName(MenuItem item, string nameFragment)
@@ -213,7 +211,7 @@ public sealed class AboutDialogSteps
         if (menuItem.Patterns.ExpandCollapse.IsSupported)
         {
             var expandCollapse = menuItem.Patterns.ExpandCollapse.Pattern;
-            if (expandCollapse.Current.ExpandCollapseState != ExpandCollapseState.Expanded)
+            if (expandCollapse.ExpandCollapseState != ExpandCollapseState.Expanded)
             {
                 expandCollapse.Expand();
             }

--- a/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
+++ b/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
@@ -82,14 +82,14 @@ public sealed class AboutDialogSteps
     public void ThenSalamanderIsNotRunning()
     {
         Assert.That(TestSession.IsRunning, Is.False, "The Salamander application is still running.");
-}
+    }
 
     private static void TryOpenAboutWithKeyboard()
     {
-        Keyboard.Press(VirtualKeyShort.MENU);
+        Keyboard.Press(VirtualKeyShort.ALT);
         Keyboard.Press(VirtualKeyShort.KEY_H);
         Keyboard.Release(VirtualKeyShort.KEY_H);
-        Keyboard.Release(VirtualKeyShort.MENU);
+        Keyboard.Release(VirtualKeyShort.ALT);
 
         Wait.UntilInputIsProcessed();
 
@@ -101,13 +101,13 @@ public sealed class AboutDialogSteps
 
     private static void InvokeAboutCommand(Window mainWindow)
     {
-        var nativeHandle = mainWindow.Properties.NativeWindowHandle.Value;
-        if (nativeHandle is null)
+        var nativeHandle = mainWindow.FrameworkAutomationElement.NativeWindowHandle;
+        if (nativeHandle == IntPtr.Zero)
         {
             throw new InvalidOperationException("The main window handle is not available.");
         }
 
-        NativeMethods.SendMessage(new IntPtr(nativeHandle.Value), NativeMethods.WM_COMMAND, new IntPtr(NativeCommandIds.HelpAbout), IntPtr.Zero);
+        NativeMethods.SendMessage(nativeHandle, NativeMethods.WM_COMMAND, new IntPtr(NativeCommandIds.HelpAbout), IntPtr.Zero);
 
         Wait.UntilInputIsProcessed();
     }

--- a/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
+++ b/tests/Salamander.AutomationTests/StepDefinitions/AboutDialogSteps.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Linq;
 using FlaUI.Core.AutomationElements;
-using FlaUI.Core.AutomationElements.MenuItems;
 using FlaUI.Core.Definitions;
 using FlaUI.Core.Input;
 using FlaUI.Core.Tools;
 using FlaUI.Core.WindowsAPI;
 using NUnit.Framework;
 using Reqnroll;
+using Menu = FlaUI.Core.AutomationElements.Menu;
+using MenuItem = FlaUI.Core.AutomationElements.MenuItem;
 
 namespace Salamander.AutomationTests.StepDefinitions;
 

--- a/tests/Salamander.AutomationTests/TestConfiguration.cs
+++ b/tests/Salamander.AutomationTests/TestConfiguration.cs
@@ -16,6 +16,10 @@ public static class TestConfiguration
         Path.Combine("..", "..", "..", "..", "bin", "Salamand.exe")
     };
 
+    private static readonly Lazy<string> RepositoryRootLazy = new(LocateRepositoryRoot);
+
+    public static string RepositoryRoot => RepositoryRootLazy.Value;
+
     /// <summary>
     /// Resolves the path to the Salamander executable to be tested.
     /// </summary>
@@ -47,5 +51,16 @@ public static class TestConfiguration
 
         throw new FileNotFoundException(
             "Could not locate Salamand.exe. Set the SALAMANDER_APP_PATH environment variable to the built executable before running the tests.");
+    }
+
+    private static string LocateRepositoryRoot()
+    {
+        var candidate = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        if (Directory.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        throw new DirectoryNotFoundException("The Salamander repository root could not be determined from the test binary location.");
     }
 }

--- a/tests/Salamander.AutomationTests/TestConfiguration.cs
+++ b/tests/Salamander.AutomationTests/TestConfiguration.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+
+namespace Salamander.AutomationTests;
+
+/// <summary>
+/// Provides configuration values for the UI automation tests.
+/// </summary>
+public static class TestConfiguration
+{
+    private const string ApplicationPathEnvironmentVariable = "SALAMANDER_APP_PATH";
+    private static readonly string[] DefaultExecutableCandidates =
+    {
+        Path.Combine("..", "..", "..", "..", "src", "vcxproj", "build", "Salamand.exe"),
+        Path.Combine("..", "..", "..", "..", "src", "vcxproj", "build", "bin", "Salamand.exe"),
+        Path.Combine("..", "..", "..", "..", "bin", "Salamand.exe")
+    };
+
+    /// <summary>
+    /// Resolves the path to the Salamander executable to be tested.
+    /// </summary>
+    /// <returns>The full path to the executable.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the executable cannot be located.</exception>
+    public static string ResolveApplicationPath()
+    {
+        var environmentOverride = Environment.GetEnvironmentVariable(ApplicationPathEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(environmentOverride))
+        {
+            var normalized = Path.GetFullPath(environmentOverride);
+            if (File.Exists(normalized))
+            {
+                return normalized;
+            }
+
+            throw new FileNotFoundException($"The path specified in the {ApplicationPathEnvironmentVariable} environment variable does not exist.", normalized);
+        }
+
+        var baseDirectory = AppContext.BaseDirectory;
+        foreach (var relativePath in DefaultExecutableCandidates)
+        {
+            var candidate = Path.GetFullPath(Path.Combine(baseDirectory, relativePath));
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        throw new FileNotFoundException(
+            "Could not locate Salamand.exe. Set the SALAMANDER_APP_PATH environment variable to the built executable before running the tests.");
+    }
+}

--- a/tests/Salamander.AutomationTests/TestSession.cs
+++ b/tests/Salamander.AutomationTests/TestSession.cs
@@ -13,13 +13,13 @@ public static class TestSession
 {
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
 
-    private static Application? _application;
+    private static FlaUI.Core.Application? _application;
     private static UIA3Automation? _automation;
     private static Window? _mainWindow;
 
     public static bool IsRunning => _application is { HasExited: false };
 
-    public static Application Application => _application ?? throw new InvalidOperationException("The application has not been started yet.");
+    public static FlaUI.Core.Application Application => _application ?? throw new InvalidOperationException("The application has not been started yet.");
 
     public static UIA3Automation Automation => _automation ?? throw new InvalidOperationException("The UI Automation instance is not available.");
 
@@ -36,7 +36,7 @@ public static class TestSession
         }
 
         var executablePath = TestConfiguration.ResolveApplicationPath();
-        _application = Application.Launch(executablePath);
+        _application = FlaUI.Core.Application.Launch(executablePath);
         _automation = new UIA3Automation();
         _mainWindow = Retry.WhileNull(
                 () => _application.GetMainWindow(_automation, DefaultTimeout),

--- a/tests/Salamander.AutomationTests/TestSession.cs
+++ b/tests/Salamander.AutomationTests/TestSession.cs
@@ -2,7 +2,7 @@ using System;
 using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Tools;
-using FlaUI.UIA3;
+using FlaUI.UIA2;
 
 namespace Salamander.AutomationTests;
 
@@ -14,14 +14,14 @@ public static class TestSession
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
 
     private static FlaUI.Core.Application? _application;
-    private static UIA3Automation? _automation;
+    private static UIA2Automation? _automation;
     private static Window? _mainWindow;
 
     public static bool IsRunning => _application is { HasExited: false };
 
     public static FlaUI.Core.Application Application => _application ?? throw new InvalidOperationException("The application has not been started yet.");
 
-    public static UIA3Automation Automation => _automation ?? throw new InvalidOperationException("The UI Automation instance is not available.");
+    public static UIA2Automation Automation => _automation ?? throw new InvalidOperationException("The UI Automation instance is not available.");
 
     public static Window MainWindow => _mainWindow ?? throw new InvalidOperationException("The main window is not available.");
 
@@ -37,7 +37,7 @@ public static class TestSession
 
         var executablePath = TestConfiguration.ResolveApplicationPath();
         _application = FlaUI.Core.Application.Launch(executablePath);
-        _automation = new UIA3Automation();
+        _automation = new UIA2Automation();
         _mainWindow = Retry.WhileNull(
                 () => _application.GetMainWindow(_automation, DefaultTimeout),
                 timeout: DefaultTimeout)

--- a/tests/Salamander.AutomationTests/TestSession.cs
+++ b/tests/Salamander.AutomationTests/TestSession.cs
@@ -42,6 +42,9 @@ public static class TestSession
                 () => _application.GetMainWindow(_automation, DefaultTimeout),
                 timeout: DefaultTimeout)
             .Result ?? throw new InvalidOperationException("Failed to locate the Salamander main window.");
+
+        _mainWindow.Focus();
+        Retry.WhileFalse(() => _mainWindow!.IsEnabled && _mainWindow.IsAvailable, timeout: DefaultTimeout);
     }
 
     /// <summary>

--- a/tests/Salamander.AutomationTests/TestSession.cs
+++ b/tests/Salamander.AutomationTests/TestSession.cs
@@ -1,0 +1,89 @@
+using System;
+using FlaUI.Core;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Tools;
+using FlaUI.UIA3;
+
+namespace Salamander.AutomationTests;
+
+/// <summary>
+/// Manages the lifecycle of the Salamander application under test.
+/// </summary>
+public static class TestSession
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(10);
+
+    private static Application? _application;
+    private static UIA3Automation? _automation;
+    private static Window? _mainWindow;
+
+    public static bool IsRunning => _application is { HasExited: false };
+
+    public static Application Application => _application ?? throw new InvalidOperationException("The application has not been started yet.");
+
+    public static UIA3Automation Automation => _automation ?? throw new InvalidOperationException("The UI Automation instance is not available.");
+
+    public static Window MainWindow => _mainWindow ?? throw new InvalidOperationException("The main window is not available.");
+
+    /// <summary>
+    /// Starts the Salamander application if it is not already running.
+    /// </summary>
+    public static void Start()
+    {
+        if (_application is { HasExited: false })
+        {
+            return;
+        }
+
+        var executablePath = TestConfiguration.ResolveApplicationPath();
+        _application = Application.Launch(executablePath);
+        _automation = new UIA3Automation();
+        _mainWindow = Retry.WhileNull(
+                () => _application.GetMainWindow(_automation, DefaultTimeout),
+                timeout: DefaultTimeout)
+            .Result ?? throw new InvalidOperationException("Failed to locate the Salamander main window.");
+    }
+
+    /// <summary>
+    /// Attempts to close the Salamander application and releases UI Automation resources.
+    /// </summary>
+    public static void Shutdown()
+    {
+        try
+        {
+            if (_mainWindow is { IsAvailable: true })
+            {
+                _mainWindow.Close();
+                WaitForExit();
+            }
+            else if (_application is { HasExited: false })
+            {
+                _application.Close();
+                WaitForExit();
+            }
+        }
+        finally
+        {
+            _mainWindow = null;
+
+            _automation?.Dispose();
+            _automation = null;
+
+            _application?.Dispose();
+            _application = null;
+        }
+    }
+
+    /// <summary>
+    /// Waits for the Salamander process to exit.
+    /// </summary>
+    public static void WaitForExit()
+    {
+        if (_application is null)
+        {
+            return;
+        }
+
+        Retry.WhileTrue(() => !_application.HasExited, timeout: DefaultTimeout);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `tests` solution with a FlaUI and Reqnroll based automation project
- provide configuration, hooks, and step definitions to control Salamander under test
- document how to run the sample About dialog scenario

## Testing
- Not run (requires Windows with .NET SDK and the Salamander executable)


------
https://chatgpt.com/codex/tasks/task_e_68d4a7f323488329bd153f815ed9cbc8