### PR TITLE
Fix custom tab color coverage for selected tabs

### DIFF
--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -1077,9 +1077,12 @@ void CTabWindow::DrawColoredTab(HDC hdc, const RECT& itemRect, const wchar_t* te
 
     RECT rect = itemRect;
     RECT fillRect = rect;
-    InflateRect(&fillRect, -1, -1);
-    if (fillRect.right <= fillRect.left || fillRect.bottom <= fillRect.top)
-        fillRect = rect;
+    if (!selected)
+    {
+        InflateRect(&fillRect, -1, -1);
+        if (fillRect.right <= fillRect.left || fillRect.bottom <= fillRect.top)
+            fillRect = rect;
+    }
 
     COLORREF fillColor = baseColor;
     if (selected)


### PR DESCRIPTION
## Summary
- prevent deflating the custom tab fill rectangle when the tab is selected so the color spans the full item area

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5b423609c8329ac1910c50ea4160c