### PR TITLE
Fix service explorer toolbar icon transparency

### DIFF
--- a/src/plugins/serviceexplorer/plugin.cpp
+++ b/src/plugins/serviceexplorer/plugin.cpp
@@ -30,6 +30,13 @@ HBITMAP CreateServiceBitmap()
   if (bitmap == NULL)
     return NULL;
 
+  if (bits != NULL)
+  {
+    DWORD* pixel = static_cast<DWORD*>(bits);
+    for (int i = 0; i < 16 * 16; ++i)
+      pixel[i] = 0x00FF00FF;
+  }
+
   HDC dc = CreateCompatibleDC(NULL);
   if (dc == NULL)
   {

--- a/src/plugins/serviceexplorer/plugin.cpp
+++ b/src/plugins/serviceexplorer/plugin.cpp
@@ -17,6 +17,12 @@ namespace
 {
 HBITMAP CreateServiceBitmap()
 {
+  HBITMAP bitmap = reinterpret_cast<HBITMAP>(
+    LoadImage(DLLInstance, MAKEINTRESOURCE(IDB_SERVICEEXPLORER_TOOLBAR), IMAGE_BITMAP,
+              0, 0, LR_CREATEDIBSECTION));
+  if (bitmap != NULL)
+    return bitmap;
+
   BITMAPINFO bmi = {};
   bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
   bmi.bmiHeader.biWidth = 16;
@@ -26,7 +32,7 @@ HBITMAP CreateServiceBitmap()
   bmi.bmiHeader.biCompression = BI_RGB;
 
   void *bits = NULL;
-  HBITMAP bitmap = CreateDIBSection(NULL, &bmi, DIB_RGB_COLORS, &bits, NULL, 0);
+  bitmap = CreateDIBSection(NULL, &bmi, DIB_RGB_COLORS, &bits, NULL, 0);
   if (bitmap == NULL)
     return NULL;
 

--- a/src/plugins/serviceexplorer/plugin.rh
+++ b/src/plugins/serviceexplorer/plugin.rh
@@ -4,6 +4,7 @@
 //
 
 #define IDI_SERVICEEXPLORER_DIR         1
+#define IDB_SERVICEEXPLORER_TOOLBAR     2
 
 // Next default values for new objects
 //

--- a/src/plugins/serviceexplorer/serviceexplorer.rc2
+++ b/src/plugins/serviceexplorer/serviceexplorer.rc2
@@ -12,6 +12,7 @@
 #include "plugin.rh"
 
 IDI_SERVICEEXPLORER_DIR ICON "res\\dir.ico"
+IDB_SERVICEEXPLORER_TOOLBAR BITMAP "res\\svc.bmp"
 
 #define SERVICEEXPLORER_LANG_FALLBACK
 #include "lang/lang.rc2"


### PR DESCRIPTION
## Summary
- fill the generated service explorer toolbar bitmap with the transparency key color before drawing the icon
- ensure the plugin manager and toolbar display the service explorer icon without a black background

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e40b52a0a48329916fad617a41dc24