### PR TITLE
Reduce tab bar flicker with buffered painting

### DIFF
--- a/src/tabwnd.h
+++ b/src/tabwnd.h
@@ -81,6 +81,8 @@ private:
     STabColor* GetTabColor(int index);
     const STabColor* GetTabColor(int index) const;
     bool TryResolveTabColor(int index, COLORREF& color) const;
+    void PaintWithBase(HDC hdc, const RECT* clipRect, bool paintTabs, bool paintIndicator);
+    bool PaintBuffered(HDC targetDC, const RECT& updateRect, bool paintTabs, bool paintIndicator);
     void PaintCustomTabs(HDC hdc, const RECT* clipRect) const;
     void DrawColoredTab(HDC hdc, const RECT& itemRect, const wchar_t* text, COLORREF baseColor,
                         bool selected, bool hot, bool hasFocus) const;


### PR DESCRIPTION
## Fix #135 

## Summary
- add helpers to reuse default tab control painting while layering custom drawing
- switch WM_PAINT handling to a buffered path to avoid visible redraws when changing tabs
- update WM_PRINTCLIENT to share the same painting routine for consistent rendering

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc39f23f948329ad527894e06a7743