### PR TITLE
Add FlaUI-based UI test project with SpecFlow scenario

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,18 @@
+# Salamander UI test suite
+
+This directory contains an automated UI test project based on [FlaUI](https://github.com/FlaUI/FlaUI) and SpecFlow Gherkin scenarios.
+
+## Project structure
+
+- `Salamander.UiTests/Salamander.UiTests.csproj` – C# test project targeting Windows, configured with FlaUI and SpecFlow dependencies.
+- `Features/` – Gherkin feature files describing behaviour-driven test scenarios.
+- `Steps/` – Step definitions implementing the behaviour described in the feature files.
+- `Support/` – Shared infrastructure used by the tests (configuration, hooks, etc.).
+
+## Running the tests
+
+1. Build the Salamander application (e.g. using Visual Studio) so that a `salamand*.exe` executable is available.
+2. Optionally set the `SALAMANDER_APP_PATH` environment variable to point directly to the executable.
+3. From the `tests/Salamander.UiTests` directory, execute `dotnet test`.
+
+The sample scenario launches the application, opens the **About** dialog, closes it, and then exits the application.

--- a/tests/Salamander.UiTests/Features/AboutDialog.feature
+++ b/tests/Salamander.UiTests/Features/AboutDialog.feature
@@ -1,0 +1,12 @@
+Feature: About dialog
+  In order to verify that the Salamander application starts correctly
+  As a Salamander power-user
+  I want to open and close the About dialog from an automated test
+
+  Scenario: Launch the application and inspect the About dialog
+    Given the Salamander application is started
+    When I open the About dialog
+    Then the About dialog is displayed
+    When I close the About dialog
+    And I exit the Salamander application
+    Then the Salamander application is closed

--- a/tests/Salamander.UiTests/Salamander.UiTests.csproj
+++ b/tests/Salamander.UiTests/Salamander.UiTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FlaUI.Core" Version="4.0.0" />
+    <PackageReference Include="FlaUI.UIA3" Version="4.0.0" />
+    <PackageReference Include="SpecFlow" Version="3.9.74" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.9.74" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" PrivateAssets="all" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+</Project>

--- a/tests/Salamander.UiTests/Steps/AboutDialogSteps.cs
+++ b/tests/Salamander.UiTests/Steps/AboutDialogSteps.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using FlaUI.Core;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using FlaUI.Core.Tools;
+using FlaUI.UIA3;
+using NUnit.Framework;
+using Salamander.UiTests.Support;
+using TechTalk.SpecFlow;
+
+namespace Salamander.UiTests.Steps;
+
+[Binding]
+public class AboutDialogSteps
+{
+    private readonly ScenarioContext _scenarioContext;
+    private Application? _application;
+    private AutomationBase? _automation;
+    private Window? _mainWindow;
+    private Window? _aboutWindow;
+
+    public AboutDialogSteps(ScenarioContext scenarioContext)
+    {
+        _scenarioContext = scenarioContext;
+    }
+
+    [Given("the Salamander application is started")]
+    public void GivenTheSalamanderApplicationIsStarted()
+    {
+        var applicationPath = TestConfiguration.ResolveApplicationPath();
+        _application = Application.Launch(new ProcessStartInfo(applicationPath)
+        {
+            WorkingDirectory = Path.GetDirectoryName(applicationPath)
+        });
+        _automation = new UIA3Automation();
+        _mainWindow = _application.GetMainWindow(_automation, TimeSpan.FromSeconds(15));
+
+        Assert.That(_mainWindow, Is.Not.Null, "The Salamander main window could not be located.");
+
+        _scenarioContext.Set(_application, nameof(Application));
+        _scenarioContext.Set(_automation, nameof(AutomationBase));
+        _scenarioContext.Set(_mainWindow, "MainWindow");
+    }
+
+    [When("I open the About dialog")]
+    public void WhenIOpenTheAboutDialog()
+    {
+        _mainWindow ??= _scenarioContext.TryGetValue("MainWindow", out Window? window)
+            ? window
+            : throw new InvalidOperationException("The main window is not available in the scenario context.");
+
+        var aboutMenuItem = _mainWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.MenuItem))
+            .FirstOrDefault(item => item.Name.Contains("About", StringComparison.OrdinalIgnoreCase));
+
+        Assert.That(aboutMenuItem, Is.Not.Null, "Unable to locate a menu item with 'About' in its name.");
+
+        aboutMenuItem.Invoke();
+    }
+
+    [Then("the About dialog is displayed")]
+    public void ThenTheAboutDialogIsDisplayed()
+    {
+        _application ??= _scenarioContext.TryGetValue(nameof(Application), out Application? application)
+            ? application
+            : throw new InvalidOperationException("The application reference was not found in the scenario context.");
+        _automation ??= _scenarioContext.TryGetValue(nameof(AutomationBase), out AutomationBase? automation)
+            ? automation
+            : throw new InvalidOperationException("The automation reference was not found in the scenario context.");
+
+        var aboutDialogResult = Retry.WhileNull(
+            () => _application.GetAllTopLevelWindows(_automation)
+                .FirstOrDefault(window => window.Title.Contains("About", StringComparison.OrdinalIgnoreCase)),
+            timeout: TimeSpan.FromSeconds(5),
+            throwOnTimeout: true);
+
+        _aboutWindow = aboutDialogResult.Result;
+
+        Assert.That(_aboutWindow, Is.Not.Null, "The About dialog did not appear within the expected time.");
+
+        _scenarioContext.Set(_aboutWindow, "AboutWindow");
+    }
+
+    [When("I close the About dialog")]
+    public void WhenICloseTheAboutDialog()
+    {
+        _aboutWindow ??= _scenarioContext.TryGetValue("AboutWindow", out Window? window)
+            ? window
+            : throw new InvalidOperationException("The About dialog reference is not available in the scenario context.");
+
+        _aboutWindow.Close();
+        Wait.UntilInputIsProcessed();
+    }
+
+    [When("I exit the Salamander application")]
+    public void WhenIExitTheSalamanderApplication()
+    {
+        _mainWindow ??= _scenarioContext.TryGetValue("MainWindow", out Window? window)
+            ? window
+            : throw new InvalidOperationException("The main window is not available in the scenario context.");
+
+        _mainWindow.Close();
+        Wait.UntilInputIsProcessed();
+    }
+
+    [Then("the Salamander application is closed")]
+    public void ThenTheSalamanderApplicationIsClosed()
+    {
+        _application ??= _scenarioContext.TryGetValue(nameof(Application), out Application? application)
+            ? application
+            : throw new InvalidOperationException("The application reference was not found in the scenario context.");
+
+        var exitResult = Retry.WhileFalse(() => _application.HasExited, timeout: TimeSpan.FromSeconds(10));
+        Assert.That(exitResult.Success, Is.True, "The Salamander process is still running after requesting it to close.");
+    }
+}

--- a/tests/Salamander.UiTests/Support/Hooks.cs
+++ b/tests/Salamander.UiTests/Support/Hooks.cs
@@ -1,0 +1,74 @@
+using FlaUI.Core;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Tools;
+using TechTalk.SpecFlow;
+
+namespace Salamander.UiTests.Support;
+
+[Binding]
+public sealed class Hooks
+{
+    private readonly ScenarioContext _scenarioContext;
+
+    public Hooks(ScenarioContext scenarioContext)
+    {
+        _scenarioContext = scenarioContext;
+    }
+
+    [AfterScenario]
+    public void Cleanup()
+    {
+        if (_scenarioContext.TryGetValue("AboutWindow", out Window? aboutWindow))
+        {
+            try
+            {
+                if (!aboutWindow.IsOffscreen)
+                {
+                    aboutWindow.Close();
+                    Wait.UntilInputIsProcessed();
+                }
+            }
+            catch
+            {
+                // ignored - best effort cleanup
+            }
+        }
+
+        if (_scenarioContext.TryGetValue("MainWindow", out Window? mainWindow))
+        {
+            try
+            {
+                if (!mainWindow.Patterns.Window.Pattern.Current.IsModal)
+                {
+                    mainWindow.Close();
+                    Wait.UntilInputIsProcessed();
+                }
+            }
+            catch
+            {
+                // ignored - best effort cleanup
+            }
+        }
+
+        if (_scenarioContext.TryGetValue(nameof(Application), out Application? application))
+        {
+            try
+            {
+                if (!application.HasExited)
+                {
+                    application.Close();
+                    application.WaitWhileMainHandleIsAlive(TimeSpan.FromSeconds(5));
+                }
+            }
+            catch
+            {
+                // ignored - best effort cleanup
+            }
+        }
+
+        if (_scenarioContext.TryGetValue(nameof(AutomationBase), out AutomationBase? automation))
+        {
+            automation.Dispose();
+        }
+    }
+}

--- a/tests/Salamander.UiTests/Support/TestConfiguration.cs
+++ b/tests/Salamander.UiTests/Support/TestConfiguration.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+
+namespace Salamander.UiTests.Support;
+
+public static class TestConfiguration
+{
+    private const string AppPathEnvironmentVariable = "SALAMANDER_APP_PATH";
+
+    public static string ResolveApplicationPath()
+    {
+        var pathFromEnvironment = Environment.GetEnvironmentVariable(AppPathEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(pathFromEnvironment) && File.Exists(pathFromEnvironment))
+        {
+            return Path.GetFullPath(pathFromEnvironment);
+        }
+
+        var potentialPath = LocateExecutableInRepository();
+        if (potentialPath is not null)
+        {
+            return potentialPath;
+        }
+
+        throw new FileNotFoundException(
+            $"Unable to find the Salamander executable. Set the '{AppPathEnvironmentVariable}' environment variable to point to the built application before running the UI tests.");
+    }
+
+    private static string? LocateExecutableInRepository()
+    {
+        var assemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        var repositoryRoot = Path.GetFullPath(Path.Combine(assemblyLocation, "..", "..", "..", ".."));
+
+        if (!Directory.Exists(repositoryRoot))
+        {
+            return null;
+        }
+
+        return Directory.EnumerateFiles(repositoryRoot, "salamand*.exe", SearchOption.AllDirectories)
+            .Concat(Directory.EnumerateFiles(repositoryRoot, "Salamander*.exe", SearchOption.AllDirectories))
+            .Select(Path.GetFullPath)
+            .FirstOrDefault(File.Exists);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Windows-targeted Salamander.UiTests project under tests with FlaUI, SpecFlow, and NUnit dependencies
- define a Gherkin feature and SpecFlow steps that launch Salamander, open the About dialog, close it, and exit the app
- provide supporting configuration helpers and documentation for running the UI automation suite

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4a798d2e8832992ff4defcea1b848