### PR TITLE
Hide separators when tabs menu is disabled

### DIFF
--- a/src/menu4.cpp
+++ b/src/menu4.cpp
@@ -100,9 +100,25 @@ void UpdateTabbedPanelMenuItems(BOOL tabsEnabled)
     submenuUpdate.Mask = MENU_MASK_SKILLLEVEL;
     submenuUpdate.SkillLevel = skillLevel;
     if (leftMenu != NULL)
+    {
         leftMenu->SetItemInfo(CML_LEFT_TABS, FALSE, &submenuUpdate);
+        int tabsIndex = leftMenu->FindItemPosition(CML_LEFT_TABS);
+        if (tabsIndex != -1)
+        {
+            UpdateSeparatorSkillLevel(leftMenu, tabsIndex - 1, skillLevel);
+            UpdateSeparatorSkillLevel(leftMenu, tabsIndex + 1, skillLevel);
+        }
+    }
     if (rightMenu != NULL)
+    {
         rightMenu->SetItemInfo(CML_RIGHT_TABS, FALSE, &submenuUpdate);
+        int tabsIndex = rightMenu->FindItemPosition(CML_RIGHT_TABS);
+        if (tabsIndex != -1)
+        {
+            UpdateSeparatorSkillLevel(rightMenu, tabsIndex - 1, skillLevel);
+            UpdateSeparatorSkillLevel(rightMenu, tabsIndex + 1, skillLevel);
+        }
+    }
 
     if (ToolBarLockImageIndex >= 0)
     {


### PR DESCRIPTION
## Summary
- hide the surrounding separators when the Tabs submenu is hidden in the Left and Right menus
- reuse UpdateSeparatorSkillLevel to keep menu layout clean when tabbed panels are disabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8af4fcccc8329aeb6a14fa5f9181b