### PR TITLE
Defer loading inactive tab settings until activation

### DIFF
--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -3334,10 +3334,7 @@ CViewModeEnum
 CFilesWindow::GetViewMode()
 {
     if (ListBox == NULL)
-    {
-        TRACE_E("ListBox == NULL");
-        return vmDetailed;
-    }
+        return StoredViewMode;
     return ListBox->ViewMode;
 }
 

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -1616,7 +1616,7 @@ CFilesWindow::~CFilesWindow()
 
 bool CFilesWindow::EnsureLightInitialization()
 {
-    if (!LightInitializationPending && FileArraysInitialized && ContextSubmenuNew != NULL && PathHistory != NULL &&
+    if (!LightInitializationPending && AreFileArraysInitialized() && ContextSubmenuNew != NULL && PathHistory != NULL &&
         ExecuteAssocEvent != NULL && ICSleepSectionInitialized && ICSectionUsingIconInitialized &&
         ICSectionUsingThumbInitialized)
     {

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -1551,6 +1551,8 @@ CFilesWindow::CFilesWindow(CMainWindow* parent, CPanelSide side, bool deferHeavy
     HeavyInitializationPending = true;
     DeferredInitialPathValid = false;
     DeferredInitialPath[0] = 0;
+    PendingConfigPathValid = false;
+    PendingConfigPath[0] = 0;
     DeferredWorkDirHistoryPending = false;
     DeferredWorkDirHistorySubKey.clear();
     DeferredPanelSettingsFromRegistry = false;

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -925,6 +925,8 @@ void CFilesWindow::ToggleDirectoryLine()
     // if the middle toolbar is displayed, give it a chance to position itself
     if (MainWindow->MiddleToolBar != NULL && MainWindow->MiddleToolBar->HWindow != NULL)
         MainWindow->LayoutWindows();
+
+    DirectoryLineVisible = (DirectoryLine->HWindow != NULL);
 }
 
 void CFilesWindow::ToggleStatusLine()
@@ -957,6 +959,8 @@ void CFilesWindow::ToggleStatusLine()
                 MAKELONG(r.right - r.left, r.bottom - r.top));
     if (StatusLine->HWindow != NULL)
         ShowWindow(StatusLine->HWindow, SW_SHOW);
+
+    StatusLineVisible = (StatusLine->HWindow != NULL);
 }
 
 void CFilesWindow::ToggleHeaderLine()
@@ -966,6 +970,23 @@ void CFilesWindow::ToggleHeaderLine()
     if (GetViewMode() == vmBrief)
         headerLine = FALSE;
     ListBox->SetMode(GetViewMode() == vmBrief ? vmBrief : vmDetailed, headerLine);
+    HeaderLineVisible = headerLine;
+}
+
+void CFilesWindow::ApplyStoredVisualState()
+{
+    if (HWindow == NULL)
+        return;
+
+    if (!!StatusLineVisible != !!(StatusLine != NULL && StatusLine->HWindow != NULL))
+        ToggleStatusLine();
+
+    if (!!DirectoryLineVisible != !!(DirectoryLine != NULL && DirectoryLine->HWindow != NULL))
+        ToggleDirectoryLine();
+
+    BOOL currentHeader = (ListBox != NULL && ListBox->HeaderLineVisible);
+    if (!!HeaderLineVisible != !!currentHeader)
+        ToggleHeaderLine();
 }
 
 int CFilesWindow::GetViewTemplateIndex()
@@ -1031,6 +1052,7 @@ BOOL CFilesWindow::SelectViewTemplate(int templateIndex, BOOL canRefreshPath,
 
     if (templateIndex == 0)
         return FALSE;
+
     CViewTemplate* newTemplate = &Parent->ViewTemplates.Items[templateIndex];
     if (lstrlen(newTemplate->Name) == 0)
     {
@@ -1039,10 +1061,13 @@ BOOL CFilesWindow::SelectViewTemplate(int templateIndex, BOOL canRefreshPath,
         newTemplate = &Parent->ViewTemplates.Items[templateIndex];
     }
 
-    CViewModeEnum oldViewMode = GetViewMode();
+    const bool hasListBox = (ListBox != NULL);
+    CViewModeEnum oldViewMode = hasListBox ? ListBox->ViewMode :
+                                             static_cast<CViewModeEnum>(ViewTemplate->Mode);
+    CViewModeEnum newViewMode = oldViewMode;
+
     if (!calledFromPluginBeforeListing || ViewTemplate != newTemplate)
     {
-        CViewModeEnum newViewMode;
         switch (templateIndex)
         {
             //      case 0: newViewMode = vmTree; break;
@@ -1062,20 +1087,32 @@ BOOL CFilesWindow::SelectViewTemplate(int templateIndex, BOOL canRefreshPath,
             newViewMode = vmDetailed;
             break;
         }
-        ViewTemplate = newTemplate;
 
-        BOOL headerLine = HeaderLineVisible;
-        if (newViewMode != vmDetailed)
-            headerLine = FALSE;
-        ListBox->SetMode(newViewMode, headerLine);
+        ViewTemplate = newTemplate;
+        StoredViewMode = newViewMode;
+
+        if (hasListBox)
+        {
+            BOOL headerLine = HeaderLineVisible;
+            if (newViewMode != vmDetailed)
+                headerLine = FALSE;
+            ListBox->SetMode(newViewMode, headerLine);
+        }
+        else if (newViewMode != vmDetailed)
+        {
+            // without a list box we cannot toggle the header immediately; remember the desired state
+            HeaderLineVisible = FALSE;
+        }
     }
+    else
+        StoredViewMode = newViewMode;
 
     // we build new columns
     BuildColumnsTemplate();
     CopyColumnsTemplateToColumns();
     DeleteColumnsWithoutData(columnValidMask);
 
-    if (!calledFromPluginBeforeListing)
+    if (!calledFromPluginBeforeListing && hasListBox)
     {
         if (PluginData.NotEmpty())
         {
@@ -1087,9 +1124,9 @@ BOOL CFilesWindow::SelectViewTemplate(int templateIndex, BOOL canRefreshPath,
 
         // once the view mode differs we must refresh (a different icon or thumbnail size is required)
         // the only exception is brief and detailed, which share the same icons
-        BOOL needRefresh = oldViewMode != GetViewMode() &&
-                           (oldViewMode != vmBrief || GetViewMode() != vmDetailed) &&
-                           (oldViewMode != vmDetailed || GetViewMode() != vmBrief);
+        BOOL needRefresh = oldViewMode != newViewMode &&
+                           (oldViewMode != vmBrief || newViewMode != vmDetailed) &&
+                           (oldViewMode != vmDetailed || newViewMode != vmBrief);
         if (canRefreshPath && needRefresh)
         {
             // until ReadDirectory we work with simple icons because the icon geometry changes
@@ -1120,7 +1157,7 @@ BOOL CFilesWindow::SelectViewTemplate(int templateIndex, BOOL canRefreshPath,
     }
 
     // when the panel mode changes we must clear saved top-indices (incompatible data are being stored)
-    if (oldViewMode != GetViewMode())
+    if (oldViewMode != newViewMode)
         TopIndexMem.Clear();
 
     return TRUE;

--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -2718,12 +2718,16 @@ void CFilesWindow::ChangeDrive(char drive)
 void CFilesWindow::UpdateFilterSymbol()
 {
     CALL_STACK_MESSAGE_NONE
+    if (DirectoryLine == NULL)
+        return;
     DirectoryLine->SetHidden(HiddenFilesCount, HiddenDirsCount);
 }
 
 void CFilesWindow::UpdateDriveIcon(BOOL check)
 {
     CALL_STACK_MESSAGE2("CFilesWindow::UpdateDriveIcon(%d)", check);
+    if (DirectoryLine == NULL)
+        return;
     if (Is(ptDisk))
     {
         if (!check || CheckPath(FALSE) == ERROR_SUCCESS)

--- a/src/fileswn9.cpp
+++ b/src/fileswn9.cpp
@@ -730,7 +730,8 @@ void CFilesWindow::ChangeFilter(BOOL disable)
         PostMessage(HWindow, WM_USER_REFRESH_DIR, 0, t1);
         UpdateFilterSymbol();
         DirectoryLineSetText();
-        DirectoryLine->InvalidateIfNeeded();
+        if (DirectoryLine != NULL)
+            DirectoryLine->InvalidateIfNeeded();
     }
     UpdateWindow(MainWindow->HWindow);
     EndStopRefresh();

--- a/src/fileswn9.cpp
+++ b/src/fileswn9.cpp
@@ -112,6 +112,36 @@ void CFilesWindow::ClearCustomTabPrefix()
     CustomTabPrefixValid = false;
 }
 
+void CFilesWindow::SetPendingConfigPath(const char* path)
+{
+    CALL_STACK_MESSAGE_NONE
+    if (path != NULL && path[0] != 0)
+    {
+        lstrcpyn(PendingConfigPath, path, _countof(PendingConfigPath));
+        PendingConfigPathValid = true;
+    }
+    else
+    {
+        ClearPendingConfigPath();
+    }
+}
+
+void CFilesWindow::ClearPendingConfigPath()
+{
+    CALL_STACK_MESSAGE_NONE
+    PendingConfigPathValid = false;
+    PendingConfigPath[0] = 0;
+}
+
+bool CFilesWindow::CopyPendingConfigPath(char* buffer, int bufferSize) const
+{
+    if (!PendingConfigPathValid || buffer == NULL || bufferSize <= 0)
+        return false;
+
+    lstrcpyn(buffer, PendingConfigPath, bufferSize);
+    return true;
+}
+
 int CFilesWindow::GetPanelCode()
 {
     CALL_STACK_MESSAGE_NONE

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -1500,20 +1500,23 @@ void CFilesWindow::SetThumbnailSize(int size)
     if (ListBox == NULL)
     {
         TRACE_E("ListBox == NULL");
+        return;
     }
-    else
-    {
-        if (size != ListBox->ThumbnailWidth || size != ListBox->ThumbnailHeight)
-        {
-            // vycisteni icon-cache
-            SleepIconCacheThread();
-            IconCache->Release();
-            EndOfIconReadingTime = GetTickCount() - 10000;
 
-            ListBox->ThumbnailWidth = size;
-            ListBox->ThumbnailHeight = size;
-        }
+    if (size == ListBox->ThumbnailWidth && size == ListBox->ThumbnailHeight)
+        return;
+
+    // vycisteni icon-cache (pokud uz byla pripravena)
+    if (IconCache != NULL)
+    {
+        SleepIconCacheThread();
+        IconCache->Release();
     }
+
+    EndOfIconReadingTime = GetTickCount() - 10000;
+
+    ListBox->ThumbnailWidth = size;
+    ListBox->ThumbnailHeight = size;
 }
 
 int CFilesWindow::GetThumbnailSize()

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -846,6 +846,8 @@ public:
 
     bool DeferredInitialPathValid;
     char DeferredInitialPath[2 * MAX_PATH];
+    bool PendingConfigPathValid;
+    char PendingConfigPath[2 * MAX_PATH];
     bool DeferredWorkDirHistoryPending;
     std::string DeferredWorkDirHistorySubKey;
     CDeferredPanelSettings DeferredPanelSettings;
@@ -1007,6 +1009,10 @@ public:
     void ClearCustomTabPrefix();
     bool IsTabLocked() const { return TabLocked; }
     void SetTabLocked(bool locked) { TabLocked = locked; }
+    void SetPendingConfigPath(const char* path);
+    void ClearPendingConfigPath();
+    bool HasPendingConfigPath() const { return PendingConfigPathValid; }
+    bool CopyPendingConfigPath(char* buffer, int bufferSize) const;
 
     BOOL IsGood() { return DirectoryLine != NULL &&
                            StatusLine != NULL && ListBox != NULL && Files != NULL && Dirs != NULL &&

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -517,6 +517,7 @@ private:
 protected:
     void PromoteFileArraysToStandardCapacity();
     bool EnsureFileArraysAllocated();
+    bool AreFileArraysInitialized() const { return FileArraysInitialized; }
 
 public:
     // contents of all columns shown in the panel (both basic data and plug-in data for archives and FS)

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -509,6 +509,10 @@ private:
     // when viewing an archive listed by a plugin or within a plugin FS
     CPluginInterfaceAbstract* PluginIface; // use exclusively for locating the plugin in Plugins (not for invoking methods)
     int PluginIfaceLastIndex;              // index of PluginIface in Plugins during the last search, use only to locate the plugin
+    bool ReducedFileArrayCapacity;
+
+protected:
+    void PromoteFileArraysToStandardCapacity();
 
 public:
     // contents of all columns shown in the panel (both basic data and plug-in data for archives and FS)
@@ -536,7 +540,7 @@ public:
     CIconCache* NewFSIconCache;             // if not NULL, new empty object for IconCache (not here, in the descendant)
 
 public:
-    CFilesWindowAncestor();
+    CFilesWindowAncestor(int filesBase = 200, int filesDelta = 800);
     ~CFilesWindowAncestor();
 
     // NULL -> Path; echo && err != ERROR_SUCCESS -> only report the error

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -510,9 +510,13 @@ private:
     CPluginInterfaceAbstract* PluginIface; // use exclusively for locating the plugin in Plugins (not for invoking methods)
     int PluginIfaceLastIndex;              // index of PluginIface in Plugins during the last search, use only to locate the plugin
     bool ReducedFileArrayCapacity;
+    bool FileArraysInitialized;
+    int InitialFilesBase;
+    int InitialFilesDelta;
 
 protected:
     void PromoteFileArraysToStandardCapacity();
+    bool EnsureFileArraysAllocated();
 
 public:
     // contents of all columns shown in the panel (both basic data and plug-in data for archives and FS)

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -462,6 +462,7 @@ public:
 
     BOOL PanelConfigPathsRestoredLeft;
     BOOL PanelConfigPathsRestoredRight;
+    bool RestoringPanelConfiguration;
 
     BOOL DragMode;
     int DragSplitX;
@@ -555,15 +556,18 @@ public:
     void FocusPanel(CFilesWindow* focus, BOOL testIfMainWndActive = FALSE); // clears EditMode because focus is put into the panel
     void FocusLeftPanel();                                                  // calls FocusPanel for the left panel
 
-    CFilesWindow* AddPanelTab(CPanelSide side, int index = -1);
+    CFilesWindow* AddPanelTab(CPanelSide side, int index = -1, bool activate = true,
+                              bool deferInitialization = false);
+    bool EnsurePanelWindowCreated(CFilesWindow* panel);
     bool InsertPanelTabInstance(CPanelSide side, int index, CFilesWindow* panel, bool preserveLockState);
-    void SwitchPanelTab(CFilesWindow* panel);
+    void SwitchPanelTab(CFilesWindow* panel, bool requestRefresh = true, bool allowAutomaticRefresh = true);
     void ClosePanelTab(CFilesWindow* panel, bool storeForReopen = true);
     void EnsurePanelAutomaticRefresh(CFilesWindow* panel);
     void EnsurePanelRefreshAndRequest(CFilesWindow* panel, bool rebuildDriveBars,
                                       bool postRefreshMessage = false);
     void RequestPanelRefresh(CFilesWindow* panel, bool rebuildDriveBars,
                              bool postRefreshMessage = false);
+    void EnsurePanelWorkDirHistoryLoaded(CFilesWindow* panel);
     void UpdatePanelTabTitle(CFilesWindow* panel);
     void UpdatePanelTabColor(CFilesWindow* panel);
     void OnPanelTabSelected(CPanelSide side, int index);
@@ -630,6 +634,9 @@ public:
     BOOL LoadConfig(BOOL importingOldConfig, const CCommandLineParams* cmdLineParams);
     void SavePanelConfig(CPanelSide side, HKEY hSalamander, const char* reg);
     void LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalamander, const char* reg);
+    BOOL RestorePanelPathFromConfig(CFilesWindow* panel, const char* path);
+    BOOL ApplyDeferredStartupPath(CFilesWindow* panel);
+    void EnsurePanelSettingsLoadedFromRegistry(CFilesWindow* panel);
     void DeleteOldConfigurations(BOOL* deleteConfigurations, BOOL autoImportConfig,
                                  const char* autoImportConfigFromKey, BOOL doNotDeleteImportedCfg);
 

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -561,6 +561,7 @@ public:
     bool EnsurePanelWindowCreated(CFilesWindow* panel);
     bool InsertPanelTabInstance(CPanelSide side, int index, CFilesWindow* panel, bool preserveLockState);
     void SwitchPanelTab(CFilesWindow* panel, bool requestRefresh = true, bool allowAutomaticRefresh = true);
+    void AdoptRestoredPanel(CFilesWindow* panel);
     void ClosePanelTab(CFilesWindow* panel, bool storeForReopen = true);
     void EnsurePanelAutomaticRefresh(CFilesWindow* panel);
     void EnsurePanelRefreshAndRequest(CFilesWindow* panel, bool rebuildDriveBars,

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -360,6 +360,7 @@ CMainWindow::CMainWindow()
 
     PanelConfigPathsRestoredLeft = FALSE;
     PanelConfigPathsRestoredRight = FALSE;
+    RestoringPanelConfiguration = false;
 
     ToolTip = new CToolTip(ooStatic);
 
@@ -1760,7 +1761,7 @@ void CMainWindow::FormatPanelPathForDisplay(CFilesWindow* panel, int mode, char*
 
     char generalPath[2 * MAX_PATH];
     generalPath[0] = 0;
-    panel->GetGeneralPath(generalPath, _countof(generalPath));
+    panel->GetStoredGeneralPath(generalPath, _countof(generalPath));
 
     switch (mode)
     {

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1747,6 +1747,12 @@ void CMainWindow::FormatPanelPathForDisplay(CFilesWindow* panel, int mode, char*
     if (mode < TITLE_BAR_MODE_DIRECTORY || mode > TITLE_BAR_MODE_FULLPATH)
         mode = TITLE_BAR_MODE_DIRECTORY;
 
+    if (panel->HasPendingConfigPath())
+    {
+        if (panel->CopyPendingConfigPath(buffer, bufferSize))
+            return;
+    }
+
     CPluginFSInterfaceEncapsulation* pluginFS = NULL;
     BOOL pluginTitleService = FALSE;
     if (panel->Is(ptPluginFS))

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -2882,7 +2882,7 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
 
             UpdatePanelTabTitle(panel);
 
-            SwitchPanelTab(panel, false, false);
+            AdoptRestoredPanel(panel);
         }
 
         CloseKey(actKey);
@@ -3019,7 +3019,7 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
 
     if (activePanel != NULL)
     {
-        SwitchPanelTab(activePanel, false, false);
+        AdoptRestoredPanel(activePanel);
     }
 
     UpdatePanelTabVisibility(side);

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -2880,39 +2880,11 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
             else
                 panel->ClearDeferredInitialPath();
 
-            if (EnsurePanelWindowCreated(panel))
-            {
-                if (side == cpsLeft)
-                    LeftPanel = panel;
-                else
-                    RightPanel = panel;
-
-                panel->SetPanelSide(side);
-                panel->ApplyDeferredPanelSettings();
-                EnsurePanelWorkDirHistoryLoaded(panel);
-
-                BOOL restored = ApplyDeferredStartupPath(panel);
-                if (restored)
-                {
-                    if (side == cpsLeft)
-                        PanelConfigPathsRestoredLeft = TRUE;
-                    else
-                        PanelConfigPathsRestoredRight = TRUE;
-                }
-
-                if (UsingSharedWorkDirHistory())
-                    UpdateAllDirectoryLineHistoryStates();
-                else
-                    UpdateDirectoryLineHistoryState(panel);
-            }
-
             UpdatePanelTabTitle(panel);
+
+            SwitchPanelTab(panel, false, false);
         }
 
-        UpdatePanelTabVisibility(side);
-        CTabWindow* tabWnd = GetPanelTabWindow(side);
-        if (tabWnd != NULL && tabWnd->HWindow != NULL && tabWnd->GetCurSel() != 0)
-            tabWnd->SetCurSel(0);
         CloseKey(actKey);
         return;
     }
@@ -3047,29 +3019,7 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
 
     if (activePanel != NULL)
     {
-        if (EnsurePanelWindowCreated(activePanel))
-        {
-            if (side == cpsLeft)
-                LeftPanel = activePanel;
-            else
-                RightPanel = activePanel;
-
-            activePanel->SetPanelSide(side);
-
-            activePanel->ApplyDeferredPanelSettings();
-
-            EnsurePanelWorkDirHistoryLoaded(activePanel);
-
-            if (UsingSharedWorkDirHistory())
-                UpdateAllDirectoryLineHistoryStates();
-            else
-                UpdateDirectoryLineHistoryState(activePanel);
-
-            int sel = GetPanelTabIndex(side, activePanel);
-            CTabWindow* tabWnd = GetPanelTabWindow(side);
-            if (tabWnd != NULL && tabWnd->HWindow != NULL && sel >= 0)
-                tabWnd->SetCurSel(sel);
-        }
+        SwitchPanelTab(activePanel, false, false);
     }
 
     UpdatePanelTabVisibility(side);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -270,7 +270,7 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel, bool requestRefresh, bool 
         return;
 
     bool alreadyActive = (previousActive == panel);
-    if (alreadyActive && panel->HWindow != NULL && !panel->HasDeferredInitialPath())
+    if (alreadyActive && panel->HWindow != NULL && !panel->HasDeferredInitialPath() && !panel->HasPendingConfigPath())
     {
         CTabWindow* tabWnd = GetPanelTabWindow(side);
         if (tabWnd != NULL && tabWnd->HWindow != NULL)
@@ -326,6 +326,11 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel, bool requestRefresh, bool 
 
     char deferredPath[2 * MAX_PATH];
     bool hadDeferredPath = panel->ConsumeDeferredInitialPath(deferredPath, _countof(deferredPath));
+    if (!hadDeferredPath && panel->HasPendingConfigPath())
+    {
+        if (panel->CopyPendingConfigPath(deferredPath, _countof(deferredPath)))
+            hadDeferredPath = true;
+    }
     if (allowAutomaticRefresh)
     {
         panel->EnsureHeavyInitialization();
@@ -336,6 +341,8 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel, bool requestRefresh, bool 
                 PanelConfigPathsRestoredLeft = restored;
             else if (side == cpsRight && !PanelConfigPathsRestoredRight)
                 PanelConfigPathsRestoredRight = restored;
+            if (!restored)
+                panel->SetDeferredInitialPath(deferredPath);
         }
     }
     else if (hadDeferredPath)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -390,6 +390,52 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel, bool requestRefresh, bool 
     }
 }
 
+void CMainWindow::AdoptRestoredPanel(CFilesWindow* panel)
+{
+    if (panel == NULL)
+        return;
+
+    CPanelSide side = panel->GetPanelSide();
+    if (!EnsurePanelWindowCreated(panel))
+        return;
+
+    if (side == cpsLeft)
+        LeftPanel = panel;
+    else
+        RightPanel = panel;
+
+    panel->SetPanelSide(side);
+
+    EnsurePanelSettingsLoadedFromRegistry(panel);
+    panel->ApplyDeferredPanelSettings();
+    EnsurePanelWorkDirHistoryLoaded(panel);
+
+    if (UsingSharedWorkDirHistory())
+        UpdateAllDirectoryLineHistoryStates();
+    else
+        UpdateDirectoryLineHistoryState(panel);
+
+    CFilesWindow* currentActive = GetActivePanel();
+    bool activateSameSide = (currentActive == NULL || currentActive->GetPanelSide() == side);
+    if (activateSameSide)
+    {
+        SetActivePanel(panel);
+        if (Created)
+            EditWindowSetDirectory();
+    }
+
+    CTabWindow* tabWnd = GetPanelTabWindow(side);
+    if (tabWnd != NULL && tabWnd->HWindow != NULL)
+    {
+        int index = GetPanelTabIndex(side, panel);
+        if (index >= 0 && tabWnd->GetCurSel() != index)
+            tabWnd->SetCurSel(index);
+    }
+
+    UpdatePanelTabTitle(panel);
+    UpdatePanelTabVisibility(side);
+}
+
 void CMainWindow::ClosePanelTab(CFilesWindow* panel, bool storeForReopen)
 {
     CALL_STACK_MESSAGE1("CMainWindow::ClosePanelTab()");


### PR DESCRIPTION
## Summary
- record registry subkeys for inactive tabs during configuration load instead of reading all panel settings immediately
- lazily hydrate deferred panel settings when a tab is activated so only the active panel performs registry work at startup
- add helpers on CFilesWindow to track deferred registry state and clear it once the settings are realized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db1525cbcc8329ac79efeaabb5b5fd