### PR TITLE
Support dragging tabs across panels

### DIFF
--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -528,6 +528,7 @@ public:
     void OnPanelTabSelected(CPanelSide side, int index);
     void OnPanelTabContextMenu(CPanelSide side, int index, const POINT& screenPt);
     void OnPanelTabReordered(CPanelSide side, int from, int to);
+    void OnPanelTabDropped(CPanelSide fromSide, int fromIndex, CPanelSide toSide, int insertIndex, bool copy);
     int GetPanelTabIndex(CPanelSide side, CFilesWindow* panel) const;
     int GetPanelTabCount(CPanelSide side) const;
     CFilesWindow* GetPanelTabAt(CPanelSide side, int index) const;

--- a/src/tabwnd.h
+++ b/src/tabwnd.h
@@ -52,11 +52,14 @@ private:
     void UpdateDragTracking(const POINT& pt);
     void FinishDragTracking(const POINT& pt, bool canceled);
     void CancelDragTracking();
-    void UpdateDragIndicator(const POINT& pt);
+    void UpdateDragIndicator(const POINT& screenPt);
     void SetInsertMark(int item, DWORD flags);
     void ClearInsertMark();
     bool ComputeDragTargetInfo(POINT pt, int fromIndex, int& targetIndex, int& markItem, DWORD& markFlags) const;
     int ComputeDragTargetIndex(POINT pt, int fromIndex) const;
+    bool ComputeExternalDropTarget(POINT pt, int& insertIndex, int& markItem, DWORD& markFlags) const;
+    bool FindDropTarget(const POINT& screenPt, bool updateInsertMarks, CTabWindow*& targetWindow,
+                        bool& isInternalTarget, int& targetIndex, int& markItem, DWORD& markFlags);
     void MoveTabInternal(int from, int to);
     void InvalidateTab(int index);
 


### PR DESCRIPTION
## Summary
- track global drag state and evaluate targets across both tab windows, updating insert marks and cross-panel drop feedback
- compute external drop slots and detect Ctrl-copy to enable dropping a tab onto the opposite panel
- move or duplicate tabs between panels while preserving view template, path, color and prefix metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5aeb610e8832981998845703eec08