### PR TITLE
Ensure render viewer sources are diffed as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 # to LF endings on checkout.
 *.sh         text eol=lf
 *.svg        text eol=lf
+*.cpp        text diff
 *.po         text eol=lf
 
 # Denote all files that are truly binary and should not be modified.

--- a/src/plugins/webview2renderviewer/DEPENDENCIES.md
+++ b/src/plugins/webview2renderviewer/DEPENDENCIES.md
@@ -1,0 +1,7 @@
+# WebView2 Render Viewer .NET Dependencies
+
+The WebView2 Render Viewer .NET plugin relies on the following components:
+
+- **Microsoft .NET Framework 4.8** — target framework for the managed assembly, provided by Microsoft Corporation under the Microsoft .NET Framework license terms.
+- **Microsoft.Web.WebView2 1.0.2420.47** — WebView2 WinForms control by Microsoft Corporation, distributed under the BSD 3-Clause license (see the package `LICENSE.txt`).
+- **Markdig 0.36.2** — Markdown processor for .NET by Alexandre Mutel and contributors, released under the BSD 2-Clause license.

--- a/src/plugins/webview2renderviewer/copy_managed_dependencies.cmd
+++ b/src/plugins/webview2renderviewer/copy_managed_dependencies.cmd
@@ -1,0 +1,52 @@
+@echo off
+setlocal EnableExtensions
+
+if "%~4"=="" (
+  echo copy_managed_dependencies.cmd expects 4 arguments: plugin_root configuration platform target_dir
+  exit /B 1
+)
+
+set "PLUGIN_ROOT=%~1"
+set "MANAGED_CONFIG=%~2"
+set "PLATFORM=%~3"
+set "TARGET_DIR=%~4"
+
+if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
+
+set "MANAGED_TRIMMED=%MANAGED_CONFIG:_x64=%"
+set "MANAGED_TRIMMED=%MANAGED_TRIMMED:_Win32=%"
+set "MANAGED_DIR=%PLUGIN_ROOT%managed\bin\%MANAGED_TRIMMED%\"
+if not exist "%MANAGED_DIR%WebView2RenderViewer.Managed.dll" set "MANAGED_DIR=%PLUGIN_ROOT%managed\bin\%MANAGED_CONFIG%\"
+if not exist "%MANAGED_DIR%WebView2RenderViewer.Managed.dll" set "MANAGED_DIR=%MANAGED_DIR%net48\"
+
+if not exist "%MANAGED_DIR%WebView2RenderViewer.Managed.dll" (
+  echo WebView2RenderViewer.Managed.dll was not found in "%PLUGIN_ROOT%managed\bin\%MANAGED_TRIMMED%" or the alternate paths checked.
+  exit /B 1
+)
+
+call :require "%MANAGED_DIR%Markdig.dll" "Markdig.dll was not found next to WebView2RenderViewer.Managed.dll in %MANAGED_DIR%."
+call :require "%MANAGED_DIR%Microsoft.Web.WebView2.WinForms.dll" "Microsoft.Web.WebView2.WinForms.dll was not found next to WebView2RenderViewer.Managed.dll in %MANAGED_DIR%."
+call :require "%MANAGED_DIR%Microsoft.Web.WebView2.Core.dll" "Microsoft.Web.WebView2.Core.dll was not found next to WebView2RenderViewer.Managed.dll in %MANAGED_DIR%."
+
+set "WEBVIEW2_LOADER=WebView2Loader.dll"
+if not exist "%MANAGED_DIR%%WEBVIEW2_LOADER%" (
+  if exist "%MANAGED_DIR%x64\WebView2Loader.dll" set "WEBVIEW2_LOADER=x64\WebView2Loader.dll"
+)
+if not exist "%MANAGED_DIR%%WEBVIEW2_LOADER%" (
+  if exist "%MANAGED_DIR%x86\WebView2Loader.dll" set "WEBVIEW2_LOADER=x86\WebView2Loader.dll"
+)
+call :require "%MANAGED_DIR%%WEBVIEW2_LOADER%" "WebView2Loader.dll was not found in %MANAGED_DIR% or its architecture subdirectories."
+
+copy /Y "%MANAGED_DIR%WebView2RenderViewer.Managed.dll" "%TARGET_DIR%WebView2RenderViewer.Managed.dll" >nul
+copy /Y "%MANAGED_DIR%Markdig.dll" "%TARGET_DIR%Markdig.dll" >nul
+copy /Y "%MANAGED_DIR%Microsoft.Web.WebView2.WinForms.dll" "%TARGET_DIR%Microsoft.Web.WebView2.WinForms.dll" >nul
+copy /Y "%MANAGED_DIR%Microsoft.Web.WebView2.Core.dll" "%TARGET_DIR%Microsoft.Web.WebView2.Core.dll" >nul
+copy /Y "%MANAGED_DIR%%WEBVIEW2_LOADER%" "%TARGET_DIR%WebView2Loader.dll" >nul
+
+endlocal
+exit /B 0
+
+:require
+if exist "%~1" exit /B 0
+echo %~2
+exit /B 1

--- a/src/plugins/webview2renderviewer/lang/lang.rc
+++ b/src/plugins/webview2renderviewer/lang/lang.rc
@@ -1,0 +1,71 @@
+﻿// Microsoft Visual C++ generated resource script.
+//
+#pragma code_page(65001)
+
+#include "lang.rh"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winresrc.h"
+
+#include "..\webview2renderviewer.rh2"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// Neutral resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "lang.rh\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winresrc.h""\r\n"
+    "\r\n"
+    "#include ""..\\webview2renderviewer.rh2""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)\r\n"
+    "LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL\r\n"
+    "#include ""lang.rc2""   // non-Microsoft Visual C++ edited resources\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // Neutral resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+#include "lang.rc2"   // non-Microsoft Visual C++ edited resources
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/src/plugins/webview2renderviewer/lang/lang.rc2
+++ b/src/plugins/webview2renderviewer/lang/lang.rc2
@@ -1,0 +1,31 @@
+//****************************************************************************
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+//
+// lang.rc2 - resources Microsoft Visual C++ does not edit directly
+//
+
+#ifdef APSTUDIO_INVOKED
+#error this file is not editable by Microsoft Visual C++
+#endif //APSTUDIO_INVOKED
+
+/////////////////////////////////////////////////////////////////////////////
+// Add manually edited resources here...
+
+#include "..\versinfo.rh2"
+#include "versinfo.rc2"
+
+STRINGTABLE
+{
+ IDS_PLUGINNAME,                 "WebView2 Render Viewer .NET"
+ IDS_ABOUT,                      "About Plugin"
+ IDS_PLUGIN_DESCRIPTION,         "Viewer that displays rendered HTML, Markdown, and web documents using WebView2."
+ IDS_PLUGIN_HOME,                "https://github.com/KRtkovo-eu-AI/salamander/"
+ IDS_VIEWER_CREATE_EVENT_FAILED, "Unable to prepare synchronization event required by the viewer."
+ IDS_FILE_TOO_LARGE,             "The selected file is too large to open. Files larger than 32 MB are not supported."
+}

--- a/src/plugins/webview2renderviewer/lang/lang.rh
+++ b/src/plugins/webview2renderviewer/lang/lang.rh
@@ -1,0 +1,15 @@
+﻿//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by lang.rc
+//
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        8500
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         8700
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/plugins/webview2renderviewer/managed/EntryPoint.cs
+++ b/src/plugins/webview2renderviewer/managed/EntryPoint.cs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace OpenSalamander.WebView2RenderViewer;
+
+public static class EntryPoint
+{
+    private static bool _initialized;
+
+    [STAThread]
+    public static int Dispatch(string? argument)
+    {
+        IntPtr parent = IntPtr.Zero;
+
+        try
+        {
+            EnsureApplicationInitialized();
+
+            var parts = (argument ?? string.Empty).Split(new[] { ';' }, 3);
+            var command = parts.Length > 0 ? parts[0] : string.Empty;
+            parent = ParseHandle(parts.Length > 1 ? parts[1] : string.Empty);
+            var payload = parts.Length > 2 ? parts[2] : string.Empty;
+
+            return command switch
+            {
+                "View" => ViewerHost.Launch(parent, payload, asynchronous: true),
+                "ViewSync" => ViewerHost.Launch(parent, payload, asynchronous: false),
+                "Release" => ViewerHost.ReleaseSessions(ShouldForceRelease(payload)),
+                _ => 1,
+            };
+        }
+        catch (Exception ex)
+        {
+            if (parent != IntPtr.Zero)
+            {
+                MessageBox.Show(new WindowHandleWrapper(parent),
+                    $"Unexpected managed exception:\n{ex.Message}",
+                    "WebView2 Render Viewer .NET Plugin",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            else
+            {
+                MessageBox.Show($"Unexpected managed exception:\n{ex.Message}",
+                    "WebView2 Render Viewer .NET Plugin",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            return -1;
+        }
+    }
+
+    private static void EnsureApplicationInitialized()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        Application.EnableVisualStyles();
+
+        try
+        {
+            if (!Application.MessageLoop && Application.OpenForms.Count == 0)
+            {
+                Application.SetCompatibleTextRenderingDefault(false);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // A WinForms control has already been created somewhere else in the
+            // process (for example, another plugin). In that case it's too late
+            // to change the compatible text rendering default, so we simply
+            // continue with the existing setting.
+        }
+
+        _initialized = true;
+    }
+
+    private static IntPtr ParseHandle(string text)
+    {
+        if (ulong.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return new IntPtr(unchecked((long)value));
+        }
+
+        return IntPtr.Zero;
+    }
+
+    private static bool ShouldForceRelease(string? payload)
+    {
+        var payloadText = payload?.Trim() ?? string.Empty;
+
+        if (payloadText.Length == 0)
+        {
+            return false;
+        }
+
+        var segments = payloadText.Split('|');
+        foreach (var segment in segments)
+        {
+            if (string.IsNullOrWhiteSpace(segment))
+            {
+                continue;
+            }
+
+            var kv = segment.Split(new[] { '=' }, 2);
+            if (kv.Length == 0)
+            {
+                continue;
+            }
+
+            var key = kv[0].Trim();
+            if (!key.Equals("force", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (kv.Length == 1)
+            {
+                return true;
+            }
+
+            var value = kv[1].Trim();
+            return value.Equals("1", StringComparison.OrdinalIgnoreCase) ||
+                   value.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+}

--- a/src/plugins/webview2renderviewer/managed/ThemeHelper.cs
+++ b/src/plugins/webview2renderviewer/managed/ThemeHelper.cs
@@ -1,0 +1,656 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Drawing;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices; // Required for DllImport/MarshalAs attributes used below
+using System.Windows.Forms;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+
+namespace OpenSalamander.WebView2RenderViewer;
+
+internal static class ThemeHelper
+{
+    private static readonly ConditionalWeakTable<WebView2, WebView2ThemeState> s_webViewThemeStates = new();
+
+    private const int SALCOL_ITEM_FG_NORMAL = 6;
+    private const int SALCOL_ITEM_FG_SELECTED = 7;
+    private const int SALCOL_ITEM_BK_NORMAL = 11;
+    private const int SALCOL_ITEM_BK_SELECTED = 12;
+    private const int SALCOL_HOT_PANEL = 23;
+
+    public static bool TryGetPalette(out ThemePalette palette)
+    {
+        var current = GetPalette();
+        if (current.HasValue)
+        {
+            palette = current.Value;
+            return true;
+        }
+
+        palette = default;
+        return false;
+    }
+
+    public static void ApplyTheme(Form form)
+    {
+        if (!TryGetPalette(out var palette))
+        {
+            NativeMethods.SetDarkModeEnabled(false);
+            return;
+        }
+
+        NativeMethods.SetDarkModeEnabled(palette.IsDark);
+        ApplyPalette(form, palette);
+
+        form.ControlAdded -= FormOnControlAddedApplyPalette;
+        form.ControlAdded += FormOnControlAddedApplyPalette;
+
+        if (form.IsHandleCreated)
+        {
+            NativeMethods.ApplyImmersiveDarkMode(form.Handle, palette.IsDark, palette.ControlBorder);
+        }
+
+        form.HandleCreated -= OnFormHandleCreatedApplyDarkMode;
+        form.HandleCreated += OnFormHandleCreatedApplyDarkMode;
+    }
+
+    public static void ApplyTheme(Control control)
+    {
+        if (!TryGetPalette(out var palette))
+        {
+            NativeMethods.SetDarkModeEnabled(false);
+            return;
+        }
+
+        NativeMethods.SetDarkModeEnabled(palette.IsDark);
+        ApplyPalette(control, palette);
+    }
+
+    private static ThemePalette? GetPalette()
+    {
+        try
+        {
+            uint background = NativeMethods.GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+            uint foreground = NativeMethods.GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+            uint highlightBackground = NativeMethods.GetCurrentColor(SALCOL_ITEM_BK_SELECTED);
+            uint highlightForeground = NativeMethods.GetCurrentColor(SALCOL_ITEM_FG_SELECTED);
+            uint accent = NativeMethods.GetCurrentColor(SALCOL_HOT_PANEL);
+
+            if (background == 0 && foreground == 0)
+            {
+                return new ThemePalette(SystemColors.Control,
+                    SystemColors.ControlText,
+                    SystemColors.Highlight,
+                    SystemColors.HighlightText,
+                    SystemColors.HotTrack);
+            }
+
+            var palette = new ThemePalette(
+                ColorTranslator.FromWin32(unchecked((int)background)),
+                ColorTranslator.FromWin32(unchecked((int)foreground)),
+                highlightBackground != 0 ? ColorTranslator.FromWin32(unchecked((int)highlightBackground)) : SystemColors.Highlight,
+                highlightForeground != 0 ? ColorTranslator.FromWin32(unchecked((int)highlightForeground)) : SystemColors.HighlightText,
+                accent != 0 ? ColorTranslator.FromWin32(unchecked((int)accent)) : SystemColors.HotTrack);
+
+            return palette;
+        }
+        catch (DllNotFoundException)
+        {
+        }
+        catch (EntryPointNotFoundException)
+        {
+        }
+
+        return null;
+    }
+
+    private static void FormOnControlAddedApplyPalette(object? sender, ControlEventArgs e)
+    {
+        if (TryGetPalette(out var palette))
+        {
+            NativeMethods.SetDarkModeEnabled(palette.IsDark);
+            ApplyPalette(e.Control, palette);
+        }
+    }
+
+    private static void OnFormHandleCreatedApplyDarkMode(object? sender, EventArgs e)
+    {
+        if (sender is not Form form)
+        {
+            return;
+        }
+
+        var palette = GetPalette();
+        if (palette.HasValue)
+        {
+            NativeMethods.ApplyImmersiveDarkMode(form.Handle, palette.Value.IsDark, palette.Value.ControlBorder);
+        }
+    }
+
+    private static void ApplyPalette(Form form, ThemePalette palette)
+    {
+        form.BackColor = palette.Background;
+        form.ForeColor = palette.Foreground;
+
+        foreach (Control child in form.Controls)
+        {
+            ApplyPalette(child, palette);
+        }
+    }
+
+    private static void ApplyPalette(Control control, ThemePalette palette)
+    {
+        switch (control)
+        {
+            case TextBoxBase textBox:
+                textBox.BackColor = palette.InputBackground;
+                textBox.ForeColor = palette.InputForeground;
+                break;
+            case ComboBox comboBox:
+                comboBox.BackColor = palette.InputBackground;
+                comboBox.ForeColor = palette.InputForeground;
+                comboBox.DrawMode = DrawMode.OwnerDrawFixed;
+                comboBox.DrawItem -= ComboBoxOnDrawItem;
+                comboBox.DrawItem += ComboBoxOnDrawItem;
+                break;
+            case ListView listView:
+                listView.BackColor = palette.InputBackground;
+                listView.ForeColor = palette.InputForeground;
+                listView.BorderStyle = BorderStyle.FixedSingle;
+                break;
+            case TreeView treeView:
+                treeView.BackColor = palette.InputBackground;
+                treeView.ForeColor = palette.InputForeground;
+                treeView.LineColor = palette.Accent;
+                break;
+            case Button button when palette.IsDark:
+                button.FlatStyle = FlatStyle.Flat;
+                button.ForeColor = palette.Foreground;
+                button.BackColor = palette.ControlBackground;
+                button.FlatAppearance.BorderColor = palette.ControlBorder;
+                break;
+            case LinkLabel link:
+                link.LinkColor = palette.Accent;
+                link.ActiveLinkColor = palette.HighlightForeground;
+                link.VisitedLinkColor = palette.Accent;
+                break;
+            case ToolStrip toolStrip:
+                ThemeRenderer.Attach(toolStrip, palette);
+                break;
+            case WebView2 webView:
+                NativeMethods.SetDarkModeEnabled(palette.IsDark);
+                ApplyWebView2Theme(webView, palette);
+                break;
+        }
+
+        if (control is not Button)
+        {
+            control.BackColor = palette.Background;
+        }
+
+        control.ForeColor = palette.Foreground;
+
+        if (control.ContextMenuStrip is ContextMenuStrip menu)
+        {
+            ThemeRenderer.Attach(menu, palette);
+        }
+
+        foreach (Control child in control.Controls)
+        {
+            ApplyPalette(child, palette);
+        }
+    }
+
+    private static void ComboBoxOnDrawItem(object? sender, DrawItemEventArgs e)
+    {
+        if (sender is not ComboBox comboBox)
+        {
+            return;
+        }
+
+        if (!TryGetPalette(out var palette))
+        {
+            comboBox.DrawMode = DrawMode.Normal;
+            return;
+        }
+
+        e.DrawBackground();
+        var background = (e.State & DrawItemState.Selected) != 0 ? palette.HighlightBackground : palette.InputBackground;
+        var foreground = (e.State & DrawItemState.Selected) != 0 ? palette.HighlightForeground : palette.InputForeground;
+
+        using (var brush = new SolidBrush(background))
+        {
+            e.Graphics.FillRectangle(brush, e.Bounds);
+        }
+
+        string text = e.Index >= 0 && e.Index < comboBox.Items.Count
+            ? Convert.ToString(comboBox.Items[e.Index]) ?? string.Empty
+            : comboBox.Text;
+
+        using (var textBrush = new SolidBrush(foreground))
+        {
+            e.Graphics.DrawString(text, comboBox.Font, textBrush, e.Bounds);
+        }
+    }
+
+    private static void ApplyWebView2Theme(WebView2 webView, ThemePalette palette)
+    {
+        webView.BackColor = palette.Background;
+        webView.ForeColor = palette.Foreground;
+
+        var state = s_webViewThemeStates.GetValue(webView, static _ => new WebView2ThemeState());
+        state.Attach(webView);
+        state.Apply(webView, palette);
+    }
+
+    private sealed class WebView2ThemeState
+    {
+        private readonly EventHandler<CoreWebView2InitializationCompletedEventArgs> _initializationCompletedHandler;
+        private readonly EventHandler<CoreWebView2NavigationCompletedEventArgs> _navigationCompletedHandler;
+        private readonly EventHandler _disposedHandler;
+        private ThemePalette? _palette;
+        private bool _attached;
+
+        public WebView2ThemeState()
+        {
+            _initializationCompletedHandler = OnInitializationCompleted;
+            _navigationCompletedHandler = OnNavigationCompleted;
+            _disposedHandler = OnDisposed;
+        }
+
+        public void Attach(WebView2 webView)
+        {
+            if (_attached)
+            {
+                return;
+            }
+
+            webView.CoreWebView2InitializationCompleted += _initializationCompletedHandler;
+            webView.NavigationCompleted += _navigationCompletedHandler;
+            webView.Disposed += _disposedHandler;
+            _attached = true;
+        }
+
+        public void Apply(WebView2 webView, ThemePalette palette)
+        {
+            _palette = palette;
+            UpdateTheme(webView, palette);
+        }
+
+        private void OnInitializationCompleted(object? sender, CoreWebView2InitializationCompletedEventArgs e)
+        {
+            if (sender is not WebView2 webView || !e.IsSuccess)
+            {
+                return;
+            }
+
+            if (_palette.HasValue)
+            {
+                UpdateTheme(webView, _palette.Value);
+            }
+        }
+
+        private void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
+        {
+            if (sender is not WebView2 webView || !_palette.HasValue)
+            {
+                return;
+            }
+
+            if (webView.CoreWebView2 is CoreWebView2 core)
+            {
+                ApplyDocumentTheme(core, _palette.Value);
+            }
+        }
+
+        private void OnDisposed(object? sender, EventArgs e)
+        {
+            if (sender is not WebView2 webView)
+            {
+                return;
+            }
+
+            webView.CoreWebView2InitializationCompleted -= _initializationCompletedHandler;
+            webView.NavigationCompleted -= _navigationCompletedHandler;
+            webView.Disposed -= _disposedHandler;
+            s_webViewThemeStates.Remove(webView);
+        }
+
+        private void UpdateTheme(WebView2 webView, ThemePalette palette)
+        {
+            if (webView.IsHandleCreated)
+            {
+                NativeMethods.ApplyDarkModeTree(webView.Handle);
+            }
+
+            webView.DefaultBackgroundColor = palette.Background;
+
+            if (webView.CoreWebView2 is CoreWebView2 core)
+            {
+                ApplyDocumentTheme(core, palette);
+            }
+        }
+
+        private static void ApplyDocumentTheme(CoreWebView2 core, ThemePalette palette)
+        {
+            string scheme = palette.IsDark ? "dark" : "light";
+            string fallback = palette.IsDark ? "light" : "dark";
+            string content = scheme + " " + fallback;
+            string script = $"(function(){{try{{var doc=document.documentElement;if(doc){{doc.setAttribute('data-theme',{ToJavaScriptStringLiteral(scheme)});doc.style.colorScheme={ToJavaScriptStringLiteral(scheme)};}}var meta=document.querySelector('meta[name=\"color-scheme\"]');if(meta){{meta.setAttribute('content',{ToJavaScriptStringLiteral(content)});}}}}catch(e){{}}}})();";
+            _ = core.ExecuteScriptAsync(script);
+        }
+    }
+
+    private static string ToJavaScriptStringLiteral(string value)
+    {
+        if (value is null)
+        {
+            return "''";
+        }
+
+        string escaped = value
+            .Replace("\\", "\\\\")
+            .Replace("'", "\\'")
+            .Replace("\r", "\\r")
+            .Replace("\n", "\\n");
+
+        return "'" + escaped + "'";
+    }
+
+    private static int ComputeLuminance(Color color)
+    {
+        return (color.R * 30 + color.G * 59 + color.B * 11) / 100;
+    }
+
+    private static Color Lighten(Color color, double amount)
+    {
+        int r = color.R + (int)((255 - color.R) * amount);
+        int g = color.G + (int)((255 - color.G) * amount);
+        int b = color.B + (int)((255 - color.B) * amount);
+        return Color.FromArgb(Clamp(r), Clamp(g), Clamp(b));
+    }
+
+    private static Color Darken(Color color, double amount)
+    {
+        int r = color.R - (int)(color.R * amount);
+        int g = color.G - (int)(color.G * amount);
+        int b = color.B - (int)(color.B * amount);
+        return Color.FromArgb(Clamp(r), Clamp(g), Clamp(b));
+    }
+
+    private static int Clamp(int value)
+    {
+        if (value < 0)
+        {
+            return 0;
+        }
+
+        if (value > 255)
+        {
+            return 255;
+        }
+
+        return value;
+    }
+
+    internal readonly struct ThemePalette
+    {
+        public ThemePalette(Color background, Color foreground, Color highlightBackground, Color highlightForeground, Color accent)
+        {
+            Background = background;
+            Foreground = foreground;
+            HighlightBackground = highlightBackground;
+            HighlightForeground = highlightForeground;
+            Accent = accent;
+
+            IsDark = ComputeLuminance(background) < 128;
+            ControlBackground = IsDark ? Lighten(background, 0.08) : Darken(background, 0.06);
+            ControlBorder = IsDark ? Lighten(background, 0.16) : Darken(background, 0.16);
+            InputBackground = IsDark ? Lighten(background, 0.12) : SystemColors.Window;
+            InputForeground = IsDark ? foreground : SystemColors.WindowText;
+        }
+
+        public Color Background { get; }
+
+        public Color Foreground { get; }
+
+        public Color HighlightBackground { get; }
+
+        public Color HighlightForeground { get; }
+
+        public Color Accent { get; }
+
+        public Color ControlBackground { get; }
+
+        public Color ControlBorder { get; }
+
+        public Color InputBackground { get; }
+
+        public Color InputForeground { get; }
+
+        public bool IsDark { get; }
+    }
+
+    private static class ThemeRenderer
+    {
+        public static void Attach(ToolStrip toolStrip, ThemePalette palette)
+        {
+            toolStrip.Renderer = new Renderer(palette);
+            toolStrip.BackColor = palette.ControlBackground;
+            toolStrip.ForeColor = palette.Foreground;
+
+            foreach (ToolStripItem item in toolStrip.Items)
+            {
+                item.ForeColor = palette.Foreground;
+            }
+        }
+
+        public static void Attach(ContextMenuStrip menu, ThemePalette palette)
+        {
+            menu.Renderer = new Renderer(palette);
+            menu.BackColor = palette.ControlBackground;
+            menu.ForeColor = palette.Foreground;
+
+            foreach (ToolStripItem item in menu.Items)
+            {
+                item.ForeColor = palette.Foreground;
+            }
+        }
+
+        private sealed class Renderer : ToolStripProfessionalRenderer
+        {
+            private readonly ThemePalette _palette;
+
+            public Renderer(ThemePalette palette)
+                : base(new ColorTable(palette))
+            {
+                _palette = palette;
+                RoundedEdges = false;
+            }
+
+            protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
+            {
+                e.Graphics.Clear(_palette.ControlBackground);
+            }
+
+            protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
+            {
+                PaintItemBackground(e);
+            }
+
+            protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
+            {
+                PaintItemBackground(e);
+            }
+
+            protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
+            {
+                e.TextColor = e.Item.Enabled ? _palette.Foreground : ControlPaint.Light(_palette.Foreground);
+                base.OnRenderItemText(e);
+            }
+
+            protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
+            {
+                using var pen = new Pen(_palette.ControlBorder);
+                var rect = e.Item.Bounds;
+                if (e.Item is ToolStripSeparator separator && separator.IsOnDropDown)
+                {
+                    int y = rect.Height / 2;
+                    e.Graphics.DrawLine(pen, rect.Left + 4, y, rect.Right - 4, y);
+                }
+                else
+                {
+                    int x = rect.Width / 2;
+                    e.Graphics.DrawLine(pen, x, rect.Top + 4, x, rect.Bottom - 4);
+                }
+            }
+
+            private void PaintItemBackground(ToolStripItemRenderEventArgs e)
+            {
+                var rect = new Rectangle(Point.Empty, e.Item.Size);
+                Color background = e.Item.Selected || e.Item.Pressed
+                    ? _palette.HighlightBackground
+                    : _palette.ControlBackground;
+                using var brush = new SolidBrush(background);
+                e.Graphics.FillRectangle(brush, rect);
+                if (e.Item.Selected || e.Item.Pressed)
+                {
+                    using var border = new Pen(_palette.ControlBorder);
+                    e.Graphics.DrawRectangle(border, new Rectangle(0, 0, rect.Width - 1, rect.Height - 1));
+                }
+            }
+        }
+
+        private sealed class ColorTable : ProfessionalColorTable
+        {
+            private readonly ThemePalette _palette;
+
+            public ColorTable(ThemePalette palette)
+            {
+                _palette = palette;
+                UseSystemColors = false;
+            }
+
+            public override Color ToolStripDropDownBackground => _palette.ControlBackground;
+
+            public override Color MenuBorder => _palette.ControlBorder;
+
+            public override Color MenuItemBorder => _palette.ControlBorder;
+
+            public override Color MenuItemSelected => _palette.HighlightBackground;
+
+            public override Color MenuItemSelectedGradientBegin => _palette.HighlightBackground;
+
+            public override Color MenuItemSelectedGradientEnd => _palette.HighlightBackground;
+
+            public override Color ImageMarginGradientBegin => _palette.ControlBackground;
+
+            public override Color ImageMarginGradientMiddle => _palette.ControlBackground;
+
+            public override Color ImageMarginGradientEnd => _palette.ControlBackground;
+        }
+    }
+
+    private static class NativeMethods
+    {
+        private const int DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20 = 19;
+        private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+        private const int DWMWA_BORDER_COLOR = 34;
+
+        [DllImport("WebView2RenderViewer.Spl", CallingConvention = CallingConvention.StdCall)]
+        public static extern uint RenderViewer_GetCurrentColor(int color);
+
+        [DllImport("dwmapi.dll", PreserveSig = true)]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+
+        [DllImport("WebView2RenderViewer.Spl", CallingConvention = CallingConvention.StdCall)]
+        private static extern void RenderViewer_ApplyDarkModeTree(IntPtr hwnd);
+
+        [DllImport("WebView2RenderViewer.Spl", CallingConvention = CallingConvention.StdCall)]
+        private static extern void RenderViewer_SetDarkModeState([MarshalAs(UnmanagedType.Bool)] bool enabled);
+
+        public static void SetDarkModeEnabled(bool enabled)
+        {
+            try
+            {
+                RenderViewer_SetDarkModeState(enabled);
+            }
+            catch (DllNotFoundException)
+            {
+            }
+            catch (EntryPointNotFoundException)
+            {
+            }
+        }
+
+        public static uint GetCurrentColor(int color)
+        {
+            try
+            {
+                return RenderViewer_GetCurrentColor(color);
+            }
+            catch (DllNotFoundException)
+            {
+                return 0;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return 0;
+            }
+        }
+
+        public static void ApplyImmersiveDarkMode(IntPtr handle, bool enable, Color borderColor)
+        {
+            if (handle == IntPtr.Zero)
+            {
+                return;
+            }
+
+            var version = Environment.OSVersion.Version;
+            if (version.Major < 10)
+            {
+                return;
+            }
+
+            int useDark = enable ? 1 : 0;
+            if (version.Build >= 18985)
+            {
+                DwmSetWindowAttribute(handle, DWMWA_USE_IMMERSIVE_DARK_MODE, ref useDark, sizeof(int));
+            }
+            else
+            {
+                DwmSetWindowAttribute(handle, DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20, ref useDark, sizeof(int));
+            }
+
+            if (version.Build >= 22000)
+            {
+                int border = enable ? borderColor.ToArgb() : -1;
+                DwmSetWindowAttribute(handle, DWMWA_BORDER_COLOR, ref border, sizeof(int));
+            }
+        }
+
+        public static void ApplyDarkModeTree(IntPtr handle)
+        {
+            if (handle == IntPtr.Zero)
+            {
+                return;
+            }
+
+            try
+            {
+                RenderViewer_ApplyDarkModeTree(handle);
+            }
+            catch (DllNotFoundException)
+            {
+            }
+            catch (EntryPointNotFoundException)
+            {
+            }
+        }
+    }
+}

--- a/src/plugins/webview2renderviewer/managed/ViewerHost.cs
+++ b/src/plugins/webview2renderviewer/managed/ViewerHost.cs
@@ -1,0 +1,1175 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+using Markdig;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+
+namespace OpenSalamander.WebView2RenderViewer;
+
+internal static class ViewerHost
+{
+    private static readonly object s_threadLock = new();
+    private static ViewerThread? s_viewerThread;
+    private static readonly object s_sessionLock = new();
+    private static readonly HashSet<ViewerSession> s_activeSessions = new();
+    private static readonly ManualResetEventSlim s_sessionsDrained = new(true);
+    private static readonly TimeSpan s_shutdownTimeout = TimeSpan.FromSeconds(5);
+
+    public static int Launch(IntPtr parent, string payload, bool asynchronous)
+    {
+        if (!ViewCommandPayload.TryParse(payload, asynchronous, out var parsed))
+        {
+            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
+                "Unable to parse parameters provided for the render viewer.",
+                "WebView2 Render Viewer .NET Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return 1;
+        }
+
+        if (asynchronous && parsed.CloseHandle == IntPtr.Zero)
+        {
+            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
+                "The native host did not provide a synchronization handle for the viewer.",
+                "WebView2 Render Viewer .NET Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return 1;
+        }
+
+        ViewerSession session;
+        try
+        {
+            session = new ViewerSession(parent, parsed, asynchronous);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
+                $"Unable to prepare the render viewer session.\n{ex.Message}",
+                "WebView2 Render Viewer .NET Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return 1;
+        }
+
+        RegisterSession(session);
+
+        ViewerThread thread;
+        try
+        {
+            thread = EnsureViewerThread();
+        }
+        catch (Exception ex)
+        {
+            session.MarkStartupFailed();
+            session.Complete();
+            MessageBox.Show(session.OwnerWindow,
+                $"Unable to initialize the render viewer.\n{ex.Message}",
+                "WebView2 Render Viewer .NET Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            if (!asynchronous)
+            {
+                session.WaitForCompletion();
+            }
+            return 1;
+        }
+
+        if (!thread.TryShow(session))
+        {
+            session.MarkStartupFailed();
+            session.Complete();
+            MessageBox.Show(session.OwnerWindow,
+                "Unable to open the render viewer window.",
+                "WebView2 Render Viewer .NET Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            if (!asynchronous)
+            {
+                session.WaitForCompletion();
+            }
+            return 1;
+        }
+
+        if (!asynchronous)
+        {
+            session.WaitForCompletion();
+            return session.StartupSucceeded ? 0 : 1;
+        }
+
+        return 0;
+    }
+
+    public static int ReleaseSessions(bool forceClose)
+    {
+        if (!forceClose)
+        {
+            return HasActiveSessions ? 1 : 0;
+        }
+
+        ViewerThread? thread;
+        lock (s_threadLock)
+        {
+            thread = s_viewerThread;
+        }
+
+        if (thread is null)
+        {
+            return 0;
+        }
+
+        if (!thread.TryClose(s_shutdownTimeout))
+        {
+            return 1;
+        }
+
+        if (!s_sessionsDrained.Wait(s_shutdownTimeout))
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static ViewerThread EnsureViewerThread()
+    {
+        lock (s_threadLock)
+        {
+            s_viewerThread ??= new ViewerThread();
+            return s_viewerThread;
+        }
+    }
+
+    private static void RegisterSession(ViewerSession session)
+    {
+        lock (s_sessionLock)
+        {
+            if (s_activeSessions.Count == 0)
+            {
+                s_sessionsDrained.Reset();
+            }
+
+            s_activeSessions.Add(session);
+        }
+    }
+
+    private static void SessionCompleted(ViewerSession session)
+    {
+        lock (s_sessionLock)
+        {
+            if (s_activeSessions.Remove(session) && s_activeSessions.Count == 0)
+            {
+                s_sessionsDrained.Set();
+            }
+        }
+    }
+
+    private static bool HasActiveSessions
+    {
+        get
+        {
+            lock (s_sessionLock)
+            {
+                return s_activeSessions.Count > 0;
+            }
+        }
+    }
+
+    private static void OnViewerThreadExited(ViewerThread thread)
+    {
+        lock (s_threadLock)
+        {
+            if (ReferenceEquals(s_viewerThread, thread))
+            {
+                s_viewerThread = null;
+            }
+        }
+    }
+
+    private sealed class ViewerThread
+    {
+        private readonly Thread _thread;
+        private readonly ManualResetEventSlim _ready = new(false);
+        private RenderViewerApplicationContext? _context;
+
+        public ViewerThread()
+        {
+            _thread = new Thread(Run)
+            {
+                IsBackground = true,
+                Name = "WebView2RenderViewer Thread"
+            };
+            _thread.SetApartmentState(ApartmentState.STA);
+            _thread.Start();
+            _ready.Wait();
+        }
+
+        public bool TryShow(ViewerSession session)
+        {
+            var context = _context;
+            if (context is null)
+            {
+                return false;
+            }
+
+            return context.TryShow(session);
+        }
+
+        public bool TryClose(TimeSpan timeout)
+        {
+            var context = _context;
+            if (context is null)
+            {
+                return true;
+            }
+
+            if (!context.TryCloseAll(timeout))
+            {
+                return false;
+            }
+
+            return _thread.Join(timeout);
+        }
+
+        private void Run()
+        {
+            try
+            {
+                using var context = new RenderViewerApplicationContext();
+                _context = context;
+                _ready.Set();
+                Application.Run(context);
+            }
+            finally
+            {
+                _context = null;
+                _ready.Set();
+                OnViewerThreadExited(this);
+            }
+        }
+    }
+
+    private sealed class ViewerSession
+    {
+        private readonly EventWaitHandle? _closeEvent;
+        private readonly ManualResetEventSlim? _completionEvent;
+        private int _closeSignaled;
+        private int _completionSignaled;
+
+        public ViewerSession(IntPtr parent, ViewCommandPayload payload, bool asynchronous)
+        {
+            Parent = parent;
+            Payload = payload;
+            OwnerWindow = parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null;
+
+            if (payload.CloseHandle != IntPtr.Zero)
+            {
+                _closeEvent = new EventWaitHandle(false, EventResetMode.AutoReset)
+                {
+                    SafeWaitHandle = new Microsoft.Win32.SafeHandles.SafeWaitHandle(payload.CloseHandle, ownsHandle: false),
+                };
+            }
+
+            if (!asynchronous)
+            {
+                _completionEvent = new ManualResetEventSlim(false);
+            }
+        }
+
+        public IntPtr Parent { get; }
+        public ViewCommandPayload Payload { get; }
+        public IWin32Window? OwnerWindow { get; }
+        public bool StartupSucceeded { get; private set; } = true;
+
+        public void MarkStartupFailed()
+        {
+            StartupSucceeded = false;
+        }
+
+        public void SignalClosed()
+        {
+            var handle = _closeEvent;
+            if (handle is null)
+            {
+                return;
+            }
+
+            if (Interlocked.Exchange(ref _closeSignaled, 1) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                handle.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+            finally
+            {
+                handle.Dispose();
+            }
+        }
+
+        public void Complete()
+        {
+            if (Interlocked.Exchange(ref _completionSignaled, 1) != 0)
+            {
+                return;
+            }
+
+            SignalClosed();
+            SessionCompleted(this);
+            _completionEvent?.Set();
+        }
+
+        public void WaitForCompletion()
+        {
+            _completionEvent?.Wait();
+        }
+    }
+
+    private sealed class RenderViewerApplicationContext : ApplicationContext
+    {
+        private readonly Control _dispatcher;
+        private readonly List<RenderViewerForm> _openForms = new();
+        private readonly object _lock = new();
+
+        public RenderViewerApplicationContext()
+        {
+            _dispatcher = new Control();
+            _dispatcher.CreateControl();
+        }
+
+        public bool TryShow(ViewerSession session)
+        {
+            if (_dispatcher.IsDisposed)
+            {
+                return false;
+            }
+
+            try
+            {
+                _dispatcher.BeginInvoke(new MethodInvoker(() => ShowInternal(session)));
+                return true;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
+
+        public bool TryCloseAll(TimeSpan timeout)
+        {
+            using var completion = new ManualResetEventSlim(false);
+
+            try
+            {
+                _dispatcher.BeginInvoke(new MethodInvoker(() =>
+                {
+                    foreach (var form in _openForms.ToArray())
+                    {
+                        form.AllowClose();
+                        form.Close();
+                    }
+
+                    completion.Set();
+                    ExitThread();
+                }));
+            }
+            catch (ObjectDisposedException)
+            {
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+
+            return completion.Wait(timeout);
+        }
+
+        private void ShowInternal(ViewerSession session)
+        {
+            if (_dispatcher.IsDisposed)
+            {
+                session.MarkStartupFailed();
+                session.Complete();
+                return;
+            }
+
+            var form = new RenderViewerForm();
+            form.FormClosed += (_, _) => OnFormClosed(form, session);
+
+            if (!form.TryShow(session))
+            {
+                form.Dispose();
+                session.MarkStartupFailed();
+                session.Complete();
+                return;
+            }
+
+            lock (_lock)
+            {
+                _openForms.Add(form);
+            }
+        }
+
+        private void OnFormClosed(RenderViewerForm form, ViewerSession session)
+        {
+            lock (_lock)
+            {
+                _openForms.Remove(form);
+            }
+
+            session.Complete();
+        }
+    }
+
+    private sealed class RenderViewerForm : Form
+    {
+        private const int WM_THEMECHANGED = 0x031A;
+        private const int WM_SETTINGCHANGE = 0x001A;
+
+        private ViewerSession? _session;
+        private WebView2? _browser;
+        private bool _allowClose;
+        private bool _taskbarStyleApplied;
+        private IntPtr _ownerRestore;
+        private bool _ownerAttached;
+        private bool _handlingThemeUpdate;
+        private string? _currentFilePath;
+        private DocumentView? _currentView;
+        private Uri? _pendingNavigationUri;
+        private string? _pendingHtmlContent;
+
+        public RenderViewerForm()
+        {
+            Text = "WebView2 Render Viewer .NET";
+            StartPosition = FormStartPosition.Manual;
+            ShowInTaskbar = false;
+            MinimizeBox = true;
+            MaximizeBox = true;
+            KeyPreview = true;
+            AutoScaleMode = AutoScaleMode.Dpi;
+            ClientSize = new Size(800, 600);
+            Icon = ViewerResources.ViewerIcon;
+
+            HandleCreated += OnHandleCreated;
+            HandleDestroyed += OnHandleDestroyed;
+            FormClosing += OnFormClosing;
+
+            ThemeHelper.ApplyTheme(this);
+        }
+
+        public bool TryShow(ViewerSession session)
+        {
+            _session = session;
+            _allowClose = false;
+
+            Text = BuildCaption(session.Payload.Caption);
+            ApplyOwner(session.Parent);
+            ApplyPlacement(session.Payload);
+            EnsureBrowser();
+
+            try
+            {
+                LoadFile(session.Payload.FilePath);
+            }
+            catch (Exception ex)
+            {
+                session.MarkStartupFailed();
+                MessageBox.Show(session.OwnerWindow,
+                    $"Unable to open the selected file.\n{ex.Message}",
+                    "WebView2 Render Viewer .NET Plugin",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                return false;
+            }
+
+            ShowInTaskbar = true;
+            Show();
+            Activate();
+            NativeMethods.SetForegroundWindow(Handle);
+            return true;
+        }
+
+        public void AllowClose()
+        {
+            _allowClose = true;
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == Keys.Escape)
+            {
+                Close();
+                return true;
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private void EnsureBrowser()
+        {
+            if (_browser is not null)
+            {
+                return;
+            }
+
+            var viewer = new WebView2
+            {
+                Dock = DockStyle.Fill,
+                AllowExternalDrop = false,
+            };
+
+            viewer.CoreWebView2InitializationCompleted += OnBrowserInitializationCompleted;
+            viewer.NavigationCompleted += (_, _) => ThemeHelper.ApplyTheme(viewer);
+
+            Controls.Add(viewer);
+            ThemeHelper.ApplyTheme(viewer);
+
+            _browser = viewer;
+
+            try
+            {
+                _ = viewer.EnsureCoreWebView2Async();
+            }
+            catch (Exception ex)
+            {
+                HandleBrowserInitializationFailure(ex);
+            }
+        }
+
+        private void LoadFile(string path)
+        {
+            _currentFilePath = path;
+
+            string caption = _session?.Payload.Caption;
+            if (string.IsNullOrWhiteSpace(caption))
+            {
+                caption = Path.GetFileName(path);
+            }
+
+            _currentView = DocumentView.Create(path, caption ?? string.Empty);
+            RenderCurrentDocument();
+        }
+
+        private void OnBrowserInitializationCompleted(object? sender, CoreWebView2InitializationCompletedEventArgs e)
+        {
+            if (sender is not WebView2 browser)
+            {
+                return;
+            }
+
+            if (!e.IsSuccess)
+            {
+                HandleBrowserInitializationFailure(e.InitializationException ?? new InvalidOperationException("WebView2 initialization failed."));
+                return;
+            }
+
+            if (browser.CoreWebView2 is CoreWebView2 core)
+            {
+                core.Settings.IsStatusBarEnabled = false;
+                core.Settings.AreDefaultContextMenusEnabled = true;
+                core.Settings.AreDefaultScriptDialogsEnabled = true;
+                core.Settings.AreDevToolsEnabled = true;
+            }
+
+            ThemeHelper.ApplyTheme(browser);
+
+            if (browser.CoreWebView2 is null)
+            {
+                return;
+            }
+
+            if (_pendingHtmlContent is not null)
+            {
+                browser.CoreWebView2.NavigateToString(_pendingHtmlContent);
+                _pendingHtmlContent = null;
+            }
+            else if (_pendingNavigationUri is not null)
+            {
+                browser.CoreWebView2.Navigate(_pendingNavigationUri.AbsoluteUri);
+                _pendingNavigationUri = null;
+            }
+            else if (_currentView is not null)
+            {
+                RenderCurrentDocument();
+            }
+        }
+
+        private void HandleBrowserInitializationFailure(Exception exception)
+        {
+            _session?.MarkStartupFailed();
+            MessageBox.Show(this,
+                $"Unable to initialize the embedded browser.\n{exception.Message}",
+                "WebView2 Render Viewer .NET Plugin",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            BeginInvoke(new MethodInvoker(() =>
+            {
+                _allowClose = true;
+                Close();
+            }));
+        }
+
+        private void OnHandleCreated(object? sender, EventArgs e)
+        {
+            ApplyOwner(_session?.Parent ?? IntPtr.Zero);
+            EnsureTaskbarVisibility();
+        }
+
+        private void OnHandleDestroyed(object? sender, EventArgs e)
+        {
+            DetachOwner();
+            _taskbarStyleApplied = false;
+        }
+
+        private void OnFormClosing(object? sender, FormClosingEventArgs e)
+        {
+            if (!_allowClose)
+            {
+                _allowClose = true;
+            }
+
+            _session?.SignalClosed();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+            _session?.Complete();
+        }
+
+        protected override void OnSystemColorsChanged(EventArgs e)
+        {
+            base.OnSystemColorsChanged(e);
+            HandleThemeChanged();
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+
+            if (m.Msg == WM_THEMECHANGED || m.Msg == WM_SETTINGCHANGE)
+            {
+                HandleThemeChanged();
+            }
+        }
+
+        private void HandleThemeChanged()
+        {
+            if (_handlingThemeUpdate)
+            {
+                return;
+            }
+
+            _handlingThemeUpdate = true;
+
+            try
+            {
+                ThemeHelper.ApplyTheme(this);
+
+                if (_browser is not null)
+                {
+                    ThemeHelper.ApplyTheme(_browser);
+                }
+
+                if (_currentFilePath is not null && _currentView is not null && _currentView.Kind == DocumentViewKind.Html)
+                {
+                    string caption = _currentView.Caption;
+                    _currentView = DocumentView.Create(_currentFilePath, caption);
+                }
+
+                RenderCurrentDocument();
+            }
+            finally
+            {
+                _handlingThemeUpdate = false;
+            }
+        }
+
+        private void RenderCurrentDocument()
+        {
+            if (_browser is null)
+            {
+                return;
+            }
+
+            if (_currentView is null)
+            {
+                return;
+            }
+
+            Text = BuildCaption(_currentView.Caption);
+
+            var core = _browser.CoreWebView2;
+            if (core is null)
+            {
+                if (_currentView.Kind == DocumentViewKind.Navigate)
+                {
+                    _pendingNavigationUri = _currentView.NavigateUri;
+                    _pendingHtmlContent = null;
+                }
+                else
+                {
+                    _pendingHtmlContent = _currentView.HtmlContent;
+                    _pendingNavigationUri = null;
+                }
+                return;
+            }
+
+            if (_currentView.Kind == DocumentViewKind.Navigate && _currentView.NavigateUri is Uri uri)
+            {
+                _pendingNavigationUri = null;
+                _pendingHtmlContent = null;
+                core.Navigate(uri.AbsoluteUri);
+            }
+            else if (_currentView.Kind == DocumentViewKind.Html)
+            {
+                string html = _currentView.HtmlContent ?? string.Empty;
+                _pendingNavigationUri = null;
+                _pendingHtmlContent = null;
+                core.NavigateToString(html);
+            }
+
+            ThemeHelper.ApplyTheme(_browser);
+        }
+
+        private void ApplyPlacement(ViewCommandPayload payload)
+        {
+            if (payload.Bounds.Width > 0 && payload.Bounds.Height > 0)
+            {
+                Bounds = payload.Bounds;
+            }
+
+            if (payload.ShowCommand == NativeMethods.SW_SHOWMAXIMIZED)
+            {
+                WindowState = FormWindowState.Maximized;
+            }
+            else if (payload.ShowCommand == NativeMethods.SW_SHOWMINIMIZED)
+            {
+                WindowState = FormWindowState.Minimized;
+            }
+
+            if (payload.AlwaysOnTop)
+            {
+                TopMost = true;
+            }
+        }
+
+        private void ApplyOwner(IntPtr parent)
+        {
+            if (parent == IntPtr.Zero || !IsHandleCreated)
+            {
+                return;
+            }
+
+            if (_ownerAttached)
+            {
+                return;
+            }
+
+            _ownerRestore = NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_HWNDPARENT, parent);
+            _ownerAttached = true;
+        }
+
+        private void DetachOwner()
+        {
+            if (!_ownerAttached || !IsHandleCreated)
+            {
+                return;
+            }
+
+            NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_HWNDPARENT, _ownerRestore);
+            _ownerAttached = false;
+        }
+
+        private void EnsureTaskbarVisibility()
+        {
+            if (!IsHandleCreated || _taskbarStyleApplied)
+            {
+                return;
+            }
+
+            int style = unchecked((int)NativeMethods.GetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE).ToInt64());
+            int updated = (style & ~NativeMethods.WS_EX_TOOLWINDOW) | NativeMethods.WS_EX_APPWINDOW;
+            if (updated != style)
+            {
+                NativeMethods.SetWindowLongPtr(Handle, NativeMethods.GWL_EXSTYLE, new IntPtr(updated));
+                NativeMethods.SetWindowPos(
+                    Handle,
+                    IntPtr.Zero,
+                    0,
+                    0,
+                    0,
+                    0,
+                    NativeMethods.SWP_NOMOVE |
+                    NativeMethods.SWP_NOSIZE |
+                    NativeMethods.SWP_NOZORDER |
+                    NativeMethods.SWP_NOACTIVATE |
+                    NativeMethods.SWP_FRAMECHANGED |
+                    NativeMethods.SWP_NOOWNERZORDER);
+            }
+
+            _taskbarStyleApplied = true;
+        }
+
+        private static string BuildCaption(string caption)
+        {
+            if (string.IsNullOrWhiteSpace(caption))
+            {
+                return "WebView2 Render Viewer .NET";
+            }
+
+            return string.Format(CultureInfo.CurrentCulture, "{0} - WebView2 Render Viewer .NET", caption);
+        }
+    }
+
+    private sealed class ViewCommandPayload
+    {
+        private ViewCommandPayload(string filePath, string caption, Rectangle bounds, uint showCommand,
+            bool alwaysOnTop, IntPtr closeHandle)
+        {
+            FilePath = filePath;
+            Caption = caption;
+            Bounds = bounds;
+            ShowCommand = showCommand;
+            AlwaysOnTop = alwaysOnTop;
+            CloseHandle = closeHandle;
+        }
+
+        public string FilePath { get; }
+        public string Caption { get; }
+        public Rectangle Bounds { get; }
+        public uint ShowCommand { get; }
+        public bool AlwaysOnTop { get; }
+        public IntPtr CloseHandle { get; }
+
+        public static bool TryParse(string payload, bool asynchronous, out ViewCommandPayload result)
+        {
+            result = null!;
+            if (string.IsNullOrEmpty(payload))
+            {
+                return false;
+            }
+
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var parts = payload.Split('|');
+            foreach (var part in parts)
+            {
+                if (string.IsNullOrEmpty(part))
+                {
+                    continue;
+                }
+
+                var kv = part.Split(new[] { '=' }, 2);
+                if (kv.Length == 2)
+                {
+                    map[kv[0]] = kv[1];
+                }
+            }
+
+            if (!map.TryGetValue("path", out var encodedPath))
+            {
+                return false;
+            }
+
+            string filePath;
+            if (TryDecodeBase64(encodedPath, out var decodedPath))
+            {
+                filePath = decodedPath;
+            }
+            else
+            {
+                filePath = encodedPath?.Trim() ?? string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            string caption = Path.GetFileName(filePath);
+            if (map.TryGetValue("caption", out var encodedCaption) && !string.IsNullOrEmpty(encodedCaption))
+            {
+                if (TryDecodeBase64(encodedCaption, out var decodedCaption) && !string.IsNullOrWhiteSpace(decodedCaption))
+                {
+                    caption = decodedCaption.Trim();
+                }
+                else if (!string.IsNullOrEmpty(encodedCaption))
+                {
+                    caption = encodedCaption.Trim();
+                }
+            }
+
+            int left = ReadInt(map, "left");
+            int top = ReadInt(map, "top");
+            int width = Math.Max(ReadInt(map, "width"), 0);
+            int height = Math.Max(ReadInt(map, "height"), 0);
+            uint showCommand = ReadUInt(map, "show");
+            bool alwaysOnTop = ReadBool(map, "ontop");
+            IntPtr closeHandle = asynchronous ? ReadHandle(map, "close") : IntPtr.Zero;
+
+            var bounds = new Rectangle(left, top, width, height);
+            result = new ViewCommandPayload(filePath, caption, bounds, showCommand, alwaysOnTop, closeHandle);
+            return true;
+        }
+
+        private static bool TryDecodeBase64(string value, out string decoded)
+        {
+            decoded = string.Empty;
+            var trimmedValue = value?.Trim();
+            if (string.IsNullOrEmpty(trimmedValue))
+            {
+                return false;
+            }
+
+            try
+            {
+                var bytes = Convert.FromBase64String(trimmedValue);
+                decoded = Encoding.UTF8.GetString(bytes);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+            catch (DecoderFallbackException)
+            {
+                return false;
+            }
+        }
+
+        private static int ReadInt(IDictionary<string, string> map, string key)
+        {
+            if (map.TryGetValue(key, out var value) && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return parsed;
+            }
+            return 0;
+        }
+
+        private static uint ReadUInt(IDictionary<string, string> map, string key)
+        {
+            if (map.TryGetValue(key, out var value) && uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return parsed;
+            }
+            return 0;
+        }
+
+        private static bool ReadBool(IDictionary<string, string> map, string key)
+        {
+            return map.TryGetValue(key, out var value) && value == "1";
+        }
+
+        private static IntPtr ReadHandle(IDictionary<string, string> map, string key)
+        {
+            if (map.TryGetValue(key, out var value) && ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                return new IntPtr(unchecked((long)parsed));
+            }
+            return IntPtr.Zero;
+        }
+    }
+
+    private enum DocumentViewKind
+    {
+        Navigate,
+        Html,
+    }
+
+    private sealed class DocumentView
+    {
+        public DocumentView(DocumentViewKind kind, string caption, Uri? navigateUri, string? htmlContent)
+        {
+            Kind = kind;
+            Caption = caption;
+            NavigateUri = navigateUri;
+            HtmlContent = htmlContent;
+        }
+
+        public DocumentViewKind Kind { get; }
+        public string Caption { get; }
+        public Uri? NavigateUri { get; }
+        public string? HtmlContent { get; }
+
+        public static DocumentView Create(string path, string caption)
+        {
+            string extension = Path.GetExtension(path)?.TrimStart('.')?.ToLowerInvariant() ?? string.Empty;
+
+            if (FileViewHelper.IsMarkdown(extension))
+            {
+                string markdown = File.ReadAllText(path);
+                string html = MarkdownRenderer.BuildHtml(markdown, path, caption);
+                return new DocumentView(DocumentViewKind.Html, caption, null, html);
+            }
+
+            var uri = new Uri(Path.GetFullPath(path));
+            return new DocumentView(DocumentViewKind.Navigate, caption, uri, null);
+        }
+    }
+
+    private static class FileViewHelper
+    {
+        private static readonly HashSet<string> s_markdownExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "md", "markdown", "mdown", "mkd", "mdx",
+        };
+
+        public static bool IsMarkdown(string extension)
+        {
+            return s_markdownExtensions.Contains(extension);
+        }
+    }
+
+    private static class MarkdownRenderer
+    {
+        private static readonly MarkdownPipeline s_pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+
+        public static string BuildHtml(string markdown, string sourcePath, string caption)
+        {
+            string htmlBody = Markdig.Markdown.ToHtml(markdown ?? string.Empty, s_pipeline);
+            ThemeHelper.ThemePalette? palette = ThemeHelper.TryGetPalette(out var value) ? value : null;
+
+            string? baseUrl = null;
+            try
+            {
+                if (!string.IsNullOrEmpty(sourcePath))
+                {
+                    var directory = Path.GetDirectoryName(sourcePath);
+                    if (!string.IsNullOrEmpty(directory))
+                    {
+                        var absolute = Path.GetFullPath(directory);
+                        if (!absolute.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+                        {
+                            absolute += Path.DirectorySeparatorChar;
+                        }
+                        baseUrl = new Uri(absolute).AbsoluteUri;
+                    }
+                }
+            }
+            catch (UriFormatException)
+            {
+                baseUrl = null;
+            }
+
+            var builder = new StringBuilder();
+            builder.AppendLine("<!DOCTYPE html>");
+            builder.Append("<html><head><meta charset=\"utf-8\"/>");
+            if (!string.IsNullOrEmpty(baseUrl))
+            {
+                builder.Append("<base href=\"")
+                    .Append(WebUtility.HtmlEncode(baseUrl))
+                    .Append("\"/>");
+            }
+            if (palette.HasValue)
+            {
+                string scheme = palette.Value.IsDark ? "dark" : "light";
+                builder.Append("<meta name=\"color-scheme\" content=\"")
+                    .Append(scheme)
+                    .Append("\"/>");
+            }
+            builder.Append("<title>")
+                .Append(WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(caption) ? "WebView2 Render Viewer .NET" : caption))
+                .Append("</title>");
+            builder.Append("<style>");
+            AppendStyles(builder, palette);
+            builder.Append("</style>");
+            builder.Append("</head><body>");
+            builder.Append(htmlBody);
+            builder.Append("</body></html>");
+            return builder.ToString();
+        }
+
+        private static void AppendStyles(StringBuilder builder, ThemeHelper.ThemePalette? palette)
+        {
+            Color background = palette?.Background ?? SystemColors.Window;
+            Color foreground = palette?.Foreground ?? SystemColors.WindowText;
+            Color accent = palette?.Accent ?? SystemColors.HotTrack;
+            Color border = palette?.ControlBorder ?? ControlPaint.Dark(background);
+            Color codeBackground = palette?.ControlBackground ?? ControlPaint.Light(background);
+
+            builder.Append("html,body{margin:0;padding:16px;font-family:'Segoe UI',SegoeUI,Helvetica,Arial,sans-serif;font-size:14px;line-height:1.6;background-color:")
+                .Append(ColorToCss(background))
+                .Append(";color:")
+                .Append(ColorToCss(foreground))
+                .Append(";}");
+            builder.Append("h1,h2,h3,h4,h5,h6{color:")
+                .Append(ColorToCss(foreground))
+                .Append(";margin-top:1.2em;}");
+            builder.Append("a{color:")
+                .Append(ColorToCss(accent))
+                .Append(";text-decoration:none;}a:hover{text-decoration:underline;}");
+            builder.Append("code{font-family:'Consolas','Courier New',monospace;background-color:")
+                .Append(ColorToCss(codeBackground))
+                .Append(";padding:2px 4px;border-radius:4px;}");
+            builder.Append("pre{overflow:auto;padding:12px;border-radius:6px;background-color:")
+                .Append(ColorToCss(codeBackground))
+                .Append(";border:1px solid ")
+                .Append(ColorToCss(border))
+                .Append(";}");
+            builder.Append("table{border-collapse:collapse;margin:1em 0;width:100%;}th,td{border:1px solid ")
+                .Append(ColorToCss(border))
+                .Append(";padding:8px;text-align:left;}");
+            builder.Append("blockquote{border-left:4px solid ")
+                .Append(ColorToCss(accent))
+                .Append(";margin:1em 0;padding:0.5em 1em;color:")
+                .Append(ColorToCss(ControlPaint.Dark(foreground)))
+                .Append(";background-color:")
+                .Append(ColorToCss(ControlPaint.LightLight(background)))
+                .Append(";}");
+            builder.Append("img,video,iframe{max-width:100%;height:auto;display:block;margin:0.5em 0;}");
+            builder.Append("hr{border:0;border-top:1px solid ")
+                .Append(ColorToCss(border))
+                .Append(";margin:2em 0;}");
+            builder.Append("ul,ol{margin:0 0 1em 1.5em;}");
+        }
+
+        private static string ColorToCss(Color color)
+        {
+            return string.Create(7, color, static (span, value) =>
+            {
+                span[0] = '#';
+                span[1] = GetHex((value.R >> 4) & 0xF);
+                span[2] = GetHex(value.R & 0xF);
+                span[3] = GetHex((value.G >> 4) & 0xF);
+                span[4] = GetHex(value.G & 0xF);
+                span[5] = GetHex((value.B >> 4) & 0xF);
+                span[6] = GetHex(value.B & 0xF);
+            });
+        }
+
+        private static char GetHex(int value) => (char)(value < 10 ? '0' + value : 'A' + (value - 10));
+    }
+}

--- a/src/plugins/webview2renderviewer/managed/ViewerResources.cs
+++ b/src/plugins/webview2renderviewer/managed/ViewerResources.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+using System.Drawing;
+using System.IO;
+using System.Reflection;
+
+namespace OpenSalamander.WebView2RenderViewer;
+
+internal static class ViewerResources
+{
+    private const string ViewerIconResourceName = "OpenSalamander.WebView2RenderViewer.Resources.viewer.ico";
+    private static Icon? s_viewerIcon;
+
+    public static Icon ViewerIcon
+    {
+        get
+        {
+            return s_viewerIcon ??= LoadViewerIcon();
+        }
+    }
+
+    private static Icon LoadViewerIcon()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        using Stream? stream = assembly.GetManifestResourceStream(ViewerIconResourceName);
+        if (stream is not null)
+        {
+            return new Icon(stream);
+        }
+
+        return SystemIcons.Application;
+    }
+}

--- a/src/plugins/webview2renderviewer/managed/WebView2RenderViewer.Managed.csproj
+++ b/src/plugins/webview2renderviewer/managed/WebView2RenderViewer.Managed.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>WebView2RenderViewer.Managed</AssemblyName>
+    <RootNamespace>OpenSalamander.WebView2RenderViewer</RootNamespace>
+    <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <ProjectGuid>{755CF63D-31EB-43B6-8402-2BB9D7D3E53F}</ProjectGuid>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2420.47" GeneratePathProperty="true" />
+    <PackageReference Include="Markdig" Version="0.36.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\\..\\..\\..\\src\\res\\viewer.ico" Link="Resources\\viewer.ico" />
+  </ItemGroup>
+
+  <Target Name="EnsureRestoreBeforeBuild"
+          BeforeTargets="CollectPackageReferences;CollectPackageReferencesDesignTime;ResolveReferences;PrepareForBuild"
+          Condition="'$(RestoreDuringBuild)' != 'true' and '$(ProjectAssetsFile)' != '' and !Exists('$(ProjectAssetsFile)')">
+    <Message Text="Running implicit restore for $(MSBuildProjectName) (missing $(ProjectAssetsFile))."
+             Importance="High" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="Restore"
+             Properties="RestoreDuringBuild=true" />
+  </Target>
+
+  <Target Name="CopyWebView2Dependencies" AfterTargets="Build">
+    <ItemGroup>
+      <_WebView2Assemblies Include="@(ReferenceCopyLocalPaths)"
+                           Condition="'%(FileName)' == 'Microsoft.Web.WebView2.Core' or '%(FileName)' == 'Microsoft.Web.WebView2.WinForms'" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_WebView2Assemblies)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true"
+          Condition="@(_WebView2Assemblies) != ''" />
+
+    <ItemGroup>
+      <_WebView2Loader Include="$(PkgMicrosoft_Web_WebView2)runtimes\\win-x64\\native\\WebView2Loader.dll"
+                       Condition="'$(PkgMicrosoft_Web_WebView2)' != '' and Exists('$(PkgMicrosoft_Web_WebView2)runtimes\\win-x64\\native\\WebView2Loader.dll')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_WebView2Loader)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true"
+          Condition="@(_WebView2Loader) != ''" />
+  </Target>
+</Project>

--- a/src/plugins/webview2renderviewer/managed/WindowInterop.cs
+++ b/src/plugins/webview2renderviewer/managed/WindowInterop.cs
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace OpenSalamander.WebView2RenderViewer;
+
+internal sealed class WindowHandleWrapper : IWin32Window
+{
+    public WindowHandleWrapper(IntPtr handle)
+    {
+        Handle = handle;
+    }
+
+    public IntPtr Handle { get; }
+}
+
+internal static class NativeMethods
+{
+    public const int GWL_HWNDPARENT = -8;
+    public const int GWL_EXSTYLE = -20;
+
+    public const int WS_EX_TOOLWINDOW = 0x00000080;
+    public const int WS_EX_APPWINDOW = 0x00040000;
+
+    public const uint SWP_NOSIZE = 0x0001;
+    public const uint SWP_NOMOVE = 0x0002;
+    public const uint SWP_NOZORDER = 0x0004;
+    public const uint SWP_NOACTIVATE = 0x0010;
+    public const uint SWP_FRAMECHANGED = 0x0020;
+    public const uint SWP_SHOWWINDOW = 0x0040;
+    public const uint SWP_NOOWNERZORDER = 0x0200;
+
+    public const int SW_SHOWMINIMIZED = 2;
+    public const int SW_SHOWMAXIMIZED = 3;
+
+    public static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+    {
+        return IntPtr.Size == 8
+            ? SetWindowLongPtr64(hWnd, nIndex, dwNewLong)
+            : new IntPtr(SetWindowLong32(hWnd, nIndex, dwNewLong.ToInt32()));
+    }
+
+    public static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
+    {
+        return IntPtr.Size == 8
+            ? GetWindowLongPtr64(hWnd, nIndex)
+            : new IntPtr(GetWindowLong32(hWnd, nIndex));
+    }
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongW", SetLastError = true)]
+    private static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongW", SetLastError = true)]
+    private static extern int GetWindowLong32(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
+    private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+    private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+}

--- a/src/plugins/webview2renderviewer/managed_bridge.cpp
+++ b/src/plugins/webview2renderviewer/managed_bridge.cpp
@@ -1,0 +1,378 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "precomp.h"
+#include "managed_bridge.h"
+
+#include "../../darkmode.h"
+
+#include <metahost.h>
+#include <mscoree.h>
+#include <strsafe.h>
+#include <wincrypt.h>
+
+#pragma comment(lib, "mscoree.lib")
+#pragma comment(lib, "crypt32.lib")
+
+namespace
+{
+ICLRRuntimeHost* gRuntimeHost = nullptr;
+std::wstring gAssemblyPath;
+const wchar_t* const kManagedType = L"OpenSalamander.WebView2RenderViewer.EntryPoint";
+const wchar_t* const kManagedMethod = L"Dispatch";
+
+std::wstring BuildArgument(const wchar_t* command, HWND parent, const wchar_t* payload)
+{
+    std::wstring argument = command;
+    argument.push_back(L';');
+
+    wchar_t buffer[32];
+    ULONGLONG handleValue = reinterpret_cast<ULONGLONG>(parent);
+    StringCchPrintfW(buffer, _countof(buffer), L"%llu", handleValue);
+    argument.append(buffer);
+
+    argument.push_back(L';');
+    if (payload != nullptr)
+    {
+        argument.append(payload);
+    }
+
+    return argument;
+}
+
+std::wstring ConvertMultiByteToWide(const char* text, UINT codePage)
+{
+    if (text == nullptr)
+    {
+        return std::wstring();
+    }
+
+    DWORD flags = (codePage == CP_UTF8) ? MB_ERR_INVALID_CHARS : 0;
+    int required = MultiByteToWideChar(codePage, flags, text, -1, nullptr, 0);
+    if (required <= 0)
+    {
+        return std::wstring();
+    }
+
+    std::wstring result;
+    result.resize(static_cast<size_t>(required));
+    int converted = MultiByteToWideChar(codePage, flags, text, -1, result.data(), required);
+    if (converted <= 0)
+    {
+        return std::wstring();
+    }
+
+    result.resize(static_cast<size_t>(converted) - 1);
+    return result;
+}
+
+std::wstring AnsiToWide(const char* text)
+{
+    if (text == nullptr)
+    {
+        return std::wstring();
+    }
+
+    std::wstring result = ConvertMultiByteToWide(text, CP_ACP);
+    if (!result.empty())
+    {
+        return result;
+    }
+
+    result = ConvertMultiByteToWide(text, CP_UTF8);
+    if (!result.empty())
+    {
+        return result;
+    }
+
+    // As a last resort, map bytes directly to Unicode code points so the
+    // managed side still receives something meaningful to work with.
+    const unsigned char* bytes = reinterpret_cast<const unsigned char*>(text);
+    while (*bytes != '\0')
+    {
+        result.push_back(static_cast<wchar_t>(*bytes));
+        ++bytes;
+    }
+
+    return result;
+}
+
+std::wstring EncodeBase64FromWide(const std::wstring& value)
+{
+    if (value.empty())
+    {
+        return std::wstring();
+    }
+
+    int utf8Length = WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if (utf8Length <= 1)
+    {
+        return std::wstring();
+    }
+
+    std::string utf8;
+    utf8.resize(utf8Length - 1);
+    if (WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, utf8.data(), utf8Length - 1, nullptr, nullptr) <= 0)
+    {
+        return std::wstring();
+    }
+
+    DWORD base64Length = 0;
+    if (!CryptBinaryToStringW(reinterpret_cast<const BYTE*>(utf8.data()), static_cast<DWORD>(utf8.size()),
+                              CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, nullptr, &base64Length))
+    {
+        return std::wstring();
+    }
+
+    std::wstring result;
+    result.resize(base64Length);
+    if (!CryptBinaryToStringW(reinterpret_cast<const BYTE*>(utf8.data()), static_cast<DWORD>(utf8.size()),
+                              CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, result.data(), &base64Length))
+    {
+        return std::wstring();
+    }
+
+    if (!result.empty() && result.back() == L'\0')
+    {
+        result.pop_back();
+    }
+    else
+    {
+        result.resize(base64Length);
+    }
+
+    return result;
+}
+
+std::wstring ExtractFileName(const std::wstring& path)
+{
+    size_t pos = path.find_last_of(L"\\/");
+    if (pos == std::wstring::npos)
+    {
+        return path;
+    }
+    return path.substr(pos + 1);
+}
+
+void AppendKeyValue(std::wstring& payload, const wchar_t* key, const wchar_t* value)
+{
+    if (!payload.empty())
+    {
+        payload.push_back(L'|');
+    }
+    payload.append(key);
+    payload.push_back(L'=');
+    if (value != nullptr)
+    {
+        payload.append(value);
+    }
+}
+
+void AppendUInt(std::wstring& payload, const wchar_t* key, unsigned long value)
+{
+    wchar_t buffer[32];
+    StringCchPrintfW(buffer, _countof(buffer), L"%lu", value);
+    AppendKeyValue(payload, key, buffer);
+}
+
+void AppendInt(std::wstring& payload, const wchar_t* key, long value)
+{
+    wchar_t buffer[32];
+    StringCchPrintfW(buffer, _countof(buffer), L"%ld", value);
+    AppendKeyValue(payload, key, buffer);
+}
+
+void AppendHandle(std::wstring& payload, const wchar_t* key, HANDLE handle)
+{
+    wchar_t buffer[32];
+    ULONGLONG value = reinterpret_cast<ULONGLONG>(handle);
+    StringCchPrintfW(buffer, _countof(buffer), L"%llu", value);
+    AppendKeyValue(payload, key, buffer);
+}
+
+bool ExecuteCommand(const wchar_t* command, HWND parent, const wchar_t* payload)
+{
+    if (gRuntimeHost == nullptr)
+    {
+        return false;
+    }
+
+    DWORD returnValue = 0;
+    std::wstring argument = BuildArgument(command, parent, payload);
+    HRESULT hr = gRuntimeHost->ExecuteInDefaultAppDomain(gAssemblyPath.c_str(), kManagedType, kManagedMethod,
+                                                         argument.c_str(), &returnValue);
+    if (FAILED(hr))
+    {
+        wchar_t message[256];
+        StringCchPrintfW(message, _countof(message), L"Failed to execute managed command '%s' (0x%08X).", command, hr);
+        MessageBoxW(parent, message, L"WebView2 Render Viewer .NET Plugin", MB_ICONERROR | MB_OK);
+        return false;
+    }
+
+    return returnValue == 0;
+}
+
+void ShowLoadError(HWND parent, const wchar_t* text)
+{
+    MessageBoxW(parent, text, L"WebView2 Render Viewer .NET Plugin", MB_ICONERROR | MB_OK);
+}
+
+} // namespace
+
+bool ManagedBridge_EnsureInitialized(HWND parent)
+{
+    if (gRuntimeHost != nullptr)
+    {
+        return true;
+    }
+
+    ICLRMetaHost* metaHost = nullptr;
+    HRESULT hr = CLRCreateInstance(CLSID_CLRMetaHost, IID_PPV_ARGS(&metaHost));
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to load CLR meta host.");
+        return false;
+    }
+
+    ICLRRuntimeInfo* runtimeInfo = nullptr;
+    hr = metaHost->GetRuntime(L"v4.0.30319", IID_PPV_ARGS(&runtimeInfo));
+    metaHost->Release();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to locate CLR v4 runtime.");
+        return false;
+    }
+
+    hr = runtimeInfo->GetInterface(CLSID_CLRRuntimeHost, IID_PPV_ARGS(&gRuntimeHost));
+    runtimeInfo->Release();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to create CLR runtime host.");
+        return false;
+    }
+
+    hr = gRuntimeHost->Start();
+    if (FAILED(hr))
+    {
+        ShowLoadError(parent, L"Failed to start CLR runtime.");
+        gRuntimeHost->Release();
+        gRuntimeHost = nullptr;
+        return false;
+    }
+
+    wchar_t modulePath[MAX_PATH] = {0};
+    if (GetModuleFileNameW(DLLInstance, modulePath, _countof(modulePath)) == 0)
+    {
+        ShowLoadError(parent, L"Failed to determine plugin path.");
+        ManagedBridge_Shutdown();
+        return false;
+    }
+
+    wchar_t* lastSlash = wcsrchr(modulePath, L'\\');
+    if (lastSlash != nullptr)
+    {
+        *(lastSlash + 1) = L'\0';
+    }
+
+    gAssemblyPath.assign(modulePath);
+    gAssemblyPath.append(L"WebView2RenderViewer.Managed.dll");
+
+    return true;
+}
+
+void ManagedBridge_Shutdown()
+{
+    if (gRuntimeHost != nullptr)
+    {
+        gRuntimeHost->Stop();
+        gRuntimeHost->Release();
+        gRuntimeHost = nullptr;
+        gAssemblyPath.clear();
+    }
+}
+
+bool ManagedBridge_RequestShutdown(HWND parent, bool forceClose)
+{
+    if (gRuntimeHost == nullptr)
+    {
+        return true;
+    }
+
+    std::wstring payload;
+    AppendKeyValue(payload, L"force", forceClose ? L"1" : L"0");
+    return ExecuteCommand(L"Release", parent, payload.c_str());
+}
+
+bool ManagedBridge_ViewDocument(HWND parent, const char* filePath, const RECT& placement,
+                                UINT showCmd, BOOL alwaysOnTop, HANDLE fileLock, bool asynchronous)
+{
+    if (!ManagedBridge_EnsureInitialized(parent))
+    {
+        return false;
+    }
+
+    std::wstring widePath = AnsiToWide(filePath);
+
+    std::wstring encodedPath = EncodeBase64FromWide(widePath);
+    if (encodedPath.empty())
+    {
+        encodedPath = widePath;
+    }
+
+    if (encodedPath.empty())
+    {
+        ShowLoadError(parent, L"Unable to prepare parameters for the render viewer.");
+        return false;
+    }
+
+    std::wstring caption = ExtractFileName(widePath);
+    if (caption.empty())
+    {
+        caption = widePath;
+    }
+
+    std::wstring encodedCaption = EncodeBase64FromWide(caption);
+    if (encodedCaption.empty())
+    {
+        encodedCaption = caption;
+    }
+
+    std::wstring payload;
+    AppendKeyValue(payload, L"path", encodedPath.c_str());
+    AppendKeyValue(payload, L"caption", encodedCaption.c_str());
+    AppendInt(payload, L"left", placement.left);
+    AppendInt(payload, L"top", placement.top);
+    AppendInt(payload, L"width", placement.right - placement.left);
+    AppendInt(payload, L"height", placement.bottom - placement.top);
+    AppendUInt(payload, L"show", showCmd);
+    AppendKeyValue(payload, L"ontop", alwaysOnTop ? L"1" : L"0");
+    AppendHandle(payload, L"close", fileLock);
+    AppendKeyValue(payload, L"async", asynchronous ? L"1" : L"0");
+
+    const wchar_t* command = asynchronous ? L"View" : L"ViewSync";
+    return ExecuteCommand(command, parent, payload.c_str());
+}
+
+extern "C" __declspec(dllexport) UINT32 __stdcall RenderViewer_GetCurrentColor(int color)
+{
+    if (SalamanderGeneral == NULL)
+    {
+        return 0;
+    }
+
+    return SalamanderGeneral->GetCurrentColor(color);
+}
+
+extern "C" __declspec(dllexport) void __stdcall RenderViewer_SetDarkModeState(BOOL enabled)
+{
+    DarkModeSetEnabled(enabled != FALSE);
+    if (enabled)
+    {
+        DarkModeFixScrollbars();
+    }
+}
+
+extern "C" __declspec(dllexport) void __stdcall RenderViewer_ApplyDarkModeTree(HWND hwnd)
+{
+    DarkModeApplyTree(hwnd);
+}

--- a/src/plugins/webview2renderviewer/managed_bridge.h
+++ b/src/plugins/webview2renderviewer/managed_bridge.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <string>
+
+bool ManagedBridge_EnsureInitialized(HWND parent);
+void ManagedBridge_Shutdown();
+bool ManagedBridge_RequestShutdown(HWND parent, bool forceClose);
+bool ManagedBridge_ViewDocument(HWND parent, const char* filePath, const RECT& placement,
+                                UINT showCmd, BOOL alwaysOnTop, HANDLE fileLock, bool asynchronous);

--- a/src/plugins/webview2renderviewer/precomp.cpp
+++ b/src/plugins/webview2renderviewer/precomp.cpp
@@ -1,0 +1,19 @@
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#include "precomp.h"
+
+// projekt WebView2 Render Viewer obsahuje tri skupiny modulu
+//
+// 1) modul precomp.cpp, ktery postavi textviewer.pch (/Yc"precomp.h")
+// 2) moduly vyuzivajici textviewer.pch (/Yu"precomp.h")
+// 3) commony maji vlastni, automaticky generovany WINDOWS.PCH
+//    (/YX"windows.h" /Fp"$(OutDir)\WINDOWS.PCH")

--- a/src/plugins/webview2renderviewer/precomp.h
+++ b/src/plugins/webview2renderviewer/precomp.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN // exclude rarely-used stuff from Windows headers
+
+#include <windows.h>
+#include <CommDlg.h>
+#include <shlobj.h>
+#ifdef _MSC_VER
+#include <crtdbg.h>
+#endif // _MSC_VER
+#include <limits.h>
+#include <process.h>
+#include <commctrl.h>
+#include <ostream>
+#include <stdio.h>
+#include <time.h>
+
+#if defined(_DEBUG) && defined(_MSC_VER)
+#define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#endif
+
+#include "versinfo.rh2"
+
+#include "spl_com.h"
+#include "spl_base.h"
+#include "spl_gen.h"
+#include "spl_gui.h"
+#include "spl_view.h"
+#include "spl_vers.h"
+
+#include "dbg.h"
+#include "mhandles.h"
+#include "arraylt.h"
+#include "winliblt.h"
+#include "auxtools.h"
+#include "textviewer.h"
+#include "managed_bridge.h"
+#include "textviewer.rh"
+#include "textviewer.rh2"
+#include "lang\lang.rh"
+
+#ifdef __BORLANDC__
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif // __BORLANDC__

--- a/src/plugins/webview2renderviewer/vcxproj/lang_webview2renderviewer.props
+++ b/src/plugins/webview2renderviewer/vcxproj/lang_webview2renderviewer.props
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros">
+    <ShortProjectName>webview2renderviewer</ShortProjectName>
+  </PropertyGroup>
+  <ItemGroup>
+    <BuildMacro Include="ShortProjectName">
+      <Value>$(ShortProjectName)</Value>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/src/plugins/webview2renderviewer/vcxproj/lang_webview2renderviewer.vcxproj
+++ b/src/plugins/webview2renderviewer/vcxproj/lang_webview2renderviewer.vcxproj
@@ -1,0 +1,151 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}</ProjectGuid>
+    <RootNamespace>lang_webview2renderviewer</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props">
+  </Import>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props">
+  </Import>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_webview2renderviewer.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_release.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_webview2renderviewer.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_debug.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_webview2renderviewer.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_release.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="lang_webview2renderviewer.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\lang_debug.props">
+    </Import>
+  </ImportGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'!=''">
+    <RenderViewerBuildRoot>$([System.IO.Path]::Combine('$(OPENSAL_BUILD_DIR)', 'salamander'))\</RenderViewerBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'==''">
+    <RenderViewerBuildRoot>$(ProjectDir)..\..\..\..\build\salamander\</RenderViewerBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RenderViewerLangDir>$(RenderViewerBuildRoot)$(Configuration)_$(ShortPlatform)\plugins\webview2renderviewer\lang\</RenderViewerLangDir>
+    <OutDir>$(RenderViewerLangDir)</OutDir>
+    <IntDir>$(OutDir)Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Label="UserMacros">
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <None Include="..\textviewer.rh2">
+    </None>
+    <None Include="..\lang\lang.rc2">
+    </None>
+    <None Include="..\lang\lang.rh">
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\lang\lang.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets">
+  </Import>
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/plugins/webview2renderviewer/vcxproj/webview2renderviewer.props
+++ b/src/plugins/webview2renderviewer/vcxproj/webview2renderviewer.props
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros"></PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/plugins/webview2renderviewer/vcxproj/webview2renderviewer.sln
+++ b/src/plugins/webview2renderviewer/vcxproj/webview2renderviewer.sln
@@ -1,0 +1,70 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29020.237
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "webview2renderviewer", "webview2renderviewer.vcxproj", "{340CB50A-0325-4FAD-9C57-06FCC80E4482}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lang_webview2renderviewer", "lang_webview2renderviewer.vcxproj", "{1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebView2RenderViewer.Managed", "..\managed\WebView2RenderViewer.Managed.csproj", "{755CF63D-31EB-43B6-8402-2BB9D7D3E53F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1BDAFFE2-B264-44E9-A670-B7EC029A726F}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.editorconfig = ..\..\..\.editorconfig
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		SDK|x64 = SDK|x64
+		SDK|x86 = SDK|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x64.ActiveCfg = Debug|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x64.Build.0 = Debug|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x86.ActiveCfg = Debug|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Debug|x86.Build.0 = Debug|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x64.ActiveCfg = Release|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x64.Build.0 = Release|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x86.ActiveCfg = Release|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.Release|x86.Build.0 = Release|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.SDK|x64.ActiveCfg = SDK|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.SDK|x64.Build.0 = SDK|x64
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.SDK|x86.ActiveCfg = SDK|Win32
+                {340CB50A-0325-4FAD-9C57-06FCC80E4482}.SDK|x86.Build.0 = SDK|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x64.ActiveCfg = Debug|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x64.Build.0 = Debug|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x86.ActiveCfg = Debug|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Debug|x86.Build.0 = Debug|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x64.ActiveCfg = Release|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x64.Build.0 = Release|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x86.ActiveCfg = Release|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.Release|x86.Build.0 = Release|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.SDK|x64.ActiveCfg = SDK|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.SDK|x64.Build.0 = SDK|x64
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.SDK|x86.ActiveCfg = SDK|Win32
+                {1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}.SDK|x86.Build.0 = SDK|Win32
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x64.Build.0 = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Debug|x86.Build.0 = Debug|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x64.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x64.Build.0 = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x86.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.Release|x86.Build.0 = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.SDK|x64.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.SDK|x64.Build.0 = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.SDK|x86.ActiveCfg = Release|Any CPU
+                {755CF63D-31EB-43B6-8402-2BB9D7D3E53F}.SDK|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {375C9D55-0C0E-42AE-8696-21DE91B07CCF}
+	EndGlobalSection
+EndGlobal

--- a/src/plugins/webview2renderviewer/vcxproj/webview2renderviewer.vcxproj
+++ b/src/plugins/webview2renderviewer/vcxproj/webview2renderviewer.vcxproj
@@ -1,0 +1,218 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{340CB50A-0325-4FAD-9C57-06FCC80E4482}</ProjectGuid>
+    <RootNamespace>webview2renderviewer</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props">
+  </Import>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props">
+  </Import>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_release.props">
+    </Import>
+    <Import Project="webview2renderviewer.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x86.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_debug.props">
+    </Import>
+    <Import Project="webview2renderviewer.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_release.props">
+    </Import>
+    <Import Project="webview2renderviewer.props">
+    </Import>
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\x64.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_base.props">
+    </Import>
+    <Import Project="..\..\shared\vcxproj\plugin_debug.props">
+    </Import>
+    <Import Project="webview2renderviewer.props">
+    </Import>
+  </ImportGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'!=''">
+    <RenderViewerBuildRoot>$([System.IO.Path]::Combine('$(OPENSAL_BUILD_DIR)', 'salamander'))\</RenderViewerBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OPENSAL_BUILD_DIR)'==''">
+    <RenderViewerBuildRoot>$(ProjectDir)..\..\..\..\build\salamander\</RenderViewerBuildRoot>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RenderViewerPluginDir>$(RenderViewerBuildRoot)$(Configuration)_$(ShortPlatform)\plugins\webview2renderviewer\</RenderViewerPluginDir>
+    <OutDir>$(RenderViewerPluginDir)</OutDir>
+    <IntDir>$(OutDir)Intermediate\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Label="UserMacros">
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\shared\auxtools.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\shared\dbg.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+    </ClCompile>
+    <ClCompile Include="..\webview2renderviewer.cpp">
+    </ClCompile>
+    <ClCompile Include="..\managed_bridge.cpp">
+    </ClCompile>
+    <ClCompile Include="..\precomp.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\shared\auxtools.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\dbg.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_base.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_com.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gen.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gui.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_vers.h">
+    </ClInclude>
+    <ClInclude Include="..\webview2renderviewer.h">
+    </ClInclude>
+    <ClInclude Include="..\managed_bridge.h">
+    </ClInclude>
+    <ClInclude Include="..\precomp.h">
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\webview2renderviewer.def">
+    </None>
+    <None Include="..\webview2renderviewer.rc2">
+    </None>
+    <None Include="..\webview2renderviewer.rh">
+    </None>
+    <None Include="..\webview2renderviewer.rh2">
+    </None>
+    <None Include="..\lang\lang.rh">
+    </None>
+    <None Include="..\versinfo.rh2">
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\webview2renderviewer.rc">
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="lang_webview2renderviewer.vcxproj">
+      <Project>{1DE1C48D-BFB7-4401-9E4C-3EF9FC3D3407}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\managed\WebView2RenderViewer.Managed.csproj">
+      <Project>{755CF63D-31EB-43B6-8402-2BB9D7D3E53F}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command><![CDATA[
+call "$(ProjectDir)..\copy_managed_dependencies.cmd" "$(ProjectDir)..\" "$(Configuration)" "$(Platform)" "$(RenderViewerPluginDir)"
+if errorlevel 1 exit /B 1
+]]></Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets">
+  </Import>
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/plugins/webview2renderviewer/vcxproj/webview2renderviewer.vcxproj.filters
+++ b/src/plugins/webview2renderviewer/vcxproj/webview2renderviewer.vcxproj.filters
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="cpp">
+      <UniqueIdentifier>{7ec3b1ea-c9ff-4c6d-a33d-01d4cc9259e3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="h">
+      <UniqueIdentifier>{b358cda3-ea28-4487-886c-6e8d3e40ba6d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rc">
+      <UniqueIdentifier>{70c292f6-5208-42dd-8264-933d8a862f5b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="shared">
+      <UniqueIdentifier>{199e8645-6a17-4b65-a388-f9700eb782af}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\webview2renderviewer.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\precomp.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\auxtools.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\dbg.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\webview2renderviewer.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\precomp.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\auxtools.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\dbg.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_base.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_com.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gen.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_gui.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\spl_vers.h">
+      <Filter>shared</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\webview2renderviewer.def">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\webview2renderviewer.rc2">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\webview2renderviewer.rh">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\webview2renderviewer.rh2">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\lang\lang.rh">
+      <Filter>rc</Filter>
+    </None>
+    <None Include="..\versinfo.rh2">
+      <Filter>rc</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\webview2renderviewer.rc">
+      <Filter>rc</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/src/plugins/webview2renderviewer/versinfo.rh2
+++ b/src/plugins/webview2renderviewer/versinfo.rh2
@@ -1,0 +1,43 @@
+//****************************************************************************
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+#ifndef __WEBVIEW2RENDERVIEWER_VERSINFO_RH2
+#define __WEBVIEW2RENDERVIEWER_VERSINFO_RH2
+
+#if defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+#error this file is not editable by Microsoft Visual C++
+#endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+
+// defines for plugin.SPL and plugin.SLG VERSIONINFO
+// look at shared\versinfo.rc
+
+#define VERSINFO_MAJOR       1
+#define VERSINFO_MINORA      0
+#define VERSINFO_MINORB      0
+
+#include "spl_vers.h" // vytahneme cisla verzi + buildu
+
+#define VERSINFO_COPYRIGHT   "Copyleft 2025 KRtekTM"
+#define VERSINFO_COMPANY     "Open Salamander"
+
+#define VERSINFO_DESCRIPTION "WebView2 Render Viewer .NET plugin for Open Salamander"
+
+#ifdef _LANG
+#define VERSINFO_INTERNAL    "ENGLISH"
+#define VERSINFO_ORIGINAL    VERSINFO_INTERNAL ".SLG"
+#else
+#define VERSINFO_INTERNAL    "WEBVIEW2RENDERVIEWER"
+#define VERSINFO_ORIGINAL    VERSINFO_INTERNAL ".SPL"
+#endif
+
+// for SLG translators
+#define VERSINFO_SLG_WEB     "www.altap.cz"
+#define VERSINFO_SLG_COMMENT "English version"
+
+#endif // __WEBVIEW2RENDERVIEWER_VERSINFO_RH2

--- a/src/plugins/webview2renderviewer/webview2renderviewer.cpp
+++ b/src/plugins/webview2renderviewer/webview2renderviewer.cpp
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: 2023-2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#include "precomp.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <utility>
+#include <unordered_set>
+#include <vector>
+
+// objekt interfacu pluginu, jeho metody se volaji ze Salamandera
+CPluginInterface PluginInterface;
+// cast interfacu CPluginInterface pro viewer
+CPluginInterfaceForViewer InterfaceForViewer;
+
+// globalni data
+const char* PluginNameEN = "WebView2 Render Viewer .NET"; // neprekladane jmeno pluginu
+const char* PluginNameShort = "WEBVIEW2VIEWER";    // jmeno pluginu (kratce, bez mezer)
+
+HINSTANCE DLLInstance = NULL; // handle k SPL-ku - jazykove nezavisle resourcy
+HINSTANCE HLanguage = NULL;   // handle k SLG-cku - jazykove zavisle resourcy
+
+// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+CSalamanderGeneralAbstract* SalamanderGeneral = NULL;
+CSalamanderGUIAbstract* SalamanderGUI = NULL;
+
+// definice promenne pro "dbg.h"
+CSalamanderDebugAbstract* SalamanderDebug = NULL;
+
+// maximum file size (in bytes) allowed for the managed viewer
+static const ULONGLONG kMaxDocumentFileSize = 32ULL * 1024ULL * 1024ULL; // 32 MB
+
+// definice promenne pro "spl_com.h"
+int SalamanderVersion = 0;
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+    if (fdwReason == DLL_PROCESS_ATTACH)
+    {
+        DLLInstance = hinstDLL;
+
+        INITCOMMONCONTROLSEX initCtrls;
+        initCtrls.dwSize = sizeof(INITCOMMONCONTROLSEX);
+        initCtrls.dwICC = ICC_BAR_CLASSES;
+        if (!InitCommonControlsEx(&initCtrls))
+        {
+            MessageBox(NULL, "InitCommonControlsEx failed!", "Error", MB_OK | MB_ICONERROR);
+            return FALSE; // DLL won't start
+        }
+    }
+
+    return TRUE; // DLL can be loaded
+}
+
+// ****************************************************************************
+
+char* LoadStr(int resID)
+{
+    return SalamanderGeneral->LoadStr(HLanguage, resID);
+}
+
+static void ShowStartupError(HWND parent, const char* text)
+{
+    SalamanderGeneral->SalMessageBox(parent, text, LoadStr(IDS_PLUGINNAME), MB_OK | MB_ICONERROR);
+}
+
+static bool IsFileTooLarge(const char* path, ULONGLONG limit)
+{
+    if (path == NULL || path[0] == '\0')
+        return false;
+
+    WIN32_FILE_ATTRIBUTE_DATA attrs;
+    if (!GetFileAttributesExA(path, GetFileExInfoStandard, &attrs))
+        return false;
+
+    if (attrs.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+        return false;
+
+    ULONGLONG size = (static_cast<ULONGLONG>(attrs.nFileSizeHigh) << 32) | attrs.nFileSizeLow;
+    return size > limit;
+}
+
+//
+// ****************************************************************************
+// SalamanderPluginGetReqVer
+//
+
+#ifdef __BORLANDC__
+extern "C"
+{
+    int WINAPI SalamanderPluginGetReqVer();
+    CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbstract* salamander);
+};
+#endif // __BORLANDC__
+
+int WINAPI SalamanderPluginGetReqVer()
+{
+    return LAST_VERSION_OF_SALAMANDER;
+}
+
+//
+// ****************************************************************************
+// SalamanderPluginEntry
+//
+
+CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbstract* salamander)
+{
+    // nastavime SalamanderDebug pro "dbg.h"
+    SalamanderDebug = salamander->GetSalamanderDebug();
+    // nastavime SalamanderVersion pro "spl_com.h"
+    SalamanderVersion = salamander->GetVersion();
+    HANDLES_CAN_USE_TRACE();
+    CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
+
+    if (SalamanderVersion < LAST_VERSION_OF_SALAMANDER)
+    {
+        MessageBox(salamander->GetParentWindow(),
+                   REQUIRE_LAST_VERSION_OF_SALAMANDER,
+                   PluginNameEN, MB_OK | MB_ICONERROR);
+        return NULL;
+    }
+
+    // nechame nacist jazykovy modul (.slg)
+    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), PluginNameEN);
+    if (HLanguage == NULL)
+        return NULL;
+
+    // ziskame obecne rozhrani Salamandera
+    SalamanderGeneral = salamander->GetSalamanderGeneral();
+    SalamanderGUI = salamander->GetSalamanderGUI();
+
+    salamander->SetBasicPluginData(LoadStr(IDS_PLUGINNAME), FUNCTION_VIEWER,
+                                   VERSINFO_VERSION_NO_PLATFORM, VERSINFO_COPYRIGHT,
+                                   LoadStr(IDS_PLUGIN_DESCRIPTION), PluginNameShort,
+                                   NULL, NULL);
+
+    salamander->SetPluginHomePageURL(LoadStr(IDS_PLUGIN_HOME));
+
+    return &PluginInterface;
+}
+
+//
+// ****************************************************************************
+// CPluginInterface
+//
+
+void WINAPI CPluginInterface::About(HWND parent)
+{
+    char text[1024];
+    _snprintf_s(text, _TRUNCATE,
+                "%s\n\n%s",
+                LoadStr(IDS_PLUGINNAME),
+                LoadStr(IDS_PLUGIN_DESCRIPTION));
+    SalamanderGeneral->SalMessageBox(parent, text, LoadStr(IDS_ABOUT), MB_OK | MB_ICONINFORMATION);
+}
+
+BOOL WINAPI CPluginInterface::Release(HWND parent, BOOL force)
+{
+    if (!ManagedBridge_RequestShutdown(parent, force != FALSE))
+        return FALSE;
+
+    ManagedBridge_Shutdown();
+    return TRUE;
+}
+
+void WINAPI CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamander)
+{
+    CALL_STACK_MESSAGE1("CPluginInterface::Connect(,)");
+
+    static const char* const kViewerExtensions[] = {
+        "html", "htm", "xhtml", "mhtml", "mht",
+        "md", "markdown", "mdown", "mkd", "mdx",
+        "svg", "svgz",
+        "webp", "avif", "apng", "png", "jpg", "jpeg", "jfif", "gif", "bmp", "ico", "tif", "tiff",
+        "pdf"
+    };
+
+    std::unordered_set<std::string> extensions;
+    extensions.reserve(_countof(kViewerExtensions));
+
+    auto addExtension = [&extensions](const char* ext) {
+        if (ext != NULL && ext[0] != '\0')
+        {
+            std::string lowered(ext);
+            std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                           [](unsigned char c) { return (char)std::tolower(c); });
+            extensions.insert(lowered);
+        }
+    };
+
+    for (const char* ext : kViewerExtensions)
+    {
+        addExtension(ext);
+    }
+
+    if (!extensions.empty())
+    {
+        constexpr size_t kMaxPatternLength = 200;
+
+        std::string pattern;
+        pattern.reserve(kMaxPatternLength);
+
+        auto flushPattern = [&]() {
+            if (!pattern.empty())
+            {
+                salamander->AddViewer(pattern.c_str(), FALSE);
+                pattern.clear();
+            }
+        };
+
+        for (const std::string& ext : extensions)
+        {
+            const std::string token = std::string("*.") + ext;
+            const size_t separator = pattern.empty() ? 0 : 1;
+
+            if (!pattern.empty() && (pattern.size() + separator + token.size()) > kMaxPatternLength)
+            {
+                flushPattern();
+            }
+
+            if (!pattern.empty())
+            {
+                pattern.push_back(';');
+            }
+
+            if (!pattern.empty() && (pattern.size() + token.size()) > kMaxPatternLength)
+            {
+                flushPattern();
+            }
+
+            pattern.append(token);
+
+            if (pattern.size() >= kMaxPatternLength)
+            {
+                flushPattern();
+            }
+        }
+
+        flushPattern();
+    }
+
+    if (SalamanderGUI != NULL)
+    {
+        CGUIIconListAbstract* iconList = SalamanderGUI->CreateIconList();
+        if (iconList != NULL)
+        {
+            if (iconList->Create(16, 16, 1))
+            {
+                UINT loadFlags = SalamanderGeneral != NULL ? SalamanderGeneral->GetIconLRFlags() : LR_DEFAULTCOLOR;
+                HICON icon16 = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_WEBVIEW2RENDERVIEWER), IMAGE_ICON, 16, 16, loadFlags);
+                if (icon16 != NULL)
+                {
+                    iconList->ReplaceIcon(0, icon16);
+                    DestroyIcon(icon16);
+                    salamander->SetIconListForGUI(iconList);
+                    salamander->SetPluginIcon(0);
+                    salamander->SetPluginMenuAndToolbarIcon(0);
+                    iconList = NULL;
+                }
+            }
+
+            if (iconList != NULL)
+                SalamanderGUI->DestroyIconList(iconList);
+        }
+    }
+}
+
+CPluginInterfaceForViewerAbstract* WINAPI CPluginInterface::GetInterfaceForViewer()
+{
+    return &InterfaceForViewer;
+}
+
+//
+// ****************************************************************************
+// CPluginInterfaceForViewer
+//
+
+BOOL WINAPI CPluginInterfaceForViewer::ViewFile(const char* name, int left, int top, int width, int height,
+                                                UINT showCmd, BOOL alwaysOnTop, BOOL returnLock, HANDLE* lock,
+                                                BOOL* lockOwner, CSalamanderPluginViewerData* viewerData,
+                                                int enumFilesSourceUID, int enumFilesCurrentIndex)
+{
+    CALL_STACK_MESSAGE1("CPluginInterfaceForViewer::ViewFile()");
+
+    if (name == NULL || name[0] == '\0')
+        return FALSE;
+
+    HWND parent = SalamanderGeneral->GetMainWindowHWND();
+
+    if (IsFileTooLarge(name, kMaxDocumentFileSize))
+    {
+        SalamanderGeneral->SalMessageBox(parent, LoadStr(IDS_FILE_TOO_LARGE), LoadStr(IDS_PLUGINNAME),
+                                         MB_OK | MB_ICONINFORMATION);
+        return FALSE;
+    }
+
+    RECT placement;
+    placement.left = left;
+    placement.top = top;
+    placement.right = left + width;
+    placement.bottom = top + height;
+
+    if (returnLock)
+    {
+        HANDLE fileLock = HANDLES(CreateEvent(NULL, FALSE, FALSE, NULL));
+        if (fileLock == NULL)
+        {
+            ShowStartupError(parent, LoadStr(IDS_VIEWER_CREATE_EVENT_FAILED));
+            return FALSE;
+        }
+
+        if (!ManagedBridge_ViewDocument(parent, name, placement, showCmd, alwaysOnTop, fileLock, true))
+        {
+            HANDLES(CloseHandle(fileLock));
+            return FALSE;
+        }
+
+        if (lock != NULL)
+            *lock = fileLock;
+        if (lockOwner != NULL)
+            *lockOwner = TRUE;
+        return TRUE;
+    }
+
+    return ManagedBridge_ViewDocument(parent, name, placement, showCmd, alwaysOnTop, NULL, false);
+}
+
+BOOL WINAPI CPluginInterfaceForViewer::CanViewFile(const char* name)
+{
+    if (name == NULL)
+        return FALSE;
+
+    const char* extension = strrchr(name, '.');
+    if (extension == NULL)
+        return FALSE;
+
+    static const char* const kExtensions[] = {
+        ".html", ".htm", ".xhtml", ".mhtml", ".mht",
+        ".md", ".markdown", ".mdown", ".mkd", ".mdx",
+        ".svg", ".svgz",
+        ".webp", ".avif", ".apng", ".png", ".jpg", ".jpeg", ".jfif", ".gif", ".bmp", ".ico", ".tif", ".tiff",
+        ".pdf"
+    };
+
+    for (size_t i = 0; i < _countof(kExtensions); ++i)
+    {
+        if (_stricmp(extension, kExtensions[i]) == 0)
+            return TRUE;
+    }
+
+    return FALSE;
+}

--- a/src/plugins/webview2renderviewer/webview2renderviewer.def
+++ b/src/plugins/webview2renderviewer/webview2renderviewer.def
@@ -1,0 +1,7 @@
+LIBRARY WEBVIEW2RENDERVIEWER.SPL
+
+EXPORTS SalamanderPluginEntry
+EXPORTS SalamanderPluginGetReqVer
+EXPORTS RenderViewer_GetCurrentColor
+EXPORTS RenderViewer_SetDarkModeState
+EXPORTS RenderViewer_ApplyDarkModeTree

--- a/src/plugins/webview2renderviewer/webview2renderviewer.h
+++ b/src/plugins/webview2renderviewer/webview2renderviewer.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//****************************************************************************
+//
+// Copyright (c) 2023 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+#pragma once
+
+// globalni data
+extern HINSTANCE DLLInstance; // handle k SPL-ku - jazykove nezavisle resourcy
+extern HINSTANCE HLanguage;   // handle k SLG-cku - jazykove zavisle resourcy
+
+// obecne rozhrani Salamandera - platne od startu az do ukonceni pluginu
+extern CSalamanderGeneralAbstract* SalamanderGeneral;
+
+char* LoadStr(int resID);
+
+class CPluginInterfaceForViewer : public CPluginInterfaceForViewerAbstract
+{
+public:
+    virtual BOOL WINAPI ViewFile(const char* name, int left, int top, int width, int height,
+                                 UINT showCmd, BOOL alwaysOnTop, BOOL returnLock, HANDLE* lock,
+                                 BOOL* lockOwner, CSalamanderPluginViewerData* viewerData,
+                                 int enumFilesSourceUID, int enumFilesCurrentIndex) override;
+
+    virtual BOOL WINAPI CanViewFile(const char* name) override;
+};
+
+class CPluginInterface : public CPluginInterfaceAbstract
+{
+public:
+    virtual void WINAPI About(HWND parent) override;
+
+    virtual BOOL WINAPI Release(HWND parent, BOOL force) override;
+
+    virtual void WINAPI LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry) override {}
+    virtual void WINAPI SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry) override {}
+    virtual void WINAPI Configuration(HWND parent) override {}
+
+    virtual void WINAPI Connect(HWND parent, CSalamanderConnectAbstract* salamander) override;
+
+    virtual void WINAPI ReleasePluginDataInterface(CPluginDataInterfaceAbstract* pluginData) override {}
+
+    virtual CPluginInterfaceForArchiverAbstract* WINAPI GetInterfaceForArchiver() override { return NULL; }
+    virtual CPluginInterfaceForViewerAbstract* WINAPI GetInterfaceForViewer() override;
+    virtual CPluginInterfaceForMenuExtAbstract* WINAPI GetInterfaceForMenuExt() override { return NULL; }
+    virtual CPluginInterfaceForFSAbstract* WINAPI GetInterfaceForFS() override { return NULL; }
+    virtual CPluginInterfaceForThumbLoaderAbstract* WINAPI GetInterfaceForThumbLoader() override { return NULL; }
+
+    virtual void WINAPI Event(int event, DWORD param) override {}
+    virtual void WINAPI ClearHistory(HWND parent) override {}
+    virtual void WINAPI AcceptChangeOnPathNotification(const char* path, BOOL includingSubdirs) override {}
+
+    virtual void WINAPI PasswordManagerEvent(HWND parent, int event) override {}
+};
+
+// rozhrani pluginu poskytnute Salamanderovi
+extern CPluginInterface PluginInterface;
+extern CPluginInterfaceForViewer InterfaceForViewer;

--- a/src/plugins/webview2renderviewer/webview2renderviewer.rc
+++ b/src/plugins/webview2renderviewer/webview2renderviewer.rc
@@ -1,0 +1,71 @@
+// Microsoft Visual C++ generated resource script.
+//
+#pragma code_page(65001)
+
+#include "webview2renderviewer.rh"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winresrc.h"
+
+#include "webview2renderviewer.rh2"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// Neutral resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE
+BEGIN
+    "webview2renderviewer.rh\0"
+END
+
+2 TEXTINCLUDE
+BEGIN
+    "#include ""winresrc.h""\r\n"
+    "\r\n"
+    "#include ""webview2renderviewer.rh2""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE
+BEGIN
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)\r\n"
+    "LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL\r\n"
+    "#include ""webview2renderviewer.rc2""   // non-Microsoft Visual C++ edited resources\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // Neutral resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_NEU)
+LANGUAGE LANG_NEUTRAL,SUBLANG_NEUTRAL
+#include "webview2renderviewer.rc2"   // non-Microsoft Visual C++ edited resources
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/src/plugins/webview2renderviewer/webview2renderviewer.rc2
+++ b/src/plugins/webview2renderviewer/webview2renderviewer.rc2
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+//
+// webview2renderviewer.rc2 - resources Microsoft Visual C++ does not edit directly
+//
+
+#ifdef APSTUDIO_INVOKED
+#error this file is not editable by Microsoft Visual C++
+#endif //APSTUDIO_INVOKED
+
+/////////////////////////////////////////////////////////////////////////////
+// Add manually edited resources here...
+
+#include "versinfo.rh2"
+#include "versinfo.rc2"
+
+IDI_WEBVIEW2RENDERVIEWER ICON "..\\..\\..\\src\\res\\viewer.ico"

--- a/src/plugins/webview2renderviewer/webview2renderviewer.rh
+++ b/src/plugins/webview2renderviewer/webview2renderviewer.rh
@@ -1,0 +1,15 @@
+﻿//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by webview2renderviewer.rc
+//
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        8001
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         8200
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/plugins/webview2renderviewer/webview2renderviewer.rh2
+++ b/src/plugins/webview2renderviewer/webview2renderviewer.rh2
@@ -1,0 +1,26 @@
+//****************************************************************************
+//
+// Copyright (c) 2023-2024 Open Salamander Authors
+//
+// This is a part of the Open Salamander SDK library.
+//
+//****************************************************************************
+
+// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+#ifndef __WEBVIEW2RENDERVIEWER_RH2
+#define __WEBVIEW2RENDERVIEWER_RH2
+
+#if defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+#error this file is not editable by Microsoft Visual C++
+#endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+
+#define IDI_WEBVIEW2RENDERVIEWER          8000
+
+#define IDS_PLUGINNAME                     46
+#define IDS_ABOUT                          47
+#define IDS_PLUGIN_DESCRIPTION             48
+#define IDS_PLUGIN_HOME                    49
+#define IDS_VIEWER_CREATE_EVENT_FAILED     50
+#define IDS_FILE_TOO_LARGE                 51
+
+#endif // __WEBVIEW2RENDERVIEWER_RH2


### PR DESCRIPTION
## Summary
- replace the stray NUL character in `webview2renderviewer.cpp` with the proper `"\\0"` literal
- update `.gitattributes` so `.cpp` files are always handled as text for diffs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df6917070c8329a236761e5c9e05e8