### PR TITLE
Fix duplicate tab shortcut on first tab

### DIFF
--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -1584,7 +1584,7 @@ LRESULT CTabWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         pt.x = pts.x;
         pt.y = pts.y;
         int hit = HitTest(pt);
-        if (hit > 0 && !IsNewTabButtonIndex(hit) && MainWindow != NULL)
+        if (hit >= 0 && !IsNewTabButtonIndex(hit) && MainWindow != NULL)
         {
             MainWindow->CommandDuplicateTab(Side, hit);
             return 0;


### PR DESCRIPTION
## Summary
- allow the WM_LBUTTONDBLCLK handler to target the first tab as well
- enable duplicate-tab shortcut to work on the default tab

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dacf4feccc8329abecc02e0afbff25