### PR TITLE
Update Bug Reporter registry path to Samandarin hive

### DIFF
--- a/src/salmon/config.cpp
+++ b/src/salmon/config.cpp
@@ -8,7 +8,7 @@
 
 #include "config.h"
 
-const char* DB_ROOT_KEY = "Software\\Open Salamander\\Bug Reporter";
+const char* DB_ROOT_KEY = "Software\\Open Salamander Samandarin\\Bug Reporter";
 const char* CONFIG_EMAIL_REG = "Email";
 
 CConfiguration Config;

--- a/src/salmoncl.cpp
+++ b/src/salmoncl.cpp
@@ -35,7 +35,7 @@ HANDLE GetBugReporterRegistryMutex()
 
 BOOL SalmonGetBugReportUID(DWORD64* uid)
 {
-    const char* BUG_REPORTER_KEY = "Software\\Open Salamander\\Bug Reporter";
+    const char* BUG_REPORTER_KEY = "Software\\Open Salamander Samandarin\\Bug Reporter";
     const char* BUG_REPORTER_UID = "ID";
 
     // tato sekce se pousti pri startu Salamandera a teoreticky muze dojit k soucasnemu ctani/zapisu registry


### PR DESCRIPTION
## Summary
- update the Bug Reporter registry root to the Samandarin-specific hive used by this fork
- ensure both the configuration loader and UID generator write to the new location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0483860348329a5475bd8ec4250b1