### PR TITLE
Ensure reactivated tab refreshes automatically

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -250,7 +250,11 @@ void CMainWindow::ClosePanelTab(CFilesWindow* panel)
         if (index >= tabs.Count)
             index = tabs.Count - 1;
         CFilesWindow* newPanel = tabs[index];
-        SwitchPanelTab(newPanel);
+        if (newPanel != NULL)
+        {
+            newPanel->NeedsRefreshOnActivation = TRUE;
+            SwitchPanelTab(newPanel);
+        }
     }
     else if (tabWnd != NULL && tabWnd->HWindow != NULL)
     {


### PR DESCRIPTION
## Summary
- mark the panel that becomes active after closing another tab as needing a refresh so it reloads immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d87d0ab7348329b04fcd9ca966d1c0