### PR TITLE
Add drag target indicator for tab reordering

### DIFF
--- a/src/tabwnd.h
+++ b/src/tabwnd.h
@@ -55,6 +55,8 @@ private:
     void UpdateDragIndicator(const POINT& pt);
     void SetInsertMark(int item, DWORD flags);
     void ClearInsertMark();
+    void UpdateInsertMarkRect();
+    void PaintDragIndicator(HDC hdc) const;
     bool ComputeDragTargetInfo(POINT pt, int fromIndex, int& targetIndex, int& markItem, DWORD& markFlags) const;
     int ComputeDragTargetIndex(POINT pt, int fromIndex) const;
     void MoveTabInternal(int from, int to);
@@ -89,6 +91,8 @@ private:
     int DragCurrentTarget;
     int DragInsertMarkItem;
     DWORD DragInsertMarkFlags;
+    RECT DragIndicatorRect;
+    bool DragIndicatorVisible;
 
     std::vector<STabColor> TabColors;
 


### PR DESCRIPTION
## Summary
- keep track of drag target geometry when updating the tab insert mark
- paint a custom drag target indicator so users can see where a tab will land
- invalidate and repaint the indicator as drag targets change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5b5e437548329a20de8c13d0942c4