### PR TITLE
Allow managed viewers to open PHP and PC files

### DIFF
--- a/src/plugins/jsonviewer/SUPPORTED_FILE_TYPES.md
+++ b/src/plugins/jsonviewer/SUPPORTED_FILE_TYPES.md
@@ -2,6 +2,6 @@
 
 | Description | Extensions |
 | --- | --- |
-| JSON data interchange files | `.json` |
+| JSON data interchange files | `.json`, `.pc` |
 
-The viewer accepts case-insensitive matches for the `.json` extension.
+The viewer accepts case-insensitive matches for the `.json` and `.pc` extensions.

--- a/src/plugins/jsonviewer/jsonviewer.cpp
+++ b/src/plugins/jsonviewer/jsonviewer.cpp
@@ -267,7 +267,7 @@ BOOL WINAPI CPluginInterfaceForViewer::CanViewFile(const char* name)
     if (extension == NULL)
         return FALSE;
 
-    if (_stricmp(extension, ".json") == 0)
+    if (_stricmp(extension, ".json") == 0 || _stricmp(extension, ".pc") == 0)
         return TRUE;
 
     return FALSE;

--- a/src/plugins/textviewer/textviewer.cpp
+++ b/src/plugins/textviewer/textviewer.cpp
@@ -749,7 +749,8 @@ BOOL WINAPI CPluginInterfaceForViewer::CanViewFile(const char* name)
 
     static const char* const kExtensions[] = {
         ".txt", ".log", ".ini", ".cfg", ".json", ".yaml", ".yml", ".xml", ".html", ".htm", ".md",
-        ".csv", ".cs", ".cpp", ".c", ".h", ".hpp", ".py", ".js", ".ts", ".css", ".sql", ".bat", ".ps1"
+        ".csv", ".cs", ".cpp", ".c", ".h", ".hpp", ".py", ".js", ".ts", ".css", ".sql", ".bat", ".ps1",
+        ".php"
     };
 
     for (size_t i = 0; i < _countof(kExtensions); ++i)


### PR DESCRIPTION
## Summary
- allow the PrismSharp text viewer to accept `.php` files when selected via viewer associations
- extend the JSON viewer to recognise `.pc` files and document the supported extensions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa75f22d4832987385e56549acd7f