### PR TITLE
Avoid flicker when switching panel tabs

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -160,8 +160,6 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
             tabWnd->SetCurSel(index);
     }
 
-    UpdatePanelTabVisibility(side);
-
     UpdatePanelTabTitle(panel);
 
     bool refreshOnActivate = panel->NeedsRefreshOnActivation != FALSE;
@@ -190,6 +188,12 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
     if (canFocusNow)
     {
         LayoutWindows();
+    }
+
+    UpdatePanelTabVisibility(side);
+
+    if (canFocusNow)
+    {
         FocusPanel(panel);
     }
 


### PR DESCRIPTION
## Fix #77 

## Summary
- defer the panel tab visibility update until after layout to avoid showing a tab before it is resized

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6dc9e9c4c8329b2716aa6a628e2a1