### PR TITLE
Fix GIF frame compositing in WIC backend

### DIFF
--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -2206,7 +2206,7 @@ HRESULT ConvertBgraSourceToCmyk(IWICImagingFactory* factory, IWICBitmapSource* s
         return hr;
     }
 
-    return bitmap.As(convertedSource);
+    return bitmap.CopyTo(convertedSource);
 }
 
 HRESULT FinalizeDecodedFrame(FrameData& frame)

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -1531,11 +1531,12 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
                 }
                 FillBufferWithColor(composed, canvasWidth, canvasHeight, GetRValue(handle.formatInfo.GIF.BgColor),
                                     GetGValue(handle.formatInfo.GIF.BgColor), GetBValue(handle.formatInfo.GIF.BgColor),
-                                    handle.gifHasBackgroundColor ? 255 : 0);
+                                    handle.gifHasBackgroundColor ? handle.gifBackgroundAlpha : 0);
             }
             ClearBufferRect(composed, canvasWidth, canvasHeight, previous.rect,
                             GetRValue(handle.formatInfo.GIF.BgColor), GetGValue(handle.formatInfo.GIF.BgColor),
-                            GetBValue(handle.formatInfo.GIF.BgColor), handle.gifHasBackgroundColor ? 255 : 0);
+                            GetBValue(handle.formatInfo.GIF.BgColor),
+                            handle.gifHasBackgroundColor ? handle.gifBackgroundAlpha : 0);
         }
 
         if (composed.size() != canvasBytes)
@@ -1547,7 +1548,7 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
             }
             FillBufferWithColor(composed, canvasWidth, canvasHeight, GetRValue(handle.formatInfo.GIF.BgColor),
                                 GetGValue(handle.formatInfo.GIF.BgColor), GetBValue(handle.formatInfo.GIF.BgColor),
-                                handle.gifHasBackgroundColor ? 255 : 0);
+                                handle.gifHasBackgroundColor ? handle.gifBackgroundAlpha : 0);
         }
     }
     else
@@ -1559,7 +1560,7 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
         }
         FillBufferWithColor(composed, canvasWidth, canvasHeight, GetRValue(handle.formatInfo.GIF.BgColor),
                             GetGValue(handle.formatInfo.GIF.BgColor), GetBValue(handle.formatInfo.GIF.BgColor),
-                            handle.gifHasBackgroundColor ? 255 : 0);
+                            handle.gifHasBackgroundColor ? handle.gifBackgroundAlpha : 0);
     }
 
     const UINT sourceWidth = frame.width;
@@ -2473,6 +2474,7 @@ HRESULT CollectFrames(Backend& backend, IWICBitmapDecoder* decoder, ImageHandle&
 
     COLORREF backgroundColor = RGB(0, 0, 0);
     handle.gifHasBackgroundColor = false;
+    handle.gifBackgroundAlpha = 0;
     if (hasBackgroundIndex)
     {
         ComPtr<IWICPalette> palette;
@@ -2489,11 +2491,13 @@ HRESULT CollectFrames(Backend& backend, IWICBitmapDecoder* decoder, ImageHandle&
                         actualCount > backgroundIndex)
                     {
                         const WICColor color = colors[backgroundIndex];
+                        const BYTE a = static_cast<BYTE>((color >> 24) & 0xFF);
                         const BYTE r = static_cast<BYTE>((color >> 16) & 0xFF);
                         const BYTE g = static_cast<BYTE>((color >> 8) & 0xFF);
                         const BYTE b = static_cast<BYTE>(color & 0xFF);
                         backgroundColor = RGB(r, g, b);
                         handle.gifHasBackgroundColor = true;
+                        handle.gifBackgroundAlpha = a;
                     }
                 }
             }

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -1620,23 +1620,35 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
                 continue;
             }
 
-            const BYTE destAlpha = destPixel[3];
+            const UINT destAlpha = destPixel[3];
             const UINT inverseAlpha = 255u - static_cast<UINT>(srcAlpha);
             const UINT blendedAlpha = static_cast<UINT>(srcAlpha) +
                                       (static_cast<UINT>(destAlpha) * inverseAlpha + 127u) / 255u;
-            const UINT blendedB = (static_cast<UINT>(srcPixel[0]) * srcAlpha +
-                                   static_cast<UINT>(destPixel[0]) * inverseAlpha + 127u) /
-                                  255u;
-            const UINT blendedG = (static_cast<UINT>(srcPixel[1]) * srcAlpha +
-                                   static_cast<UINT>(destPixel[1]) * inverseAlpha + 127u) /
-                                  255u;
-            const UINT blendedR = (static_cast<UINT>(srcPixel[2]) * srcAlpha +
-                                   static_cast<UINT>(destPixel[2]) * inverseAlpha + 127u) /
-                                  255u;
-            destPixel[0] = static_cast<BYTE>(std::min(blendedB, 255u));
-            destPixel[1] = static_cast<BYTE>(std::min(blendedG, 255u));
-            destPixel[2] = static_cast<BYTE>(std::min(blendedR, 255u));
-            destPixel[3] = static_cast<BYTE>(std::min(blendedAlpha, 255u));
+            const UINT srcBPremul = static_cast<UINT>(srcPixel[0]) * static_cast<UINT>(srcAlpha);
+            const UINT srcGPremul = static_cast<UINT>(srcPixel[1]) * static_cast<UINT>(srcAlpha);
+            const UINT srcRPremul = static_cast<UINT>(srcPixel[2]) * static_cast<UINT>(srcAlpha);
+            const UINT destBPremul = static_cast<UINT>(destPixel[0]) * static_cast<UINT>(destAlpha);
+            const UINT destGPremul = static_cast<UINT>(destPixel[1]) * static_cast<UINT>(destAlpha);
+            const UINT destRPremul = static_cast<UINT>(destPixel[2]) * static_cast<UINT>(destAlpha);
+            const UINT destContributionB = (destBPremul * inverseAlpha + 127u) / 255u;
+            const UINT destContributionG = (destGPremul * inverseAlpha + 127u) / 255u;
+            const UINT destContributionR = (destRPremul * inverseAlpha + 127u) / 255u;
+            const UINT blendedBPremul = srcBPremul + destContributionB;
+            const UINT blendedGPremul = srcGPremul + destContributionG;
+            const UINT blendedRPremul = srcRPremul + destContributionR;
+            if (blendedAlpha > 0)
+            {
+                destPixel[0] = static_cast<BYTE>((blendedBPremul + blendedAlpha / 2u) / blendedAlpha);
+                destPixel[1] = static_cast<BYTE>((blendedGPremul + blendedAlpha / 2u) / blendedAlpha);
+                destPixel[2] = static_cast<BYTE>((blendedRPremul + blendedAlpha / 2u) / blendedAlpha);
+            }
+            else
+            {
+                destPixel[0] = 0;
+                destPixel[1] = 0;
+                destPixel[2] = 0;
+            }
+            destPixel[3] = static_cast<BYTE>(blendedAlpha);
         }
     }
 

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -1584,12 +1584,23 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
     const LONGLONG endX64 = std::min<LONGLONG>(canvasWidth64, destRight64);
     const LONGLONG endY64 = std::min<LONGLONG>(canvasHeight64, destBottom64);
 
+    RECT compositedRect{};
+    compositedRect.left = static_cast<LONG>(std::clamp(destLeft64, 0ll, canvasWidth64));
+    compositedRect.top = static_cast<LONG>(std::clamp(destTop64, 0ll, canvasHeight64));
+    compositedRect.right = static_cast<LONG>(std::clamp(destRight64, 0ll, canvasWidth64));
+    compositedRect.bottom = static_cast<LONG>(std::clamp(destBottom64, 0ll, canvasHeight64));
+
     if (sourceWidth > 0 && sourceHeight > 0 && startX64 < endX64 && startY64 < endY64)
     {
         const LONG startX = static_cast<LONG>(startX64);
         const LONG startY = static_cast<LONG>(startY64);
         const LONG endX = static_cast<LONG>(endX64);
         const LONG endY = static_cast<LONG>(endY64);
+
+        compositedRect.left = startX;
+        compositedRect.top = startY;
+        compositedRect.right = endX;
+        compositedRect.bottom = endY;
 
         for (LONG y = startY; y < endY; ++y)
         {
@@ -1612,6 +1623,17 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
             }
         }
     }
+
+    if (compositedRect.right < compositedRect.left)
+    {
+        compositedRect.right = compositedRect.left;
+    }
+    if (compositedRect.bottom < compositedRect.top)
+    {
+        compositedRect.bottom = compositedRect.top;
+    }
+
+    frame.rect = compositedRect;
 
     frame.width = canvasWidth;
     frame.height = canvasHeight;

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -4048,7 +4048,9 @@ PVCODE SaveFrame(ImageHandle& handle, int imageIndex, const wchar_t* path, const
             }
             if (IsEqualGUID(pixelFormat, GUID_WICPixelFormat32bppCMYK))
             {
-                hr = ConvertBgraSourceToCmyk(handle.backend->Factory(), baseSource.Get(), &frameSource);
+                frameSource.Reset();
+                hr = ConvertBgraSourceToCmyk(handle.backend->Factory(), baseSource.Get(),
+                                             frameSource.ReleaseAndGetAddressOf());
                 if (FAILED(hr))
                 {
                     return recordFailure(hr, "ConvertBgraSourceToCmyk");

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -1562,6 +1562,7 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
     {
         FillBufferWithColor(handle.gifComposeCanvas, canvasWidth, canvasHeight, backgroundR, backgroundG, backgroundB,
                             backgroundA);
+        ZeroTransparentPixels(handle.gifComposeCanvas);
         handle.gifCanvasInitialized = true;
         handle.gifSavedCanvas.clear();
     }
@@ -1574,6 +1575,7 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
         case PVDM_BACKGROUND:
             ClearBufferRect(handle.gifComposeCanvas, canvasWidth, canvasHeight, previousLogicalRect, backgroundR,
                             backgroundG, backgroundB, backgroundA);
+            ZeroTransparentPixels(handle.gifComposeCanvas);
             handle.gifSavedCanvas.clear();
             break;
         case PVDM_PREVIOUS:
@@ -1593,9 +1595,11 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
                 FillBufferWithColor(handle.gifComposeCanvas, canvasWidth, canvasHeight, backgroundR, backgroundG,
                                     backgroundB, backgroundA);
             }
+            ZeroTransparentPixels(handle.gifComposeCanvas);
             handle.gifSavedCanvas.clear();
             break;
         default:
+            ZeroTransparentPixels(handle.gifComposeCanvas);
             handle.gifSavedCanvas.clear();
             break;
         }
@@ -1611,6 +1615,7 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
         {
             return E_OUTOFMEMORY;
         }
+        ZeroTransparentPixels(handle.gifSavedCanvas);
     }
     else
     {
@@ -1702,6 +1707,8 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
     frame.height = canvasHeight;
     frame.stride = static_cast<UINT>(canvasStride);
     frame.disposalBuffer.clear();
+
+    ZeroTransparentPixels(handle.gifComposeCanvas);
 
     try
     {

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -1480,35 +1480,20 @@ HRESULT CopyBgraFromSource(FrameData& frame, IWICBitmapSource* source)
 
     UINT targetWidth = width;
     UINT targetHeight = height;
-    WICRect rect{0, 0, static_cast<INT>(width), static_cast<INT>(height)};
-
-    if (frame.rawWidth > 0 && frame.rawHeight > 0 &&
-        (frame.rawWidth <= width && frame.rawHeight <= height))
+    if (frame.rawWidth > 0 && frame.rawWidth <= width)
     {
         targetWidth = frame.rawWidth;
+    }
+    if (frame.rawHeight > 0 && frame.rawHeight <= height)
+    {
         targetHeight = frame.rawHeight;
-        rect.Width = static_cast<INT>(targetWidth);
-        rect.Height = static_cast<INT>(targetHeight);
     }
 
-    if (frame.hasGifFrameRect)
-    {
-        const LONG clampedLeft = std::clamp(frame.gifFrameRect.left, 0L, static_cast<LONG>(width));
-        const LONG clampedTop = std::clamp(frame.gifFrameRect.top, 0L, static_cast<LONG>(height));
-        const LONG clampedRight = std::clamp(frame.gifFrameRect.right, clampedLeft, static_cast<LONG>(width));
-        const LONG clampedBottom = std::clamp(frame.gifFrameRect.bottom, clampedTop, static_cast<LONG>(height));
-        const LONG rectWidth = std::max<LONG>(0, clampedRight - clampedLeft);
-        const LONG rectHeight = std::max<LONG>(0, clampedBottom - clampedTop);
-        if (rectWidth > 0 && rectHeight > 0)
-        {
-            rect.X = static_cast<INT>(clampedLeft);
-            rect.Y = static_cast<INT>(clampedTop);
-            rect.Width = static_cast<INT>(rectWidth);
-            rect.Height = static_cast<INT>(rectHeight);
-            targetWidth = static_cast<UINT>(rectWidth);
-            targetHeight = static_cast<UINT>(rectHeight);
-        }
-    }
+    WICRect rect{};
+    rect.X = 0;
+    rect.Y = 0;
+    rect.Width = static_cast<INT>(targetWidth);
+    rect.Height = static_cast<INT>(targetHeight);
 
     hr = AllocatePixelStorage(frame, targetWidth, targetHeight);
     if (FAILED(hr))
@@ -1703,6 +1688,15 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
     }
 
     frame.rect = compositedRect;
+    if (frame.hasGifFrameRect)
+    {
+        frame.gifFrameRect = compositedRect;
+    }
+    else
+    {
+        frame.gifFrameRect = compositedRect;
+        frame.hasGifFrameRect = true;
+    }
 
     frame.width = canvasWidth;
     frame.height = canvasHeight;

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -1562,7 +1562,6 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
     {
         FillBufferWithColor(handle.gifComposeCanvas, canvasWidth, canvasHeight, backgroundR, backgroundG, backgroundB,
                             backgroundA);
-        ZeroTransparentPixels(handle.gifComposeCanvas);
         handle.gifCanvasInitialized = true;
         handle.gifSavedCanvas.clear();
     }
@@ -1575,7 +1574,6 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
         case PVDM_BACKGROUND:
             ClearBufferRect(handle.gifComposeCanvas, canvasWidth, canvasHeight, previousLogicalRect, backgroundR,
                             backgroundG, backgroundB, backgroundA);
-            ZeroTransparentPixels(handle.gifComposeCanvas);
             handle.gifSavedCanvas.clear();
             break;
         case PVDM_PREVIOUS:
@@ -1595,11 +1593,9 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
                 FillBufferWithColor(handle.gifComposeCanvas, canvasWidth, canvasHeight, backgroundR, backgroundG,
                                     backgroundB, backgroundA);
             }
-            ZeroTransparentPixels(handle.gifComposeCanvas);
             handle.gifSavedCanvas.clear();
             break;
         default:
-            ZeroTransparentPixels(handle.gifComposeCanvas);
             handle.gifSavedCanvas.clear();
             break;
         }
@@ -1615,7 +1611,6 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
         {
             return E_OUTOFMEMORY;
         }
-        ZeroTransparentPixels(handle.gifSavedCanvas);
     }
     else
     {
@@ -1707,8 +1702,6 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
     frame.height = canvasHeight;
     frame.stride = static_cast<UINT>(canvasStride);
     frame.disposalBuffer.clear();
-
-    ZeroTransparentPixels(handle.gifComposeCanvas);
 
     try
     {
@@ -1851,9 +1844,9 @@ void FillBufferWithColor(std::vector<BYTE>& buffer, UINT width, UINT height, BYT
     {
         return;
     }
-    const BYTE fillR = (a == 0) ? 0 : r;
-    const BYTE fillG = (a == 0) ? 0 : g;
-    const BYTE fillB = (a == 0) ? 0 : b;
+    const BYTE fillR = r;
+    const BYTE fillG = g;
+    const BYTE fillB = b;
     const size_t stride = static_cast<size_t>(width) * kBytesPerPixel;
     for (UINT y = 0; y < height; ++y)
     {
@@ -1888,9 +1881,9 @@ void ClearBufferRect(std::vector<BYTE>& buffer, UINT width, UINT height, const R
         return;
     }
 
-    const BYTE fillR = (a == 0) ? 0 : r;
-    const BYTE fillG = (a == 0) ? 0 : g;
-    const BYTE fillB = (a == 0) ? 0 : b;
+    const BYTE fillR = r;
+    const BYTE fillG = g;
+    const BYTE fillB = b;
     const size_t stride = static_cast<size_t>(width) * kBytesPerPixel;
     for (LONG y = top; y < bottom; ++y)
     {

--- a/src/plugins/pictview/wic/WicBackend.cpp
+++ b/src/plugins/pictview/wic/WicBackend.cpp
@@ -1580,7 +1580,6 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
         {
             return E_OUTOFMEMORY;
         }
-        ZeroTransparentPixels(frame.disposalBuffer);
     }
     else
     {
@@ -1641,8 +1640,6 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
         }
     }
 
-    ZeroTransparentPixels(composed);
-
     frame.width = canvasWidth;
     frame.height = canvasHeight;
     frame.stride = static_cast<UINT>(canvasStride);
@@ -1655,6 +1652,8 @@ HRESULT CompositeGifFrame(ImageHandle& handle, size_t index)
     {
         return E_OUTOFMEMORY;
     }
+
+    ZeroTransparentPixels(composed);
 
     frame.pixels.swap(composed);
     return S_OK;

--- a/src/plugins/pictview/wic/WicBackend.h
+++ b/src/plugins/pictview/wic/WicBackend.h
@@ -35,6 +35,7 @@ struct FrameData
     std::vector<BYTE> pixels;
     std::vector<BYTE*> linePointers;
     std::vector<RGBQUAD> palette;
+    std::vector<BYTE> disposalBuffer;
     BITMAPINFOHEADER bmi{};
     HBITMAP hbitmap = nullptr;
     HBITMAP transparencyMask = nullptr;
@@ -61,6 +62,7 @@ struct ImageHandle
     bool hasFormatSpecificInfo = false;
     LONG canvasWidth = 0;
     LONG canvasHeight = 0;
+    bool gifHasBackgroundColor = false;
 };
 
 /**

--- a/src/plugins/pictview/wic/WicBackend.h
+++ b/src/plugins/pictview/wic/WicBackend.h
@@ -33,6 +33,7 @@ struct FrameData
     UINT height = 0;
     UINT stride = 0;
     std::vector<BYTE> pixels;
+    std::vector<BYTE> compositedPixels;
     std::vector<BYTE*> linePointers;
     std::vector<RGBQUAD> palette;
     std::vector<BYTE> disposalBuffer;

--- a/src/plugins/pictview/wic/WicBackend.h
+++ b/src/plugins/pictview/wic/WicBackend.h
@@ -65,6 +65,9 @@ struct ImageHandle
     LONG canvasHeight = 0;
     bool gifHasBackgroundColor = false;
     BYTE gifBackgroundAlpha = 0;
+    std::vector<BYTE> gifComposeCanvas;
+    std::vector<BYTE> gifSavedCanvas;
+    bool gifCanvasInitialized = false;
 };
 
 /**

--- a/src/plugins/pictview/wic/WicBackend.h
+++ b/src/plugins/pictview/wic/WicBackend.h
@@ -32,6 +32,9 @@ struct FrameData
     UINT width = 0;
     UINT height = 0;
     UINT stride = 0;
+    UINT rawWidth = 0;
+    UINT rawHeight = 0;
+    UINT rawStride = 0;
     std::vector<BYTE> pixels;
     std::vector<BYTE> compositedPixels;
     std::vector<BYTE*> linePointers;
@@ -42,7 +45,15 @@ struct FrameData
     HBITMAP transparencyMask = nullptr;
     DWORD delayMs = 0;
     RECT rect{};
+    RECT gifFrameRect{};
     DWORD disposal = PVDM_UNDEFINED;
+    GUID sourcePixelFormat{};
+    DWORD reportedColors = PV_COLOR_TC32;
+    DWORD reportedBitDepth = 32;
+    DWORD colorModel = PVCM_RGB;
+    UINT paletteColorCount = 0;
+    UINT bitsPerPixel = 0;
+    bool hasGifFrameRect = false;
     bool decoded = false;
     bool hasTransparency = false;
 };

--- a/src/plugins/pictview/wic/WicBackend.h
+++ b/src/plugins/pictview/wic/WicBackend.h
@@ -64,6 +64,7 @@ struct ImageHandle
     LONG canvasWidth = 0;
     LONG canvasHeight = 0;
     bool gifHasBackgroundColor = false;
+    BYTE gifBackgroundAlpha = 0;
 };
 
 /**


### PR DESCRIPTION
## Summary
- compose GIF frames onto the logical screen before finalizing decoded data to remove artefacts
- capture the GIF background colour and store per-frame disposal buffers to honour disposal methods
- clear cached disposal data when frames are modified via crop or rotation

## Testing
- not run (Windows-specific build tools are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7156df10c83298a5a34cdf353d860