### PR TITLE
Adjust Windows dark mode hot active color

### DIFF
--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -386,6 +386,7 @@ static void BuildWindowsDarkPalette(SALCOLOR* target, SALCOLOR* viewerTarget)
     const COLORREF progressBg = RGB(64, 64, 64);
     const COLORREF inactiveCaptionBg = RGB(45, 45, 48);
     const COLORREF inactiveCaptionFg = RGB(190, 190, 190);
+    const COLORREF hotActive = RGB(0, 0, 0);
     const COLORREF thumbnailFrame = RGB(94, 94, 94);
 
     auto setColor = [](SALCOLOR& entry, COLORREF color) {
@@ -421,7 +422,7 @@ static void BuildWindowsDarkPalette(SALCOLOR* target, SALCOLOR* viewerTarget)
     setColor(target[PROGRESS_BK_SELECTED], accent);
 
     setColor(target[HOT_PANEL], accent);
-    setColor(target[HOT_ACTIVE], accent);
+    setColor(target[HOT_ACTIVE], hotActive);
     setColor(target[HOT_INACTIVE], accent);
 
     setColor(target[ACTIVE_CAPTION_FG], accentText);


### PR DESCRIPTION
## Summary
- set the Windows dark mode color palette to render Hot Items - Active Caption as black for better contrast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd72ae67308329926290d14022b13e