### PR TITLE
Defer panel activation during configuration load

### DIFF
--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -555,7 +555,7 @@ public:
     void FocusPanel(CFilesWindow* focus, BOOL testIfMainWndActive = FALSE); // clears EditMode because focus is put into the panel
     void FocusLeftPanel();                                                  // calls FocusPanel for the left panel
 
-    CFilesWindow* AddPanelTab(CPanelSide side, int index = -1);
+    CFilesWindow* AddPanelTab(CPanelSide side, int index = -1, bool activate = true);
     bool InsertPanelTabInstance(CPanelSide side, int index, CFilesWindow* panel, bool preserveLockState);
     void SwitchPanelTab(CFilesWindow* panel);
     void ClosePanelTab(CFilesWindow* panel, bool storeForReopen = true);

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -2716,7 +2716,7 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
 
     if (tabs.Count == 0)
     {
-        CFilesWindow* panel = AddPanelTab(side, 0);
+        CFilesWindow* panel = AddPanelTab(side, 0, false);
         if (panel != NULL)
         {
             DWORD style = WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
@@ -2751,7 +2751,7 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
     while (tabs.Count < tabCount)
     {
         CFilesWindow* previous = (side == cpsLeft) ? LeftPanel : RightPanel;
-        CFilesWindow* panel = AddPanelTab(side, tabs.Count);
+        CFilesWindow* panel = AddPanelTab(side, tabs.Count, false);
         if (panel == NULL)
             break;
 

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -94,7 +94,7 @@ namespace
     constexpr size_t kMaxStoredClosedTabs = 10;
 }
 
-CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side, int index)
+CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side, int index, bool activate)
 {
     CALL_STACK_MESSAGE2("CMainWindow::AddPanelTab(%d)", side);
     CFilesWindow* panel = new CFilesWindow(this, side);
@@ -107,7 +107,8 @@ CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side, int index)
         return NULL;
     }
 
-    SwitchPanelTab(panel);
+    if (activate)
+        SwitchPanelTab(panel);
     return panel;
 }
 
@@ -1326,7 +1327,7 @@ void CMainWindow::CommandNewTab(CPanelSide side, bool addAtEnd)
 
     CFilesWindow* previous = (side == cpsLeft) ? LeftPanel : RightPanel;
 
-    CFilesWindow* panel = AddPanelTab(side, insertIndex);
+    CFilesWindow* panel = AddPanelTab(side, insertIndex, false);
     if (panel == NULL)
         return;
 
@@ -1567,7 +1568,7 @@ CFilesWindow* CMainWindow::CreateDuplicatePanelTab(CPanelSide targetSide, CFiles
 
     CFilesWindow* previousTarget = (targetSide == cpsLeft) ? LeftPanel : RightPanel;
 
-    CFilesWindow* newPanel = AddPanelTab(targetSide, insertIndex);
+    CFilesWindow* newPanel = AddPanelTab(targetSide, insertIndex, false);
     if (newPanel == NULL)
         return NULL;
 
@@ -1730,7 +1731,7 @@ bool CMainWindow::CommandReopenClosedTab(CPanelSide side)
 
     CFilesWindow* previous = (side == cpsLeft) ? LeftPanel : RightPanel;
 
-    CFilesWindow* panel = AddPanelTab(side, insertIndex);
+    CFilesWindow* panel = AddPanelTab(side, insertIndex, false);
     if (panel == NULL)
     {
         ClosedPanelTabs[vectorIndex].push_back(std::move(entry));


### PR DESCRIPTION
## Summary
- add an optional activation flag to `AddPanelTab` so tab creation can defer refresh work
- stop switching to every tab during `LoadPanelConfig` to avoid redundant startup refreshes
- update tab-creation helpers to request activation explicitly when they need it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db1525cbcc8329ac79efeaabb5b5fd