### PR TITLE
Add managed text viewer plugin

### DIFF
--- a/src/plugins/jsonviewer/managed/JsonViewer.Managed.csproj
+++ b/src/plugins/jsonviewer/managed/JsonViewer.Managed.csproj
@@ -13,7 +13,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <ProjectGuid>{FAA575FC-812E-4C0F-A39A-543115FDC31F}</ProjectGuid>
-    <ApplicationIcon>..\..\..\..\jsonViewer\JsonView\curly_brackets_w39_icon.ico</ApplicationIcon>
+    <ApplicationIcon>..\..\..\..\3rd-party\jsonViewer\JsonView\curly_brackets_w39_icon.ico</ApplicationIcon>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,59 +21,59 @@
     <Compile Include="ViewerHost.cs" />
     <Compile Include="WindowInterop.cs" />
 
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\GridVisualizer.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\GridVisualizer.cs">
       <Link>JsonViewer\GridVisualizer.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\GridVisualizer.Designer.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\GridVisualizer.Designer.cs">
       <Link>JsonViewer\GridVisualizer.Designer.cs</Link>
       <DependentUpon>GridVisualizer.cs</DependentUpon>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\InternalPlugins.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\InternalPlugins.cs">
       <Link>JsonViewer\InternalPlugins.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\IJsonViewerPlugin.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\IJsonViewerPlugin.cs">
       <Link>JsonViewer\IJsonViewerPlugin.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonFields.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonFields.cs">
       <Link>JsonViewer\JsonFields.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonObject.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonObject.cs">
       <Link>JsonViewer\JsonObject.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonObjectTree.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonObjectTree.cs">
       <Link>JsonViewer\JsonObjectTree.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonObjectTypeConverter.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonObjectTypeConverter.cs">
       <Link>JsonViewer\JsonObjectTypeConverter.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonObjectVisualizer.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonObjectVisualizer.cs">
       <Link>JsonViewer\JsonObjectVisualizer.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonObjectVisualizer.Designer.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonObjectVisualizer.Designer.cs">
       <Link>JsonViewer\JsonObjectVisualizer.Designer.cs</Link>
       <DependentUpon>JsonObjectVisualizer.cs</DependentUpon>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonTreeObjectTypeDescriptor.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonTreeObjectTypeDescriptor.cs">
       <Link>JsonViewer\JsonTreeObjectTypeDescriptor.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonViewer.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonViewer.cs">
       <Link>JsonViewer\JsonViewer.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\JsonViewer.Designer.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonViewer.Designer.cs">
       <Link>JsonViewer\JsonViewer.Designer.cs</Link>
       <DependentUpon>JsonViewer.cs</DependentUpon>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\PluginsManager.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\PluginsManager.cs">
       <Link>JsonViewer\PluginsManager.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\UnbufferedStringReader.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\UnbufferedStringReader.cs">
       <Link>JsonViewer\UnbufferedStringReader.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\ViewerConfiguration.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\ViewerConfiguration.cs">
       <Link>JsonViewer\ViewerConfiguration.cs</Link>
     </Compile>
 
-    <Compile Include="..\..\..\..\jsonViewer\JsonViewer\Properties\AssemblyInfo.cs">
+    <Compile Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\Properties\AssemblyInfo.cs">
       <Link>JsonViewer\Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Properties\Resources.Designer.cs">
@@ -84,15 +84,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="..\..\..\..\jsonViewer\JsonViewer\GridVisualizer.resx">
+    <EmbeddedResource Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\GridVisualizer.resx">
       <Link>JsonViewer\GridVisualizer.resx</Link>
       <DependentUpon>GridVisualizer.cs</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\..\..\..\jsonViewer\JsonViewer\JsonObjectVisualizer.resx">
+    <EmbeddedResource Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonObjectVisualizer.resx">
       <Link>JsonViewer\JsonObjectVisualizer.resx</Link>
       <DependentUpon>JsonObjectVisualizer.cs</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\..\..\..\jsonViewer\JsonViewer\JsonViewer.resx">
+    <EmbeddedResource Include="..\..\..\..\3rd-party\jsonViewer\JsonViewer\JsonViewer.resx">
       <Link>JsonViewer\JsonViewer.resx</Link>
       <DependentUpon>JsonViewer.cs</DependentUpon>
     </EmbeddedResource>

--- a/src/plugins/shared/baseaddr_x64.txt
+++ b/src/plugins/shared/baseaddr_x64.txt
@@ -107,4 +107,6 @@ csdemo          0x0000010029f00000
 lang_csdemo     0x0000010039f00000
 jsonviewer      0x000001002a000000
 lang_jsonviewer 0x000001003a000000
+textviewer      0x000001002a100000
+lang_textviewer 0x000001003a100000
 

--- a/src/plugins/shared/baseaddr_x86.txt
+++ b/src/plugins/shared/baseaddr_x86.txt
@@ -107,4 +107,6 @@ csdemo          0x29f00000
 lang_csdemo     0x39f00000
 jsonviewer      0x2a000000
 lang_jsonviewer 0x3a000000
+textviewer      0x2a100000
+lang_textviewer 0x3a100000
 

--- a/src/plugins/textviewer/lang/lang.rc
+++ b/src/plugins/textviewer/lang/lang.rc
@@ -1,0 +1,71 @@
+﻿// Microsoft Visual C++ generated resource script.
+//
+#pragma code_page(65001)
+
+#include "lang.rh"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winresrc.h"
+
+#include "..\textviewer.rh2"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// Neutral resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "lang.rh\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winresrc.h""\r\n"
+    "\r\n"
+    "#include ""..\\textviewer.rh2""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)\r\n"
+    "LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL\r\n"
+    "#include ""lang.rc2""   // non-Microsoft Visual C++ edited resources\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // Neutral resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+#include "lang.rc2"   // non-Microsoft Visual C++ edited resources
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/src/plugins/textviewer/lang/lang.rc2
+++ b/src/plugins/textviewer/lang/lang.rc2
@@ -1,0 +1,31 @@
+//****************************************************************************
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+//
+// lang.rc2 - resources Microsoft Visual C++ does not edit directly
+//
+
+#ifdef APSTUDIO_INVOKED
+#error this file is not editable by Microsoft Visual C++
+#endif //APSTUDIO_INVOKED
+
+/////////////////////////////////////////////////////////////////////////////
+// Add manually edited resources here...
+
+#include "..\versinfo.rh2"
+#include "versinfo.rc2"
+
+STRINGTABLE
+{
+ IDS_PLUGINNAME,                 "Text Viewer"
+ IDS_ABOUT,                      "About Plugin"
+ IDS_PLUGIN_DESCRIPTION,         "Internal viewer that renders text files with managed syntax highlighting."
+ IDS_PLUGIN_HOME,                "https://github.com/KRtkovo-eu-AI/salamander/"
+ IDS_VIEWER_CREATE_EVENT_FAILED, "Unable to prepare synchronization event required by the viewer."
+ IDS_FILE_TOO_LARGE,             "The selected file is too large to open. Files larger than 4 MB are not supported."
+}

--- a/src/plugins/textviewer/lang/lang.rh
+++ b/src/plugins/textviewer/lang/lang.rh
@@ -1,0 +1,15 @@
+﻿//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by lang.rc
+//
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        8500
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         8700
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/plugins/textviewer/managed/EntryPoint.cs
+++ b/src/plugins/textviewer/managed/EntryPoint.cs
@@ -64,7 +64,22 @@ public static class EntryPoint
         }
 
         Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
+
+        try
+        {
+            if (!Application.MessageLoop && Application.OpenForms.Count == 0)
+            {
+                Application.SetCompatibleTextRenderingDefault(false);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // A WinForms control has already been created somewhere else in the
+            // process (for example, another plugin). In that case it's too late
+            // to change the compatible text rendering default, so we simply
+            // continue with the existing setting.
+        }
+
         _initialized = true;
     }
 

--- a/src/plugins/textviewer/managed/EntryPoint.cs
+++ b/src/plugins/textviewer/managed/EntryPoint.cs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace OpenSalamander.TextViewer;
+
+public static class EntryPoint
+{
+    private static bool _initialized;
+
+    [STAThread]
+    public static int Dispatch(string? argument)
+    {
+        IntPtr parent = IntPtr.Zero;
+
+        try
+        {
+            EnsureApplicationInitialized();
+
+            var parts = (argument ?? string.Empty).Split(new[] { ';' }, 3);
+            var command = parts.Length > 0 ? parts[0] : string.Empty;
+            parent = ParseHandle(parts.Length > 1 ? parts[1] : string.Empty);
+            var payload = parts.Length > 2 ? parts[2] : string.Empty;
+
+            return command switch
+            {
+                "View" => ViewerHost.Launch(parent, payload, asynchronous: true),
+                "ViewSync" => ViewerHost.Launch(parent, payload, asynchronous: false),
+                "Release" => ViewerHost.ReleaseSessions(ShouldForceRelease(payload)),
+                _ => 1,
+            };
+        }
+        catch (Exception ex)
+        {
+            if (parent != IntPtr.Zero)
+            {
+                MessageBox.Show(new WindowHandleWrapper(parent),
+                    $"Unexpected managed exception:\n{ex.Message}",
+                    "Text Viewer Plugin",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            else
+            {
+                MessageBox.Show($"Unexpected managed exception:\n{ex.Message}",
+                    "Text Viewer Plugin",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            return -1;
+        }
+    }
+
+    private static void EnsureApplicationInitialized()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+        _initialized = true;
+    }
+
+    private static IntPtr ParseHandle(string text)
+    {
+        if (ulong.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return new IntPtr(unchecked((long)value));
+        }
+
+        return IntPtr.Zero;
+    }
+
+    private static bool ShouldForceRelease(string? payload)
+    {
+        var payloadText = payload?.Trim() ?? string.Empty;
+
+        if (payloadText.Length == 0)
+        {
+            return false;
+        }
+
+        var segments = payloadText.Split('|');
+        foreach (var segment in segments)
+        {
+            if (string.IsNullOrWhiteSpace(segment))
+            {
+                continue;
+            }
+
+            var kv = segment.Split(new[] { '=' }, 2);
+            if (kv.Length == 0)
+            {
+                continue;
+            }
+
+            var key = kv[0].Trim();
+            if (!key.Equals("force", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (kv.Length == 1)
+            {
+                return true;
+            }
+
+            var value = kv[1].Trim();
+            return value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+}

--- a/src/plugins/textviewer/managed/TextViewer.Managed.csproj
+++ b/src/plugins/textviewer/managed/TextViewer.Managed.csproj
@@ -8,6 +8,7 @@
     <LangVersion>10.0</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
     <ProjectGuid>{755CF63D-31EB-43B6-8402-2BB9D7D3E53F}</ProjectGuid>
   </PropertyGroup>
 

--- a/src/plugins/textviewer/managed/TextViewer.Managed.csproj
+++ b/src/plugins/textviewer/managed/TextViewer.Managed.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>TextViewer.Managed</AssemblyName>
+    <RootNamespace>OpenSalamander.TextViewer</RootNamespace>
+    <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <ProjectGuid>{755CF63D-31EB-43B6-8402-2BB9D7D3E53F}</ProjectGuid>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ColorfulCode" Version="1.0.0-preview1" />
+  </ItemGroup>
+
+  <Target Name="EnsureRestoreBeforeBuild"
+          BeforeTargets="CollectPackageReferences;CollectPackageReferencesDesignTime;ResolveReferences;PrepareForBuild"
+          Condition="'$(RestoreDuringBuild)' != 'true' and '$(ProjectAssetsFile)' != '' and !Exists('$(ProjectAssetsFile)')">
+    <Message Text="Running implicit restore for $(MSBuildProjectName) (missing $(ProjectAssetsFile))."
+             Importance="High" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="Restore"
+             Properties="RestoreDuringBuild=true" />
+  </Target>
+</Project>

--- a/src/plugins/textviewer/managed/ViewerHost.cs
+++ b/src/plugins/textviewer/managed/ViewerHost.cs
@@ -1003,7 +1003,7 @@ internal static class ViewerHost
                 var after = match.Groups[3].Value;
 
                 var fullTag = match.Value;
-                if (fullTag.IndexOf("style=", StringComparison.OrdinalIgnoreCase) >= 0)
+                if (fullTag.IndexOf("style=", 0, StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     return fullTag;
                 }
@@ -1143,15 +1143,15 @@ internal static class ViewerHost
                 return;
             }
 
-            if (value.IndexOf("italic", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (value.IndexOf("italic", 0, StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 builder.Append("font-style:italic;");
             }
-            if (value.IndexOf("bold", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (value.IndexOf("bold", 0, StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 builder.Append("font-weight:bold;");
             }
-            if (value.IndexOf("underline", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (value.IndexOf("underline", 0, StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 builder.Append("text-decoration:underline;");
             }

--- a/src/plugins/textviewer/managed/ViewerHost.cs
+++ b/src/plugins/textviewer/managed/ViewerHost.cs
@@ -1,0 +1,1084 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace OpenSalamander.TextViewer;
+
+internal static class ViewerHost
+{
+    private static readonly object s_threadLock = new();
+    private static ViewerThread? s_viewerThread;
+    private static readonly object s_sessionLock = new();
+    private static readonly HashSet<ViewerSession> s_activeSessions = new();
+    private static readonly ManualResetEventSlim s_sessionsDrained = new(true);
+    private static readonly TimeSpan s_shutdownTimeout = TimeSpan.FromSeconds(5);
+
+    public static int Launch(IntPtr parent, string payload, bool asynchronous)
+    {
+        if (!ViewCommandPayload.TryParse(payload, asynchronous, out var parsed))
+        {
+            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
+                "Unable to parse parameters provided for the text viewer.",
+                "Text Viewer Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return 1;
+        }
+
+        if (asynchronous && parsed.CloseHandle == IntPtr.Zero)
+        {
+            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
+                "The native host did not provide a synchronization handle for the viewer.",
+                "Text Viewer Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return 1;
+        }
+
+        ViewerSession session;
+        try
+        {
+            session = new ViewerSession(parent, parsed, asynchronous);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
+                $"Unable to prepare the text viewer session.\n{ex.Message}",
+                "Text Viewer Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return 1;
+        }
+
+        RegisterSession(session);
+
+        ViewerThread thread;
+        try
+        {
+            thread = EnsureViewerThread();
+        }
+        catch (Exception ex)
+        {
+            session.MarkStartupFailed();
+            session.Complete();
+            MessageBox.Show(session.OwnerWindow,
+                $"Unable to initialize the text viewer.\n{ex.Message}",
+                "Text Viewer Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            if (!asynchronous)
+            {
+                session.WaitForCompletion();
+            }
+            return 1;
+        }
+
+        if (!thread.TryShow(session))
+        {
+            session.MarkStartupFailed();
+            session.Complete();
+            MessageBox.Show(session.OwnerWindow,
+                "Unable to open the text viewer window.",
+                "Text Viewer Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            if (!asynchronous)
+            {
+                session.WaitForCompletion();
+            }
+            return 1;
+        }
+
+        if (!asynchronous)
+        {
+            session.WaitForCompletion();
+            return session.StartupSucceeded ? 0 : 1;
+        }
+
+        return 0;
+    }
+
+    public static int ReleaseSessions(bool forceClose)
+    {
+        if (!forceClose)
+        {
+            return HasActiveSessions ? 1 : 0;
+        }
+
+        ViewerThread? thread;
+        lock (s_threadLock)
+        {
+            thread = s_viewerThread;
+        }
+
+        if (thread is null)
+        {
+            return 0;
+        }
+
+        if (!thread.TryClose(s_shutdownTimeout))
+        {
+            return 1;
+        }
+
+        if (!s_sessionsDrained.Wait(s_shutdownTimeout))
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static ViewerThread EnsureViewerThread()
+    {
+        lock (s_threadLock)
+        {
+            s_viewerThread ??= new ViewerThread();
+            return s_viewerThread;
+        }
+    }
+
+    private static void RegisterSession(ViewerSession session)
+    {
+        lock (s_sessionLock)
+        {
+            if (s_activeSessions.Count == 0)
+            {
+                s_sessionsDrained.Reset();
+            }
+
+            s_activeSessions.Add(session);
+        }
+    }
+
+    private static void SessionCompleted(ViewerSession session)
+    {
+        lock (s_sessionLock)
+        {
+            if (s_activeSessions.Remove(session) && s_activeSessions.Count == 0)
+            {
+                s_sessionsDrained.Set();
+            }
+        }
+    }
+
+    private static bool HasActiveSessions
+    {
+        get
+        {
+            lock (s_sessionLock)
+            {
+                return s_activeSessions.Count > 0;
+            }
+        }
+    }
+
+    private static void OnViewerThreadExited(ViewerThread thread)
+    {
+        lock (s_threadLock)
+        {
+            if (ReferenceEquals(s_viewerThread, thread))
+            {
+                s_viewerThread = null;
+            }
+        }
+    }
+
+    private sealed class ViewerThread
+    {
+        private readonly Thread _thread;
+        private readonly AutoResetEvent _ready = new(false);
+        private TextViewerApplicationContext? _context;
+
+        public ViewerThread()
+        {
+            _thread = new Thread(Run)
+            {
+                IsBackground = true,
+                Name = "Text Viewer",
+            };
+            _thread.SetApartmentState(ApartmentState.STA);
+            _thread.Start();
+            _ready.WaitOne();
+        }
+
+        public bool TryShow(ViewerSession session)
+        {
+            var context = _context;
+            if (context is null)
+            {
+                return false;
+            }
+
+            return context.TryShow(session);
+        }
+
+        public bool TryClose(TimeSpan timeout)
+        {
+            var context = _context;
+            if (context is not null)
+            {
+                if (!context.TryCloseAll(timeout))
+                {
+                    return false;
+                }
+            }
+
+            if (timeout <= TimeSpan.Zero)
+            {
+                _thread.Join();
+                return true;
+            }
+
+            return _thread.Join(timeout);
+        }
+
+        private void Run()
+        {
+            try
+            {
+                using var context = new TextViewerApplicationContext();
+                _context = context;
+                _ready.Set();
+                Application.Run(context);
+            }
+            finally
+            {
+                _context = null;
+                _ready.Set();
+                OnViewerThreadExited(this);
+            }
+        }
+    }
+
+    private sealed class ViewerSession
+    {
+        private readonly EventWaitHandle? _closeEvent;
+        private readonly ManualResetEventSlim? _completionEvent;
+        private int _closeSignaled;
+        private int _completionSignaled;
+
+        public ViewerSession(IntPtr parent, ViewCommandPayload payload, bool asynchronous)
+        {
+            Parent = parent;
+            Payload = payload;
+            OwnerWindow = parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null;
+
+            if (payload.CloseHandle != IntPtr.Zero)
+            {
+                _closeEvent = new EventWaitHandle(false, EventResetMode.AutoReset)
+                {
+                    SafeWaitHandle = new Microsoft.Win32.SafeHandles.SafeWaitHandle(payload.CloseHandle, ownsHandle: false),
+                };
+            }
+
+            if (!asynchronous)
+            {
+                _completionEvent = new ManualResetEventSlim(false);
+            }
+        }
+
+        public IntPtr Parent { get; }
+        public ViewCommandPayload Payload { get; }
+        public IWin32Window? OwnerWindow { get; }
+        public bool StartupSucceeded { get; private set; } = true;
+
+        public void SignalClosed()
+        {
+            var handle = _closeEvent;
+            if (handle is null)
+            {
+                return;
+            }
+
+            if (Interlocked.Exchange(ref _closeSignaled, 1) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                handle.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            finally
+            {
+                handle.Dispose();
+            }
+        }
+
+        public void Complete()
+        {
+            if (Interlocked.Exchange(ref _completionSignaled, 1) != 0)
+            {
+                return;
+            }
+
+            SignalClosed();
+            SessionCompleted(this);
+            _completionEvent?.Set();
+        }
+
+        public void WaitForCompletion()
+        {
+            _completionEvent?.Wait();
+        }
+
+        public void MarkStartupFailed()
+        {
+            StartupSucceeded = false;
+        }
+    }
+
+    private sealed class TextViewerApplicationContext : ApplicationContext
+    {
+        private readonly Control _dispatcher;
+        private readonly List<TextViewerForm> _openForms = new();
+        private readonly object _lock = new();
+
+        public TextViewerApplicationContext()
+        {
+            _dispatcher = new Control();
+            _dispatcher.HandleCreated += OnDispatcherHandleCreated;
+            _dispatcher.HandleDestroyed += OnDispatcherHandleDestroyed;
+            _dispatcher.CreateControl();
+        }
+
+        public bool TryShow(ViewerSession session)
+        {
+            if (_dispatcher.IsDisposed)
+            {
+                return false;
+            }
+
+            try
+            {
+                _dispatcher.BeginInvoke(new MethodInvoker(() => ShowInternal(session)));
+                return true;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
+
+        public bool TryCloseAll(TimeSpan timeout)
+        {
+            using var completion = new ManualResetEventSlim(false);
+
+            try
+            {
+                _dispatcher.BeginInvoke(new MethodInvoker(() =>
+                {
+                    foreach (var form in _openForms.ToArray())
+                    {
+                        form.AllowClose();
+                        form.Close();
+                    }
+
+                    completion.Set();
+                }));
+            }
+            catch (ObjectDisposedException)
+            {
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+
+            return completion.Wait(timeout);
+        }
+
+        private void ShowInternal(ViewerSession session)
+        {
+            if (_dispatcher.IsDisposed)
+            {
+                session.MarkStartupFailed();
+                session.Complete();
+                return;
+            }
+
+            var form = new TextViewerForm();
+            form.FormClosed += (_, _) => OnFormClosed(form, session);
+
+            if (!form.TryShow(session))
+            {
+                form.Dispose();
+                session.MarkStartupFailed();
+                session.Complete();
+                return;
+            }
+
+            lock (_lock)
+            {
+                _openForms.Add(form);
+            }
+        }
+
+        private void OnDispatcherHandleCreated(object? sender, EventArgs e)
+        {
+        }
+
+        private void OnDispatcherHandleDestroyed(object? sender, EventArgs e)
+        {
+        }
+
+        private void OnFormClosed(TextViewerForm form, ViewerSession session)
+        {
+            lock (_lock)
+            {
+                _openForms.Remove(form);
+            }
+
+            session.Complete();
+        }
+    }
+
+    private sealed class TextViewerForm : Form
+    {
+        private ViewerSession? _session;
+        private Control? _editor;
+        private bool _allowClose;
+        private bool _taskbarStyleApplied;
+        private IntPtr _ownerRestore;
+        private bool _ownerAttached;
+
+        public TextViewerForm()
+        {
+            Text = "Text Viewer";
+            StartPosition = FormStartPosition.Manual;
+            ShowInTaskbar = false;
+            MinimizeBox = true;
+            MaximizeBox = true;
+            KeyPreview = true;
+            AutoScaleMode = AutoScaleMode.Dpi;
+            ClientSize = new Size(800, 600);
+
+            HandleCreated += OnHandleCreated;
+            HandleDestroyed += OnHandleDestroyed;
+            FormClosing += OnFormClosing;
+        }
+
+        public bool TryShow(ViewerSession session)
+        {
+            _session = session;
+            _allowClose = false;
+
+            Text = BuildCaption(session.Payload.Caption);
+            ApplyOwner(session.Parent);
+            ApplyPlacement(session.Payload);
+            EnsureEditor();
+
+            try
+            {
+                LoadFile(session.Payload.FilePath);
+            }
+            catch (Exception ex)
+            {
+                session.MarkStartupFailed();
+                MessageBox.Show(session.OwnerWindow,
+                    $"Unable to open the selected file.\n{ex.Message}",
+                    "Text Viewer Plugin",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return false;
+            }
+
+            ShowInTaskbar = true;
+            Show();
+            Activate();
+            NativeMethods.SetForegroundWindow(Handle);
+            return true;
+        }
+
+        public void AllowClose()
+        {
+            _allowClose = true;
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == Keys.Escape)
+            {
+                Close();
+                return true;
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private void EnsureEditor()
+        {
+            if (_editor is not null)
+            {
+                return;
+            }
+
+            var editor = ColorfulCodeAdapter.CreateEditor();
+            editor.Dock = DockStyle.Fill;
+            Controls.Add(editor);
+            _editor = editor;
+        }
+
+        private void LoadFile(string path)
+        {
+            if (_editor is null)
+            {
+                return;
+            }
+
+            string text = File.ReadAllText(path);
+            string language = LanguageGuesser.FromFileName(path);
+
+            if (!ColorfulCodeAdapter.TryApplyHighlight(_editor, text, language))
+            {
+                if (_editor is TextBoxBase textBox)
+                {
+                    textBox.Text = text;
+                    textBox.SelectionStart = 0;
+                    textBox.SelectionLength = 0;
+                }
+            }
+        }
+
+        private void OnHandleCreated(object? sender, EventArgs e)
+        {
+            ApplyOwner(_session?.Parent ?? IntPtr.Zero);
+            EnsureTaskbarVisibility();
+        }
+
+        private void OnHandleDestroyed(object? sender, EventArgs e)
+        {
+            DetachOwner();
+            _taskbarStyleApplied = false;
+        }
+
+        private void OnFormClosing(object? sender, FormClosingEventArgs e)
+        {
+            if (!_allowClose)
+            {
+                _allowClose = true;
+            }
+
+            _session?.SignalClosed();
+        }
+
+        private void ApplyPlacement(ViewCommandPayload payload)
+        {
+            Rectangle bounds = payload.Bounds;
+            if (bounds.Width > 0 && bounds.Height > 0)
+            {
+                Bounds = bounds;
+            }
+            else if (!Visible)
+            {
+                StartPosition = FormStartPosition.CenterScreen;
+            }
+
+            WindowState = FormWindowState.Normal;
+            if (payload.ShowCommand == NativeMethods.SW_SHOWMAXIMIZED)
+            {
+                WindowState = FormWindowState.Maximized;
+            }
+            else if (payload.ShowCommand == NativeMethods.SW_SHOWMINIMIZED)
+            {
+                WindowState = FormWindowState.Minimized;
+            }
+
+            TopMost = payload.AlwaysOnTop;
+        }
+
+        private void ApplyOwner(IntPtr parent)
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            if (_ownerAttached)
+            {
+                NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_HWNDPARENT, _ownerRestore);
+                _ownerRestore = IntPtr.Zero;
+                _ownerAttached = false;
+            }
+
+            if (parent != IntPtr.Zero)
+            {
+                _ownerRestore = NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_HWNDPARENT, parent);
+                _ownerAttached = true;
+            }
+        }
+
+        private void DetachOwner()
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            if (_ownerAttached)
+            {
+                NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_HWNDPARENT, _ownerRestore);
+                _ownerRestore = IntPtr.Zero;
+                _ownerAttached = false;
+            }
+        }
+
+        private void EnsureTaskbarVisibility()
+        {
+            if (!IsHandleCreated || _taskbarStyleApplied)
+            {
+                return;
+            }
+
+            int style = unchecked((int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE).ToInt64());
+            int updated = (style & ~NativeMethods.WS_EX_TOOLWINDOW) | NativeMethods.WS_EX_APPWINDOW;
+            if (updated != style)
+            {
+                NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE, new IntPtr(updated));
+                NativeMethods.SetWindowPos(
+                    Handle,
+                    IntPtr.Zero,
+                    0,
+                    0,
+                    0,
+                    0,
+                    NativeMethods.SWP_NOMOVE |
+                    NativeMethods.SWP_NOSIZE |
+                    NativeMethods.SWP_NOZORDER |
+                    NativeMethods.SWP_NOACTIVATE |
+                    NativeMethods.SWP_FRAMECHANGED |
+                    NativeMethods.SWP_NOOWNERZORDER);
+            }
+
+            _taskbarStyleApplied = true;
+        }
+
+        private static string BuildCaption(string caption)
+        {
+            if (string.IsNullOrWhiteSpace(caption))
+            {
+                return "Text Viewer";
+            }
+
+            return string.Format(CultureInfo.CurrentCulture, "{0} - Text Viewer", caption);
+        }
+    }
+
+    private sealed class ViewCommandPayload
+    {
+        private ViewCommandPayload(string filePath, string caption, Rectangle bounds, uint showCommand,
+            bool alwaysOnTop, IntPtr closeHandle)
+        {
+            FilePath = filePath;
+            Caption = caption;
+            Bounds = bounds;
+            ShowCommand = showCommand;
+            AlwaysOnTop = alwaysOnTop;
+            CloseHandle = closeHandle;
+        }
+
+        public string FilePath { get; }
+        public string Caption { get; }
+        public Rectangle Bounds { get; }
+        public uint ShowCommand { get; }
+        public bool AlwaysOnTop { get; }
+        public IntPtr CloseHandle { get; }
+
+        public static bool TryParse(string payload, bool asynchronous, out ViewCommandPayload result)
+        {
+            result = null!;
+            if (string.IsNullOrEmpty(payload))
+            {
+                return false;
+            }
+
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var parts = payload.Split('|');
+            foreach (var part in parts)
+            {
+                if (string.IsNullOrEmpty(part))
+                {
+                    continue;
+                }
+
+                var kv = part.Split(new[] { '=' }, 2);
+                if (kv.Length == 2)
+                {
+                    map[kv[0]] = kv[1];
+                }
+            }
+
+            if (!map.TryGetValue("path", out var encodedPath))
+            {
+                return false;
+            }
+
+            string filePath;
+            if (TryDecodeBase64(encodedPath, out var decodedPath))
+            {
+                filePath = decodedPath;
+            }
+            else
+            {
+                filePath = encodedPath?.Trim() ?? string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            string caption = Path.GetFileName(filePath);
+            if (map.TryGetValue("caption", out var encodedCaption) && !string.IsNullOrEmpty(encodedCaption))
+            {
+                if (TryDecodeBase64(encodedCaption, out var decodedCaption) && !string.IsNullOrWhiteSpace(decodedCaption))
+                {
+                    caption = decodedCaption.Trim();
+                }
+                else if (!string.IsNullOrEmpty(encodedCaption))
+                {
+                    caption = encodedCaption.Trim();
+                }
+            }
+
+            int left = ReadInt(map, "left");
+            int top = ReadInt(map, "top");
+            int width = Math.Max(ReadInt(map, "width"), 0);
+            int height = Math.Max(ReadInt(map, "height"), 0);
+            uint showCommand = ReadUInt(map, "show");
+            bool alwaysOnTop = ReadBool(map, "ontop");
+            IntPtr closeHandle = asynchronous ? ReadHandle(map, "close") : IntPtr.Zero;
+
+            var bounds = new Rectangle(left, top, width, height);
+            result = new ViewCommandPayload(filePath, caption, bounds, showCommand, alwaysOnTop, closeHandle);
+            return true;
+        }
+
+        private static bool TryDecodeBase64(string value, out string decoded)
+        {
+            decoded = string.Empty;
+            var trimmedValue = value?.Trim();
+            if (string.IsNullOrEmpty(trimmedValue))
+            {
+                return false;
+            }
+
+            try
+            {
+                var bytes = Convert.FromBase64String(trimmedValue);
+                decoded = Encoding.UTF8.GetString(bytes);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+            catch (DecoderFallbackException)
+            {
+                return false;
+            }
+        }
+
+        private static int ReadInt(IDictionary<string, string> map, string key)
+        {
+            if (map.TryGetValue(key, out var value) && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return parsed;
+            }
+            return 0;
+        }
+
+        private static uint ReadUInt(IDictionary<string, string> map, string key)
+        {
+            if (map.TryGetValue(key, out var value) && uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return parsed;
+            }
+            return 0;
+        }
+
+        private static bool ReadBool(IDictionary<string, string> map, string key)
+        {
+            return map.TryGetValue(key, out var value) && value == "1";
+        }
+
+        private static IntPtr ReadHandle(IDictionary<string, string> map, string key)
+        {
+            if (map.TryGetValue(key, out var value) && ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return new IntPtr(unchecked((long)parsed));
+            }
+            return IntPtr.Zero;
+        }
+    }
+
+    private static class LanguageGuesser
+    {
+        private static readonly Dictionary<string, string> s_languageByExtension = new(StringComparer.OrdinalIgnoreCase)
+        {
+            [".cs"] = "csharp",
+            [".cpp"] = "cpp",
+            [".cxx"] = "cpp",
+            [".cc"] = "cpp",
+            [".c"] = "c",
+            [".h"] = "cpp",
+            [".hpp"] = "cpp",
+            [".js"] = "javascript",
+            [".ts"] = "typescript",
+            [".json"] = "json",
+            [".xml"] = "xml",
+            [".html"] = "html",
+            [".htm"] = "html",
+            [".css"] = "css",
+            [".py"] = "python",
+            [".rb"] = "ruby",
+            [".java"] = "java",
+            [".cshtml"] = "html",
+            [".xaml"] = "xml",
+            [".yaml"] = "yaml",
+            [".yml"] = "yaml",
+            [".ini"] = "ini",
+            [".cfg"] = "ini",
+            [".md"] = "markdown",
+            [".sql"] = "sql",
+            [".bat"] = "dos",
+            [".ps1"] = "powershell",
+        };
+
+        public static string FromFileName(string filePath)
+        {
+            var extension = Path.GetExtension(filePath);
+            if (string.IsNullOrEmpty(extension))
+            {
+                return "";
+            }
+
+            return s_languageByExtension.TryGetValue(extension, out var language) ? language : string.Empty;
+        }
+    }
+
+    private static class ColorfulCodeAdapter
+    {
+        private static bool s_initialized;
+        private static Func<string, string, string?>? s_rtfFormatter;
+
+        public static Control CreateEditor()
+        {
+            EnsureInitialized();
+
+            var box = new RichTextBox
+            {
+                BorderStyle = BorderStyle.None,
+                DetectUrls = false,
+                HideSelection = false,
+                Multiline = true,
+                ReadOnly = true,
+                ScrollBars = RichTextBoxScrollBars.Both,
+                WordWrap = false,
+                Font = new Font("Consolas", 10.0f, FontStyle.Regular),
+            };
+
+            return box;
+        }
+
+        public static bool TryApplyHighlight(Control editor, string text, string language)
+        {
+            EnsureInitialized();
+
+            if (editor is RichTextBox richText)
+            {
+                if (s_rtfFormatter is not null)
+                {
+                    try
+                    {
+                        var formatted = s_rtfFormatter(text, language);
+                        if (!string.IsNullOrEmpty(formatted))
+                        {
+                            richText.Rtf = formatted;
+                            return true;
+                        }
+                    }
+                    catch
+                    {
+                        // ignore and fallback
+                    }
+                }
+
+                richText.Text = text;
+                return true;
+            }
+
+            try
+            {
+                var type = editor.GetType();
+                var method = type.GetMethod("SetText", BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (method is not null)
+                {
+                    method.Invoke(editor, new object?[] { text });
+                    TryApplyLanguage(type, editor, language);
+                    return true;
+                }
+
+                var textProperty = type.GetProperty("Text", BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (textProperty is not null && textProperty.CanWrite)
+                {
+                    textProperty.SetValue(editor, text);
+                    TryApplyLanguage(type, editor, language);
+                    return true;
+                }
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+
+        private static void TryApplyLanguage(Type controlType, object control, string language)
+        {
+            if (string.IsNullOrEmpty(language))
+            {
+                return;
+            }
+
+            try
+            {
+                var property = controlType.GetProperty("Language", BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (property is not null && property.CanWrite)
+                {
+                    property.SetValue(control, language);
+                    return;
+                }
+
+                var method = controlType.GetMethod("SetLanguage", BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (method is not null)
+                {
+                    method.Invoke(control, new object?[] { language });
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private static void EnsureInitialized()
+        {
+            if (s_initialized)
+            {
+                return;
+            }
+
+            s_initialized = true;
+
+            try
+            {
+                var assembly = LoadColorfulCodeAssembly();
+                if (assembly is null)
+                {
+                    return;
+                }
+
+                var formatterType = assembly
+                    .GetTypes()
+                    .FirstOrDefault(t => !t.IsAbstract && t.Name.IndexOf("Rtf", StringComparison.OrdinalIgnoreCase) >= 0 && t.GetMethods().Any(m => string.Equals(m.Name, "Format", StringComparison.OrdinalIgnoreCase)));
+
+                if (formatterType is null)
+                {
+                    return;
+                }
+
+                var method = formatterType
+                    .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+                    .FirstOrDefault(m => string.Equals(m.Name, "Format", StringComparison.OrdinalIgnoreCase) &&
+                                         m.GetParameters().Length >= 2 &&
+                                         m.GetParameters()[0].ParameterType == typeof(string));
+
+                if (method is null)
+                {
+                    return;
+                }
+
+                object? instance = method.IsStatic ? null : Activator.CreateInstance(formatterType);
+
+                s_rtfFormatter = (code, language) =>
+                {
+                    try
+                    {
+                        var parameters = method.GetParameters();
+                        var args = new object?[parameters.Length];
+                        args[0] = code;
+                        if (parameters.Length > 1)
+                        {
+                            args[1] = language;
+                        }
+
+                        for (int i = 2; i < args.Length; i++)
+                        {
+                            args[i] = null;
+                        }
+
+                        var result = method.Invoke(instance, args);
+                        return result as string;
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                };
+            }
+            catch
+            {
+            }
+        }
+
+        private static Assembly? LoadColorfulCodeAssembly()
+        {
+            var loaded = AppDomain.CurrentDomain
+                .GetAssemblies()
+                .FirstOrDefault(a => string.Equals(a.GetName().Name, "ColorfulCode", StringComparison.OrdinalIgnoreCase));
+            if (loaded is not null)
+            {
+                return loaded;
+            }
+
+            try
+            {
+                return Assembly.Load("ColorfulCode");
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/plugins/textviewer/managed/ViewerHost.cs
+++ b/src/plugins/textviewer/managed/ViewerHost.cs
@@ -407,6 +407,7 @@ internal static class ViewerHost
                     }
 
                     completion.Set();
+                    ExitThread();
                 }));
             }
             catch (ObjectDisposedException)

--- a/src/plugins/textviewer/managed/ViewerHost.cs
+++ b/src/plugins/textviewer/managed/ViewerHost.cs
@@ -1097,7 +1097,7 @@ internal static class ViewerHost
                 builder.Append(style);
             }
 
-            if (token.IndexOf('.', StringComparison.Ordinal) >= 0)
+            if (token.IndexOf('.') >= 0)
             {
                 var parts = token.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var part in parts)

--- a/src/plugins/textviewer/managed/ViewerHost.cs
+++ b/src/plugins/textviewer/managed/ViewerHost.cs
@@ -996,26 +996,30 @@ internal static class ViewerHost
                 return html;
             }
 
-            return Regex.Replace(html, "(<[^>]+\\sclass=\")([^\"]+)(\"[^>]*>)", match =>
-            {
-                var before = match.Groups[1].Value;
-                var classValue = match.Groups[2].Value;
-                var after = match.Groups[3].Value;
-
-                var fullTag = match.Value;
-                if (fullTag.IndexOf("style=", 0, StringComparison.OrdinalIgnoreCase) >= 0)
+            return Regex.Replace(html,
+                "(<[^>]+?\\sclass\\s*=\\s*)([\"'])([^\"'>]+)(\\2[^>]*>)",
+                match =>
                 {
-                    return fullTag;
-                }
+                    var before = match.Groups[1].Value;
+                    var quote = match.Groups[2].Value;
+                    var classValue = match.Groups[3].Value;
+                    var after = match.Groups[4].Value;
 
-                var style = BuildStyleForClasses(classValue, styleMap);
-                if (string.IsNullOrEmpty(style))
-                {
-                    return fullTag;
-                }
+                    var fullTag = match.Value;
+                    if (fullTag.IndexOf("style=", 0, StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        return fullTag;
+                    }
 
-                return $"{before}{classValue}\" style=\"{style}{after}";
-            }, RegexOptions.IgnoreCase);
+                    var style = BuildStyleForClasses(classValue, styleMap);
+                    if (string.IsNullOrEmpty(style))
+                    {
+                        return fullTag;
+                    }
+
+                    var suffix = after.Length > 0 ? after.Substring(1) : string.Empty;
+                    return $"{before}{quote}{classValue}{quote} style=\"{style}\"{suffix}";
+                }, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         }
 
         private static IReadOnlyDictionary<string, string> BuildClassStyleMap(Theme theme, out string? globalPreStyle)

--- a/src/plugins/textviewer/managed/ViewerHost.cs
+++ b/src/plugins/textviewer/managed/ViewerHost.cs
@@ -862,8 +862,8 @@ internal static class ViewerHost
     private static class ColorfulCodeRenderer
     {
         private const string DefaultThemeName = "InspiredGitHub";
-        private static readonly Lazy<SyntaxSet> s_syntaxSet = new(SyntaxSet.LoadDefaults);
-        private static readonly Lazy<ThemeSet> s_themeSet = new(ThemeSet.LoadDefaults);
+        private static readonly Lazy<SyntaxSet> s_syntaxSet = new(() => SyntaxSet.LoadDefaults());
+        private static readonly Lazy<ThemeSet> s_themeSet = new(() => ThemeSet.LoadDefaults());
 
         public static string BuildDocument(string text, string extension, string? caption)
         {

--- a/src/plugins/textviewer/managed/WindowInterop.cs
+++ b/src/plugins/textviewer/managed/WindowInterop.cs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace OpenSalamander.TextViewer;
+
+internal sealed class WindowHandleWrapper : IWin32Window
+{
+    public WindowHandleWrapper(IntPtr handle)
+    {
+        Handle = handle;
+    }
+
+    public IntPtr Handle { get; }
+}
+
+internal static class NativeMethods
+{
+    public const int GWL_HWNDPARENT = -8;
+    public const int GWL_EXSTYLE = -20;
+
+    public const int WS_EX_TOOLWINDOW = 0x00000080;
+    public const int WS_EX_APPWINDOW = 0x00040000;
+
+    public const uint SWP_NOSIZE = 0x0001;
+    public const uint SWP_NOMOVE = 0x0002;
+    public const uint SWP_NOZORDER = 0x0004;
+    public const uint SWP_NOACTIVATE = 0x0010;
+    public const uint SWP_FRAMECHANGED = 0x0020;
+    public const uint SWP_SHOWWINDOW = 0x0040;
+    public const uint SWP_NOOWNERZORDER = 0x0200;
+
+    public const int SW_SHOWMINIMIZED = 2;
+    public const int SW_SHOWMAXIMIZED = 3;
+
+    public static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+    {
+        return IntPtr.Size == 8
+            ? SetWindowLongPtr64(hWnd, nIndex, dwNewLong)
+            : new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
+    }
+
+    public static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
+    {
+        return IntPtr.Size == 8
+            ? GetWindowLongPtr64(hWnd, nIndex)
+            : new IntPtr(GetWindowLong32(hWnd, nIndex));
+    }
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongW", SetLastError = true)]
+    private static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongW", SetLastError = true)]
+    private static extern int GetWindowLong32(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
+    private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+    private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+}

--- a/src/plugins/textviewer/managed_bridge.cpp
+++ b/src/plugins/textviewer/managed_bridge.cpp
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "precomp.h"
+#include "managed_bridge.h"
+
+#include <metahost.h>
+#include <mscoree.h>
+#include <strsafe.h>
+#include <wincrypt.h>
+
+#pragma comment(lib, "mscoree.lib")
+#pragma comment(lib, "crypt32.lib")
+
+namespace
+{
+ICLRRuntimeHost* gRuntimeHost = nullptr;
+std::wstring gAssemblyPath;
+const wchar_t* const kManagedType = L"OpenSalamander.TextViewer.EntryPoint";
+const wchar_t* const kManagedMethod = L"Dispatch";
+
+std::wstring BuildArgument(const wchar_t* command, HWND parent, const wchar_t* payload)
+{
+    std::wstring argument = command;
+    argument.push_back(L';');
+
+    wchar_t buffer[32];
+    ULONGLONG handleValue = reinterpret_cast<ULONGLONG>(parent);
+    StringCchPrintfW(buffer, _countof(buffer), L"%llu", handleValue);
+    argument.append(buffer);
+
+    argument.push_back(L';');
+    if (payload != nullptr)
+    {
+        argument.append(payload);
+    }
+
+    return argument;
+}
+
+std::wstring ConvertMultiByteToWide(const char* text, UINT codePage)
+{
+    if (text == nullptr)
+    {
+        return std::wstring();
+    }
+
+    DWORD flags = (codePage == CP_UTF8) ? MB_ERR_INVALID_CHARS : 0;
+    int required = MultiByteToWideChar(codePage, flags, text, -1, nullptr, 0);
+    if (required <= 0)
+    {
+        return std::wstring();
+    }
+
+    std::wstring result;
+    result.resize(static_cast<size_t>(required));
+    int converted = MultiByteToWideChar(codePage, flags, text, -1, result.data(), required);
+    if (converted <= 0)
+    {
+        return std::wstring();
+    }
+
+    result.resize(static_cast<size_t>(converted) - 1);
+    return result;
+}
+
+std::wstring AnsiToWide(const char* text)
+{
+    if (text == nullptr)
+    {
+        return std::wstring();
+    }
+
+    std::wstring result = ConvertMultiByteToWide(text, CP_ACP);
+    if (!result.empty())
+    {
+        return result;
+    }
+
+    result = ConvertMultiByteToWide(text, CP_UTF8);
+    if (!result.empty())
+    {
+        return result;
+    }
+
+    // As a last resort, map bytes directly to Unicode code points so the
+    // managed side still receives something meaningful to work with.
+    const unsigned char* bytes = reinterpret_cast<const unsigned char*>(text);
+    while (*bytes != '\0')
+    {
+        result.push_back(static_cast<wchar_t>(*bytes));
+        ++bytes;
+    }
+
+    return result;
+}
+
+std::wstring EncodeBase64FromWide(const std::wstring& value)
+{
+    if (value.empty())
+    {
+        return std::wstring();
+    }
+
+    int utf8Length = WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if (utf8Length <= 1)
+    {
+        return std::wstring();
+    }
+
+    std::string utf8;
+    utf8.resize(utf8Length - 1);
+    if (WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, utf8.data(), utf8Length - 1, nullptr, nullptr) <= 0)
+    {
+        return std::wstring();
+    }
+
+    DWORD base64Length = 0;
+    if (!CryptBinaryToStringW(reinterpret_cast<const BYTE*>(utf8.data()), static_cast<DWORD>(utf8.size()),
+                              CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, nullptr, &base64Length))
+    {
+        return std::wstring();
+    }
+
+    std::wstring result;
+    result.resize(base64Length);
+    if (!CryptBinaryToStringW(reinterpret_cast<const BYTE*>(utf8.data()), static_cast<DWORD>(utf8.size()),
+                              CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, result.data(), &base64Length))
+    {
+        return std::wstring();
+    }
+
+    if (!result.empty() && result.back() == L'\0')
+    {
+        result.pop_back();
+    }
+    else
+    {
+        result.resize(base64Length);
+    }
+
+    return result;
+}
+
+std::wstring ExtractFileName(const std::wstring& path)
+{
+    size_t pos = path.find_last_of(L"\\/");
+    if (pos == std::wstring::npos)
+    {
+        return path;
+    }
+    return path.substr(pos + 1);
+}
+
+void AppendKeyValue(std::wstring& payload, const wchar_t* key, const wchar_t* value)
+{
+    if (!payload.empty())
+    {
+        payload.push_back(L'|');
+    }
+    payload.append(key);
+    payload.push_back(L'=');
+    if (value != nullptr)
+    {
+        payload.append(value);
+    }
+}
+
+void AppendUInt(std::wstring& payload, const wchar_t* key, unsigned long value)
+{
+    wchar_t buffer[32];
+    StringCchPrintfW(buffer, _countof(buffer), L"%lu", value);
+    AppendKeyValue(payload, key, buffer);
+}
+
+void AppendInt(std::wstring& payload, const wchar_t* key, long value)
+{
+    wchar_t buffer[32];
+    StringCchPrintfW(buffer, _countof(buffer), L"%ld", value);
+    AppendKeyValue(payload, key, buffer);
+}
+
+void AppendHandle(std::wstring& payload, const wchar_t* key, HANDLE handle)
+{
+    wchar_t buffer[32];
+    ULONGLONG value = reinterpret_cast<ULONGLONG>(handle);
+    StringCchPrintfW(buffer, _countof(buffer), L"%llu", value);
+    AppendKeyValue(payload, key, buffer);
+}
+
+bool ExecuteCommand(const wchar_t* command, HWND parent, const wchar_t* payload)
+{
+    if (gRuntimeHost == nullptr)
+    {
+        return false;
+    }
+
+    DWORD returnValue = 0;
+    std::wstring argument = BuildArgument(command, parent, payload);
+    HRESULT hr = gRuntimeHost->ExecuteInDefaultAppDomain(gAssemblyPath.c_str(), kManagedType, kManagedMethod,
+                                                         argument.c_str(), &returnValue);
+    if (FAILED(hr))
+    {
+        wchar_t message[256];
+        StringCchPrintfW(message, _countof(message), L"Failed to execute managed command '%s' (0x%08X).", command, hr);
+        MessageBoxW(parent, message, L"Text Viewer Plugin", MB_ICONERROR | MB_OK);
+        return false;
+    }
+
+    return returnValue == 0;
+}
+
+void ShowLoadError(HWND parent, const wchar_t* text)
+{
+    MessageBoxW(parent, text, L"Text Viewer Plugin", MB_ICONERROR | MB_OK);
+}
+
+} // namespace
+
+bool ManagedBridge_EnsureInitialized(HWND parent)
+{
+    if (gRuntimeHost != nullptr)
+    {
+        return true;
+    }
+
+    ICLRMetaHost* metaHost = nullptr;
+    HRESULT hr = CLRCreateInstance(CLSID_CLRMetaHost, IID_PPV_ARGS(&metaHost));
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to load CLR meta host.");
+        return false;
+    }
+
+    ICLRRuntimeInfo* runtimeInfo = nullptr;
+    hr = metaHost->GetRuntime(L"v4.0.30319", IID_PPV_ARGS(&runtimeInfo));
+    metaHost->Release();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to locate CLR v4 runtime.");
+        return false;
+    }
+
+    hr = runtimeInfo->GetInterface(CLSID_CLRRuntimeHost, IID_PPV_ARGS(&gRuntimeHost));
+    runtimeInfo->Release();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to create CLR runtime host.");
+        return false;
+    }
+
+    hr = gRuntimeHost->Start();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to start CLR runtime.");
+        gRuntimeHost->Release();
+        gRuntimeHost = nullptr;
+        return false;
+    }
+
+    wchar_t modulePath[MAX_PATH] = {0};
+    if (GetModuleFileNameW(DLLInstance, modulePath, _countof(modulePath)) == 0)
+    {
+        ShowLoadError(parent, L"Failed to determine plugin path.");
+        ManagedBridge_Shutdown();
+        return false;
+    }
+
+    wchar_t* lastSlash = wcsrchr(modulePath, L'\\');
+    if (lastSlash != nullptr)
+    {
+        *(lastSlash + 1) = L'\0';
+    }
+
+    gAssemblyPath.assign(modulePath);
+    gAssemblyPath.append(L"TextViewer.Managed.dll");
+
+    return true;
+}
+
+void ManagedBridge_Shutdown()
+{
+    if (gRuntimeHost != nullptr)
+    {
+        gRuntimeHost->Stop();
+        gRuntimeHost->Release();
+        gRuntimeHost = nullptr;
+        gAssemblyPath.clear();
+    }
+}
+
+bool ManagedBridge_RequestShutdown(HWND parent, bool forceClose)
+{
+    if (gRuntimeHost == nullptr)
+    {
+        return true;
+    }
+
+    std::wstring payload;
+    AppendKeyValue(payload, L"force", forceClose ? L"1" : L"0");
+    return ExecuteCommand(L"Release", parent, payload.c_str());
+}
+
+bool ManagedBridge_ViewTextFile(HWND parent, const char* filePath, const RECT& placement,
+                                UINT showCmd, BOOL alwaysOnTop, HANDLE fileLock, bool asynchronous)
+{
+    if (!ManagedBridge_EnsureInitialized(parent))
+    {
+        return false;
+    }
+
+    std::wstring widePath = AnsiToWide(filePath);
+
+    std::wstring encodedPath = EncodeBase64FromWide(widePath);
+    if (encodedPath.empty())
+    {
+        encodedPath = widePath;
+    }
+
+    if (encodedPath.empty())
+    {
+        ShowLoadError(parent, L"Unable to prepare parameters for the text viewer.");
+        return false;
+    }
+
+    std::wstring caption = ExtractFileName(widePath);
+    if (caption.empty())
+    {
+        caption = widePath;
+    }
+
+    std::wstring encodedCaption = EncodeBase64FromWide(caption);
+    if (encodedCaption.empty())
+    {
+        encodedCaption = caption;
+    }
+
+    std::wstring payload;
+    AppendKeyValue(payload, L"path", encodedPath.c_str());
+    AppendKeyValue(payload, L"caption", encodedCaption.c_str());
+    AppendInt(payload, L"left", placement.left);
+    AppendInt(payload, L"top", placement.top);
+    AppendInt(payload, L"width", placement.right - placement.left);
+    AppendInt(payload, L"height", placement.bottom - placement.top);
+    AppendUInt(payload, L"show", showCmd);
+    AppendKeyValue(payload, L"ontop", alwaysOnTop ? L"1" : L"0");
+    AppendHandle(payload, L"close", fileLock);
+    AppendKeyValue(payload, L"async", asynchronous ? L"1" : L"0");
+
+    const wchar_t* command = asynchronous ? L"View" : L"ViewSync";
+    return ExecuteCommand(command, parent, payload.c_str());
+}

--- a/src/plugins/textviewer/managed_bridge.h
+++ b/src/plugins/textviewer/managed_bridge.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+bool ManagedBridge_EnsureInitialized(HWND parent);
+void ManagedBridge_Shutdown();
+bool ManagedBridge_RequestShutdown(HWND parent, bool forceClose);
+bool ManagedBridge_ViewTextFile(HWND parent, const char* filePath, const RECT& placement,
+                                UINT showCmd, BOOL alwaysOnTop, HANDLE fileLock, bool asynchronous);

--- a/src/plugins/textviewer/precomp.cpp
+++ b/src/plugins/textviewer/precomp.cpp
@@ -1,0 +1,19 @@
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#include "precomp.h"
+
+// projekt TextViewer obsahuje tri skupiny modulu
+//
+// 1) modul precomp.cpp, ktery postavi textviewer.pch (/Yc"precomp.h")
+// 2) moduly vyuzivajici textviewer.pch (/Yu"precomp.h")
+// 3) commony maji vlastni, automaticky generovany WINDOWS.PCH
+//    (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")

--- a/src/plugins/textviewer/precomp.h
+++ b/src/plugins/textviewer/precomp.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN // exclude rarely-used stuff from Windows headers
+
+#include <windows.h>
+#include <CommDlg.h>
+#include <shlobj.h>
+#ifdef _MSC_VER
+#include <crtdbg.h>
+#endif // _MSC_VER
+#include <limits.h>
+#include <process.h>
+#include <commctrl.h>
+#include <ostream>
+#include <stdio.h>
+#include <time.h>
+
+#if defined(_DEBUG) && defined(_MSC_VER)
+#define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#endif
+
+#include "versinfo.rh2"
+
+#include "spl_com.h"
+#include "spl_base.h"
+#include "spl_gen.h"
+#include "spl_gui.h"
+#include "spl_view.h"
+#include "spl_vers.h"
+
+#include "dbg.h"
+#include "mhandles.h"
+#include "arraylt.h"
+#include "winliblt.h"
+#include "auxtools.h"
+#include "textviewer.h"
+#include "managed_bridge.h"
+#include "textviewer.rh"
+#include "textviewer.rh2"
+#include "lang\lang.rh"
+
+#ifdef __BORLANDC__
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif // __BORLANDC__

--- a/src/plugins/textviewer/textviewer.cpp
+++ b/src/plugins/textviewer/textviewer.cpp
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2023-2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#include "precomp.h"
+
+// objekt interfacu pluginu, jeho metody se volaji ze Salamandera
+CPluginInterface PluginInterface;
+// cast interfacu CPluginInterface pro viewer
+CPluginInterfaceForViewer InterfaceForViewer;
+
+// globalni data
+const char* PluginNameEN = "Text Viewer";      // neprekladane jmeno pluginu
+const char* PluginNameShort = "TEXTVIEWER";    // jmeno pluginu (kratce, bez mezer)
+
+HINSTANCE DLLInstance = NULL; // handle k SPL-ku - jazykove nezavisle resourcy
+HINSTANCE HLanguage = NULL;   // handle k SLG-cku - jazykove zavisle resourcy
+
+// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+CSalamanderGeneralAbstract* SalamanderGeneral = NULL;
+CSalamanderGUIAbstract* SalamanderGUI = NULL;
+
+// definice promenne pro "dbg.h"
+CSalamanderDebugAbstract* SalamanderDebug = NULL;
+
+// maximum file size (in bytes) allowed for the managed viewer
+static const ULONGLONG kMaxTextFileSize = 4ULL * 1024ULL * 1024ULL; // 4 MB
+
+// definice promenne pro "spl_com.h"
+int SalamanderVersion = 0;
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+    if (fdwReason == DLL_PROCESS_ATTACH)
+    {
+        DLLInstance = hinstDLL;
+
+        INITCOMMONCONTROLSEX initCtrls;
+        initCtrls.dwSize = sizeof(INITCOMMONCONTROLSEX);
+        initCtrls.dwICC = ICC_BAR_CLASSES;
+        if (!InitCommonControlsEx(&initCtrls))
+        {
+            MessageBox(NULL, "InitCommonControlsEx failed!", "Error", MB_OK | MB_ICONERROR);
+            return FALSE; // DLL won't start
+        }
+    }
+
+    return TRUE; // DLL can be loaded
+}
+
+// ****************************************************************************
+
+char* LoadStr(int resID)
+{
+    return SalamanderGeneral->LoadStr(HLanguage, resID);
+}
+
+static void ShowStartupError(HWND parent, const char* text)
+{
+    SalamanderGeneral->SalMessageBox(parent, text, LoadStr(IDS_PLUGINNAME), MB_OK | MB_ICONERROR);
+}
+
+static bool IsFileTooLarge(const char* path, ULONGLONG limit)
+{
+    if (path == NULL || path[0] == '\0')
+        return false;
+
+    WIN32_FILE_ATTRIBUTE_DATA attrs;
+    if (!GetFileAttributesExA(path, GetFileExInfoStandard, &attrs))
+        return false;
+
+    if (attrs.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+        return false;
+
+    ULONGLONG size = (static_cast<ULONGLONG>(attrs.nFileSizeHigh) << 32) | attrs.nFileSizeLow;
+    return size > limit;
+}
+
+//
+// ****************************************************************************
+// SalamanderPluginGetReqVer
+//
+
+#ifdef __BORLANDC__
+extern "C"
+{
+    int WINAPI SalamanderPluginGetReqVer();
+    CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbstract* salamander);
+};
+#endif // __BORLANDC__
+
+int WINAPI SalamanderPluginGetReqVer()
+{
+    return LAST_VERSION_OF_SALAMANDER;
+}
+
+//
+// ****************************************************************************
+// SalamanderPluginEntry
+//
+
+CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbstract* salamander)
+{
+    // nastavime SalamanderDebug pro "dbg.h"
+    SalamanderDebug = salamander->GetSalamanderDebug();
+    // nastavime SalamanderVersion pro "spl_com.h"
+    SalamanderVersion = salamander->GetVersion();
+    HANDLES_CAN_USE_TRACE();
+    CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
+
+    if (SalamanderVersion < LAST_VERSION_OF_SALAMANDER)
+    {
+        MessageBox(salamander->GetParentWindow(),
+                   REQUIRE_LAST_VERSION_OF_SALAMANDER,
+                   PluginNameEN, MB_OK | MB_ICONERROR);
+        return NULL;
+    }
+
+    // nechame nacist jazykovy modul (.slg)
+    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), PluginNameEN);
+    if (HLanguage == NULL)
+        return NULL;
+
+    // ziskame obecne rozhrani Salamandera
+    SalamanderGeneral = salamander->GetSalamanderGeneral();
+    SalamanderGUI = salamander->GetSalamanderGUI();
+
+    salamander->SetBasicPluginData(LoadStr(IDS_PLUGINNAME), FUNCTION_VIEWER,
+                                   VERSINFO_VERSION_NO_PLATFORM, VERSINFO_COPYRIGHT,
+                                   LoadStr(IDS_PLUGIN_DESCRIPTION), PluginNameShort,
+                                   NULL, NULL);
+
+    salamander->SetPluginHomePageURL(LoadStr(IDS_PLUGIN_HOME));
+
+    return &PluginInterface;
+}
+
+//
+// ****************************************************************************
+// CPluginInterface
+//
+
+void WINAPI CPluginInterface::About(HWND parent)
+{
+    char text[1024];
+    _snprintf_s(text, _TRUNCATE,
+                "%s\n\n%s",
+                LoadStr(IDS_PLUGINNAME),
+                LoadStr(IDS_PLUGIN_DESCRIPTION));
+    SalamanderGeneral->SalMessageBox(parent, text, LoadStr(IDS_ABOUT), MB_OK | MB_ICONINFORMATION);
+}
+
+BOOL WINAPI CPluginInterface::Release(HWND parent, BOOL force)
+{
+    if (!ManagedBridge_RequestShutdown(parent, force != FALSE))
+        return FALSE;
+
+    ManagedBridge_Shutdown();
+    return TRUE;
+}
+
+void WINAPI CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamander)
+{
+    CALL_STACK_MESSAGE1("CPluginInterface::Connect(,)");
+
+    salamander->AddViewer("*.txt;*.log;*.ini;*.cfg;*.json;*.yaml;*.yml;*.xml;*.html;*.htm;*.md;*.csv;*.cs;*.cpp;*.c;*.h;*.hpp;*.py;*.js;*.ts;*.css;*.sql;*.bat;*.ps1", FALSE);
+
+    if (SalamanderGUI != NULL)
+    {
+        CGUIIconListAbstract* iconList = SalamanderGUI->CreateIconList();
+        if (iconList != NULL)
+        {
+            if (iconList->Create(16, 16, 1))
+            {
+                UINT loadFlags = SalamanderGeneral != NULL ? SalamanderGeneral->GetIconLRFlags() : LR_DEFAULTCOLOR;
+                HICON icon16 = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_TEXTVIEWER), IMAGE_ICON, 16, 16, loadFlags);
+                if (icon16 != NULL)
+                {
+                    iconList->ReplaceIcon(0, icon16);
+                    DestroyIcon(icon16);
+                    salamander->SetIconListForGUI(iconList);
+                    salamander->SetPluginIcon(0);
+                    salamander->SetPluginMenuAndToolbarIcon(0);
+                    iconList = NULL;
+                }
+            }
+
+            if (iconList != NULL)
+                SalamanderGUI->DestroyIconList(iconList);
+        }
+    }
+}
+
+CPluginInterfaceForViewerAbstract* WINAPI CPluginInterface::GetInterfaceForViewer()
+{
+    return &InterfaceForViewer;
+}
+
+//
+// ****************************************************************************
+// CPluginInterfaceForViewer
+//
+
+BOOL WINAPI CPluginInterfaceForViewer::ViewFile(const char* name, int left, int top, int width, int height,
+                                                UINT showCmd, BOOL alwaysOnTop, BOOL returnLock, HANDLE* lock,
+                                                BOOL* lockOwner, CSalamanderPluginViewerData* viewerData,
+                                                int enumFilesSourceUID, int enumFilesCurrentIndex)
+{
+    CALL_STACK_MESSAGE1("CPluginInterfaceForViewer::ViewFile()");
+
+    if (name == NULL || name[0] == '\0')
+        return FALSE;
+
+    HWND parent = SalamanderGeneral->GetMainWindowHWND();
+
+    if (IsFileTooLarge(name, kMaxTextFileSize))
+    {
+        SalamanderGeneral->SalMessageBox(parent, LoadStr(IDS_FILE_TOO_LARGE), LoadStr(IDS_PLUGINNAME),
+                                         MB_OK | MB_ICONINFORMATION);
+        return FALSE;
+    }
+
+    RECT placement;
+    placement.left = left;
+    placement.top = top;
+    placement.right = left + width;
+    placement.bottom = top + height;
+
+    if (returnLock)
+    {
+        HANDLE fileLock = HANDLES(CreateEvent(NULL, FALSE, FALSE, NULL));
+        if (fileLock == NULL)
+        {
+            ShowStartupError(parent, LoadStr(IDS_VIEWER_CREATE_EVENT_FAILED));
+            return FALSE;
+        }
+
+        if (!ManagedBridge_ViewTextFile(parent, name, placement, showCmd, alwaysOnTop, fileLock, true))
+        {
+            HANDLES(CloseHandle(fileLock));
+            return FALSE;
+        }
+
+        if (lock != NULL)
+            *lock = fileLock;
+        if (lockOwner != NULL)
+            *lockOwner = TRUE;
+        return TRUE;
+    }
+
+    return ManagedBridge_ViewTextFile(parent, name, placement, showCmd, alwaysOnTop, NULL, false);
+}
+
+BOOL WINAPI CPluginInterfaceForViewer::CanViewFile(const char* name)
+{
+    if (name == NULL)
+        return FALSE;
+
+    const char* extension = strrchr(name, '.');
+    if (extension == NULL)
+        return FALSE;
+
+    static const char* const kExtensions[] = {
+        ".txt", ".log", ".ini", ".cfg", ".json", ".yaml", ".yml", ".xml", ".html", ".htm", ".md",
+        ".csv", ".cs", ".cpp", ".c", ".h", ".hpp", ".py", ".js", ".ts", ".css", ".sql", ".bat", ".ps1"
+    };
+
+    for (size_t i = 0; i < _countof(kExtensions); ++i)
+    {
+        if (_stricmp(extension, kExtensions[i]) == 0)
+            return TRUE;
+    }
+
+    return FALSE;
+}

--- a/src/plugins/textviewer/textviewer.def
+++ b/src/plugins/textviewer/textviewer.def
@@ -1,0 +1,4 @@
+LIBRARY TEXTVIEWER.SPL
+
+EXPORTS SalamanderPluginEntry
+EXPORTS SalamanderPluginGetReqVer

--- a/src/plugins/textviewer/textviewer.h
+++ b/src/plugins/textviewer/textviewer.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#pragma once
+
+// globalni data
+extern HINSTANCE DLLInstance; // handle k SPL-ku - jazykove nezavisle resourcy
+extern HINSTANCE HLanguage;   // handle k SLG-cku - jazykove zavisle resourcy
+
+// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+extern CSalamanderGeneralAbstract* SalamanderGeneral;
+
+char* LoadStr(int resID);
+
+class CPluginInterfaceForViewer : public CPluginInterfaceForViewerAbstract
+{
+public:
+    virtual BOOL WINAPI ViewFile(const char* name, int left, int top, int width, int height,
+                                 UINT showCmd, BOOL alwaysOnTop, BOOL returnLock, HANDLE* lock,
+                                 BOOL* lockOwner, CSalamanderPluginViewerData* viewerData,
+                                 int enumFilesSourceUID, int enumFilesCurrentIndex) override;
+
+    virtual BOOL WINAPI CanViewFile(const char* name) override;
+};
+
+class CPluginInterface : public CPluginInterfaceAbstract
+{
+public:
+    virtual void WINAPI About(HWND parent) override;
+
+    virtual BOOL WINAPI Release(HWND parent, BOOL force) override;
+
+    virtual void WINAPI LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry) override {}
+    virtual void WINAPI SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry) override {}
+    virtual void WINAPI Configuration(HWND parent) override {}
+
+    virtual void WINAPI Connect(HWND parent, CSalamanderConnectAbstract* salamander) override;
+
+    virtual void WINAPI ReleasePluginDataInterface(CPluginDataInterfaceAbstract* pluginData) override {}
+
+    virtual CPluginInterfaceForArchiverAbstract* WINAPI GetInterfaceForArchiver() override { return NULL; }
+    virtual CPluginInterfaceForViewerAbstract* WINAPI GetInterfaceForViewer() override;
+    virtual CPluginInterfaceForMenuExtAbstract* WINAPI GetInterfaceForMenuExt() override { return NULL; }
+    virtual CPluginInterfaceForFSAbstract* WINAPI GetInterfaceForFS() override { return NULL; }
+    virtual CPluginInterfaceForThumbLoaderAbstract* WINAPI GetInterfaceForThumbLoader() override { return NULL; }
+
+    virtual void WINAPI Event(int event, DWORD param) override {}
+    virtual void WINAPI ClearHistory(HWND parent) override {}
+    virtual void WINAPI AcceptChangeOnPathNotification(const char* path, BOOL includingSubdirs) override {}
+
+    virtual void WINAPI PasswordManagerEvent(HWND parent, int event) override {}
+};
+
+// rozhrani pluginu poskytnute Salamanderovi
+extern CPluginInterface PluginInterface;
+extern CPluginInterfaceForViewer InterfaceForViewer;

--- a/src/plugins/textviewer/textviewer.rc
+++ b/src/plugins/textviewer/textviewer.rc
@@ -1,0 +1,71 @@
+// Microsoft Visual C++ generated resource script.
+//
+#pragma code_page(65001)
+
+#include "textviewer.rh"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winresrc.h"
+
+#include "textviewer.rh2"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// Neutral resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE
+BEGIN
+    "textviewer.rh\0"
+END
+
+2 TEXTINCLUDE
+BEGIN
+    "#include ""winresrc.h""\r\n"
+    "\r\n"
+    "#include ""textviewer.rh2""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE
+BEGIN
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)\r\n"
+    "LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL\r\n"
+    "#include ""textviewer.rc2""   // non-Microsoft Visual C++ edited resources\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // Neutral resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+#include "textviewer.rc2"   // non-Microsoft Visual C++ edited resources
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/src/plugins/textviewer/textviewer.rc2
+++ b/src/plugins/textviewer/textviewer.rc2
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+//
+// textviewer.rc2 - resources Microsoft Visual C++ does not edit directly
+//
+
+#ifdef APSTUDIO_INVOKED
+#error this file is not editable by Microsoft Visual C++
+#endif //APSTUDIO_INVOKED
+
+/////////////////////////////////////////////////////////////////////////////
+// Add manually edited resources here...
+
+#include "versinfo.rh2"
+#include "versinfo.rc2"
+
+IDI_TEXTVIEWER ICON "..\\..\\..\\jsonViewer\\JsonView\\curly_brackets_w39_icon.ico"

--- a/src/plugins/textviewer/textviewer.rc2
+++ b/src/plugins/textviewer/textviewer.rc2
@@ -19,4 +19,4 @@
 #include "versinfo.rh2"
 #include "versinfo.rc2"
 
-IDI_TEXTVIEWER ICON "..\\..\\..\\jsonViewer\\JsonView\\curly_brackets_w39_icon.ico"
+IDI_TEXTVIEWER ICON "..\\..\\..\\3rd-party\\jsonViewer\\JsonView\\curly_brackets_w39_icon.ico"

--- a/src/plugins/textviewer/textviewer.rh
+++ b/src/plugins/textviewer/textviewer.rh
@@ -1,0 +1,15 @@
+﻿//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by textviewer.rc
+//
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        8001
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         8200
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/plugins/textviewer/textviewer.rh2
+++ b/src/plugins/textviewer/textviewer.rh2
@@ -1,0 +1,26 @@
+//****************************************************************************
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+#ifndef __TEXTVIEWER_RH2
+#define __TEXTVIEWER_RH2
+
+#if defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+#error this file is not editable by Microsoft Visual C++
+#endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+
+#define IDI_TEXTVIEWER                    8000
+
+#define IDS_PLUGINNAME                     46
+#define IDS_ABOUT                          47
+#define IDS_PLUGIN_DESCRIPTION             48
+#define IDS_PLUGIN_HOME                    49
+#define IDS_VIEWER_CREATE_EVENT_FAILED     50
+#define IDS_FILE_TOO_LARGE                 51
+
+#endif // __TEXTVIEWER_RH2

--- a/src/plugins/textviewer/vcxproj/lang_textviewer.props
+++ b/src/plugins/textviewer/vcxproj/lang_textviewer.props
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros">
+    <ShortProjectName>textviewer</ShortProjectName>
+  </PropertyGroup>
+  <ItemGroup>
+    <BuildMacro Include="ShortProjectName">
+      <Value>$(ShortProjectName)</Value>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/src/plugins/textviewer/vcxproj/lang_textviewer.vcxproj
+++ b/src/plugins/textviewer/vcxproj/lang_textviewer.vcxproj
@@ -1,0 +1,151 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}</ProjectGuid>
+    <RootNamespace>lang_textviewer</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props">
+  </Import>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props">
+  </Import>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_textviewer.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_release.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_textviewer.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_debug.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_textviewer.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_release.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_textviewer.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_debug.props">
+    </Import>
+  </ImportGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'!=''">
+    <TextViewerBuildRoot>$([System.IO.Path]::Combine('$(OPENSAL_BUILD_DIR)', 'salamander'))\</TextViewerBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'==''">
+    <TextViewerBuildRoot>$(ProjectDir)..\..\..\..\build\salamander\</TextViewerBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TextViewerLangDir>$(TextViewerBuildRoot)$(Configuration)_$(ShortPlatform)\plugins\textviewer\lang\</TextViewerLangDir>
+    <OutDir>$(TextViewerLangDir)</OutDir>
+    <IntDir>$(OutDir)Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Label="UserMacros">
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <None Include="..\textviewer.rh2">
+    </None>
+    <None Include="..\lang\lang.rc2">
+    </None>
+    <None Include="..\lang\lang.rh">
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\lang\lang.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets">
+  </Import>
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/plugins/textviewer/vcxproj/textviewer.props
+++ b/src/plugins/textviewer/vcxproj/textviewer.props
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros"></PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/plugins/textviewer/vcxproj/textviewer.sln
+++ b/src/plugins/textviewer/vcxproj/textviewer.sln
@@ -1,0 +1,70 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29020.237
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "textviewer", "textviewer.vcxproj", "{340CB50A-0325-4FAD-9C57-06FCC80E4482}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lang_textviewer", "lang_textviewer.vcxproj", "{1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextViewer.Managed", "..\managed\TextViewer.Managed.csproj", "{755CF63D-31EB-43B6-8402-2BB9D7D3E53F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1BDAFFE2-B264-44E9-A670-B7EC029A726F}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.editorconfig = ..\..\..\.editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		SDK|x64 = SDK|x64
+		SDK|x86 = SDK|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x64.ActiveCfg = Debug|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x64.Build.0 = Debug|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x86.ActiveCfg = Debug|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x86.Build.0 = Debug|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x64.ActiveCfg = Release|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x64.Build.0 = Release|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x86.ActiveCfg = Release|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x86.Build.0 = Release|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.SDK|x64.ActiveCfg = SDK|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.SDK|x64.Build.0 = SDK|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.SDK|x86.ActiveCfg = SDK|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.SDK|x86.Build.0 = SDK|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x64.ActiveCfg = Debug|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x64.Build.0 = Debug|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x86.ActiveCfg = Debug|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x86.Build.0 = Debug|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x64.ActiveCfg = Release|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x64.Build.0 = Release|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x86.ActiveCfg = Release|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x86.Build.0 = Release|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.SDK|x64.ActiveCfg = SDK|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.SDK|x64.Build.0 = SDK|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.SDK|x86.ActiveCfg = SDK|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.SDK|x86.Build.0 = SDK|Win32
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x64.Build.0 = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x86.Build.0 = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x64.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x64.Build.0 = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x86.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x86.Build.0 = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.SDK|x64.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.SDK|x64.Build.0 = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.SDK|x86.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.SDK|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {375C9D55-0C0E-42AE-8696-21DE91B07CCF}
+	EndGlobalSection
+EndGlobal

--- a/src/plugins/textviewer/vcxproj/textviewer.vcxproj
+++ b/src/plugins/textviewer/vcxproj/textviewer.vcxproj
@@ -1,0 +1,213 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{340CB50A-0325-4FAD-9C57-06FCC80E4482}</ProjectGuid>
+    <RootNamespace>textviewer</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props">
+  </Import>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props">
+  </Import>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_release.props">
+    </Import>
+    <Import Project="textviewer.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_debug.props">
+    </Import>
+    <Import Project="textviewer.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_release.props">
+    </Import>
+    <Import Project="textviewer.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_debug.props">
+    </Import>
+    <Import Project="textviewer.props">
+    </Import>
+  </ImportGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'!=''">
+    <TextViewerBuildRoot>$([System.IO.Path]::Combine('$(OPENSAL_BUILD_DIR)', 'salamander'))\</TextViewerBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'==''">
+    <TextViewerBuildRoot>$(ProjectDir)..\..\..\..\build\salamander\</TextViewerBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TextViewerPluginDir>$(TextViewerBuildRoot)$(Configuration)_$(ShortPlatform)\plugins\textviewer\</TextViewerPluginDir>
+    <OutDir>$(TextViewerPluginDir)</OutDir>
+    <IntDir>$(OutDir)Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Label="UserMacros">
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\shared\auxtools.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\shared\dbg.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+    </ClCompile>
+    <ClCompile Include="..\textviewer.cpp">
+    </ClCompile>
+    <ClCompile Include="..\managed_bridge.cpp">
+    </ClCompile>
+    <ClCompile Include="..\precomp.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\shared\auxtools.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\dbg.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_base.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_com.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gen.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gui.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_vers.h">
+    </ClInclude>
+    <ClInclude Include="..\textviewer.h">
+    </ClInclude>
+    <ClInclude Include="..\managed_bridge.h">
+    </ClInclude>
+    <ClInclude Include="..\precomp.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\textviewer.def">
+    </None>
+    <None Include="..\textviewer.rc2">
+    </None>
+    <None Include="..\textviewer.rh">
+    </None>
+    <None Include="..\textviewer.rh2">
+    </None>
+    <None Include="..\lang\lang.rh">
+    </None>
+    <None Include="..\versinfo.rh2">
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\textviewer.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="lang_textviewer.vcxproj">
+      <Project>{1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\managed\TextViewer.Managed.csproj">
+      <Project>{755CF63D-31EB-43B6-8402-2BB9D7D3E53F}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>if not exist "$(TextViewerPluginDir)" mkdir "$(TextViewerPluginDir)"&#x0D;&#x0A;set "MANAGED_DIR=$(ProjectDir)..\managed\bin\$(Configuration)\"&#x0D;&#x0A;if not exist "%MANAGED_DIR%TextViewer.Managed.dll" set "MANAGED_DIR=%MANAGED_DIR%net48\"&#x0D;&#x0A;if not exist "%MANAGED_DIR%TextViewer.Managed.dll" (&#x0D;&#x0A;  echo TextViewer.Managed.dll was not found in "$(ProjectDir)..\managed\bin\$(Configuration)" or its net48 subfolder.&#x0D;&#x0A;  exit /B 1&#x0D;&#x0A;)&#x0D;&#x0A;if not exist "%MANAGED_DIR%ColorfulCode.dll" (&#x0D;&#x0A;  echo ColorfulCode.dll was not found next to TextViewer.Managed.dll in %MANAGED_DIR%.&#x0D;&#x0A;  exit /B 1&#x0D;&#x0A;)&#x0D;&#x0A;copy /Y "%MANAGED_DIR%TextViewer.Managed.dll" "$(TextViewerPluginDir)TextViewer.Managed.dll"&#x0D;&#x0A;copy /Y "%MANAGED_DIR%ColorfulCode.dll" "$(TextViewerPluginDir)ColorfulCode.dll"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets">
+  </Import>
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/plugins/textviewer/vcxproj/textviewer.vcxproj.filters
+++ b/src/plugins/textviewer/vcxproj/textviewer.vcxproj.filters
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="cpp">
+      <UniqueIdentifier>{7ec3b1ea-c9ff-4c6d-a33d-01d4cc9259e3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="h">
+      <UniqueIdentifier>{b358cda3-ea28-4487-886c-6e8d3e40ba6d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rc">
+      <UniqueIdentifier>{70c292f6-5208-42dd-8264-933d8a862f5b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="shared">
+      <UniqueIdentifier>{199e8645-6a17-4b65-a388-f9700eb782af}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\textviewer.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\precomp.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\auxtools.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\dbg.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\textviewer.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\precomp.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\auxtools.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\dbg.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_base.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_com.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gen.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gui.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_vers.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\textviewer.def">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\textviewer.rc2">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\textviewer.rh">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\textviewer.rh2">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\lang\lang.rh">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\versinfo.rh2">
+      <Filter>rc</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\textviewer.rc">
+      <Filter>rc</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/src/plugins/textviewer/versinfo.rh2
+++ b/src/plugins/textviewer/versinfo.rh2
@@ -1,0 +1,43 @@
+//****************************************************************************
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+#ifndef __TEXTVIEWER_VERSINFO_RH2
+#define __TEXTVIEWER_VERSINFO_RH2
+
+#if defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+#error this file is not editable by Microsoft Visual C++
+#endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+
+// defines for plugin.SPL and plugin.SLG VERSIONINFO
+// look at shared\versinfo.rc
+
+#define VERSINFO_MAJOR       1
+#define VERSINFO_MINORA      0
+#define VERSINFO_MINORB      0
+
+#include "spl_vers.h" // vytahneme cisla verzi + buildu
+
+#define VERSINFO_COPYRIGHT   "Copyleft 2017-2025 realworld666, KRtekTM"
+#define VERSINFO_COMPANY     "Open Salamander"
+
+#define VERSINFO_DESCRIPTION "Text Viewer plugin for Open Salamander"
+
+#ifdef _LANG
+#define VERSINFO_INTERNAL    "ENGLISH"
+#define VERSINFO_ORIGINAL    VERSINFO_INTERNAL ".SLG"
+#else
+#define VERSINFO_INTERNAL    "TEXTVIEWER"
+#define VERSINFO_ORIGINAL    VERSINFO_INTERNAL ".SPL"
+#endif
+
+// for SLG translators
+#define VERSINFO_SLG_WEB     "www.altap.cz"
+#define VERSINFO_SLG_COMMENT "English version"
+
+#endif // __TEXTVIEWER_VERSINFO_RH2

--- a/src/vcxproj/salamand.sln
+++ b/src/vcxproj/salamand.sln
@@ -111,6 +111,12 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lang_jsonviewer", "..\plugi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonViewer.Managed", "..\plugins\jsonviewer\managed\JsonViewer.Managed.csproj", "{FAA575FC-812E-4C0F-A39A-543115FDC31F}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "textviewer", "..\plugins\textviewer\vcxproj\textviewer.vcxproj", "{340CB50A-0325-4FAD-9C57-06FCC80E4482}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lang_textviewer", "..\plugins\textviewer\vcxproj\lang_textviewer.vcxproj", "{1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextViewer.Managed", "..\plugins\textviewer\managed\TextViewer.Managed.csproj", "{755CF63D-31EB-43B6-8402-2BB9D7D3E53F}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "demoplug", "..\plugins\demoplug\vcxproj\demoplug.vcxproj", "{C355231B-65C2-4826-B419-37518E187F78}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "demoview", "..\plugins\demoview\vcxproj\demoview.vcxproj", "{B6636FCB-B76E-4DD5-8E08-350F2F8C5163}"
@@ -1146,7 +1152,37 @@ Global
                 {FAA575FC-812E-4C0F-A39A-543115FDC31F}.Release|x64.Build.0 = Release|Any CPU
                 {FAA575FC-812E-4C0F-A39A-543115FDC31F}.Utils (Release)|Win32.ActiveCfg = Release|Any CPU
                 {FAA575FC-812E-4C0F-A39A-543115FDC31F}.Utils (Release)|x64.ActiveCfg = Release|Any CPU
-        EndGlobalSection
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|Win32.ActiveCfg = Debug|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|Win32.Build.0 = Debug|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x64.ActiveCfg = Debug|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x64.Build.0 = Debug|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|Win32.ActiveCfg = Release|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|Win32.Build.0 = Release|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x64.ActiveCfg = Release|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x64.Build.0 = Release|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Utils (Release)|Win32.ActiveCfg = Release|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Utils (Release)|x64.ActiveCfg = Release|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|Win32.ActiveCfg = Debug|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|Win32.Build.0 = Debug|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x64.ActiveCfg = Debug|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x64.Build.0 = Debug|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|Win32.ActiveCfg = Release|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|Win32.Build.0 = Release|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x64.ActiveCfg = Release|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x64.Build.0 = Release|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Utils (Release)|Win32.ActiveCfg = Release|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Utils (Release)|x64.ActiveCfg = Release|x64
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|Win32.ActiveCfg = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|Win32.Build.0 = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x64.Build.0 = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|Win32.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|Win32.Build.0 = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x64.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x64.Build.0 = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Utils (Release)|Win32.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Utils (Release)|x64.ActiveCfg = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a new textviewer plugin that connects to a managed WinForms viewer
- use the ColorfulCode package to syntax highlight a range of text-based file types
- register the plugin in the main solution and assign base addresses for both architectures

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d944570de48329ac6e656f10899a3a