### PR TITLE
Fix UTF-8 trimming in file name dialogs

### DIFF
--- a/src/fileswn5.cpp
+++ b/src/fileswn5.cpp
@@ -1881,7 +1881,12 @@ BOOL FileNameInvalidForManualCreate(const char* path)
     {
         name++;
         int nameLen = (int)strlen(name);
-        return nameLen > 0 && (*name <= ' ' || name[nameLen - 1] <= ' ' || name[nameLen - 1] == '.');
+        if (nameLen > 0)
+        {
+            unsigned char first = static_cast<unsigned char>(*name);
+            unsigned char last = static_cast<unsigned char>(name[nameLen - 1]);
+            return first <= ' ' || last <= ' ' || last == '.';
+        }
     }
     return FALSE;
 }
@@ -1893,7 +1898,7 @@ BOOL MakeValidFileName(char* path)
     // and https://forum.altap.cz/viewtopic.php?f=2&t=4210
     BOOL ch = FALSE;
     char* n = path;
-    while (*n != 0 && *n <= ' ')
+    while (*n != 0 && static_cast<unsigned char>(*n) <= ' ')
         n++;
     if (n > path)
     {
@@ -1901,7 +1906,7 @@ BOOL MakeValidFileName(char* path)
         ch = TRUE;
     }
     n = path + strlen(path);
-    while (n > path && (*(n - 1) <= ' ' || *(n - 1) == '.'))
+    while (n > path && (static_cast<unsigned char>(*(n - 1)) <= ' ' || *(n - 1) == '.'))
         n--;
     if (*n != 0)
     {
@@ -1916,7 +1921,7 @@ BOOL CutSpacesFromBothSides(char* path)
     // trim spaces at the beginning and end of the name
     BOOL ch = FALSE;
     char* n = path;
-    while (*n != 0 && *n <= ' ')
+    while (*n != 0 && static_cast<unsigned char>(*n) <= ' ')
         n++;
     if (n > path)
     {
@@ -1924,7 +1929,7 @@ BOOL CutSpacesFromBothSides(char* path)
         ch = TRUE;
     }
     n = path + strlen(path);
-    while (n > path && (*(n - 1) <= ' '))
+    while (n > path && static_cast<unsigned char>(*(n - 1)) <= ' ')
         n--;
     if (*n != 0)
     {
@@ -2111,7 +2116,7 @@ void CFilesWindow::CreateDir(CFilesWindow* target)
 void CFilesWindow::RenameFileInternal(CFileData* f, const char* formatedFileName, BOOL* mayChange, BOOL* tryAgain)
 {
     *tryAgain = TRUE;
-    const char* s = formatedFileName;
+    const unsigned char* s = reinterpret_cast<const unsigned char*>(formatedFileName);
     while (*s != 0 && *s != '\\' && *s != '/' && *s != ':' &&
            *s >= 32 && *s != '<' && *s != '>' && *s != '|' && *s != '"')
         s++;

--- a/src/salamdr3.cpp
+++ b/src/salamdr3.cpp
@@ -416,8 +416,13 @@ BOOL SalGetFullName(char* name, int* errTextID, const char* curDir, char* nextFo
 
     int rootOffset = 3; // offset zacatku adresarove casti cesty (3 pro "c:\path")
     char* s = name;
-    while (*s >= 1 && *s <= ' ')
+    while (*s != 0)
+    {
+        unsigned char ch = static_cast<unsigned char>(*s);
+        if (ch < 1 || ch > ' ')
+            break;
         s++;
+    }
     if (*s == '\\' && *(s + 1) == '\\') // UNC (\\server\share\...)
     {                                   // eliminace mezer na zacatku cesty
         if (s != name)
@@ -1185,13 +1190,15 @@ AGAIN:
             BOOL first = TRUE;
             while (*st != 0)
             {
-                BOOL invalidName = manualCrDir && *st <= ' '; // mezery na zacatku jmena vytvareneho adresare jsou nezadouci jen pri rucnim vytvareni (Windows to umi, ale je to potencialne nebezpecne)
+                unsigned char firstChar = static_cast<unsigned char>(*st);
+                BOOL invalidName = manualCrDir && firstChar <= ' '; // mezery na zacatku jmena vytvareneho adresare jsou nezadouci jen pri rucnim vytvareni (Windows to umi, ale je to potencialne nebezpecne)
                 const char* slash = strchr(st, '\\');
                 if (slash == NULL)
                     slash = st + strlen(st);
                 memcpy(name + len, st, slash - st);
                 name[len += (int)(slash - st)] = 0;
-                if (name[len - 1] <= ' ' || name[len - 1] == '.')
+                unsigned char lastChar = static_cast<unsigned char>(name[len - 1]);
+                if (lastChar <= ' ' || lastChar == '.')
                     invalidName = TRUE; // mezery a tecky na konci jmena vytvareneho adresare jsou nezadouci
             AGAIN2:
                 if (invalidName || !CreateDirectory(name, NULL))


### PR DESCRIPTION
## Summary
- treat UTF-8 file name bytes as unsigned when validating or trimming characters
- update rename sanitization logic to avoid dropping characters with the high bit set
- adjust SalGetFullName directory creation checks to respect non-ASCII leading/trailing characters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4eac20534832993c94ea8091fff26