### PR TITLE
Fix dark mode tab bar flicker

### DIFF
--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -1551,6 +1551,25 @@ LRESULT CTabWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CTabWindow::WindowProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_ERASEBKGND:
+    {
+        HDC hdc = reinterpret_cast<HDC>(wParam);
+        if (hdc != NULL && HWindow != NULL)
+        {
+            RECT clientRect;
+            if (GetClientRect(HWindow, &clientRect))
+            {
+                HBRUSH brush = CreateSolidBrush(ResolveDefaultTabColor());
+                if (brush != NULL)
+                {
+                    FillRect(hdc, &clientRect, brush);
+                    DeleteObject(brush);
+                }
+            }
+        }
+        return TRUE;
+    }
+
     case WM_PAINT:
     {
         RECT updateRect;


### PR DESCRIPTION
## Summary
- draw the tab control background ourselves so the dark scheme no longer flashes white during redraws

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc31807a688329b99b18c9677a5af2