### PR TITLE
Handle null owner when showing JSON viewer error dialog

### DIFF
--- a/src/plugins/jsonviewer/managed/EntryPoint.cs
+++ b/src/plugins/jsonviewer/managed/EntryPoint.cs
@@ -37,11 +37,21 @@ public static class EntryPoint
         }
         catch (Exception ex)
         {
-            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
-                $"Unexpected managed exception:\n{ex.Message}",
-                "JSON Viewer Plugin",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Error);
+            if (parent != IntPtr.Zero)
+            {
+                MessageBox.Show(new WindowHandleWrapper(parent),
+                    $"Unexpected managed exception:\n{ex.Message}",
+                    "JSON Viewer Plugin",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            else
+            {
+                MessageBox.Show($"Unexpected managed exception:\n{ex.Message}",
+                    "JSON Viewer Plugin",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
             return -1;
         }
     }


### PR DESCRIPTION
## Summary
- avoid passing a null owner window to MessageBox in the JSON viewer entry point by selecting the appropriate overload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d927d5ffe083299879851b09c2e9d7