### PR TITLE
Point setup icons to repo samandarin asset

### DIFF
--- a/src/setup/doinst.c
+++ b/src/setup/doinst.c
@@ -2136,7 +2136,7 @@ void AddWERLocalDump(const char* exeName)
     // Pozor, obchazeni redirectoru se tyka i modulu remove.c!
     HKEY hKey;
     DWORD dwDisposition;
-    DWORD altapRefCount = 0;
+    DWORD samandarinRefCount = 0;
     REGSAM samDesired = 0;
     if (IsWow64())
         samDesired = KEY_WOW64_64KEY;
@@ -2151,19 +2151,19 @@ void AddWERLocalDump(const char* exeName)
             DWORD dumpCount;
             DWORD dumpType;
             DWORD customDumpFlags;
-            const char* dumpFolder = "%LOCALAPPDATA%\\Open Salamander";
+            const char* dumpFolder = "%LOCALAPPDATA%\\Open Salamander Samandarin";
             // pokud klic jiz existoval, nacteme pocet referenci
             if (dwDisposition == REG_OPENED_EXISTING_KEY)
             {
-                DWORD size = sizeof(altapRefCount);
+                DWORD size = sizeof(samandarinRefCount);
                 dwType = REG_DWORD;
-                if (RegQueryValueEx(hExeKey, "AltapRefCount", 0, &dwType, (BYTE*)&altapRefCount, &size) != ERROR_SUCCESS || dwType != REG_DWORD)
-                    altapRefCount = 0;
+                if (RegQueryValueEx(hExeKey, "SamandarinRefCount", 0, &dwType, (BYTE*)&samandarinRefCount, &size) != ERROR_SUCCESS || dwType != REG_DWORD)
+                    samandarinRefCount = 0;
             }
-            altapRefCount++;
+            samandarinRefCount++;
 
             dwType = REG_DWORD;
-            RegSetValueEx(hExeKey, "AltapRefCount", 0, dwType, (const BYTE*)&altapRefCount, sizeof(altapRefCount));
+            RegSetValueEx(hExeKey, "SamandarinRefCount", 0, dwType, (const BYTE*)&samandarinRefCount, sizeof(samandarinRefCount));
             dumpCount = 50;
             RegSetValueEx(hExeKey, "DumpCount", 0, dwType, (const BYTE*)&dumpCount, sizeof(dumpCount));
             dumpType = 0; // custom dump type

--- a/src/setup/manifest.xml
+++ b/src/setup/manifest.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 <assemblyIdentity
-    name="Open.Salamander.Setup"
+    name="Open.Salamander.Samandarin.Setup"
     processorArchitecture="*"
     type="win32"
     version="1.70.0.0">
 </assemblyIdentity>
-<description>Open Salamander Setup</description>
+<description>Open Salamander: Samandarin Setup</description>
 <dependency>
     <dependentAssembly>
         <assemblyIdentity

--- a/src/setup/remove/manifest.xml
+++ b/src/setup/remove/manifest.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 <assemblyIdentity
-    name="Altap.Uninstall"
+    name="Open.Salamander.Samandarin.Uninstall"
     processorArchitecture="*"
     type="win32"
     version="1.26.0.0">
 </assemblyIdentity>
-<description>Altap Uninstall</description>
+<description>Open Salamander: Samandarin Uninstall</description>
 <dependency>
     <dependentAssembly>
         <assemblyIdentity

--- a/src/setup/remove/remove.c
+++ b/src/setup/remove/remove.c
@@ -943,7 +943,7 @@ void DoRemoveWERLocalDump(const char* exeName)
     // http://msdn.microsoft.com/en-us/library/windows/desktop/aa384129%28v=vs.85%29.aspx
     // Pozor, obchazeni redirectoru se tyka i modulu doinst.c!
     HKEY hKey;
-    DWORD altapRefCount = 0xffffffff;
+    DWORD samandarinRefCount = 0xffffffff;
     BOOL delExeKey = FALSE;
     REGSAM samDesired = 0;
     if (RemoveIsWow64())
@@ -955,14 +955,14 @@ void DoRemoveWERLocalDump(const char* exeName)
         if (RegOpenKeyEx(hKey, exeName, 0, samDesired | KEY_READ | KEY_WRITE, &hExeKey) == ERROR_SUCCESS)
         {
             DWORD dwType;
-            DWORD size = sizeof(altapRefCount);
-            const char* dumpFolder = "%LOCALAPPDATA%\\Altap\\Open Salamander";
+            DWORD size = sizeof(samandarinRefCount);
+            const char* dumpFolder = "%LOCALAPPDATA%\\Open Salamander Samandarin";
             dwType = REG_DWORD;
-            if (RegQueryValueEx(hExeKey, "AltapRefCount", 0, &dwType, (BYTE*)&altapRefCount, &size) == ERROR_SUCCESS && dwType == REG_DWORD)
+            if (RegQueryValueEx(hExeKey, "SamandarinRefCount", 0, &dwType, (BYTE*)&samandarinRefCount, &size) == ERROR_SUCCESS && dwType == REG_DWORD)
             {
-                if (altapRefCount != 0xffffffff && altapRefCount > 0)
-                    altapRefCount--;
-                if (altapRefCount == 0)
+                if (samandarinRefCount != 0xffffffff && samandarinRefCount > 0)
+                    samandarinRefCount--;
+                if (samandarinRefCount == 0)
                 {
                     // po zavreni cely klic smazeme
                     delExeKey = TRUE;
@@ -971,7 +971,7 @@ void DoRemoveWERLocalDump(const char* exeName)
                 {
                     // ulozime novy RefCount
                     dwType = REG_DWORD;
-                    RegSetValueEx(hExeKey, "AltapRefCount", 0, dwType, (const BYTE*)&altapRefCount, sizeof(altapRefCount));
+                    RegSetValueEx(hExeKey, "SamandarinRefCount", 0, dwType, (const BYTE*)&samandarinRefCount, sizeof(samandarinRefCount));
                 }
             }
             RegCloseKey(hExeKey);

--- a/src/setup/remove/remove.rc
+++ b/src/setup/remove/remove.rc
@@ -72,14 +72,14 @@ LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 #ifndef INSIDE_SETUP
 IDD_CONFIRMATION DIALOGEX 85, 45, 336, 102
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
-CAPTION "Altap Uninstall"
+CAPTION "Open Salamander: Samandarin Uninstall"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
     ICON            3100,IDC_MYICON,10,11,20,20
     DEFPUSHBUTTON   "&Ano",IDYES,115,81,50,14,WS_GROUP
     PUSHBUTTON      "&Ne",IDNO,169,81,50,14
     LTEXT           "Opravdu si přejete odstranit %s?",IDC_QUESTION,39,10,290,18
-    LTEXT           "Obě x64 a x86 verze Open Salamandera sdílí jednu konfiguraci v Registru.",IDC_STATIC,39,36,290,8
+    LTEXT           "Obě x64 a x86 verze Open Salamander: Samandarin sdílí jednu konfiguraci v Registru.",IDC_STATIC,39,36,290,8
     CONTROL         "Zároveň odstranit &konfiguraci z Registru",IDC_REMOVECONFIGURATION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,39,47,164,12
 END
@@ -119,14 +119,14 @@ LANGUAGE LANG_GERMAN, SUBLANG_NEUTRAL
 #ifndef INSIDE_SETUP
 IDD_CONFIRMATION DIALOGEX 85, 45, 362, 103
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
-CAPTION "Altap-Deinstallation"
+CAPTION "Open Salamander: Samandarin-Deinstallation"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
     ICON            3100,IDC_MYICON,10,11,20,20
     DEFPUSHBUTTON   "&Ja",IDYES,125,80,50,14,WS_GROUP
     PUSHBUTTON      "&Nein",IDNO,179,80,50,14
     LTEXT           "Möchten Sie %s wirklich entfernen?",IDC_QUESTION,39,10,305,18
-    LTEXT           "Beide Versionen von Open Salamander, die x64 und die x86, benutzen dieselbe Konfiguration.",IDC_STATIC,39,36,318,8
+    LTEXT           "Beide Versionen von Open Salamander: Samandarin, die x64 und die x86, benutzen dieselbe Konfiguration.",IDC_STATIC,39,36,318,8
     CONTROL         "Ebenfalls die &Konfiguration aus der Registry entfernen",IDC_REMOVECONFIGURATION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,39,47,214,12
 END
@@ -166,14 +166,14 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #ifndef INSIDE_SETUP
 IDD_CONFIRMATION DIALOGEX 85, 45, 337, 100
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
-CAPTION "Altap Uninstall"
+CAPTION "Open Salamander: Samandarin Uninstall"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
     ICON            3100,IDC_MYICON,10,11,20,20
     DEFPUSHBUTTON   "&Yes",IDYES,116,78,50,14,WS_GROUP
     PUSHBUTTON      "&No",IDNO,170,78,50,14
     LTEXT           "Are you sure that you want to remove the %s?",IDC_QUESTION,39,10,293,17
-    LTEXT           "Both x64 and x86 versions of Open Salamander are sharing the same configuration.",IDC_STATIC,39,35,293,8
+    LTEXT           "Both x64 and x86 versions of Open Salamander: Samandarin are sharing the same configuration.",IDC_STATIC,39,35,293,8
     CONTROL         "Remove also &configuration from Registry",IDC_REMOVECONFIGURATION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,39,46,167,12
 END

--- a/src/setup/remove/remove.rc2
+++ b/src/setup/remove/remove.rc2
@@ -10,7 +10,7 @@ CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "manifest.xml"
 // Icon
 //
 
-IDI_ICON1 ICON "icon1.ico"
+IDI_ICON1 ICON "..\\..\\res\\samandarin.ico"
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -34,10 +34,10 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "Open Salamander"
-            VALUE "FileDescription", "Open Salamander Uninstaller"
+            VALUE "CompanyName", "Open Salamander Samandarin"
+            VALUE "FileDescription", "Open Salamander: Samandarin Uninstaller"
             VALUE "FileVersion", "1.28.0.0"
-            VALUE "InternalName", "Open Salamander Uninstaller"
+            VALUE "InternalName", "Open Salamander: Samandarin Uninstaller"
             VALUE "OriginalFilename", "remove.exe"
             VALUE "LegalCopyright", "Copyright © 1997-2025 Open Salamander Authors"
         END

--- a/src/setup/setup.rc
+++ b/src/setup/setup.rc
@@ -48,10 +48,10 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "Open Salamander"
-            VALUE "FileDescription", "Open Salamander Setup"
+            VALUE "CompanyName", "Open Salamander Samandarin"
+            VALUE "FileDescription", "Open Salamander: Samandarin Setup"
             VALUE "FileVersion", "1.70.0.0"
-            VALUE "InternalName", "Open Salamander Installer"
+            VALUE "InternalName", "Open Salamander: Samandarin Installer"
             VALUE "OriginalFilename", "setup.exe"
             VALUE "LegalCopyright", "Copyright © 1997-2025 Open Salamander Authors"
         END
@@ -70,7 +70,7 @@ END
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-EXE_ICON                ICON                    "res\\setup.ico"
+EXE_ICON                ICON                    "..\\res\\samandarin.ico"
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -375,13 +375,13 @@ BEGIN
     IDS_WZR_INSTALL         "&Instalovat"
     IDS_INSTFAILED          "Instalace není kompletní. Program %s není nainstalován.\n\nInstalační program můžete spustit později a instalaci dokončit."
     ERROR_CMDLINE           "Použití:\nSETUP [/?] [/s] [/d dest_dir] [/id <y,n>] [/is <y,n>] [/au <y,n>]\n\n[x] znamená, že je parametr x nepovinný.\n<y,n> znamená, že jsou parametry y nebo n povinné.\n\n/? -- Zobrazí tuto zprávu o použití.\n/s -- Tichá instalace.\n/d -- Cílový adresář.\n/id -- Nainstalovat zástupce na plochu.\n/is -- Nainstalovat zástupce do nabídky Start.\n/au -- Společné složky všech uživatelů."
-    IDS_CONFLICTWITHNEWER   "Adresář '%s' již obsahuje novější verzi instalovaného programu.\n\nPro instalaci do tohoto adresáře napřed odinstalujte existující Open Salamander.\n\nPřípadně můžete zvolit jiný adresář."
+    IDS_CONFLICTWITHNEWER   "Adresář '%s' již obsahuje novější verzi instalovaného programu.\n\nPro instalaci do tohoto adresáře napřed odinstalujte existující Open Salamander: Samandarin.\n\nPřípadně můžete zvolit jiný adresář."
     IDS_INSTNEEDRESTART     "Instalace nebyla dokončena. Pro dokončení instalace je potřeba provést restart Windows, po kterém se odinstalují shell extensions.\n\nRestartujte prosím Windows a spusťte tento instalační program znovu pro dokončení instalace."
     IDS_TARGETDIRUPGRADE    "Cílový adresář (upgrade)"
     IDS_CONFLICTPRIOR       "Adresář '%s' již obsahuje starší verzi instalovaného programu.\n\nStiskněte OK pro jeho upgrade.\nStiskněte Storno pro instalaci do jiného adresáře."
     IDS_CONFLICTSAME        "Adresář '%s' již obsahuje stejnou verzi instalovaného programu.\n\nStiskněte OK pro jeho opravu.\nStiskněte Storno pro instalaci do jiného adresáře."
-    IDS_PREVIEWBUILDWARNING "Toto je PREVIEW BUILD programu Open Salamander, uvolněný v Early Access Programu. Tato verze by neměla být používána v produkčním prostředí. Používejte ji pouze pro testování. Těšíme se na Vaše připomínky a náměty, které vkládejte do Early Access Program sekce na forum.altap.cz.\nPoznámka: tato verze je časově omezená."
-    IDS_BETAWARNING         "Toto je BETA verze programu Open Salamander. Tato verze by neměla být používána v produkčním prostředí. Používejte ji pouze pro testování. Těšíme se na Vaše připomínky a náměty, které vkládejte na forum.altap.cz.\nPoznámka: tato verze je časově omezená."
+    IDS_PREVIEWBUILDWARNING "Toto je PREVIEW BUILD programu Open Salamander: Samandarin, uvolněný v Early Access Programu. Tato verze by neměla být používána v produkčním prostředí. Používejte ji pouze pro testování. Těšíme se na Vaše připomínky a náměty, které vkládejte do Early Access Program sekce na forum.altap.cz.\nPoznámka: tato verze je časově omezená."
+    IDS_BETAWARNING         "Toto je BETA verze programu Open Salamander: Samandarin. Tato verze by neměla být používána v produkčním prostředí. Používejte ji pouze pro testování. Těšíme se na Vaše připomínky a náměty, které vkládejte na forum.altap.cz.\nPoznámka: tato verze je časově omezená."
 END
 
 STRINGTABLE 
@@ -657,13 +657,13 @@ BEGIN
     IDS_WZR_INSTALL         "&Installieren"
     IDS_INSTFAILED          "Das Setup ist noch nicht abgeschlossen. Die Anwendung %s wurde nicht installiert.\n\nSie können das Setup zu einem späteren Zeitpunkt nochmals ausführen, um die Installation zu vervollständigen."
     ERROR_CMDLINE           "Verwendung:\nSETUP [/?] [/s] [/d Ziel_Verz] [/id <y,n>] [/is <y,n>] [/au <y,n>]\n\n[x] bedeutet, dass der Parameter x optional ist.\n<y,n> bedeutet, dass der Parameter y oder n benötigt wird.\n\n/? -- Generiert diesen Nutzungshinweis.\n/s -- Automatische unbeaufsichtigte Installation.\n/d -- Zielverzeichnis.\n/id -- Installiert Desktop-Verknüpfung.\n/is -- Installiert Startmenü-Verknüpfung.\n/au -- Für alle Benutzer gemeinsame Ordner."
-    IDS_CONFLICTWITHNEWER   "Das Verzeichnis '%s' enthält bereits eine neuere Version der installierten Anwendung.\n\nUm in dieses Verzeichnis zu installieren, müssen Sie die jetzige Version entfernen. Anschließend können Sie diese Version von Open Salamander installieren.\n\nAlternativ können Sie auch ein anderes Verzeichnis wählen."
+    IDS_CONFLICTWITHNEWER   "Das Verzeichnis '%s' enthält bereits eine neuere Version der installierten Anwendung.\n\nUm in dieses Verzeichnis zu installieren, müssen Sie die jetzige Version entfernen. Anschließend können Sie diese Version von Open Salamander: Samandarin installieren.\n\nAlternativ können Sie auch ein anderes Verzeichnis wählen."
     IDS_INSTNEEDRESTART     "Das Setup ist noch nicht abgeschlossen. Ein Windows-Neustart ist nötig um die verwendeten Shell-Erweiterungen zu deinstallieren.\n\nBitte starten Sie Windows neu und führen Sie das Setup nochmals aus um die Installation zu vervollständigen."
     IDS_TARGETDIRUPGRADE    "Zielverzeichnis (Aktualisierung)"
     IDS_CONFLICTPRIOR       "Das Verzeichnis '%s' enthält bereits eine frühere Version der installierten Anwendung.\n\nDrücken Sie ""OK"", um diese zu aktualisieren.\nDrücken Sie auf ""Abbrechen"", um sie in ein anderes Verzeichnis zu installieren."
     IDS_CONFLICTSAME        "Das Verzeichnis '%s' enthält bereits die selbe Version der installierten Anwendung.\n\nDrücken Sie ""OK"", um diese zu reparieren.\nDrücken Sie auf ""Abbrechen"", um sie in ein anderes Verzeichnis zu installieren."
-    IDS_PREVIEWBUILDWARNING "Dies ist eine Vorabversion von Open Salamander, veröffentlicht im Early Access Programm. Sie sollte NICHT in Produktionsumgebungen verwendet werden. Benutzen Sie diese nur für Testzwecke. Wir freuen uns auf Ihre Meinung in der ""Early Access Program Section"" im forum.altap.cz.\nHinweis: diese Version ist zeitlich begrenzt."
-    IDS_BETAWARNING         "Dies ist eine BETA Version von Open Salamander. Sie sollte NICHT in Produktionsumgebungen verwendet werden. Benutzen Sie diese nur für Testzwecke. Wir freuen uns auf Ihre Meinung im forum.altap.cz.\nHinweis: diese Version ist zeitlich begrenzt."
+    IDS_PREVIEWBUILDWARNING "Dies ist eine Vorabversion von Open Salamander: Samandarin, veröffentlicht im Early Access Programm. Sie sollte NICHT in Produktionsumgebungen verwendet werden. Benutzen Sie diese nur für Testzwecke. Wir freuen uns auf Ihre Meinung in der ""Early Access Program Section"" im forum.altap.cz.\nHinweis: diese Version ist zeitlich begrenzt."
+    IDS_BETAWARNING         "Dies ist eine BETA Version von Open Salamander: Samandarin. Sie sollte NICHT in Produktionsumgebungen verwendet werden. Benutzen Sie diese nur für Testzwecke. Wir freuen uns auf Ihre Meinung im forum.altap.cz.\nHinweis: diese Version ist zeitlich begrenzt."
 END
 
 STRINGTABLE 
@@ -939,13 +939,13 @@ BEGIN
     IDS_WZR_INSTALL         "&Install"
     IDS_INSTFAILED          "Setup is not complete. Application %s is not installed.\n\nYou may run the Setup program at a later time to complete the installation."
     ERROR_CMDLINE           "Usage:\nSETUP [/?] [/s] [/d dest_dir] [/id <y,n>] [/is <y,n>] [/au <y,n>]\n\n[x] means that parameter x is optional.\n<y,n> means that parameter y or n is required.\n\n/? -- Generates this Usage message.\n/s -- Silent unattended install.\n/d -- Destination directory.\n/id -- Install Desktop Shortcut.\n/is -- Install Start Menu Shortcut.\n/au -- All users common folders."
-    IDS_CONFLICTWITHNEWER   "The directory '%s' already contains newer version of installed application.\n\nTo install to this directory, uninstall the existing Open Salamander. Then you can install this version of Open Salamander.\n\nOtherwise you can choose another directory."
+    IDS_CONFLICTWITHNEWER   "The directory '%s' already contains newer version of installed application.\n\nTo install to this directory, uninstall the existing Open Salamander: Samandarin. Then you can install this version of Open Salamander: Samandarin.\n\nOtherwise you can choose another directory."
     IDS_INSTNEEDRESTART     "Setup is not complete. Windows restart is needed to finish uninstalling shell extensions that are in use.\n\nPlease restart your Windows and run the Setup program again to complete the installation."
     IDS_TARGETDIRUPGRADE    "Target directory (Upgrade)"
     IDS_CONFLICTPRIOR       "The directory '%s' already contains a prior version of the installed application.\n\nPress OK to upgrade it.\nPress Cancel to install to another directory."
     IDS_CONFLICTSAME        "The directory '%s' already contains the same version of the installed application.\n\nPress OK to repair it.\nPress Cancel to install to another directory."
-    IDS_PREVIEWBUILDWARNING "This is PREVIEW BUILD of Open Salamander, released in Early Access Program. It should NOT be used in production environments. Use it for testing only. We are looking for your feedback at Early Access Program section on forum.altap.cz.\nNote: this version is time limited."
-    IDS_BETAWARNING         "This is BETA version of Open Salamander. It should NOT be used in production environments. Use it for testing purpose only. We are looking for your feedback on forum.altap.cz.\nNote: this version is time limited."
+    IDS_PREVIEWBUILDWARNING "This is PREVIEW BUILD of Open Salamander: Samandarin, released in Early Access Program. It should NOT be used in production environments. Use it for testing only. We are looking for your feedback at Early Access Program section on forum.altap.cz.\nNote: this version is time limited."
+    IDS_BETAWARNING         "This is BETA version of Open Salamander: Samandarin. It should NOT be used in production environments. Use it for testing purpose only. We are looking for your feedback on forum.altap.cz.\nNote: this version is time limited."
 END
 
 STRINGTABLE 


### PR DESCRIPTION
## Summary
- update setup branding, identity, and messaging to use "Open Salamander: Samandarin" and reference the repository samandarin icon asset
- align the uninstaller resources with the Samandarin branding and manifest identity
- retarget installer and uninstaller WER registration to the Open Salamander Samandarin local dump location
- remove the unused third-party Samandarin icon asset from the repository

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e015e2d620832997a9e753724a7772