### PR TITLE
Fix viewer colors when leaving Windows dark mode

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -1274,6 +1274,7 @@ extern SALCOLOR NavigatorColors[NUMBER_OF_COLORS];  // standardni barvy
 extern SALCOLOR ViewerColors[NUMBER_OF_VIEWERCOLORS]; // barvy vieweru
 
 void WindowsDarkModeBuildPalette(SALCOLOR* colors, SALCOLOR* viewerColors);
+void ResetViewerColorsToDefaults();
 
 extern COLORREF CustomColors[NUMBER_OF_CUSTOMCOLORS]; // pro standardni color dialog
 

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -488,7 +488,6 @@ static void WindowsDarkModeUpdatePalette(bool useDarkColors)
         gWindowsDarkPaletteAppliedInitialized = false;
     }
 
-    bool capturedViewerBackup = false;
     if (!gWindowsDarkPaletteActive)
     {
         gWindowsDarkPaletteTarget = target;
@@ -498,52 +497,64 @@ static void WindowsDarkModeUpdatePalette(bool useDarkColors)
         gWindowsDarkPaletteActive = true;
         gWindowsDarkPaletteCustomized = false;
         gWindowsDarkPaletteAppliedInitialized = false;
-        capturedViewerBackup = true;
-    }
 
-    SALCOLOR defaultColors[NUMBER_OF_COLORS];
-    SALCOLOR defaultViewer[NUMBER_OF_VIEWERCOLORS];
-    WindowsDarkModeBuildPalette(defaultColors, defaultViewer);
-
-    if (capturedViewerBackup)
+        SALCOLOR defaultColors[NUMBER_OF_COLORS];
+        SALCOLOR defaultViewer[NUMBER_OF_VIEWERCOLORS];
+        WindowsDarkModeBuildPalette(defaultColors, defaultViewer);
         gWindowsDarkViewerBackupIsDark =
             memcmp(gWindowsDarkViewerBackup, defaultViewer, sizeof(defaultViewer)) == 0;
-
-    bool matchesDefault = memcmp(target, defaultColors, sizeof(defaultColors)) == 0 &&
-                          memcmp(ViewerColors, defaultViewer, sizeof(defaultViewer)) == 0;
-
-    if (matchesDefault)
-    {
-        gWindowsDarkPaletteCustomized = false;
-    }
-    else
-    {
-        if (!gWindowsDarkPaletteAppliedInitialized ||
-            memcmp(target, gWindowsDarkPaletteApplied, sizeof(gWindowsDarkPaletteApplied)) != 0 ||
-            memcmp(ViewerColors, gWindowsDarkViewerApplied, sizeof(gWindowsDarkViewerApplied)) != 0)
-        {
-            gWindowsDarkPaletteCustomized = true;
-            memcpy(gWindowsDarkPaletteApplied, target, sizeof(gWindowsDarkPaletteApplied));
-            memcpy(gWindowsDarkViewerApplied, ViewerColors, sizeof(gWindowsDarkViewerApplied));
-            gWindowsDarkPaletteAppliedInitialized = true;
-        }
     }
 
     if (gWindowsDarkPaletteCustomized)
     {
-        if (!gWindowsDarkPaletteAppliedInitialized)
+        bool paletteChanged = memcmp(target, gWindowsDarkPaletteApplied, sizeof(gWindowsDarkPaletteApplied)) != 0 ||
+                              memcmp(ViewerColors, gWindowsDarkViewerApplied, sizeof(gWindowsDarkViewerApplied)) != 0;
+        if (!paletteChanged)
+            return;
+
+        SALCOLOR defaultColors[NUMBER_OF_COLORS];
+        SALCOLOR defaultViewer[NUMBER_OF_VIEWERCOLORS];
+        WindowsDarkModeBuildPalette(defaultColors, defaultViewer);
+        bool matchesDefault = memcmp(target, defaultColors, sizeof(defaultColors)) == 0 &&
+                              memcmp(ViewerColors, defaultViewer, sizeof(defaultViewer)) == 0;
+        if (!matchesDefault)
         {
             memcpy(gWindowsDarkPaletteApplied, target, sizeof(gWindowsDarkPaletteApplied));
             memcpy(gWindowsDarkViewerApplied, ViewerColors, sizeof(gWindowsDarkViewerApplied));
             gWindowsDarkPaletteAppliedInitialized = true;
+            return;
         }
-        return;
+
+        gWindowsDarkPaletteCustomized = false;
+        gWindowsDarkPaletteAppliedInitialized = false;
+    }
+
+    if (gWindowsDarkPaletteAppliedInitialized)
+    {
+        bool paletteChanged = memcmp(target, gWindowsDarkPaletteApplied, sizeof(gWindowsDarkPaletteApplied)) != 0 ||
+                              memcmp(ViewerColors, gWindowsDarkViewerApplied, sizeof(gWindowsDarkViewerApplied)) != 0;
+        if (paletteChanged)
+        {
+            SALCOLOR defaultColors[NUMBER_OF_COLORS];
+            SALCOLOR defaultViewer[NUMBER_OF_VIEWERCOLORS];
+            WindowsDarkModeBuildPalette(defaultColors, defaultViewer);
+            bool matchesDefault = memcmp(target, defaultColors, sizeof(defaultColors)) == 0 &&
+                                  memcmp(ViewerColors, defaultViewer, sizeof(defaultViewer)) == 0;
+            if (!matchesDefault)
+            {
+                gWindowsDarkPaletteCustomized = true;
+                memcpy(gWindowsDarkPaletteApplied, target, sizeof(gWindowsDarkPaletteApplied));
+                memcpy(gWindowsDarkViewerApplied, ViewerColors, sizeof(gWindowsDarkViewerApplied));
+                return;
+            }
+        }
     }
 
     WindowsDarkModeBuildPalette(target, ViewerColors);
     memcpy(gWindowsDarkPaletteApplied, target, sizeof(gWindowsDarkPaletteApplied));
     memcpy(gWindowsDarkViewerApplied, ViewerColors, sizeof(gWindowsDarkViewerApplied));
     gWindowsDarkPaletteAppliedInitialized = true;
+    gWindowsDarkPaletteCustomized = false;
 }
 
 

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -457,13 +457,16 @@ static void WindowsDarkModeUpdatePalette(bool useDarkColors)
     SALCOLOR* target = CurrentColors;
     if (!useDarkColors)
     {
-        if (gWindowsDarkPaletteActive && gWindowsDarkPaletteTarget != NULL)
-            memcpy(gWindowsDarkPaletteTarget, gWindowsDarkPaletteBackup, sizeof(gWindowsDarkPaletteBackup));
+        if (gWindowsDarkPaletteActive)
+        {
+            if (gWindowsDarkPaletteTarget != NULL)
+                memcpy(gWindowsDarkPaletteTarget, gWindowsDarkPaletteBackup, sizeof(gWindowsDarkPaletteBackup));
 
-        if (gWindowsDarkViewerSaved && !gWindowsDarkViewerBackupIsDark)
-            memcpy(ViewerColors, gWindowsDarkViewerBackup, sizeof(gWindowsDarkViewerBackup));
-        else
-            ResetViewerColorsToDefaults();
+            if (gWindowsDarkViewerSaved && !gWindowsDarkViewerBackupIsDark)
+                memcpy(ViewerColors, gWindowsDarkViewerBackup, sizeof(gWindowsDarkViewerBackup));
+            else
+                ResetViewerColorsToDefaults();
+        }
 
         gWindowsDarkPaletteActive = false;
         gWindowsDarkPaletteTarget = NULL;


### PR DESCRIPTION

## Summary
- remember when the Windows dark-mode palette backup only contains dark values and fall back to the default viewer palette when turning the mode off
- provide a helper with the viewer defaults so their colors reliably return to the light scheme after leaving dark mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd95df13448329a0e4e62e3643401a