### PR TITLE
Add Tree View browser plugin

### DIFF
--- a/src/plugins/treeview/lang/lang.rc
+++ b/src/plugins/treeview/lang/lang.rc
@@ -1,0 +1,71 @@
+﻿// Microsoft Visual C++ generated resource script.
+//
+#pragma code_page(65001)
+
+#include "lang.rh"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winresrc.h"
+
+#include "..\treeview.rh2"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// Neutral resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "lang.rh\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winresrc.h""\r\n"
+    "\r\n"
+    "#include ""..\\treeview.rh2""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)\r\n"
+    "LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL\r\n"
+    "#include ""lang.rc2""   // non-Microsoft Visual C++ edited resources\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // Neutral resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+#include "lang.rc2"   // non-Microsoft Visual C++ edited resources
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/src/plugins/treeview/lang/lang.rc2
+++ b/src/plugins/treeview/lang/lang.rc2
@@ -1,0 +1,30 @@
+﻿//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+//
+// lang.rc2 - resources Microsoft Visual C++ does not edit directly
+//
+
+#ifdef APSTUDIO_INVOKED
+#error this file is not editable by Microsoft Visual C++
+#endif //APSTUDIO_INVOKED
+
+/////////////////////////////////////////////////////////////////////////////
+// Add manually edited resources here...
+
+#include "..\versinfo.rh2"
+#include "versinfo.rc2"
+
+STRINGTABLE
+{
+ IDS_PLUGINNAME,             "Tree View Browser"
+ IDS_ABOUT,                  "About Plugin"
+ IDS_PLUGIN_DESCRIPTION,     "Browse Windows folders using the managed Raccoom tree view control."
+ IDS_PLUGIN_HOME,            "https://github.com/KRtkovo-eu-AI/salamander/"
+ IDS_MENU_OPEN_BROWSER,      "Open &Tree View Browser"
+}

--- a/src/plugins/treeview/lang/lang.rh
+++ b/src/plugins/treeview/lang/lang.rh
@@ -1,0 +1,15 @@
+﻿//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by lang.rc
+//
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        8500
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         8700
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/plugins/treeview/managed/BrowserHost.cs
+++ b/src/plugins/treeview/managed/BrowserHost.cs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Forms;
+
+namespace OpenSalamander.TreeViewBrowser;
+
+internal static class BrowserHost
+{
+    public static int Show(IntPtr parent, string payload)
+    {
+        var initialPath = ParseInitialPath(payload);
+
+        using var window = new TreeViewBrowserForm(initialPath);
+        if (parent != IntPtr.Zero)
+        {
+            window.ShowDialog(new WindowHandleWrapper(parent));
+        }
+        else
+        {
+            window.ShowDialog();
+        }
+
+        return 0;
+    }
+
+    private static string ParseInitialPath(string? payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return string.Empty;
+        }
+
+        var entries = payload.Split('|');
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+            {
+                continue;
+            }
+
+            var kv = entry.Split(new[] { '=' }, 2);
+            if (kv.Length == 0)
+            {
+                continue;
+            }
+
+            var key = kv[0].Trim();
+            var value = kv.Length > 1 ? kv[1] : string.Empty;
+            if (key.Length == 0)
+            {
+                continue;
+            }
+
+            map[key] = value;
+        }
+
+        if (!map.TryGetValue("path", out var encodedPath) || string.IsNullOrWhiteSpace(encodedPath))
+        {
+            return string.Empty;
+        }
+
+        return TryDecodeBase64(encodedPath, out var decoded)
+            ? decoded
+            : encodedPath.Trim();
+    }
+
+    private static bool TryDecodeBase64(string value, out string decoded)
+    {
+        decoded = string.Empty;
+        var trimmed = value?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return false;
+        }
+
+        try
+        {
+            var bytes = Convert.FromBase64String(trimmed);
+            decoded = Encoding.UTF8.GetString(bytes);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/plugins/treeview/managed/EntryPoint.cs
+++ b/src/plugins/treeview/managed/EntryPoint.cs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace OpenSalamander.TreeViewBrowser;
+
+public static class EntryPoint
+{
+    private static bool _visualsEnabled;
+
+    [STAThread]
+    public static int Dispatch(string? argument)
+    {
+        IntPtr parent = IntPtr.Zero;
+
+        try
+        {
+            EnsureApplicationInitialized();
+
+            var parts = (argument ?? string.Empty).Split(new[] { ';' }, 3);
+            var command = parts.Length > 0 ? parts[0] : string.Empty;
+            parent = ParseHandle(parts.Length > 1 ? parts[1] : string.Empty);
+            var payload = parts.Length > 2 ? parts[2] : string.Empty;
+
+            return command switch
+            {
+                "ShowBrowser" => BrowserHost.Show(parent, payload),
+                _ => 1,
+            };
+        }
+        catch (Exception ex)
+        {
+            ShowError(parent, ex);
+            return -1;
+        }
+    }
+
+    private static void EnsureApplicationInitialized()
+    {
+        if (_visualsEnabled)
+        {
+            return;
+        }
+
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+        _visualsEnabled = true;
+    }
+
+    private static IntPtr ParseHandle(string text)
+    {
+        if (ulong.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return new IntPtr(unchecked((long)value));
+        }
+
+        return IntPtr.Zero;
+    }
+
+    private static void ShowError(IntPtr parent, Exception ex)
+    {
+        var message = $"Unexpected managed exception:\n{ex.Message}";
+        var caption = "Tree View Browser Plugin";
+
+        if (parent != IntPtr.Zero)
+        {
+            MessageBox.Show(new WindowHandleWrapper(parent), message, caption,
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        else
+        {
+            MessageBox.Show(message, caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+}

--- a/src/plugins/treeview/managed/TreeView.Managed.csproj
+++ b/src/plugins/treeview/managed/TreeView.Managed.csproj
@@ -1,0 +1,66 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>TreeView.Managed</AssemblyName>
+    <RootNamespace>OpenSalamander.TreeViewBrowser</RootNamespace>
+    <ProjectGuid>{A769BC7D-62CC-4792-A06F-9DE8C6909AE5}</ProjectGuid>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing.Design" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="EntryPoint.cs" />
+    <Compile Include="BrowserHost.cs" />
+    <Compile Include="TreeViewBrowserForm.cs" />
+    <Compile Include="WindowInterop.cs" />
+
+    <Compile Include="..\..\..\..\3rd-party\treeview\BaseAssemblyInfo.cs">
+      <Link>ThirdParty\BaseAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\3rd-party\treeview\Raccoom.TreeViewFolderBrowser\**\*.cs">
+      <Link>ThirdParty\TreeViewFolderBrowser\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\3rd-party\treeview\Raccoom.TreeViewFolderBrowser.DataProviders\**\*.cs">
+      <Link>ThirdParty\DataProviders\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\..\..\3rd-party\treeview\Raccoom.TreeViewFolderBrowser.DataProviders\TreeViewFolderBrowserDataProvider.resx">
+      <Link>ThirdParty\DataProviders\TreeViewFolderBrowserDataProvider.resx</Link>
+      <DependentUpon>TreeViewFolderBrowserDataProvider.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\..\..\..\3rd-party\treeview\Raccoom.TreeViewFolderBrowser.DataProviders\TreeViewStrategyCultureInfo.resx">
+      <Link>ThirdParty\DataProviders\TreeViewStrategyCultureInfo.resx</Link>
+      <DependentUpon>TreeViewStrategyCultureInfo.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <Target Name="EnsureRestoreBeforeBuild"
+          BeforeTargets="CollectPackageReferences;CollectPackageReferencesDesignTime;ResolveReferences;PrepareForBuild"
+          Condition="'$(RestoreDuringBuild)' != 'true' and '$(ProjectAssetsFile)' != '' and !Exists('$(ProjectAssetsFile)')">
+    <Message Text="Running implicit restore for $(MSBuildProjectName) (missing $(ProjectAssetsFile))."
+             Importance="High" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="Restore"
+             Properties="RestoreDuringBuild=true" />
+  </Target>
+</Project>

--- a/src/plugins/treeview/managed/TreeViewBrowserForm.cs
+++ b/src/plugins/treeview/managed/TreeViewBrowserForm.cs
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Forms;
+using Raccoom.Windows.Forms;
+
+namespace OpenSalamander.TreeViewBrowser;
+
+internal sealed class TreeViewBrowserForm : Form
+{
+    private readonly TreeViewFolderBrowser _folderBrowser;
+    private readonly ListBox _selectionList;
+    private readonly ToolStripStatusLabel _statusLabel;
+    private readonly ToolStripComboBox _rootCombo;
+    private readonly ToolStripButton _showVirtualButton;
+    private readonly TreeStrategyShell32Provider _shellProvider;
+    private bool _initializingRoot;
+    private string _initialPath;
+
+    public TreeViewBrowserForm(string? initialPath)
+    {
+        _initialPath = initialPath ?? string.Empty;
+
+        Text = "Tree View Browser";
+        StartPosition = FormStartPosition.CenterParent;
+        MinimumSize = new Size(720, 480);
+
+        _shellProvider = new TreeStrategyShell32Provider
+        {
+            EnableContextMenu = true,
+            ShowAllShellObjects = true,
+            ShowFiles = false,
+            RootFolder = Raccoom.Win32.ShellAPI.CSIDL.DRIVES,
+        };
+
+        _folderBrowser = new TreeViewFolderBrowser
+        {
+            Dock = DockStyle.Fill,
+            CheckBoxBehaviorMode = CheckBoxBehaviorMode.RecursiveChecked,
+        };
+        _folderBrowser.DataSource = _shellProvider;
+        _folderBrowser.SelectedDirectoriesChanged += OnSelectedDirectoriesChanged;
+        _folderBrowser.AfterSelect += OnAfterSelect;
+        _folderBrowser.KeyUp += OnFolderBrowserKeyUp;
+
+        _selectionList = new ListBox
+        {
+            Dock = DockStyle.Fill,
+        };
+
+        var selectionGroup = new GroupBox
+        {
+            Dock = DockStyle.Fill,
+            Text = "Checked directories",
+        };
+        selectionGroup.Controls.Add(_selectionList);
+
+        var splitContainer = new SplitContainer
+        {
+            Dock = DockStyle.Fill,
+            Orientation = Orientation.Vertical,
+            Panel2MinSize = 180,
+            Panel1MinSize = 260,
+            SplitterDistance = 460,
+        };
+        splitContainer.Panel1.Controls.Add(_folderBrowser);
+        splitContainer.Panel2.Controls.Add(selectionGroup);
+
+        var statusStrip = new StatusStrip();
+        _statusLabel = new ToolStripStatusLabel
+        {
+            Spring = true,
+            TextAlign = ContentAlignment.MiddleLeft,
+            Text = "Ready.",
+        };
+        statusStrip.Items.Add(_statusLabel);
+
+        var toolStrip = new ToolStrip
+        {
+            GripStyle = ToolStripGripStyle.Hidden,
+            RenderMode = ToolStripRenderMode.System,
+        };
+
+        toolStrip.Items.Add(new ToolStripLabel("Root:"));
+
+        _rootCombo = new ToolStripComboBox
+        {
+            DropDownStyle = ComboBoxStyle.DropDownList,
+            AutoSize = false,
+            Width = 220,
+        };
+        _rootCombo.SelectedIndexChanged += OnRootComboSelectedIndexChanged;
+        _rootCombo.Items.Add(new RootFolderOption("Desktop", Raccoom.Win32.ShellAPI.CSIDL.DESKTOP));
+        _rootCombo.Items.Add(new RootFolderOption("Computer", Raccoom.Win32.ShellAPI.CSIDL.DRIVES));
+        _rootCombo.Items.Add(new RootFolderOption("Documents", Raccoom.Win32.ShellAPI.CSIDL.PERSONAL));
+        _rootCombo.Items.Add(new RootFolderOption("User Profile", Raccoom.Win32.ShellAPI.CSIDL.PROFILE));
+        toolStrip.Items.Add(_rootCombo);
+
+        toolStrip.Items.Add(new ToolStripSeparator());
+
+        var refreshButton = new ToolStripButton("Refresh")
+        {
+            DisplayStyle = ToolStripItemDisplayStyle.Text,
+        };
+        refreshButton.Click += (_, _) => RefreshTree(GetSelectedNodePath());
+        toolStrip.Items.Add(refreshButton);
+
+        _showVirtualButton = new ToolStripButton("Virtual Folders")
+        {
+            Checked = _shellProvider.ShowAllShellObjects,
+            CheckOnClick = true,
+            DisplayStyle = ToolStripItemDisplayStyle.Text,
+        };
+        _showVirtualButton.CheckedChanged += (_, _) => ToggleVirtualFolders();
+        toolStrip.Items.Add(_showVirtualButton);
+
+        Controls.Add(splitContainer);
+        Controls.Add(statusStrip);
+        Controls.Add(toolStrip);
+
+        toolStrip.Dock = DockStyle.Top;
+        statusStrip.Dock = DockStyle.Bottom;
+
+        Shown += OnShown;
+    }
+
+    private void OnShown(object? sender, EventArgs e)
+    {
+        _initializingRoot = true;
+        try
+        {
+            _rootCombo.SelectedIndex = 1; // Computer by default
+        }
+        finally
+        {
+            _initializingRoot = false;
+        }
+
+        RefreshTree(string.IsNullOrWhiteSpace(_initialPath) ? null : _initialPath);
+        _initialPath = string.Empty;
+    }
+
+    private void OnRootComboSelectedIndexChanged(object? sender, EventArgs e)
+    {
+        if (_initializingRoot)
+        {
+            return;
+        }
+
+        RefreshTree(null);
+    }
+
+    private void ToggleVirtualFolders()
+    {
+        _shellProvider.ShowAllShellObjects = _showVirtualButton.Checked;
+        RefreshTree(GetSelectedNodePath());
+    }
+
+    private void RefreshTree(string? pathToSelect)
+    {
+        if (_rootCombo.SelectedItem is RootFolderOption option)
+        {
+            _shellProvider.RootFolder = option.Csidl;
+        }
+
+        string? targetPath = string.IsNullOrWhiteSpace(pathToSelect) ? null : pathToSelect;
+
+        try
+        {
+            UseWaitCursor = true;
+            _folderBrowser.Populate(targetPath);
+        }
+        finally
+        {
+            UseWaitCursor = false;
+        }
+
+        UpdateSelectionList();
+        UpdateSelectionStatus();
+
+        if (!string.IsNullOrEmpty(targetPath))
+        {
+            _statusLabel.Text = targetPath;
+        }
+        else if (_folderBrowser.SelectedNode is TreeNodePath node && !string.IsNullOrEmpty(node.Path))
+        {
+            _statusLabel.Text = node.Path;
+        }
+    }
+
+    private void OnSelectedDirectoriesChanged(object? sender, SelectedDirectoriesChangedEventArgs e)
+    {
+        UpdateSelectionList();
+        UpdateSelectionStatus();
+
+        if (!string.IsNullOrEmpty(e.Path))
+        {
+            _statusLabel.Text = string.Format(CultureInfo.CurrentCulture,
+                "Checked: {0} → {1}", e.Path, e.CheckState);
+        }
+    }
+
+    private void UpdateSelectionList()
+    {
+        _selectionList.BeginUpdate();
+        _selectionList.Items.Clear();
+        foreach (var path in _folderBrowser.SelectedDirectories)
+        {
+            _selectionList.Items.Add(path);
+        }
+        _selectionList.EndUpdate();
+    }
+
+    private void UpdateSelectionStatus()
+    {
+        int count = _folderBrowser.SelectedDirectories.Count;
+        if (count == 0)
+        {
+            _statusLabel.Text = "No directories checked.";
+        }
+        else
+        {
+            _statusLabel.Text = string.Format(CultureInfo.CurrentCulture,
+                "Checked directories: {0}", count);
+        }
+    }
+
+    private void OnAfterSelect(object? sender, TreeViewEventArgs e)
+    {
+        if (e.Node is TreeNodePath node && !string.IsNullOrEmpty(node.Path))
+        {
+            _statusLabel.Text = node.Path;
+        }
+    }
+
+    private void OnFolderBrowserKeyUp(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.F5)
+        {
+            RefreshTree(GetSelectedNodePath());
+            e.Handled = true;
+        }
+    }
+
+    private string? GetSelectedNodePath()
+    {
+        return (_folderBrowser.SelectedNode as TreeNodePath)?.Path;
+    }
+
+    private sealed record RootFolderOption(string Text, Raccoom.Win32.ShellAPI.CSIDL Csidl)
+    {
+        public override string ToString() => Text;
+    }
+}

--- a/src/plugins/treeview/managed/WindowInterop.cs
+++ b/src/plugins/treeview/managed/WindowInterop.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Windows.Forms;
+
+namespace OpenSalamander.TreeViewBrowser;
+
+internal sealed class WindowHandleWrapper : IWin32Window
+{
+    public WindowHandleWrapper(IntPtr handle)
+    {
+        Handle = handle;
+    }
+
+    public IntPtr Handle { get; }
+}

--- a/src/plugins/treeview/managed_bridge.cpp
+++ b/src/plugins/treeview/managed_bridge.cpp
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "precomp.h"
+#include "managed_bridge.h"
+
+#include <metahost.h>
+#include <mscoree.h>
+#include <strsafe.h>
+#include <wincrypt.h>
+
+#pragma comment(lib, "mscoree.lib")
+#pragma comment(lib, "crypt32.lib")
+
+namespace
+{
+ICLRRuntimeHost* gRuntimeHost = nullptr;
+std::wstring gAssemblyPath;
+const wchar_t* const kManagedType = L"OpenSalamander.TreeViewBrowser.EntryPoint";
+const wchar_t* const kManagedMethod = L"Dispatch";
+
+std::wstring BuildArgument(const wchar_t* command, HWND parent, const wchar_t* payload)
+{
+    std::wstring argument = command;
+    argument.push_back(L';');
+
+    wchar_t buffer[32];
+    ULONGLONG handleValue = reinterpret_cast<ULONGLONG>(parent);
+    StringCchPrintfW(buffer, _countof(buffer), L"%llu", handleValue);
+    argument.append(buffer);
+
+    argument.push_back(L';');
+    if (payload != nullptr)
+    {
+        argument.append(payload);
+    }
+
+    return argument;
+}
+
+std::wstring ConvertMultiByteToWide(const char* text, UINT codePage)
+{
+    if (text == nullptr)
+    {
+        return std::wstring();
+    }
+
+    DWORD flags = (codePage == CP_UTF8) ? MB_ERR_INVALID_CHARS : 0;
+    int required = MultiByteToWideChar(codePage, flags, text, -1, nullptr, 0);
+    if (required <= 0)
+    {
+        return std::wstring();
+    }
+
+    std::wstring result;
+    result.resize(required);
+    int converted = MultiByteToWideChar(codePage, flags, text, -1, result.data(), required);
+    if (converted <= 0)
+    {
+        return std::wstring();
+    }
+
+    result.resize(converted - 1);
+    return result;
+}
+
+std::wstring AnsiToWide(const char* text)
+{
+    if (text == nullptr)
+    {
+        return std::wstring();
+    }
+
+    std::wstring converted = ConvertMultiByteToWide(text, CP_ACP);
+    if (!converted.empty())
+    {
+        return converted;
+    }
+
+    converted = ConvertMultiByteToWide(text, CP_UTF8);
+    if (!converted.empty())
+    {
+        return converted;
+    }
+
+    const unsigned char* bytes = reinterpret_cast<const unsigned char*>(text);
+    while (*bytes != '\0')
+    {
+        converted.push_back(static_cast<wchar_t>(*bytes));
+        ++bytes;
+    }
+
+    return converted;
+}
+
+std::wstring EncodeBase64FromWide(const std::wstring& value)
+{
+    if (value.empty())
+    {
+        return std::wstring();
+    }
+
+    int utf8Length = WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if (utf8Length <= 1)
+    {
+        return std::wstring();
+    }
+
+    std::string utf8;
+    utf8.resize(static_cast<size_t>(utf8Length) - 1);
+    if (WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, utf8.data(), utf8Length - 1, nullptr, nullptr) <= 0)
+    {
+        return std::wstring();
+    }
+
+    DWORD base64Length = 0;
+    if (!CryptBinaryToStringW(reinterpret_cast<const BYTE*>(utf8.data()), static_cast<DWORD>(utf8.size()),
+                              CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, nullptr, &base64Length))
+    {
+        return std::wstring();
+    }
+
+    std::wstring result;
+    result.resize(base64Length);
+    if (!CryptBinaryToStringW(reinterpret_cast<const BYTE*>(utf8.data()), static_cast<DWORD>(utf8.size()),
+                              CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, result.data(), &base64Length))
+    {
+        return std::wstring();
+    }
+
+    if (!result.empty() && result.back() == L'\0')
+    {
+        result.pop_back();
+    }
+    else
+    {
+        result.resize(base64Length);
+    }
+
+    return result;
+}
+
+void AppendKeyValue(std::wstring& payload, const wchar_t* key, const std::wstring& value)
+{
+    if (key == nullptr || *key == L'\0')
+    {
+        return;
+    }
+
+    if (!payload.empty())
+    {
+        payload.push_back(L'|');
+    }
+
+    payload.append(key);
+    payload.push_back(L'=');
+
+    if (!value.empty())
+    {
+        payload.append(value);
+    }
+}
+
+bool ExecuteCommand(const wchar_t* command, HWND parent, const wchar_t* payload)
+{
+    if (gRuntimeHost == nullptr)
+    {
+        return false;
+    }
+
+    DWORD returnValue = 0;
+    std::wstring argument = BuildArgument(command, parent, payload);
+    HRESULT hr = gRuntimeHost->ExecuteInDefaultAppDomain(gAssemblyPath.c_str(), kManagedType, kManagedMethod,
+                                                         argument.c_str(), &returnValue);
+    if (FAILED(hr))
+    {
+        wchar_t message[256];
+        StringCchPrintfW(message, _countof(message), L"Failed to execute managed command '%s' (0x%08X).", command, hr);
+        MessageBoxW(parent, message, L"Tree View Browser Plugin", MB_ICONERROR | MB_OK);
+        return false;
+    }
+
+    return returnValue == 0;
+}
+
+void ShowLoadError(HWND parent, const wchar_t* text)
+{
+    MessageBoxW(parent, text, L"Tree View Browser Plugin", MB_ICONERROR | MB_OK);
+}
+
+} // namespace
+
+bool ManagedBridge_EnsureInitialized(HWND parent)
+{
+    if (gRuntimeHost != nullptr)
+    {
+        return true;
+    }
+
+    ICLRMetaHost* metaHost = nullptr;
+    HRESULT hr = CLRCreateInstance(CLSID_CLRMetaHost, IID_PPV_ARGS(&metaHost));
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to load CLR meta host.");
+        return false;
+    }
+
+    ICLRRuntimeInfo* runtimeInfo = nullptr;
+    hr = metaHost->GetRuntime(L"v4.0.30319", IID_PPV_ARGS(&runtimeInfo));
+    metaHost->Release();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to locate CLR v4 runtime.");
+        return false;
+    }
+
+    hr = runtimeInfo->GetInterface(CLSID_CLRRuntimeHost, IID_PPV_ARGS(&gRuntimeHost));
+    runtimeInfo->Release();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to create CLR runtime host.");
+        return false;
+    }
+
+    hr = gRuntimeHost->Start();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to start CLR runtime.");
+        gRuntimeHost->Release();
+        gRuntimeHost = nullptr;
+        return false;
+    }
+
+    wchar_t modulePath[MAX_PATH] = {0};
+    if (GetModuleFileNameW(DLLInstance, modulePath, _countof(modulePath)) == 0)
+    {
+        ShowLoadError(parent, L"Failed to determine plugin path.");
+        ManagedBridge_Shutdown();
+        return false;
+    }
+
+    wchar_t* lastSlash = wcsrchr(modulePath, L'\\');
+    if (lastSlash != nullptr)
+    {
+        *(lastSlash + 1) = L'\0';
+    }
+
+    gAssemblyPath.assign(modulePath);
+    gAssemblyPath.append(L"TreeView.Managed.dll");
+
+    return true;
+}
+
+void ManagedBridge_Shutdown()
+{
+    if (gRuntimeHost != nullptr)
+    {
+        gRuntimeHost->Stop();
+        gRuntimeHost->Release();
+        gRuntimeHost = nullptr;
+        gAssemblyPath.clear();
+    }
+}
+
+bool ManagedBridge_ShowBrowser(HWND parent, const char* initialPath)
+{
+    if (!ManagedBridge_EnsureInitialized(parent))
+    {
+        return false;
+    }
+
+    std::wstring payload;
+    if (initialPath != nullptr && initialPath[0] != '\0')
+    {
+        std::wstring widePath = AnsiToWide(initialPath);
+        std::wstring encodedPath = EncodeBase64FromWide(widePath);
+        AppendKeyValue(payload, L"path", !encodedPath.empty() ? encodedPath : widePath);
+    }
+
+    return ExecuteCommand(L"ShowBrowser", parent, payload.empty() ? nullptr : payload.c_str());
+}

--- a/src/plugins/treeview/managed_bridge.h
+++ b/src/plugins/treeview/managed_bridge.h
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+bool ManagedBridge_EnsureInitialized(HWND parent);
+void ManagedBridge_Shutdown();
+bool ManagedBridge_ShowBrowser(HWND parent, const char* initialPath);
+

--- a/src/plugins/treeview/menu.cpp
+++ b/src/plugins/treeview/menu.cpp
@@ -1,0 +1,53 @@
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#include "precomp.h"
+
+// ****************************************************************************
+// SEKCE MENU
+// ****************************************************************************
+
+BOOL WINAPI
+CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* salamander,
+                                            HWND parent, int id, DWORD eventMask)
+{
+    switch (id)
+    {
+    case MENUCMD_SHOWBROWSER:
+    {
+        char initialPath[2 * MAX_PATH] = {0};
+        int pathType = 0;
+        if (!SalamanderGeneral->GetPanelPath(PANEL_SOURCE, initialPath, sizeof(initialPath), &pathType, NULL) ||
+            pathType != PATH_TYPE_WINDOWS)
+        {
+            initialPath[0] = '\0';
+        }
+
+        if (!ManagedBridge_ShowBrowser(parent, initialPath[0] != '\0' ? initialPath : NULL))
+        {
+            SalamanderGeneral->ShowMessageBox("Unable to open the Tree View browser window.",
+                                             LoadStr(IDS_PLUGINNAME), MSGBOX_ERROR);
+        }
+        break;
+    }
+
+    default:
+        SalamanderGeneral->ShowMessageBox("Unknown command.", LoadStr(IDS_PLUGINNAME), MSGBOX_ERROR);
+        break;
+    }
+    return FALSE; // neodznacovat polozky v panelu
+}
+
+BOOL WINAPI
+CPluginInterfaceForMenuExt::HelpForMenuItem(HWND parent, int id)
+{
+    return FALSE;
+}

--- a/src/plugins/treeview/precomp.cpp
+++ b/src/plugins/treeview/precomp.cpp
@@ -1,0 +1,19 @@
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#include "precomp.h"
+
+// projekt TreeView obsahuje tri skupiny modulu
+//
+// 1) modul precomp.cpp, ktery postavi treeview.pch (/Yc"precomp.h")
+// 2) moduly vyuzivajici treeview.pch (/Yu"precomp.h")
+// 3) commony maji vlastni, automaticky generovany WINDOWS.PCH
+//    (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")

--- a/src/plugins/treeview/precomp.h
+++ b/src/plugins/treeview/precomp.h
@@ -1,0 +1,58 @@
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN // exclude rarely-used stuff from Windows headers
+
+#include <windows.h>
+#include <CommDlg.h>
+#include <shlobj.h>
+#ifdef _MSC_VER
+#include <crtdbg.h>
+#endif // _MSC_VER
+#include <limits.h>
+#include <process.h>
+#include <commctrl.h>
+#include <ostream>
+#include <stdio.h>
+#include <time.h>
+
+#if defined(_DEBUG) && defined(_MSC_VER) // without passing file+line to 'new' operator, list of memory leaks shows only 'crtdbg.h(552)'
+#define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#endif
+
+#include "versinfo.rh2"
+
+#include "spl_com.h"
+#include "spl_base.h"
+#include "spl_gen.h"
+#include "spl_menu.h"
+#include "spl_thum.h"
+#include "spl_view.h"
+#include "spl_vers.h"
+#include "spl_gui.h"
+
+#include "dbg.h"
+#include "mhandles.h"
+#include "arraylt.h"
+#include "winliblt.h"
+#include "auxtools.h"
+#include "treeview.h"
+#include "managed_bridge.h"
+#include "treeview.rh"
+#include "treeview.rh2"
+#include "lang\lang.rh"
+
+#ifdef __BORLANDC__
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif // __BORLANDC__

--- a/src/plugins/treeview/treeview.cpp
+++ b/src/plugins/treeview/treeview.cpp
@@ -1,0 +1,177 @@
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#include "precomp.h"
+
+// objekt interfacu pluginu, jeho metody se volaji ze Salamandera
+CPluginInterface PluginInterface;
+// dalsi casti interfacu CPluginInterface
+CPluginInterfaceForMenuExt InterfaceForMenuExt;
+
+// globalni data
+const char* PluginNameEN = "Tree View Browser";    // neprekladane jmeno pluginu
+const char* PluginNameShort = "TREEVIEW";          // jmeno pluginu (kratce, bez mezer)
+
+HINSTANCE DLLInstance = NULL; // handle k SPL-ku - jazykove nezavisle resourcy
+HINSTANCE HLanguage = NULL;   // handle k SLG-cku - jazykove zavisle resourcy
+
+// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+CSalamanderGeneralAbstract* SalamanderGeneral = NULL;
+
+// definice promenne pro "dbg.h"
+CSalamanderDebugAbstract* SalamanderDebug = NULL;
+
+// definice promenne pro "spl_com.h"
+int SalamanderVersion = 0;
+
+// rozhrani poskytujici upravene Windows controly pouzivane v Salamanderovi
+//CSalamanderGUIAbstract *SalamanderGUI = NULL;
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+    if (fdwReason == DLL_PROCESS_ATTACH)
+    {
+        DLLInstance = hinstDLL;
+
+        INITCOMMONCONTROLSEX initCtrls;
+        initCtrls.dwSize = sizeof(INITCOMMONCONTROLSEX);
+        initCtrls.dwICC = ICC_BAR_CLASSES;
+        if (!InitCommonControlsEx(&initCtrls))
+        {
+            MessageBox(NULL, "InitCommonControlsEx failed!", "Error", MB_OK | MB_ICONERROR);
+            return FALSE; // DLL won't start
+        }
+    }
+
+    return TRUE; // DLL can be loaded
+}
+
+// ****************************************************************************
+
+char* LoadStr(int resID)
+{
+    return SalamanderGeneral->LoadStr(HLanguage, resID);
+}
+
+void OnAbout(HWND hParent)
+{
+    char text[1024];
+    _snprintf_s(text, _TRUNCATE,
+                "%s\n\n%s",
+                LoadStr(IDS_PLUGINNAME),
+                LoadStr(IDS_PLUGIN_DESCRIPTION));
+    SalamanderGeneral->SalMessageBox(hParent, text, LoadStr(IDS_ABOUT), MB_OK | MB_ICONINFORMATION);
+}
+
+//
+// ****************************************************************************
+// SalamanderPluginGetReqVer
+//
+
+#ifdef __BORLANDC__
+extern "C"
+{
+    int WINAPI SalamanderPluginGetReqVer();
+    CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbstract* salamander);
+};
+#endif // __BORLANDC__
+
+int WINAPI SalamanderPluginGetReqVer()
+{
+    return LAST_VERSION_OF_SALAMANDER;
+}
+
+//
+// ****************************************************************************
+// SalamanderPluginEntry
+//
+
+CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbstract* salamander)
+{
+    // nastavime SalamanderDebug pro "dbg.h"
+    SalamanderDebug = salamander->GetSalamanderDebug();
+    // nastavime SalamanderVersion pro "spl_com.h"
+    SalamanderVersion = salamander->GetVersion();
+    HANDLES_CAN_USE_TRACE();
+    CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
+
+    // tento plugin je delany pro aktualni verzi Salamandera a vyssi - provedeme kontrolu
+    if (SalamanderVersion < LAST_VERSION_OF_SALAMANDER)
+    { // starsi verze odmitneme
+        MessageBox(salamander->GetParentWindow(),
+                   REQUIRE_LAST_VERSION_OF_SALAMANDER,
+                   PluginNameEN, MB_OK | MB_ICONERROR);
+        return NULL;
+    }
+
+    // nechame nacist jazykovy modul (.slg)
+    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), PluginNameEN);
+    if (HLanguage == NULL)
+        return NULL;
+
+    // ziskame obecne rozhrani Salamandera
+    SalamanderGeneral = salamander->GetSalamanderGeneral();
+    // ziskame rozhrani poskytujici upravene Windows controly pouzivane v Salamanderovi
+    //  SalamanderGUI = salamander->GetSalamanderGUI();
+
+    // nastavime zakladni informace o pluginu
+    salamander->SetBasicPluginData(LoadStr(IDS_PLUGINNAME), FUNCTION_DYNAMICMENUEXT,
+                                   VERSINFO_VERSION_NO_PLATFORM, VERSINFO_COPYRIGHT,
+                                   LoadStr(IDS_PLUGIN_DESCRIPTION), PluginNameShort,
+                                   NULL, NULL);
+
+    // nastavime URL home-page pluginu
+    salamander->SetPluginHomePageURL(LoadStr(IDS_PLUGIN_HOME));
+
+    return &PluginInterface;
+}
+
+//
+// ****************************************************************************
+// CPluginInterface
+//
+
+void WINAPI CPluginInterface::About(HWND parent) { OnAbout(parent); }
+
+BOOL WINAPI
+CPluginInterface::Release(HWND parent, BOOL force)
+{
+    ManagedBridge_Shutdown();
+    return TRUE;
+}
+
+void WINAPI
+CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamander)
+{
+    CALL_STACK_MESSAGE1("CPluginInterface::Connect(,)");
+
+    // zakladni cast:
+    salamander->AddMenuItem(-1, LoadStr(IDS_MENU_OPEN_BROWSER), 0,
+                            MENUCMD_SHOWBROWSER, FALSE, MENU_EVENT_TRUE, MENU_EVENT_TRUE, MENU_SKILLLEVEL_ALL);
+
+    /*
+  CGUIIconListAbstract *iconList = SalamanderGUI->CreateIconList();
+  iconList->Create(16, 16, 1);
+  HICON hIcon = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_PLUGINICON), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
+  iconList->ReplaceIcon(0, hIcon);
+  DestroyIcon(hIcon);
+  salamander->SetIconListForGUI(iconList); // o destrukci iconlistu se postara Salamander
+
+  salamander->SetPluginIcon(0);
+  salamander->SetPluginMenuAndToolbarIcon(0);
+*/
+}
+
+CPluginInterfaceForMenuExtAbstract* WINAPI
+CPluginInterface::GetInterfaceForMenuExt()
+{
+    return &InterfaceForMenuExt;
+}

--- a/src/plugins/treeview/treeview.def
+++ b/src/plugins/treeview/treeview.def
@@ -1,0 +1,4 @@
+LIBRARY TREEVIEW.SPL
+
+EXPORTS SalamanderPluginEntry
+EXPORTS SalamanderPluginGetReqVer

--- a/src/plugins/treeview/treeview.h
+++ b/src/plugins/treeview/treeview.h
@@ -1,0 +1,73 @@
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#pragma once
+
+// globalni data
+extern HINSTANCE DLLInstance; // handle k SPL-ku - jazykove nezavisle resourcy
+extern HINSTANCE HLanguage;   // handle k SLG-cku - jazykove zavisle resourcy
+
+// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+extern CSalamanderGeneralAbstract* SalamanderGeneral;
+
+char* LoadStr(int resID);
+
+// prikazy pluginoveho menu
+#define MENUCMD_SHOWBROWSER 1
+
+//
+// ****************************************************************************
+// CPluginInterface
+//
+
+class CPluginInterfaceForMenuExt : public CPluginInterfaceForMenuExtAbstract
+{
+public:
+    virtual DWORD WINAPI GetMenuItemState(int id, DWORD eventMask) { return 0; }
+    virtual BOOL WINAPI ExecuteMenuItem(CSalamanderForOperationsAbstract* salamander, HWND parent,
+                                        int id, DWORD eventMask);
+    virtual BOOL WINAPI HelpForMenuItem(HWND parent, int id);
+    virtual void WINAPI BuildMenu(HWND parent, CSalamanderBuildMenuAbstract* salamander) {}
+};
+
+class CPluginInterface : public CPluginInterfaceAbstract
+{
+public:
+    virtual void WINAPI About(HWND parent);
+
+    virtual BOOL WINAPI Release(HWND parent, BOOL force);
+
+    virtual void WINAPI LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry) {}
+    virtual void WINAPI SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry) {}
+    virtual void WINAPI Configuration(HWND parent) {}
+
+    virtual void WINAPI Connect(HWND parent, CSalamanderConnectAbstract* salamander);
+
+    virtual void WINAPI ReleasePluginDataInterface(CPluginDataInterfaceAbstract* pluginData) {}
+
+    virtual CPluginInterfaceForArchiverAbstract* WINAPI GetInterfaceForArchiver() { return NULL; }
+    virtual CPluginInterfaceForViewerAbstract* WINAPI GetInterfaceForViewer() { return NULL; }
+    virtual CPluginInterfaceForMenuExtAbstract* WINAPI GetInterfaceForMenuExt();
+    virtual CPluginInterfaceForFSAbstract* WINAPI GetInterfaceForFS() { return NULL; }
+    virtual CPluginInterfaceForThumbLoaderAbstract* WINAPI GetInterfaceForThumbLoader() { return NULL; }
+
+    virtual void WINAPI Event(int event, DWORD param) {}
+    virtual void WINAPI ClearHistory(HWND parent) {}
+    virtual void WINAPI AcceptChangeOnPathNotification(const char* path, BOOL includingSubdirs) {}
+
+    virtual void WINAPI PasswordManagerEvent(HWND parent, int event) {}
+};
+
+// rozhrani pluginu poskytnute Salamanderovi
+extern CPluginInterface PluginInterface;
+
+// otevre About okno
+void OnAbout(HWND hParent);

--- a/src/plugins/treeview/treeview.rc
+++ b/src/plugins/treeview/treeview.rc
@@ -1,0 +1,71 @@
+﻿// Microsoft Visual C++ generated resource script.
+//
+#pragma code_page(65001)
+
+#include "treeview.rh"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winresrc.h"
+
+#include "treeview.rh2"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// Neutral resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "treeview.rh\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winresrc.h""\r\n"
+    "\r\n"
+    "#include ""treeview.rh2""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)\r\n"
+    "LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL\r\n"
+    "#include ""treeview.rc2""   // non-Microsoft Visual C++ edited resources\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // Neutral resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+#include "treeview.rc2"   // non-Microsoft Visual C++ edited resources
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/src/plugins/treeview/treeview.rc2
+++ b/src/plugins/treeview/treeview.rc2
@@ -1,0 +1,21 @@
+﻿//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+//
+// treeview.rc2 - resources Microsoft Visual C++ does not edit directly
+//
+
+#ifdef APSTUDIO_INVOKED
+#error this file is not editable by Microsoft Visual C++
+#endif //APSTUDIO_INVOKED
+
+/////////////////////////////////////////////////////////////////////////////
+// Add manually edited resources here...
+
+#include "versinfo.rh2"
+#include "versinfo.rc2"

--- a/src/plugins/treeview/treeview.rh
+++ b/src/plugins/treeview/treeview.rh
@@ -1,0 +1,15 @@
+﻿//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by treeview.rc
+//
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        8000
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         8200
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/plugins/treeview/treeview.rh2
+++ b/src/plugins/treeview/treeview.rh2
@@ -1,0 +1,23 @@
+﻿//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+#ifndef __TREEVIEW_RH2
+#define __TREEVIEW_RH2
+
+#if defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+#error this file is not editable by Microsoft Visual C++
+#endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+
+#define IDS_PLUGINNAME           46
+#define IDS_ABOUT                47
+#define IDS_PLUGIN_DESCRIPTION   48
+#define IDS_PLUGIN_HOME          49
+#define IDS_MENU_OPEN_BROWSER    50
+
+#endif // __TREEVIEW_RH2

--- a/src/plugins/treeview/vcxproj/lang_treeview.props
+++ b/src/plugins/treeview/vcxproj/lang_treeview.props
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros">
+    <ShortProjectName>treeview</ShortProjectName>
+  </PropertyGroup>
+  <ItemGroup>
+    <BuildMacro Include="ShortProjectName">
+      <Value>$(ShortProjectName)</Value>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/src/plugins/treeview/vcxproj/lang_treeview.vcxproj
+++ b/src/plugins/treeview/vcxproj/lang_treeview.vcxproj
@@ -1,0 +1,151 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}</ProjectGuid>
+    <RootNamespace>lang_treeview</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props">
+  </Import>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props">
+  </Import>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_treeview.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_release.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_treeview.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_debug.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_treeview.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_release.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_treeview.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_debug.props">
+    </Import>
+  </ImportGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'!=''">
+    <TreeViewBuildRoot>$([System.IO.Path]::Combine('$(OPENSAL_BUILD_DIR)', 'salamander'))\</TreeViewBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'==''">
+    <TreeViewBuildRoot>$(ProjectDir)..\..\..\..\build\salamander\</TreeViewBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TreeViewLangDir>$(TreeViewBuildRoot)$(Configuration)_$(ShortPlatform)\plugins\treeview\lang\</TreeViewLangDir>
+    <OutDir>$(TreeViewLangDir)</OutDir>
+    <IntDir>$(OutDir)Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Label="UserMacros">
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <None Include="..\treeview.rh2">
+    </None>
+    <None Include="..\lang\lang.rc2">
+    </None>
+    <None Include="..\lang\lang.rh">
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\lang\lang.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets">
+  </Import>
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/plugins/treeview/vcxproj/treeview.props
+++ b/src/plugins/treeview/vcxproj/treeview.props
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros"></PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/plugins/treeview/vcxproj/treeview.sln
+++ b/src/plugins/treeview/vcxproj/treeview.sln
@@ -1,0 +1,70 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29020.237
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "treeview", "treeview.vcxproj", "{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lang_treeview", "lang_treeview.vcxproj", "{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TreeView.Managed", "..\managed\TreeView.Managed.csproj", "{A769BC7D-62CC-4792-A06F-9DE8C6909AE5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1BDAFFE2-B264-44E9-A670-B7EC029A726F}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.editorconfig = ..\..\..\.editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		SDK|x64 = SDK|x64
+		SDK|x86 = SDK|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.Debug|x64.ActiveCfg = Debug|x64
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.Debug|x64.Build.0 = Debug|x64
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.Debug|x86.ActiveCfg = Debug|Win32
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.Debug|x86.Build.0 = Debug|Win32
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.Release|x64.ActiveCfg = Release|x64
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.Release|x64.Build.0 = Release|x64
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.Release|x86.ActiveCfg = Release|Win32
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.Release|x86.Build.0 = Release|Win32
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.SDK|x64.ActiveCfg = SDK|x64
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.SDK|x64.Build.0 = SDK|x64
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.SDK|x86.ActiveCfg = SDK|Win32
+		{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}.SDK|x86.Build.0 = SDK|Win32
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.Debug|x64.ActiveCfg = Debug|x64
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.Debug|x64.Build.0 = Debug|x64
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.Debug|x86.ActiveCfg = Debug|Win32
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.Debug|x86.Build.0 = Debug|Win32
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.Release|x64.ActiveCfg = Release|x64
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.Release|x64.Build.0 = Release|x64
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.Release|x86.ActiveCfg = Release|Win32
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.Release|x86.Build.0 = Release|Win32
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.SDK|x64.ActiveCfg = SDK|x64
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.SDK|x64.Build.0 = SDK|x64
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.SDK|x86.ActiveCfg = SDK|Win32
+		{3CB8B01D-BCB3-4F4E-B60A-9B46D2AF2F69}.SDK|x86.Build.0 = SDK|Win32
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.Debug|x86.Build.0 = Debug|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.Release|x64.Build.0 = Release|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.Release|x86.Build.0 = Release|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.SDK|x64.ActiveCfg = Release|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.SDK|x64.Build.0 = Release|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.SDK|x86.ActiveCfg = Release|Any CPU
+		{E9F70914-3011-4D4F-9E79-3A9540A5E0F3}.SDK|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {375C9D55-0C0E-42AE-8696-21DE91B07CCF}
+	EndGlobalSection
+EndGlobal

--- a/src/plugins/treeview/vcxproj/treeview.vcxproj
+++ b/src/plugins/treeview/vcxproj/treeview.vcxproj
@@ -1,0 +1,219 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{8C89C5D0-4D7C-4A6D-8BFB-57C9B0E1682C}</ProjectGuid>
+    <RootNamespace>treeview</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props">
+  </Import>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props">
+  </Import>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_release.props">
+    </Import>
+    <Import Project="treeview.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_debug.props">
+    </Import>
+    <Import Project="treeview.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_release.props">
+    </Import>
+    <Import Project="treeview.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_debug.props">
+    </Import>
+    <Import Project="treeview.props">
+    </Import>
+  </ImportGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'!=''">
+    <TreeViewBuildRoot>$([System.IO.Path]::Combine('$(OPENSAL_BUILD_DIR)', 'salamander'))\</TreeViewBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'==''">
+    <TreeViewBuildRoot>$(ProjectDir)..\..\..\..\build\salamander\</TreeViewBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TreeViewPluginDir>$(TreeViewBuildRoot)$(Configuration)_$(ShortPlatform)\plugins\treeview\</TreeViewPluginDir>
+    <OutDir>$(TreeViewPluginDir)</OutDir>
+    <IntDir>$(OutDir)Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Label="UserMacros">
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\shared\auxtools.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\shared\dbg.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+    </ClCompile>
+    <ClCompile Include="..\treeview.cpp">
+    </ClCompile>
+    <ClCompile Include="..\managed_bridge.cpp">
+    </ClCompile>
+    <ClCompile Include="..\menu.cpp">
+    </ClCompile>
+    <ClCompile Include="..\precomp.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\shared\auxtools.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\dbg.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_base.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_com.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gen.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gui.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_menu.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_thum.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_vers.h">
+    </ClInclude>
+    <ClInclude Include="..\treeview.h">
+    </ClInclude>
+    <ClInclude Include="..\managed_bridge.h">
+    </ClInclude>
+    <ClInclude Include="..\precomp.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\treeview.def">
+    </None>
+    <None Include="..\treeview.rc2">
+    </None>
+    <None Include="..\treeview.rh">
+    </None>
+    <None Include="..\treeview.rh2">
+    </None>
+    <None Include="..\lang\lang.rh">
+    </None>
+    <None Include="..\versinfo.rh2">
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\treeview.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="lang_treeview.vcxproj">
+      <Project>{3cb8b01d-bcb3-4f4e-b60a-9b46d2af2f69}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\managed\TreeView.Managed.csproj">
+      <Project>{A769BC7D-62CC-4792-A06F-9DE8C6909AE5}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>if not exist "$(TreeViewPluginDir)" mkdir "$(TreeViewPluginDir)"&#x0D;&#x0A;set "MANAGED_DIR=$(ProjectDir)..\managed\bin\$(Configuration)\"&#x0D;&#x0A;if not exist "%MANAGED_DIR%TreeView.Managed.dll" set "MANAGED_DIR=%MANAGED_DIR%net48\"&#x0D;&#x0A;if not exist "%MANAGED_DIR%TreeView.Managed.dll" (&#x0D;&#x0A;  echo TreeView.Managed.dll was not found in "$(ProjectDir)..\managed\bin\$(Configuration)" or its net48 subfolder.&#x0D;&#x0A;  exit /B 1&#x0D;&#x0A;)&#x0D;&#x0A;copy /Y "%MANAGED_DIR%TreeView.Managed.dll" "$(TreeViewPluginDir)TreeView.Managed.dll"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets">
+  </Import>
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/plugins/treeview/vcxproj/treeview.vcxproj.filters
+++ b/src/plugins/treeview/vcxproj/treeview.vcxproj.filters
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="cpp">
+      <UniqueIdentifier>{7ec3b1ea-c9ff-4c6d-a33d-01d4cc9259e3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="h">
+      <UniqueIdentifier>{b358cda3-ea28-4487-886c-6e8d3e40ba6d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rc">
+      <UniqueIdentifier>{70c292f6-5208-42dd-8264-933d8a862f5b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="shared">
+      <UniqueIdentifier>{199e8645-6a17-4b65-a388-f9700eb782af}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\treeview.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\menu.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\precomp.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\auxtools.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\dbg.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\treeview.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\precomp.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\auxtools.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\dbg.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_base.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_com.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gen.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gui.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_menu.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_thum.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_vers.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\treeview.def">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\treeview.rc2">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\treeview.rh">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\treeview.rh2">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\lang\lang.rh">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\versinfo.rh2">
+      <Filter>rc</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\treeview.rc">
+      <Filter>rc</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/src/plugins/treeview/versinfo.rh2
+++ b/src/plugins/treeview/versinfo.rh2
@@ -1,0 +1,43 @@
+﻿//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+#ifndef __TREEVIEW_VERSINFO_RH2
+#define __TREEVIEW_VERSINFO_RH2
+
+#if defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+#error this file is not editable by Microsoft Visual C++
+#endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+
+// defines for plugin.SPL and plugin.SLG VERSIONINFO
+// look at shared\versinfo.rc
+
+#define VERSINFO_MAJOR       1
+#define VERSINFO_MINORA      0
+#define VERSINFO_MINORB      2
+
+#include "spl_vers.h" // vytahneme cisla verzi + buildu
+
+#define VERSINFO_COPYRIGHT   "Copyright © 2009-2023 Open Salamander Authors"
+#define VERSINFO_COMPANY     "Open Salamander"
+
+#define VERSINFO_DESCRIPTION "Tree view browser plugin for Open Salamander"
+
+#ifdef _LANG
+#define VERSINFO_INTERNAL    "ENGLISH"
+#define VERSINFO_ORIGINAL    VERSINFO_INTERNAL ".SLG"
+#else
+#define VERSINFO_INTERNAL    "TREEVIEW"
+#define VERSINFO_ORIGINAL    VERSINFO_INTERNAL ".SPL"
+#endif
+
+// for SLG translators
+#define VERSINFO_SLG_WEB     "www.altap.cz"
+#define VERSINFO_SLG_COMMENT "English version"
+
+#endif // __TREEVIEW_VERSINFO_RH2


### PR DESCRIPTION
## Summary
- add a native Tree View plugin that registers a menu entry and localized resources
- implement a bridge that loads the managed TreeView.Managed assembly and forwards the selected panel path
- build a WinForms browser around the Raccoom tree view control and include the upstream sources in a new managed project

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9410686d48329adf21cc6053c4165