### PR TITLE
Adjust dark mode scheme ordering and customization

### DIFF
--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -755,6 +755,7 @@ protected:
     CHighlightMasks* SourceHighlightMasks;
 
     BOOL Dirty;
+    int SelectedSchemeId;
 
 public:
     CCfgPageColors();
@@ -769,6 +770,7 @@ protected:
     void LoadMasks();
     void StoreMasks();
     void EnableControls();
+    void OnSchemeChanged();
 };
 
 //

--- a/src/consts.h
+++ b/src/consts.h
@@ -871,7 +871,6 @@ void AlterFileName(char* tgtName, char* filename, int filenameLen, int format, i
 void GetFileOverwriteInfo(char* buff, int buffLen, HANDLE file, const char* fileName, FILETIME* fileTime = NULL, BOOL* getTimeFailed = NULL);
 
 void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons);                // volat po zmene barev
-void WindowsDarkModeBuildPalette(SALCOLOR* colors, SALCOLOR* viewerColors);
 HICON GetDriveIcon(const char* root, UINT type, BOOL accessible, BOOL large = FALSE); // ikona drivu
 HICON SalLoadIcon(HINSTANCE hDLL, int id, int iconSize);
 
@@ -1273,6 +1272,8 @@ extern SALCOLOR NortonColors[NUMBER_OF_COLORS];     // standardni barvy
 extern SALCOLOR NavigatorColors[NUMBER_OF_COLORS];  // standardni barvy
 
 extern SALCOLOR ViewerColors[NUMBER_OF_VIEWERCOLORS]; // barvy vieweru
+
+void WindowsDarkModeBuildPalette(SALCOLOR* colors, SALCOLOR* viewerColors);
 
 extern COLORREF CustomColors[NUMBER_OF_CUSTOMCOLORS]; // pro standardni color dialog
 

--- a/src/consts.h
+++ b/src/consts.h
@@ -871,6 +871,7 @@ void AlterFileName(char* tgtName, char* filename, int filenameLen, int format, i
 void GetFileOverwriteInfo(char* buff, int buffLen, HANDLE file, const char* fileName, FILETIME* fileTime = NULL, BOOL* getTimeFailed = NULL);
 
 void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons);                // volat po zmene barev
+void WindowsDarkModeBuildPalette(SALCOLOR* colors, SALCOLOR* viewerColors);
 HICON GetDriveIcon(const char* root, UINT type, BOOL accessible, BOOL large = FALSE); // ikona drivu
 HICON SalLoadIcon(HINSTANCE hDLL, int id, int iconSize);
 


### PR DESCRIPTION
## Summary
- reorder the configuration color scheme list so the custom entry precedes Windows Dark Mode
- track the selected scheme state and initialize Windows dark colors without forcing a switch to custom
- update the Windows dark palette handling to respect user edits and expose a helper for initializing the defaults

## Testing
- Not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc14d642948329bc8580cdbc4c08f4