### PR TITLE
Ensure active file panel tabs resume automatic refresh after closing tabs

### DIFF
--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -533,6 +533,7 @@ public:
     CFilesWindow* AddPanelTab(CPanelSide side, int index = -1);
     void SwitchPanelTab(CFilesWindow* panel);
     void ClosePanelTab(CFilesWindow* panel);
+    void RequestPanelRefresh(CFilesWindow* panel, bool rebuildDriveBars);
     void UpdatePanelTabTitle(CFilesWindow* panel);
     void UpdatePanelTabColor(CFilesWindow* panel);
     void OnPanelTabSelected(CPanelSide side, int index);

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -534,6 +534,7 @@ public:
     void SwitchPanelTab(CFilesWindow* panel);
     void ClosePanelTab(CFilesWindow* panel);
     void EnsurePanelAutomaticRefresh(CFilesWindow* panel);
+    void EnsurePanelRefreshAndRequest(CFilesWindow* panel, bool rebuildDriveBars);
     void RequestPanelRefresh(CFilesWindow* panel, bool rebuildDriveBars);
     void UpdatePanelTabTitle(CFilesWindow* panel);
     void UpdatePanelTabColor(CFilesWindow* panel);

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -534,8 +534,10 @@ public:
     void SwitchPanelTab(CFilesWindow* panel);
     void ClosePanelTab(CFilesWindow* panel);
     void EnsurePanelAutomaticRefresh(CFilesWindow* panel);
-    void EnsurePanelRefreshAndRequest(CFilesWindow* panel, bool rebuildDriveBars);
-    void RequestPanelRefresh(CFilesWindow* panel, bool rebuildDriveBars);
+    void EnsurePanelRefreshAndRequest(CFilesWindow* panel, bool rebuildDriveBars,
+                                      bool postRefreshMessage = false);
+    void RequestPanelRefresh(CFilesWindow* panel, bool rebuildDriveBars,
+                             bool postRefreshMessage = false);
     void UpdatePanelTabTitle(CFilesWindow* panel);
     void UpdatePanelTabColor(CFilesWindow* panel);
     void OnPanelTabSelected(CPanelSide side, int index);

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -533,6 +533,7 @@ public:
     CFilesWindow* AddPanelTab(CPanelSide side, int index = -1);
     void SwitchPanelTab(CFilesWindow* panel);
     void ClosePanelTab(CFilesWindow* panel);
+    void EnsurePanelAutomaticRefresh(CFilesWindow* panel);
     void RequestPanelRefresh(CFilesWindow* panel, bool rebuildDriveBars);
     void UpdatePanelTabTitle(CFilesWindow* panel);
     void UpdatePanelTabColor(CFilesWindow* panel);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -302,6 +302,13 @@ void CMainWindow::ClosePanelTab(CFilesWindow* panel)
             EnsurePanelAutomaticRefresh(currentPanel);
             RequestPanelRefresh(currentPanel, false);
         }
+
+        CFilesWindow* activePanel = GetActivePanel();
+        if (activePanel != NULL && activePanel != currentPanel)
+        {
+            EnsurePanelAutomaticRefresh(activePanel);
+            RequestPanelRefresh(activePanel, false);
+        }
     }
 
     if (destroyWindow)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -299,27 +299,17 @@ void CMainWindow::ClosePanelTab(CFilesWindow* panel)
         LayoutWindows();
     }
 
-    if (Created)
-    {
-        CFilesWindow* currentPanel = (side == cpsLeft) ? LeftPanel : RightPanel;
-        CFilesWindow* activePanel = GetActivePanel();
-
-        if (currentPanel != NULL)
-        {
-            bool isActive = (currentPanel == activePanel);
-            EnsurePanelRefreshAndRequest(currentPanel, isActive);
-        }
-
-        if (activePanel != NULL && activePanel != currentPanel)
-        {
-            EnsurePanelRefreshAndRequest(activePanel, true);
-        }
-    }
-
     if (destroyWindow)
         DestroyWindow(panelWindow);
     else
         delete panel;
+
+    if (Created)
+    {
+        CFilesWindow* activePanel = GetActivePanel();
+        if (activePanel != NULL)
+            EnsurePanelRefreshAndRequest(activePanel, true);
+    }
 }
 
 BOOL MainFrameIsActive = FALSE;

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -174,6 +174,13 @@ void CMainWindow::EnsurePanelAutomaticRefresh(CFilesWindow* panel)
     panel->NeedsRefreshOnActivation = FALSE;
 }
 
+void CMainWindow::EnsurePanelRefreshAndRequest(CFilesWindow* panel, bool rebuildDriveBars)
+{
+    EnsurePanelAutomaticRefresh(panel);
+    if (panel != NULL && Created)
+        RequestPanelRefresh(panel, rebuildDriveBars);
+}
+
 void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
 {
     CALL_STACK_MESSAGE1("CMainWindow::SwitchPanelTab()");
@@ -216,8 +223,6 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
 
     UpdatePanelTabTitle(panel);
 
-    EnsurePanelAutomaticRefresh(panel);
-
     if (canFocusNow)
     {
         LayoutWindows();
@@ -230,8 +235,8 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
         FocusPanel(panel);
     }
 
-    if (Created)
-        RequestPanelRefresh(panel, false);
+    bool refreshActive = (panel == GetActivePanel());
+    EnsurePanelRefreshAndRequest(panel, refreshActive);
 }
 
 void CMainWindow::ClosePanelTab(CFilesWindow* panel)
@@ -297,17 +302,17 @@ void CMainWindow::ClosePanelTab(CFilesWindow* panel)
     if (Created)
     {
         CFilesWindow* currentPanel = (side == cpsLeft) ? LeftPanel : RightPanel;
+        CFilesWindow* activePanel = GetActivePanel();
+
         if (currentPanel != NULL)
         {
-            EnsurePanelAutomaticRefresh(currentPanel);
-            RequestPanelRefresh(currentPanel, false);
+            bool isActive = (currentPanel == activePanel);
+            EnsurePanelRefreshAndRequest(currentPanel, isActive);
         }
 
-        CFilesWindow* activePanel = GetActivePanel();
         if (activePanel != NULL && activePanel != currentPanel)
         {
-            EnsurePanelAutomaticRefresh(activePanel);
-            RequestPanelRefresh(activePanel, false);
+            EnsurePanelRefreshAndRequest(activePanel, true);
         }
     }
 


### PR DESCRIPTION
## Fix #35 

## Summary
- add a helper to trigger panel refresh using the same logic as the manual refresh command
- use the helper when switching or closing tabs so the visible tab keeps automatic refresh active
- reuse the helper for refresh commands to centralize the behavior

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d881bfaba08329a630e8f488090f5b