### PR TITLE
Retry directory monitoring after failures

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -1181,6 +1181,7 @@ struct COpenViewerData
 #define WM_USER_SLGINCOMPLETE WM_APP + 414 // [0, 0] - upozorneni, ze SLG neni kompletne prelozene, motivacni text aby se zapojili
 
 #define WM_USER_USERMENUICONS_READY WM_APP + 415 // [bkgndReaderData, threadID] - notifikace pro hl. okno, ze se dokoncilo cteni ikon pro User Menu v threadu s ID 'threadID'
+#define WM_USER_MONITOR_RETRY WM_APP + 416       // [registerDevNotification, 0] - odlozeny pokus o znovuotevreni change-notify
 
 // states for Shift+F1 help mode
 #define HELP_INACTIVE 0 // not in Shift+F1 help mode (must be 0)
@@ -1756,6 +1757,7 @@ DWORD CfgSkillLevelToMenu(BYTE cfgSkillLevel);
 #define IDT_THROBBER 949
 #define IDT_DELAYEDTHROBBER 950
 #define IDT_UPDATETASKLIST 951
+#define IDT_MONITOR_RETRY 952
 
 // POZOR: skoro vsechny funkce v teto sekci pri chybe zobrazuji hlaseni o LOAD / SAVE
 //        konfigurace, coz z nich dela nevhodne pro bezny pristup do Registry,

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -2258,7 +2258,12 @@ bool CFilesWindow::EnsureActiveDiskMonitoring(BOOL registerDevNotification)
         return false;
 
     if (!GetMonitorChanges())
+    {
+        // Monitoring is disabled for this path, so the caller should refresh on
+        // activation to keep the listing current even without change
+        // notifications.
         return true;
+    }
 
     EnsureWatching(this, registerDevNotification);
     if (!AutomaticRefresh)

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -2247,34 +2247,6 @@ void CFilesWindow::ScheduleMonitorRetry(BOOL registerDevNotification)
     }
 }
 
-bool CFilesWindow::EnsureActiveDiskMonitoring(BOOL registerDevNotification)
-{
-    CALL_STACK_MESSAGE_NONE
-    if (!(Is(ptDisk) || Is(ptZIPArchive)))
-        return false;
-
-    const char* path = GetPath();
-    if (path == NULL || path[0] == 0)
-        return false;
-
-    if (!GetMonitorChanges())
-    {
-        // Monitoring is disabled for this path, so the caller should refresh on
-        // activation to keep the listing current even without change
-        // notifications.
-        return true;
-    }
-
-    EnsureWatching(this, registerDevNotification);
-    if (!AutomaticRefresh)
-    {
-        ScheduleMonitorRetry(registerDevNotification);
-        return true;
-    }
-
-    return false;
-}
-
 void CFilesWindow::RequestPluginRefreshOnActivation()
 {
     CALL_STACK_MESSAGE_NONE

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -2474,7 +2474,19 @@ BOOL CFilesWindow::CommonRefresh(HWND parent, int suggestedTopIndex, const char*
     else
     {
         if (Is(ptDisk) || Is(ptZIPArchive))
+        {
+            BOOL registerDevNotification = FALSE;
+            if (Is(ptDisk))
+            {
+                int driveType = GetPathDriveType();
+                registerDevNotification = (driveType == DRIVE_REMOVABLE || driveType == DRIVE_FIXED);
+            }
+
             DetachDirectory(this); // something went wrong
+
+            if (GetMonitorChanges())
+                ScheduleMonitorRetry(registerDevNotification);
+        }
     }
     //TRACE_I("read directory: begin");
 

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -2247,6 +2247,39 @@ void CFilesWindow::ScheduleMonitorRetry(BOOL registerDevNotification)
     }
 }
 
+bool CFilesWindow::EnsureActiveDiskMonitoring(BOOL registerDevNotification)
+{
+    CALL_STACK_MESSAGE_NONE
+    if (!(Is(ptDisk) || Is(ptZIPArchive)))
+        return false;
+
+    const char* path = GetPath();
+    if (path == NULL || path[0] == 0)
+        return false;
+
+    if (!GetMonitorChanges())
+        return true;
+
+    EnsureWatching(this, registerDevNotification);
+    if (!AutomaticRefresh)
+    {
+        ScheduleMonitorRetry(registerDevNotification);
+        return true;
+    }
+
+    return false;
+}
+
+void CFilesWindow::RequestPluginRefreshOnActivation()
+{
+    CALL_STACK_MESSAGE_NONE
+    if (!Is(ptPluginFS) || HWindow == NULL)
+        return;
+
+    if (!PostMessage(HWindow, WM_USER_REFRESH_PLUGINFS, 0, 0))
+        SendMessage(HWindow, WM_USER_REFRESH_PLUGINFS, 0, 0);
+}
+
 void CFilesWindow::GotoRoot()
 {
     CALL_STACK_MESSAGE1("CFilesWindow::GotoRoot()");

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -406,6 +406,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_USER_MONITOR_RETRY:
     {
         MonitorRetryPending = FALSE;
+        MonitorRetryRequested = FALSE;
         MonitorRetryRegisterDevNotification = MonitorRetryRegisterDevNotification || (BOOL)wParam;
 
         DWORD now = GetTickCount();
@@ -1101,6 +1102,9 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         // srovname nastaveni promenne AutomaticRefresh a directory-liny
         SetAutomaticRefresh(AutomaticRefresh, TRUE);
+
+        if (MonitorRetryRequested)
+            ScheduleMonitorRetry(MonitorRetryRegisterDevNotification);
 
         return 0;
     }

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -433,6 +433,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 TRACE_I("Automatic refresh restored for '" << (restoredPath != NULL ? restoredPath : "") << "'.");
             }
             MonitorRetryRegisterDevNotification = FALSE;
+            KickMonitorRetry();
         }
         else if (!MonitorRetryTimerSet && !MonitorRetryPending)
         {

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -824,6 +824,11 @@ public:
     BOOL RefreshDirExTimerSet; // TRUE when the timer for sending WM_USER_REFRESH_DIR_EX_DELAYED is running
     LPARAM RefreshDirExLParam; // lParam for sending WM_USER_REFRESH_DIR_EX_DELAYED
 
+    BOOL MonitorRetryTimerSet;               // TRUE when the timer for retrying directory monitoring is running
+    BOOL MonitorRetryPending;                // TRUE when a retry message is queued
+    BOOL MonitorRetryRegisterDevNotification; // TRUE if retry should register for device notifications
+    DWORD LastMonitorRetryAttempt;           // GetTickCount() timestamp of the last retry attempt
+
     BOOL InactiveRefreshTimerSet;   // TRUE when the timer for sending WM_USER_INACTREFRESH_DIR is running
     LPARAM InactRefreshLParam;      // lParam for sending WM_USER_INACTREFRESH_DIR
     DWORD LastInactiveRefreshStart; // info about the last snooper-initiated refresh in an inactive window: when did it start + matching the line below...
@@ -1189,6 +1194,7 @@ public:
     void InvalidateChangesInPanelWeHaveNewListing();
 
     void SetAutomaticRefresh(BOOL value, BOOL force = FALSE);
+    void ScheduleMonitorRetry(BOOL registerDevNotification);
 
     // it sets ValidFileData; it checks if the VALID_DATA_PL_XXX constants can be used
     // (PluginData must not be empty and the corresponding constant VALID_DATA_SIZE,

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1196,6 +1196,8 @@ public:
 
     void SetAutomaticRefresh(BOOL value, BOOL force = FALSE);
     void ScheduleMonitorRetry(BOOL registerDevNotification);
+    bool EnsureActiveDiskMonitoring(BOOL registerDevNotification);
+    void RequestPluginRefreshOnActivation();
 
     // it sets ValidFileData; it checks if the VALID_DATA_PL_XXX constants can be used
     // (PluginData must not be empty and the corresponding constant VALID_DATA_SIZE,

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1196,7 +1196,6 @@ public:
 
     void SetAutomaticRefresh(BOOL value, BOOL force = FALSE);
     void ScheduleMonitorRetry(BOOL registerDevNotification);
-    bool EnsureActiveDiskMonitoring(BOOL registerDevNotification);
     void RequestPluginRefreshOnActivation();
 
     // it sets ValidFileData; it checks if the VALID_DATA_PL_XXX constants can be used

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1196,6 +1196,8 @@ public:
 
     void SetAutomaticRefresh(BOOL value, BOOL force = FALSE);
     void ScheduleMonitorRetry(BOOL registerDevNotification);
+    void KickMonitorRetry(); // internal helper used when monitor slots become available
+    static void NotifyMonitorRetrySlotsFreed();
     void RequestPluginRefreshOnActivation();
 
     // it sets ValidFileData; it checks if the VALID_DATA_PL_XXX constants can be used

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -827,6 +827,7 @@ public:
     BOOL MonitorRetryTimerSet;               // TRUE when the timer for retrying directory monitoring is running
     BOOL MonitorRetryPending;                // TRUE when a retry message is queued
     BOOL MonitorRetryRegisterDevNotification; // TRUE if retry should register for device notifications
+    BOOL MonitorRetryRequested;              // TRUE when a retry should be scheduled once the window exists
     DWORD LastMonitorRetryAttempt;           // GetTickCount() timestamp of the last retry attempt
 
     BOOL InactiveRefreshTimerSet;   // TRUE when the timer for sending WM_USER_INACTREFRESH_DIR is running

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -185,7 +185,15 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
         }
 
         if (refreshOnActivate && panel->HWindow != NULL)
+        {
             panel->ChangePathToDisk(panel->HWindow, path);
+            if (panel->GetMonitorChanges())
+            {
+                EnsureWatching(panel, registerDevNotification);
+                if (!panel->AutomaticRefresh)
+                    panel->ScheduleMonitorRetry(registerDevNotification);
+            }
+        }
     }
     else if (isPluginFS && panel->HWindow != NULL)
     {

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -170,8 +170,19 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
     {
         BOOL registerDevNotification = panel->GetPathDriveType() == DRIVE_REMOVABLE ||
                                        panel->GetPathDriveType() == DRIVE_FIXED;
-        if (panel->EnsureActiveDiskMonitoring(registerDevNotification))
+        if (!panel->GetMonitorChanges())
+        {
             refreshOnActivate = true;
+        }
+        else
+        {
+            EnsureWatching(panel, registerDevNotification);
+            if (!panel->AutomaticRefresh)
+            {
+                panel->ScheduleMonitorRetry(registerDevNotification);
+                refreshOnActivate = true;
+            }
+        }
 
         if (refreshOnActivate && panel->HWindow != NULL)
             panel->ChangePathToDisk(panel->HWindow, path);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -177,7 +177,10 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
         {
             EnsureWatching(panel, registerDevNotification);
             if (!panel->AutomaticRefresh)
+            {
+                panel->ScheduleMonitorRetry(registerDevNotification);
                 refreshOnActivate = true;
+            }
         }
 
         if (refreshOnActivate && panel->HWindow != NULL)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -88,6 +88,8 @@ const int MIN_WIN_WIDTH = 2; // minimal panel width
 
 extern BOOL CacheNextSetFocus;
 
+static void EnsurePanelAutoRefresh(CFilesWindow* panel);
+
 CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side, int index)
 {
     CALL_STACK_MESSAGE2("CMainWindow::AddPanelTab(%d)", side);

--- a/src/snooper.cpp
+++ b/src/snooper.cpp
@@ -258,6 +258,8 @@ static void RemoveWatchEntryInternal(WatchEntry* entry, DWORD closeTimeout)
     }
 
     delete entry;
+
+    CFilesWindow::NotifyMonitorRetrySlotsFreed();
 }
 
 static bool AttachPanelInternal(CFilesWindow* win, const PreparedWatchPath& prepared, BOOL registerDevNotification)

--- a/src/snooper.cpp
+++ b/src/snooper.cpp
@@ -857,6 +857,7 @@ void AddDirectory(CFilesWindow* win, const char* path, BOOL registerDevNotificat
         if (!AttachPanelInternal(win, prepared, registerDevNotification))
         {
             win->SetAutomaticRefresh(FALSE);
+            win->ScheduleMonitorRetry(registerDevNotification);
             TRACE_W("Unable to receive change notifications for directory '" << prepared.Path << "' (auto-refresh will not work).");
         }
     }
@@ -973,6 +974,7 @@ void ChangeDirectory(CFilesWindow* win, const char* newPath, BOOL registerDevNot
         if (!AttachPanelInternal(win, prepared, registerDevNotification))
         {
             win->SetAutomaticRefresh(FALSE);
+            win->ScheduleMonitorRetry(registerDevNotification);
             TRACE_W("Unable to receive change notifications for directory '" << prepared.Path << "' (auto-refresh will not work).");
         }
     }
@@ -1032,7 +1034,10 @@ void EnsureWatching(CFilesWindow* win, BOOL registerDevNotification)
     if (!attached)
     {
         if (!AttachPanelInternal(win, prepared, registerDevNotification))
+        {
             win->SetAutomaticRefresh(FALSE);
+            win->ScheduleMonitorRetry(registerDevNotification);
+        }
     }
 
     ReleaseMutex(DataUsageMutex);


### PR DESCRIPTION
## Summary
- add a retry message/timer so panels re-attempt to attach directory change notifications after failures
- reschedule retries from snooper and log when automatic refresh is restored

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f05f7efc8329b40a940494618b27