### PR TITLE
Fix selection in UTF-8 quick rename edit

### DIFF
--- a/src/fileswn5.cpp
+++ b/src/fileswn5.cpp
@@ -2797,11 +2797,24 @@ void CFilesWindow::QuickRenameBegin(int index, const RECT* labelRect)
     }
     if (selectionEndForControl >= 0)
     {
-        SendMessage(hWnd, EM_SETSEL, selectionEndForControl, (LPARAM)-1);
-        SendMessage(hWnd, EM_SETSEL, 0, selectionEndForControl);
+        if (unicodeEdit)
+        {
+            SendMessageW(hWnd, EM_SETSEL, selectionEndForControl, (LPARAM)-1);
+            SendMessageW(hWnd, EM_SETSEL, 0, selectionEndForControl);
+        }
+        else
+        {
+            SendMessage(hWnd, EM_SETSEL, selectionEndForControl, (LPARAM)-1);
+            SendMessage(hWnd, EM_SETSEL, 0, selectionEndForControl);
+        }
     }
     else
-        SendMessage(hWnd, EM_SETSEL, 0, (LPARAM)-1);
+    {
+        if (unicodeEdit)
+            SendMessageW(hWnd, EM_SETSEL, 0, (LPARAM)-1);
+        else
+            SendMessage(hWnd, EM_SETSEL, 0, (LPARAM)-1);
+    }
 
     ShowWindow(hWnd, SW_SHOW);
     SetFocus(hWnd);


### PR DESCRIPTION
## Fix #74 

## Summary
- ensure quick rename edit controls created in Unicode mode use SendMessageW for selection commands
- restore expected text selection behavior for UTF-8 filenames when Quick Rename starts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e05b90948329b6b77bee8e471d2d