### PR TITLE
Respect PVSaveImageInfo encoder settings

### DIFF
--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -330,7 +330,13 @@ std::optional<BYTE> MapTiffCompression(DWORD compression)
     case PVCS_DEFLATE:
         return static_cast<BYTE>(WICTiffCompressionZIP);
     case PVCS_JPEG_HUFFMAN:
+#if defined(WICTiffCompressionJPEG)
         return static_cast<BYTE>(WICTiffCompressionJPEG);
+#elif defined(WICTiffCompressionJPEGYCBCR)
+        return static_cast<BYTE>(WICTiffCompressionJPEGYCBCR);
+#else
+        return std::nullopt;
+#endif
     default:
         return std::nullopt;
     }

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3376,7 +3376,8 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
                     }
                     PropVariantClear(&prop);
                     if (FAILED(metaHr) && metaHr != WINCODEC_ERR_PROPERTYNOTSUPPORTED &&
-                        metaHr != WINCODEC_ERR_PROPERTYNOTFOUND)
+                        metaHr != WINCODEC_ERR_PROPERTYNOTFOUND && metaHr != E_INVALIDARG &&
+                        metaHr != HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER))
                     {
                         return recordFailure(metaHr, "Set GIF Version");
                     }

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3225,25 +3225,8 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
             return HResultToPvCode(hr);
         }
 
-        Microsoft::WRL::ComPtr<IWICBitmap> indexedBitmap;
-        hr = handle.backend->Factory()->CreateBitmapFromMemory(targetWidth, targetHeight, selection.pixelFormat,
-                                                               encodedStride, static_cast<UINT>(encodedBufferSize),
-                                                               indexedPixels.data(), &indexedBitmap);
-        if (FAILED(hr))
-        {
-            return HResultToPvCode(hr);
-        }
-
-        if (framePalette)
-        {
-            hr = indexedBitmap->SetPalette(framePalette.Get());
-            if (FAILED(hr))
-            {
-                return HResultToPvCode(hr);
-            }
-        }
-
-        hr = frameEncode->WriteSource(indexedBitmap.Get(), nullptr);
+        hr = frameEncode->WritePixels(targetHeight, encodedStride, static_cast<UINT>(encodedBufferSize),
+                                      indexedPixels.data());
         if (FAILED(hr))
         {
             return HResultToPvCode(hr);

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3325,6 +3325,38 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
             {
                 if (gifMetadataWriter)
                 {
+                    if (gifMetadataWriter.Get() == encoderMetadataWriter.Get())
+                    {
+                        const UINT gifMaxDimension = static_cast<UINT>(std::numeric_limits<USHORT>::max());
+                        if (targetWidth > gifMaxDimension || targetHeight > gifMaxDimension)
+                        {
+                            return recordFailure(WINCODEC_ERR_INVALIDPARAMETER, "GIF Logical Screen too large");
+                        }
+
+                        PROPVARIANT prop;
+                        PropVariantInit(&prop);
+                        prop.vt = VT_UI2;
+                        prop.uiVal = static_cast<USHORT>(targetWidth);
+                        metaHr = gifMetadataWriter->SetMetadataByName(L"/logscrdesc/Width", &prop);
+                        PropVariantClear(&prop);
+                        if (FAILED(metaHr) && metaHr != WINCODEC_ERR_PROPERTYNOTSUPPORTED &&
+                            metaHr != WINCODEC_ERR_PROPERTYNOTFOUND)
+                        {
+                            return recordFailure(metaHr, "Set GIF LogicalScreenWidth");
+                        }
+
+                        PropVariantInit(&prop);
+                        prop.vt = VT_UI2;
+                        prop.uiVal = static_cast<USHORT>(targetHeight);
+                        metaHr = gifMetadataWriter->SetMetadataByName(L"/logscrdesc/Height", &prop);
+                        PropVariantClear(&prop);
+                        if (FAILED(metaHr) && metaHr != WINCODEC_ERR_PROPERTYNOTSUPPORTED &&
+                            metaHr != WINCODEC_ERR_PROPERTYNOTFOUND)
+                        {
+                            return recordFailure(metaHr, "Set GIF LogicalScreenHeight");
+                        }
+                    }
+
                     PROPVARIANT prop;
                     PropVariantInit(&prop);
                     prop.vt = VT_BSTR;

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3307,49 +3307,10 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
         }
     }
 
-    if (encoderIsIndexed)
+    hr = frameEncode->WriteSource(frameSource.Get(), nullptr);
+    if (FAILED(hr))
     {
-        if (encodedStride == 0)
-        {
-            return PVC_UNSUP_OUT_PARAMS;
-        }
-
-        const size_t encodedBufferSize = static_cast<size_t>(encodedStride) * targetHeight;
-        if (encodedBufferSize > std::numeric_limits<UINT>::max())
-        {
-            return PVC_OUT_OF_MEMORY;
-        }
-
-        std::vector<BYTE> indexedPixels;
-        try
-        {
-            indexedPixels.resize(encodedBufferSize);
-        }
-        catch (const std::bad_alloc&)
-        {
-            return PVC_OUT_OF_MEMORY;
-        }
-
-        hr = frameSource->CopyPixels(nullptr, encodedStride, static_cast<UINT>(encodedBufferSize), indexedPixels.data());
-        if (FAILED(hr))
-        {
-            return HResultToPvCode(hr);
-        }
-
-        hr = frameEncode->WritePixels(targetHeight, encodedStride, static_cast<UINT>(encodedBufferSize),
-                                      indexedPixels.data());
-        if (FAILED(hr))
-        {
-            return HResultToPvCode(hr);
-        }
-    }
-    else
-    {
-        hr = frameEncode->WriteSource(frameSource.Get(), nullptr);
-        if (FAILED(hr))
-        {
-            return HResultToPvCode(hr);
-        }
+        return HResultToPvCode(hr);
     }
 
     hr = frameEncode->Commit();

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3168,23 +3168,14 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
             return HResultToPvCode(hr);
         }
 
-        const size_t bufferSize = static_cast<size_t>(encodedStride) * targetHeight;
-        std::vector<BYTE> indexed(bufferSize);
-        if (!indexed.empty())
-        {
-            hr = converter->CopyPixels(nullptr, encodedStride, static_cast<UINT>(indexed.size()), indexed.data());
-        }
-        else
-        {
-            hr = converter->CopyPixels(nullptr, encodedStride, 0, nullptr);
-        }
+        Microsoft::WRL::ComPtr<IWICBitmapSource> indexedSource;
+        hr = converter.As(&indexedSource);
         if (FAILED(hr))
         {
             return HResultToPvCode(hr);
         }
 
-        hr = frameEncode->WritePixels(targetHeight, encodedStride, indexed.empty() ? 0 : static_cast<UINT>(indexed.size()),
-                                      indexed.empty() ? nullptr : indexed.data());
+        hr = frameEncode->WriteSource(indexedSource.Get(), nullptr);
         if (FAILED(hr))
         {
             return HResultToPvCode(hr);

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -2356,8 +2356,8 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
 
         const UINT maxCropWidth = processedWidth - info->CropLeft;
         const UINT maxCropHeight = processedHeight - info->CropTop;
-        UINT cropWidth = std::min(info->CropWidth, maxCropWidth);
-        UINT cropHeight = std::min(info->CropHeight, maxCropHeight);
+        const UINT cropWidth = std::min<UINT>(static_cast<UINT>(info->CropWidth), maxCropWidth);
+        const UINT cropHeight = std::min<UINT>(static_cast<UINT>(info->CropHeight), maxCropHeight);
         if (cropWidth == 0 || cropHeight == 0)
         {
             return PVC_UNSUP_OUT_PARAMS;

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3143,8 +3143,8 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
             if (transparencyIndex.has_value())
             {
                 PropVariantInit(&prop);
-                prop.vt = VT_UI2;
-                prop.uiVal = transparencyIndex.value();
+                prop.vt = VT_UI1;
+                prop.bVal = static_cast<BYTE>(transparencyIndex.value());
                 metaHr = metadataWriter->SetMetadataByName(L"/grctlext/TransparentColorIndex", &prop);
                 PropVariantClear(&prop);
                 if (FAILED(metaHr) && metaHr != WINCODEC_ERR_PROPERTYNOTSUPPORTED && metaHr != WINCODEC_ERR_PROPERTYNOTFOUND)

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3148,6 +3148,17 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
             }
         }
 
+        if (framePalette && mapping.container == GUID_ContainerFormatGif)
+        {
+            // The GIF encoder caches the palette when SetPalette is called. Re-register the palette
+            // after aligning it with the negotiated pixel format so the encoder sees the final colors.
+            hr = encoder->SetPalette(framePalette.Get());
+            if (FAILED(hr))
+            {
+                return HResultToPvCode(hr);
+            }
+        }
+
         Microsoft::WRL::ComPtr<IWICFormatConverter> converter;
         hr = handle.backend->Factory()->CreateFormatConverter(&converter);
         if (FAILED(hr))

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3307,51 +3307,10 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
         }
     }
 
-    if (encoderIsIndexed)
+    hr = frameEncode->WriteSource(frameSource.Get(), nullptr);
+    if (FAILED(hr))
     {
-        if (encodedStride == 0)
-        {
-            return PVC_INVALID_DIMENSIONS;
-        }
-
-        const size_t totalSize = static_cast<size_t>(encodedStride) * targetHeight;
-        if (totalSize / encodedStride != targetHeight ||
-            totalSize > static_cast<size_t>(std::numeric_limits<UINT>::max()))
-        {
-            return PVC_OUT_OF_MEMORY;
-        }
-
-        std::vector<BYTE> indexedPixels;
-        try
-        {
-            indexedPixels.resize(totalSize);
-        }
-        catch (const std::bad_alloc&)
-        {
-            return PVC_OUT_OF_MEMORY;
-        }
-
-        hr = frameSource->CopyPixels(nullptr, encodedStride, static_cast<UINT>(indexedPixels.size()),
-                                      indexedPixels.data());
-        if (FAILED(hr))
-        {
-            return HResultToPvCode(hr);
-        }
-
-        hr = frameEncode->WritePixels(targetHeight, encodedStride, static_cast<UINT>(indexedPixels.size()),
-                                      indexedPixels.data());
-        if (FAILED(hr))
-        {
-            return HResultToPvCode(hr);
-        }
-    }
-    else
-    {
-        hr = frameEncode->WriteSource(frameSource.Get(), nullptr);
-        if (FAILED(hr))
-        {
-            return HResultToPvCode(hr);
-        }
+        return HResultToPvCode(hr);
     }
 
     hr = frameEncode->Commit();

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstring>
 #include <cwchar>
 #include <iomanip>
 #include <limits>
@@ -3359,11 +3360,14 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
 
                     PROPVARIANT prop;
                     PropVariantInit(&prop);
-                    prop.vt = VT_BSTR;
-                    const wchar_t* version = (info->Flags & PVSF_GIF89) != 0 ? L"89a" : L"87a";
-                    prop.bstrVal = SysAllocString(version);
-                    if (prop.bstrVal)
+                    prop.vt = VT_UI1 | VT_VECTOR;
+                    prop.caub.cElems = 3;
+                    prop.caub.pElems =
+                        static_cast<BYTE*>(CoTaskMemAlloc(prop.caub.cElems * sizeof(BYTE)));
+                    if (prop.caub.pElems)
                     {
+                        const char* version = (info->Flags & PVSF_GIF89) != 0 ? "89a" : "87a";
+                        memcpy(prop.caub.pElems, version, prop.caub.cElems);
                         metaHr = gifMetadataWriter->SetMetadataByName(L"/logscrdesc/Version", &prop);
                     }
                     else

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3337,7 +3337,16 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
     hr = frameEncode->SetResolution(dpiX, dpiY);
     if (FAILED(hr))
     {
+#if defined(WINCODEC_ERR_UNSUPPORTEDOPERATION)
+        if (hr != WINCODEC_ERR_UNSUPPORTEDOPERATION)
+        {
+            return recordFailure(hr, "FrameEncode::SetResolution");
+        }
+        // Some encoders (e.g., GIF, ICO) do not support DPI metadata. In that
+        // case, leave the encoder's default resolution untouched.
+#else
         return recordFailure(hr, "FrameEncode::SetResolution");
+#endif
     }
 
     Microsoft::WRL::ComPtr<IWICMetadataQueryWriter> metadataWriter;

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -3121,6 +3121,15 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
             }
         }
 
+        if (mapping.container == GUID_ContainerFormatGif)
+        {
+            hr = encoder->SetPalette(palette.Get());
+            if (FAILED(hr))
+            {
+                return HResultToPvCode(hr);
+            }
+        }
+
         hr = frameEncode->SetPalette(palette.Get());
         if (FAILED(hr))
         {

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -2996,6 +2996,18 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
         return HResultToPvCode(hr);
     }
 
+    if (mapping.container == GUID_ContainerFormatGif && palette)
+    {
+        // The GIF encoder expects its global palette to be registered before the frame is
+        // initialized so it can negotiate pixel formats correctly. Set it up immediately after
+        // creating the frame to avoid WRONGSTATE errors when writing indexed data later on.
+        hr = encoder->SetPalette(palette.Get());
+        if (FAILED(hr))
+        {
+            return HResultToPvCode(hr);
+        }
+    }
+
     hr = bagWriter.Write(bag.Get());
     if (FAILED(hr))
     {
@@ -3132,15 +3144,6 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
                 {
                     return HResultToPvCode(hr);
                 }
-            }
-        }
-
-        if (mapping.container == GUID_ContainerFormatGif && framePalette)
-        {
-            hr = encoder->SetPalette(framePalette.Get());
-            if (FAILED(hr))
-            {
-                return HResultToPvCode(hr);
             }
         }
 


### PR DESCRIPTION
## Summary
- configure WIC encoders with the caller-provided PVSaveImageInfo options for JPEG quality/subsampling, TIFF compression, GIF interlacing, and transparency
- honour requested output dimensions and DPI by scaling the source bitmap before writing
- update GIF encoding to rebuild palettes with transparency metadata and rely on WriteSource for other formats

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e465ff3f8483298c1e76dd08ec35ce