### PR TITLE
Ensure default panel tab always displays lock icon

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -490,7 +490,12 @@ static std::wstring BuildTabDisplayText(CFilesWindow* panel, int index)
     if (panel != NULL && panel->HasCustomTabPrefix())
         prefix = panel->GetCustomTabPrefix();
     std::wstring result;
-    if (panel != NULL && panel->IsTabLocked())
+    bool shouldShowLock = (panel != NULL && panel->IsTabLocked());
+    if (!shouldShowLock && index == 0)
+        // The default tab is always considered locked from the UI perspective,
+        // even if the persisted state marks it as unlocked.
+        shouldShowLock = true;
+    if (shouldShowLock)
         result = L"\U0001F512";
     if (!prefix.empty())
     {


### PR DESCRIPTION
## Fix #105 

## Summary
- ensure the tab caption builder always prepends the lock glyph for the default panel tab, even when it is not persisted as locked

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8b513c4c08329b7bba16353e4e0b3