### PR TITLE
Fix GIF frame metadata usage in WIC backend

### DIFF
--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -896,13 +896,15 @@ HRESULT EnsureTransparencyMask(FrameData& frame)
     BITMAPINFO maskInfo{};
     maskInfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
     maskInfo.bmiHeader.biWidth = static_cast<LONG>(frame.width);
-    maskInfo.bmiHeader.biHeight = -static_cast<LONG>(frame.height);
+    maskInfo.bmiHeader.biHeight = static_cast<LONG>(frame.height);
     maskInfo.bmiHeader.biPlanes = 1;
     maskInfo.bmiHeader.biBitCount = 1;
     maskInfo.bmiHeader.biCompression = BI_RGB;
     maskInfo.bmiHeader.biSizeImage = maskSize64 > std::numeric_limits<DWORD>::max()
                                          ? 0
                                          : static_cast<DWORD>(maskSize64);
+    maskInfo.bmiHeader.biXPelsPerMeter = 0;
+    maskInfo.bmiHeader.biYPelsPerMeter = 0;
     maskInfo.bmiColors[0].rgbBlue = 0;
     maskInfo.bmiColors[0].rgbGreen = 0;
     maskInfo.bmiColors[0].rgbRed = 0;
@@ -928,7 +930,8 @@ HRESULT EnsureTransparencyMask(FrameData& frame)
     for (UINT y = 0; y < frame.height; ++y)
     {
         const BYTE* srcRow = frame.pixels.data() + static_cast<size_t>(y) * frame.stride;
-        BYTE* dstRow = maskData + static_cast<size_t>(y) * maskStride;
+        const size_t invertedRow = static_cast<size_t>(frame.height - 1 - y);
+        BYTE* dstRow = maskData + invertedRow * maskStride;
         for (UINT x = 0; x < frame.width; ++x)
         {
             if (srcRow[static_cast<size_t>(x) * 4 + 3] != 0)

--- a/src/plugins/pictview/wic/WicBackend.h
+++ b/src/plugins/pictview/wic/WicBackend.h
@@ -37,10 +37,12 @@ struct FrameData
     std::vector<RGBQUAD> palette;
     BITMAPINFOHEADER bmi{};
     HBITMAP hbitmap = nullptr;
+    HBITMAP transparencyMask = nullptr;
     DWORD delayMs = 0;
     RECT rect{};
     DWORD disposal = PVDM_UNDEFINED;
     bool decoded = false;
+    bool hasTransparency = false;
 };
 
 struct ImageHandle

--- a/src/plugins/pictview/wic/WicBackend.h
+++ b/src/plugins/pictview/wic/WicBackend.h
@@ -38,6 +38,8 @@ struct FrameData
     BITMAPINFOHEADER bmi{};
     HBITMAP hbitmap = nullptr;
     DWORD delayMs = 0;
+    RECT rect{};
+    DWORD disposal = PVDM_UNDEFINED;
     bool decoded = false;
 };
 

--- a/src/plugins/pictview/wic/WicBackend.h
+++ b/src/plugins/pictview/wic/WicBackend.h
@@ -55,6 +55,10 @@ struct ImageHandle
     COLORREF background = RGB(0, 0, 0);
     PVImageInfo baseInfo{};
     PVImageHandles handles{};
+    PVFormatSpecificInfo formatInfo{};
+    bool hasFormatSpecificInfo = false;
+    LONG canvasWidth = 0;
+    LONG canvasHeight = 0;
 };
 
 /**


### PR DESCRIPTION
## Summary
- read GIF frame position and disposal metadata from WIC frames and store it on FrameData
- propagate the stored rectangle and disposal method when building PVImageSequence nodes
- default clipboard-backed frames to full-frame rectangles and link against propsys for PropVariant helpers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e45847a814832991a5e6eb631291b1