### PR TITLE
Improve tab drag reordering feedback

### DIFF
--- a/src/tabwnd.h
+++ b/src/tabwnd.h
@@ -47,6 +47,10 @@ private:
     void UpdateDragTracking(const POINT& pt);
     void FinishDragTracking(const POINT& pt, bool canceled);
     void CancelDragTracking();
+    void UpdateDragIndicator(const POINT& pt);
+    void SetInsertMark(int item, DWORD flags);
+    void ClearInsertMark();
+    bool ComputeDragTargetInfo(POINT pt, int fromIndex, int& targetIndex, int& markItem, DWORD& markFlags) const;
     int ComputeDragTargetIndex(POINT pt, int fromIndex) const;
     void MoveTabInternal(int from, int to);
 
@@ -58,4 +62,7 @@ private:
     bool Dragging;
     POINT DragStartPoint;
     int DragSourceIndex;
+    int DragCurrentTarget;
+    int DragInsertMarkItem;
+    DWORD DragInsertMarkFlags;
 };

--- a/src/tabwnd.h
+++ b/src/tabwnd.h
@@ -50,6 +50,8 @@ private:
     void UpdateDragIndicator(const POINT& pt);
     void SetInsertMark(int item, DWORD flags);
     void ClearInsertMark();
+    void SetDragCursor(HCURSOR cursor);
+    void ResetDragCursor();
     bool ComputeDragTargetInfo(POINT pt, int fromIndex, int& targetIndex, int& markItem, DWORD& markFlags) const;
     int ComputeDragTargetIndex(POINT pt, int fromIndex) const;
     void MoveTabInternal(int from, int to);
@@ -65,4 +67,8 @@ private:
     int DragCurrentTarget;
     int DragInsertMarkItem;
     DWORD DragInsertMarkFlags;
+    HCURSOR DragCursorAllowed;
+    HCURSOR DragCursorDenied;
+    HCURSOR DragCursorDefault;
+    HCURSOR DragCursorCurrent;
 };


### PR DESCRIPTION
## Summary
- adjust tab drag target detection to rely on hit-testing for symmetric left/right movement
- add insert-mark handling so the tab control shows the drop position while dragging
- track and reuse the last valid drag target when finishing a drag operation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c50e34b083298233c40bcd4a8c78