### PR TITLE
Add Unicode wide string helpers and conversions

### DIFF
--- a/src/common/str.cpp
+++ b/src/common/str.cpp
@@ -191,8 +191,16 @@ void InitializeCase()
     int i;
     WCHAR src[2] = {0};
     WCHAR mapped[4] = {0};
+    const bool acpIsUtf8 = GetACP() == CP_UTF8;
     for (i = 0; i < 256; i++)
     {
+        if (acpIsUtf8 && i >= 0x80)
+        {
+            LowerCase[i] = static_cast<BYTE>(i);
+            UpperCase[i] = static_cast<BYTE>(i);
+            continue;
+        }
+
         src[0] = static_cast<WCHAR>(i);
         int lowerCount = LCMapStringEx(LOCALE_NAME_USER_DEFAULT, LCMAP_LOWERCASE, src, 1, mapped, _countof(mapped), NULL, NULL, 0);
         if (lowerCount > 0 && mapped[0] <= 0x00FF)

--- a/src/common/str.cpp
+++ b/src/common/str.cpp
@@ -133,7 +133,7 @@ char* DupStrEx(const char* str, BOOL& err)
     return s;
 }
 
-WCHAR* StrNCatW(WCHAR* dst, const WCHAR* src, int dstSize)
+WCHAR* SalStrNCatW(WCHAR* dst, const WCHAR* src, int dstSize)
 {
     if (dst == NULL || src == NULL || dstSize <= 0)
         return dst;
@@ -160,13 +160,10 @@ char* StrNCat(char* dst, const char* src, int dstSize)
     if (!srcWide)
         return dst;
 
-    std::wstring dest = dstWide.to_wstring();
-    std::wstring source = srcWide.to_wstring();
+    std::wstring_view dstView(dstWide.c_str(), dstWide.length());
+    std::wstring_view srcView(srcWide.c_str(), srcWide.length());
 
-    dest.reserve(dest.size() + source.size());
-    dest.append(source);
-
-    SalWideString combined(dest);
+    SalWideString combined = SalWideString::Concat(dstView, srcView);
     if (!combined)
         return dst;
 

--- a/src/common/str.cpp
+++ b/src/common/str.cpp
@@ -5,6 +5,7 @@
 
 #include <windows.h>
 #include <crtdbg.h>
+#include <cstring>
 #include <ostream>
 #include <commctrl.h> // potrebuju LPCOLORMAP
 
@@ -103,24 +104,14 @@ char* DupStr(const char* txt)
     if (txt == NULL)
         return NULL;
 
-    SalWideString wide = SalWideString::FromAnsi(txt, -1, CP_ACP);
-    if (!wide)
-        return NULL;
-
-    std::string ansi = wide.ToAnsi(FALSE, CP_ACP);
-    if (ansi.empty() && wide.length() > 0)
-        return NULL;
-
-    size_t bytes = ansi.size() + 1;
-    char* s = static_cast<char*>(malloc(bytes));
+    size_t len = strlen(txt);
+    char* s = static_cast<char*>(malloc(len + 1));
     if (s == NULL)
     {
         TRACE_E("Low memory.");
         return NULL;
     }
-    if (!ansi.empty())
-        memcpy(s, ansi.data(), ansi.size());
-    s[ansi.size()] = 0;
+    memcpy(s, txt, len + 1);
     return s;
 }
 

--- a/src/common/str.h
+++ b/src/common/str.h
@@ -153,6 +153,10 @@ char* DupStr(const char* txt);
 // navic pri nedostatku pameti nastavi 'err' na TRUE
 char* DupStrEx(const char* str, BOOL& err);
 
+// wide-character equivalents managed through SalWideString helper
+WCHAR* DupStrW(const WCHAR* txt);
+WCHAR* DupStrExW(const WCHAR* str, BOOL& err);
+
 // vraci prvni vyskyt 'pattern' v 'txt' nebo NULL, je case-insensitive
 const char* StrIStr(const char* txt, const char* pattern);
 
@@ -164,6 +168,7 @@ const char* StrIStr(const char* txtStart, const char* txtEnd,
 // retezec zakoncuje nulou, ktera spada do delky 'dstSize'
 // vraci 'dst'
 char* StrNCat(char* dst, const char* src, int dstSize);
+WCHAR* StrNCatW(WCHAR* dst, const WCHAR* src, int dstSize);
 
 // tento historicky kod uz nikdo nepouziva
 /*

--- a/src/common/str.h
+++ b/src/common/str.h
@@ -168,7 +168,7 @@ const char* StrIStr(const char* txtStart, const char* txtEnd,
 // retezec zakoncuje nulou, ktera spada do delky 'dstSize'
 // vraci 'dst'
 char* StrNCat(char* dst, const char* src, int dstSize);
-WCHAR* StrNCatW(WCHAR* dst, const WCHAR* src, int dstSize);
+WCHAR* SalStrNCatW(WCHAR* dst, const WCHAR* src, int dstSize);
 
 // tento historicky kod uz nikdo nepouziva
 /*

--- a/src/common/unicode.cpp
+++ b/src/common/unicode.cpp
@@ -7,13 +7,15 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <initializer_list>
 #include <limits>
+#include <vector>
 
 namespace salamander::unicode
 {
 namespace
 {
-constexpr size_t kMaxSize = static_cast<size_t>(std::numeric_limits<int>::max());
+constexpr size_t kMaxSize = static_cast<size_t>((std::numeric_limits<int>::max)());
 
 [[nodiscard]] bool ShouldIncludeTerminator(int length)
 {
@@ -158,7 +160,13 @@ SalWideString SalWideString::Duplicate(std::wstring_view text)
 
 SalWideString SalWideString::Concat(std::wstring_view first, std::wstring_view second)
 {
-    return Concat(std::vector<std::wstring_view>{first, second});
+    return Concat({first, second});
+}
+
+SalWideString SalWideString::Concat(std::initializer_list<std::wstring_view> parts)
+{
+    std::vector<std::wstring_view> buffer(parts.begin(), parts.end());
+    return Concat(buffer);
 }
 
 SalWideString SalWideString::Concat(const std::vector<std::wstring_view>& parts)

--- a/src/common/unicode.cpp
+++ b/src/common/unicode.cpp
@@ -1,0 +1,403 @@
+// SPDX-FileCopyrightText: 2025 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "precomp.h"
+
+#include "unicode.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <limits>
+
+namespace salamander::unicode
+{
+namespace
+{
+constexpr size_t kMaxSize = static_cast<size_t>(std::numeric_limits<int>::max());
+
+[[nodiscard]] bool ShouldIncludeTerminator(int length)
+{
+    return length == -1;
+}
+
+[[nodiscard]] bool HasRoomFor(size_t value)
+{
+    return value <= kMaxSize;
+}
+} // namespace
+
+SalWideString::SalWideString() noexcept
+    : buffer_(nullptr), length_(0), valid_(true)
+{
+}
+
+SalWideString::SalWideString(size_t length)
+    : buffer_(nullptr), length_(0), valid_(true)
+{
+    if (!HasRoomFor(length))
+    {
+        SetLastError(ERROR_INSUFFICIENT_BUFFER);
+        Invalidate();
+        return;
+    }
+    buffer_ = Allocate(length);
+    if (!buffer_)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        Invalidate();
+        return;
+    }
+    length_ = length;
+    buffer_[length_] = L'\0';
+}
+
+SalWideString::SalWideString(std::wstring_view text)
+    : buffer_(nullptr), length_(0), valid_(true)
+{
+    Assign(text);
+}
+
+SalWideString::SalWideString(const SalWideString& other)
+    : buffer_(nullptr), length_(0), valid_(other.valid_)
+{
+    if (!other.valid_)
+    {
+        Invalidate();
+        return;
+    }
+
+    if (other.buffer_)
+        Assign(std::wstring_view(other.buffer_, other.length_));
+    else
+        Assign(std::wstring_view());
+}
+
+SalWideString::SalWideString(SalWideString&& other) noexcept
+    : buffer_(other.buffer_), length_(other.length_), valid_(other.valid_)
+{
+    other.buffer_ = nullptr;
+    other.length_ = 0;
+    other.valid_ = true;
+}
+
+SalWideString::~SalWideString()
+{
+    ReleaseStorage();
+}
+
+SalWideString& SalWideString::operator=(const SalWideString& other)
+{
+    if (this != &other)
+    {
+        if (!other.valid_)
+        {
+            Invalidate();
+        }
+        else if (other.buffer_)
+        {
+            Assign(std::wstring_view(other.buffer_, other.length_));
+        }
+        else
+        {
+            Assign(std::wstring_view());
+        }
+    }
+    return *this;
+}
+
+SalWideString& SalWideString::operator=(SalWideString&& other) noexcept
+{
+    if (this != &other)
+    {
+        ReleaseStorage();
+        buffer_ = other.buffer_;
+        length_ = other.length_;
+        valid_ = other.valid_;
+        other.buffer_ = nullptr;
+        other.length_ = 0;
+        other.valid_ = true;
+    }
+    return *this;
+}
+
+void SalWideString::clear() noexcept
+{
+    ReleaseStorage();
+    valid_ = true;
+}
+
+void SalWideString::swap(SalWideString& other) noexcept
+{
+    std::swap(buffer_, other.buffer_);
+    std::swap(length_, other.length_);
+    std::swap(valid_, other.valid_);
+}
+
+std::wstring SalWideString::to_wstring() const
+{
+    if (!valid_ || !buffer_)
+        return {};
+    return std::wstring(buffer_, length_);
+}
+
+wchar_t* SalWideString::release() noexcept
+{
+    if (!valid_)
+        return nullptr;
+    wchar_t* tmp = buffer_;
+    buffer_ = nullptr;
+    length_ = 0;
+    valid_ = true;
+    return tmp;
+}
+
+SalWideString SalWideString::Duplicate(std::wstring_view text)
+{
+    return SalWideString(text);
+}
+
+SalWideString SalWideString::Concat(std::wstring_view first, std::wstring_view second)
+{
+    return Concat(std::vector<std::wstring_view>{first, second});
+}
+
+SalWideString SalWideString::Concat(const std::vector<std::wstring_view>& parts)
+{
+    size_t total = 0;
+    for (const std::wstring_view part : parts)
+    {
+        if (!HasRoomFor(part.size()) || part.size() > kMaxSize - total)
+        {
+            SalWideString failure;
+            SetLastError(ERROR_INSUFFICIENT_BUFFER);
+            failure.Invalidate();
+            return failure;
+        }
+        total += part.size();
+    }
+
+    SalWideString result(total);
+    if (!result)
+        return result;
+
+    size_t offset = 0;
+    for (const std::wstring_view part : parts)
+    {
+        if (!part.empty())
+        {
+            memcpy(result.buffer_ + offset, part.data(), part.size() * sizeof(wchar_t));
+            offset += part.size();
+        }
+    }
+    result.buffer_[result.length_] = L'\0';
+    return result;
+}
+
+SalWideString SalWideString::Slice(std::wstring_view source, size_t start, size_t length)
+{
+    if (source.empty())
+        return SalWideString(0);
+
+    size_t safeStart = AdjustSliceStart(source, start);
+    size_t safeEnd = AdjustSliceEnd(source, safeStart, length);
+    if (safeStart >= safeEnd)
+        return SalWideString(0);
+    return SalWideString(std::wstring_view(source.data() + safeStart, safeEnd - safeStart));
+}
+
+SalWideString SalWideString::FromAnsi(const char* src, int srcLen, unsigned int codepage)
+{
+    if (!src)
+    {
+        SalWideString failure;
+        SetLastError(ERROR_INVALID_PARAMETER);
+        failure.Invalidate();
+        return failure;
+    }
+
+    if (srcLen != -1 && srcLen < 0)
+    {
+        SalWideString failure;
+        SetLastError(ERROR_INVALID_PARAMETER);
+        failure.Invalidate();
+        return failure;
+    }
+
+    if (srcLen == 0)
+        return SalWideString(0);
+
+    const bool includeTerminator = ShouldIncludeTerminator(srcLen);
+    int required = MultiByteToWideChar(codepage, 0, src, srcLen, nullptr, 0);
+    if (required <= 0)
+    {
+        SalWideString failure;
+        DWORD err = GetLastError();
+        failure.Invalidate();
+        SetLastError(err);
+        return failure;
+    }
+
+    if (includeTerminator)
+        --required;
+
+    if (!HasRoomFor(static_cast<size_t>(required)))
+    {
+        SalWideString failure;
+        SetLastError(ERROR_INSUFFICIENT_BUFFER);
+        failure.Invalidate();
+        return failure;
+    }
+
+    SalWideString result(static_cast<size_t>(required));
+    if (!result)
+        return result;
+
+    int copy = MultiByteToWideChar(codepage, 0, src, srcLen, result.buffer_, required + (includeTerminator ? 1 : 0));
+    if (copy <= 0)
+    {
+        DWORD err = GetLastError();
+        result.Invalidate();
+        SetLastError(err);
+        return result;
+    }
+
+    if (includeTerminator)
+    {
+        result.length_ = static_cast<size_t>(copy > 0 ? copy - 1 : 0);
+    }
+    else
+    {
+        result.length_ = static_cast<size_t>(copy);
+        result.buffer_[result.length_] = L'\0';
+    }
+
+    return result;
+}
+
+SalWideString SalWideString::FromUtf8(const char* src, int srcLen)
+{
+    return FromAnsi(src, srcLen, CP_UTF8);
+}
+
+std::string SalWideString::ToAnsi(bool compositeCheck, unsigned int codepage) const
+{
+    if (!valid_ || !buffer_)
+        return std::string();
+
+    DWORD flags = compositeCheck ? WC_COMPOSITECHECK : 0;
+    int required = WideCharToMultiByte(codepage, flags, buffer_, static_cast<int>(length_), nullptr, 0, nullptr, nullptr);
+    if (required <= 0 && compositeCheck)
+    {
+        flags = 0;
+        required = WideCharToMultiByte(codepage, flags, buffer_, static_cast<int>(length_), nullptr, 0, nullptr, nullptr);
+    }
+
+    if (required <= 0)
+    {
+        DWORD err = GetLastError();
+        SetLastError(err);
+        return std::string();
+    }
+
+    std::string result(static_cast<size_t>(required), '\0');
+    int converted = WideCharToMultiByte(codepage, flags, buffer_, static_cast<int>(length_), result.data(), required, nullptr, nullptr);
+    if (converted <= 0)
+    {
+        DWORD err = GetLastError();
+        SetLastError(err);
+        return std::string();
+    }
+
+    if (static_cast<size_t>(converted) < result.size())
+        result.resize(static_cast<size_t>(converted));
+
+    return result;
+}
+
+std::string SalWideString::ToUtf8() const
+{
+    return ToAnsi(FALSE, CP_UTF8);
+}
+
+wchar_t* SalWideString::Allocate(size_t length) noexcept
+{
+    size_t bytes = (length + 1) * sizeof(wchar_t);
+    auto* buffer = static_cast<wchar_t*>(malloc(bytes));
+    if (!buffer)
+        return nullptr;
+    buffer[length] = L'\0';
+    return buffer;
+}
+
+void SalWideString::Assign(std::wstring_view text)
+{
+    ReleaseStorage();
+    valid_ = true;
+
+    if (!HasRoomFor(text.size()))
+    {
+        SetLastError(ERROR_INSUFFICIENT_BUFFER);
+        Invalidate();
+        return;
+    }
+
+    buffer_ = Allocate(text.size());
+    if (!buffer_)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        Invalidate();
+        return;
+    }
+
+    length_ = text.size();
+    if (length_ != 0)
+        memcpy(buffer_, text.data(), length_ * sizeof(wchar_t));
+    buffer_[length_] = L'\0';
+}
+
+void SalWideString::Invalidate() noexcept
+{
+    ReleaseStorage();
+    valid_ = false;
+}
+
+void SalWideString::ReleaseStorage() noexcept
+{
+    if (buffer_)
+        free(buffer_);
+    buffer_ = nullptr;
+    length_ = 0;
+}
+
+bool IsHighSurrogate(wchar_t ch) noexcept
+{
+    return ch >= 0xD800 && ch <= 0xDBFF;
+}
+
+bool IsLowSurrogate(wchar_t ch) noexcept
+{
+    return ch >= 0xDC00 && ch <= 0xDFFF;
+}
+
+size_t AdjustSliceStart(std::wstring_view text, size_t start) noexcept
+{
+    if (start >= text.size())
+        return text.size();
+    if (start > 0 && IsLowSurrogate(text[start]) && IsHighSurrogate(text[start - 1]))
+        return start - 1;
+    return start;
+}
+
+size_t AdjustSliceEnd(std::wstring_view text, size_t start, size_t length) noexcept
+{
+    if (start >= text.size())
+        return text.size();
+    size_t end = start + length;
+    if (end > text.size())
+        end = text.size();
+    if (end < text.size() && IsLowSurrogate(text[end]) && IsHighSurrogate(text[end - 1]))
+        ++end;
+    return end;
+}
+
+} // namespace salamander::unicode

--- a/src/common/unicode.h
+++ b/src/common/unicode.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace salamander::unicode
+{
+class SalWideString
+{
+public:
+    SalWideString() noexcept;
+    explicit SalWideString(size_t length);
+    explicit SalWideString(std::wstring_view text);
+    SalWideString(const SalWideString& other);
+    SalWideString(SalWideString&& other) noexcept;
+    ~SalWideString();
+
+    SalWideString& operator=(const SalWideString& other);
+    SalWideString& operator=(SalWideString&& other) noexcept;
+
+    [[nodiscard]] bool empty() const noexcept { return length_ == 0; }
+    [[nodiscard]] size_t length() const noexcept { return length_; }
+    [[nodiscard]] const wchar_t* c_str() const noexcept { return buffer_ ? buffer_ : L""; }
+    [[nodiscard]] wchar_t* data() noexcept { return buffer_; }
+    [[nodiscard]] explicit operator bool() const noexcept { return valid_; }
+
+    void clear() noexcept;
+    void swap(SalWideString& other) noexcept;
+
+    [[nodiscard]] std::wstring to_wstring() const;
+    [[nodiscard]] wchar_t* release() noexcept;
+
+    static SalWideString Duplicate(std::wstring_view text);
+    static SalWideString Concat(std::wstring_view first, std::wstring_view second);
+    static SalWideString Concat(const std::vector<std::wstring_view>& parts);
+    static SalWideString Slice(std::wstring_view source, size_t start, size_t length);
+
+    static SalWideString FromAnsi(const char* src, int srcLen, unsigned int codepage);
+    static SalWideString FromUtf8(const char* src, int srcLen);
+
+    [[nodiscard]] std::string ToAnsi(bool compositeCheck, unsigned int codepage) const;
+    [[nodiscard]] std::string ToUtf8() const;
+
+private:
+    wchar_t* buffer_;
+    size_t length_;
+    bool valid_;
+
+    static wchar_t* Allocate(size_t length) noexcept;
+    void Assign(std::wstring_view text);
+    void Invalidate() noexcept;
+    void ReleaseStorage() noexcept;
+};
+
+bool IsHighSurrogate(wchar_t ch) noexcept;
+bool IsLowSurrogate(wchar_t ch) noexcept;
+size_t AdjustSliceStart(std::wstring_view text, size_t start) noexcept;
+size_t AdjustSliceEnd(std::wstring_view text, size_t start, size_t length) noexcept;
+
+} // namespace salamander::unicode

--- a/src/common/unicode.h
+++ b/src/common/unicode.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <initializer_list>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -36,6 +37,7 @@ public:
 
     static SalWideString Duplicate(std::wstring_view text);
     static SalWideString Concat(std::wstring_view first, std::wstring_view second);
+    static SalWideString Concat(std::initializer_list<std::wstring_view> parts);
     static SalWideString Concat(const std::vector<std::wstring_view>& parts);
     static SalWideString Slice(std::wstring_view source, size_t start, size_t length);
 

--- a/src/plugins/pictview/exif/config.h
+++ b/src/plugins/pictview/exif/config.h
@@ -89,8 +89,14 @@
 
 #define ssize_t int
 
-// static inline not supported by MSVC and not usefull here -> define it out
-#define inline
+// MSVC names the C inline keyword __inline.  Keep the semantics intact instead
+// of dropping the keyword entirely (which pulls inline function definitions
+// into every translation unit and breaks the link step with duplicate symbols).
+#if !defined(__cplusplus)
+#    if !defined(inline)
+#        define inline __inline
+#    endif
+#endif
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846

--- a/src/vcxproj/salamand.vcxproj
+++ b/src/vcxproj/salamand.vcxproj
@@ -253,6 +253,8 @@
     </ClCompile>
     <ClCompile Include="..\common\messages.cpp">
     </ClCompile>
+    <ClCompile Include="..\common\unicode.cpp">
+    </ClCompile>
     <ClCompile Include="..\common\moore.cpp">
     </ClCompile>
     <ClCompile Include="..\common\multimon.cpp">
@@ -704,6 +706,8 @@
     <ClInclude Include="..\common\heap.h">
     </ClInclude>
     <ClInclude Include="..\common\messages.h">
+    </ClInclude>
+    <ClInclude Include="..\common\unicode.h">
     </ClInclude>
     <ClInclude Include="..\common\moore.h">
     </ClInclude>

--- a/src/vcxproj/salamand.vcxproj.filters
+++ b/src/vcxproj/salamand.vcxproj.filters
@@ -393,6 +393,9 @@
     <ClCompile Include="..\common\messages.cpp">
       <Filter>common</Filter>
     </ClCompile>
+    <ClCompile Include="..\common\unicode.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
     <ClCompile Include="..\common\moore.cpp">
       <Filter>common</Filter>
     </ClCompile>
@@ -705,6 +708,9 @@
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\common\messages.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\unicode.h">
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\common\moore.h">

--- a/src/vcxproj/salmon/salmon.vcxproj
+++ b/src/vcxproj/salmon/salmon.vcxproj
@@ -127,6 +127,8 @@
     </ClCompile>
     <ClCompile Include="..\..\common\ms_init.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\common\unicode.cpp">
+    </ClCompile>
     <ClCompile Include="..\..\common\str.cpp">
     </ClCompile>
     <ClCompile Include="..\..\common\trace.cpp">
@@ -162,6 +164,8 @@
     <ClInclude Include="..\..\common\lstrfix.h">
     </ClInclude>
     <ClInclude Include="..\..\common\messages.h">
+    </ClInclude>
+    <ClInclude Include="..\..\common\unicode.h">
     </ClInclude>
     <ClInclude Include="..\..\common\str.h">
     </ClInclude>

--- a/src/vcxproj/salmon/salmon.vcxproj.filters
+++ b/src/vcxproj/salmon/salmon.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\..\common\ms_init.cpp">
       <Filter>common</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\common\unicode.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\common\str.cpp">
       <Filter>common</Filter>
     </ClCompile>
@@ -75,6 +78,9 @@
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\common\messages.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\unicode.h">
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\common\str.h">

--- a/src/vcxproj/translator/translator.vcxproj
+++ b/src/vcxproj/translator/translator.vcxproj
@@ -139,6 +139,7 @@
     <ClCompile Include="..\..\common\heap.cpp" />
     <ClCompile Include="..\..\common\lstrfix.cpp" />
     <ClCompile Include="..\..\common\messages.cpp" />
+    <ClCompile Include="..\..\common\unicode.cpp" />
     <ClCompile Include="..\..\common\str.cpp" />
     <ClCompile Include="..\..\common\trace.cpp" />
     <ClCompile Include="..\..\common\winlib.cpp" />
@@ -184,6 +185,7 @@
     <ClInclude Include="..\..\common\handles.h" />
     <ClInclude Include="..\..\common\lstrfix.h" />
     <ClInclude Include="..\..\common\messages.h" />
+    <ClInclude Include="..\..\common\unicode.h" />
     <ClInclude Include="..\..\common\str.h" />
     <ClInclude Include="..\..\common\trace.h" />
     <ClInclude Include="..\..\common\winlib.h" />

--- a/src/vcxproj/translator/translator.vcxproj.filters
+++ b/src/vcxproj/translator/translator.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="..\common\messages.cpp">
       <Filter>Commons</Filter>
     </ClCompile>
+    <ClCompile Include="..\common\unicode.cpp">
+      <Filter>Commons</Filter>
+    </ClCompile>
     <ClCompile Include="..\common\str.cpp">
       <Filter>Commons</Filter>
     </ClCompile>
@@ -210,6 +213,9 @@
       <Filter>Commons</Filter>
     </ClInclude>
     <ClInclude Include="..\common\messages.h">
+      <Filter>Commons</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\unicode.h">
       <Filter>Commons</Filter>
     </ClInclude>
     <ClInclude Include="..\common\str.h">

--- a/src/vcxproj/tserver/tserver.vcxproj
+++ b/src/vcxproj/tserver/tserver.vcxproj
@@ -134,6 +134,7 @@
     <ClCompile Include="..\..\common\heap.cpp" />
     <ClCompile Include="..\..\common\lstrfix.cpp" />
     <ClCompile Include="..\..\common\messages.cpp" />
+    <ClCompile Include="..\..\common\unicode.cpp" />
     <ClCompile Include="..\..\common\multimon.cpp" />
     <ClCompile Include="..\..\common\sheets.cpp" />
     <ClCompile Include="..\..\common\strutils.cpp" />
@@ -160,6 +161,7 @@
     <ClInclude Include="..\..\common\heap.h" />
     <ClInclude Include="..\..\common\lstrfix.h" />
     <ClInclude Include="..\..\common\messages.h" />
+    <ClInclude Include="..\..\common\unicode.h" />
     <ClInclude Include="..\..\common\multimon.h" />
     <ClInclude Include="..\..\common\sheets.h" />
     <ClInclude Include="..\..\common\strutils.h" />

--- a/src/vcxproj/tserver/tserver.vcxproj.filters
+++ b/src/vcxproj/tserver/tserver.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClCompile Include="..\common\messages.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\common\unicode.cpp">
+      <Filter>Common Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\common\trace.cpp">
       <Filter>Common Files</Filter>
     </ClCompile>
@@ -114,6 +117,9 @@
       <Filter>Common Files</Filter>
     </ClInclude>
     <ClInclude Include="..\common\messages.h">
+      <Filter>Common Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\unicode.h">
       <Filter>Common Files</Filter>
     </ClInclude>
     <ClInclude Include="..\common\trace.h">

--- a/tests/unicode_string_tests.cpp
+++ b/tests/unicode_string_tests.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "common/unicode.h"
+#include "common/str.h"
+
+#include <array>
+#include <cassert>
+#include <string>
+
+using salamander::unicode::SalWideString;
+
+void TestDuplicateAndRelease()
+{
+    const wchar_t* sample = L"Unicode 😀 string";
+    SalWideString duplicated = SalWideString::Duplicate(sample);
+    assert(duplicated);
+    assert(std::wstring(sample) == duplicated.to_wstring());
+
+    wchar_t* raw = duplicated.release();
+    assert(raw != nullptr);
+    std::wstring restored(raw);
+    free(raw);
+    assert(restored == sample);
+}
+
+void TestConcatenate()
+{
+    std::wstring left = L"Hello ";
+    std::wstring right = L"世界";
+    SalWideString combined = SalWideString::Concat({left, right});
+    assert(combined);
+    assert(combined.to_wstring() == left + right);
+}
+
+void TestSliceSurrogate()
+{
+    const std::wstring text = L"A\U0001F600B"; // includes surrogate pair for 😀
+    SalWideString slice = SalWideString::Slice(text, 1, 1);
+    assert(slice);
+    assert(slice.length() == 2); // high + low surrogate preserved
+    assert(slice.to_wstring() == L"\U0001F600");
+}
+
+void TestUtf8RoundTrip()
+{
+    const char* utf8Sample = u8"Encoding 😀 test";
+    SalWideString fromUtf8 = SalWideString::FromUtf8(utf8Sample, -1);
+    assert(fromUtf8);
+    std::string utf8 = fromUtf8.ToUtf8();
+    assert(utf8 == utf8Sample);
+}
+
+void TestStrNCatWide()
+{
+    std::array<wchar_t, 16> buffer{};
+    lstrcpyW(buffer.data(), L"Hi");
+    StrNCatW(buffer.data(), L" 😀", static_cast<int>(buffer.size()));
+    assert(std::wstring(buffer.data()) == L"Hi 😀");
+}
+
+int main()
+{
+    TestDuplicateAndRelease();
+    TestConcatenate();
+    TestSliceSurrogate();
+    TestUtf8RoundTrip();
+    TestStrNCatWide();
+    return 0;
+}

--- a/tests/unicode_string_tests.cpp
+++ b/tests/unicode_string_tests.cpp
@@ -6,6 +6,8 @@
 
 #include <array>
 #include <cassert>
+#include <cstdlib>
+#include <cwchar>
 #include <string>
 
 using salamander::unicode::SalWideString;
@@ -20,7 +22,7 @@ void TestDuplicateAndRelease()
     wchar_t* raw = duplicated.release();
     assert(raw != nullptr);
     std::wstring restored(raw);
-    free(raw);
+    std::free(raw);
     assert(restored == sample);
 }
 
@@ -54,7 +56,7 @@ void TestUtf8RoundTrip()
 void TestStrNCatWide()
 {
     std::array<wchar_t, 16> buffer{};
-    lstrcpyW(buffer.data(), L"Hi");
+    std::wcscpy(buffer.data(), L"Hi");
     SalStrNCatW(buffer.data(), L" 😀", static_cast<int>(buffer.size()));
     assert(std::wstring(buffer.data()) == L"Hi 😀");
 }

--- a/tests/unicode_string_tests.cpp
+++ b/tests/unicode_string_tests.cpp
@@ -55,7 +55,7 @@ void TestStrNCatWide()
 {
     std::array<wchar_t, 16> buffer{};
     lstrcpyW(buffer.data(), L"Hi");
-    StrNCatW(buffer.data(), L" 😀", static_cast<int>(buffer.size()));
+    SalStrNCatW(buffer.data(), L" 😀", static_cast<int>(buffer.size()));
     assert(std::wstring(buffer.data()) == L"Hi 😀");
 }
 


### PR DESCRIPTION
## Summary
- add a SalWideString RAII helper with duplication, concatenation, slicing, and multibyte conversions
- refactor ConvertA2U/ConvertU2A to reuse the wide-string core and improve error handling
- extend str.cpp with wide-character duplication/catenation helpers and update case tables via LCMapStringEx
- add unit tests exercising surrogate-aware helpers and UTF-8 round-trips

## Testing
- Not run (Windows-only build system unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9b99d3f7c8329a0b7e1919b5ee7cf