### PR TITLE
Integrate optional darkmodelib adapter for dark mode

### DIFF
--- a/doc/darkmodelib.md
+++ b/doc/darkmodelib.md
@@ -1,0 +1,31 @@
+# Dark mode library adapter
+
+The optional `darkmodelib.dll` runtime can extend Salamander's existing dark-mode
+pipeline. The adapter is loaded on-demand; builds continue to work even when the
+library is absent.
+
+## Responsibilities mapped
+
+* **Palette building:** `DarkModeQueryPreferredPalette` asks the library for
+  dialog text, background, and accent colors. When present, the palette feeds
+  the Windows dark scheme created in `BuildWindowsDarkPalette` so list views and
+  dialogs inherit accent-aware colors.
+* **Window registration:** `DarkModeSetEnabled`, `DarkModeApplyWindow`, and
+  `DarkModeApplyTree` prefer `darkmodelib` APIs to opt windows into immersive
+  title bars and automatic control theming. The in-tree helpers remain as
+  fallbacks.
+* **Title bar refresh:** `DarkModeRefreshTitleBar` delegates to the library
+  first so non-client rendering benefits from any additional heuristics.
+
+## Fallbacks and toggles
+
+* Set the environment variable `SALAMANDER_DISABLE_DARKMODELIB=1` to skip the
+  library entirely and use the built-in helpers.
+* When the DLL is missing or incomplete, Salamander reverts to the existing
+  native dark-mode shim without functional regressions.
+
+## Runtime expectation
+
+If you want the extended behaviors (automatic control theming, accent-aware
+palettes), place `darkmodelib.dll` next to `salamander.exe` (or anywhere in the
+standard DLL search path). No build-time dependency is required.

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -3,6 +3,7 @@
 
 #include "precomp.h"
 #include "darkmode.h"
+#include "darkmodelib.h"
 
 #include <delayimp.h>
 #include <uxtheme.h>
@@ -18,6 +19,12 @@
 
 #ifndef LOAD_LIBRARY_SEARCH_SYSTEM32
 #define LOAD_LIBRARY_SEARCH_SYSTEM32 0x00000800
+#endif
+#ifndef LOAD_LIBRARY_SEARCH_APPLICATION_DIR
+#define LOAD_LIBRARY_SEARCH_APPLICATION_DIR 0x00000200
+#endif
+#ifndef LOAD_LIBRARY_SEARCH_DEFAULT_DIRS
+#define LOAD_LIBRARY_SEARCH_DEFAULT_DIRS 0x00001000
 #endif
 
 namespace
@@ -184,6 +191,16 @@ fnShouldSystemUseDarkMode gShouldSystemUseDarkMode = nullptr;
 fnSetPreferredAppMode gSetPreferredAppMode = nullptr;
 fnIsDarkModeAllowedForApp gIsDarkModeAllowedForApp = nullptr;
 
+HMODULE gDarkModeLib = nullptr;
+DarkModeLibApi gDarkModeLibApi;
+bool gDarkModeLibInitialized = false;
+bool gDarkModeLibAvailable = false;
+bool gDarkModeLibPaletteValid = false;
+bool gDarkModeLibPreferred = true;
+COLORREF gDarkModeLibPaletteText = 0;
+COLORREF gDarkModeLibPaletteBackground = 0;
+COLORREF gDarkModeLibPaletteAccent = 0;
+
 DWORD gBuildNumber = 0;
 bool gInitialized = false;
 bool gSupported = false;
@@ -197,6 +214,44 @@ static bool gPropagatingThemeChange = false;
 
 const wchar_t* kDarkModeThemeProp = L"Salamander.DarkMode.Theme";
 const wchar_t* kDarkModeClassicButtonProp = L"Salamander.DarkMode.ClassicButton";
+
+void InitializeDarkModeLib()
+{
+    if (gDarkModeLibInitialized)
+        return;
+
+    gDarkModeLibInitialized = true;
+
+    wchar_t disableEnv[2];
+    if (GetEnvironmentVariableW(L"SALAMANDER_DISABLE_DARKMODELIB", disableEnv, _countof(disableEnv)) > 0)
+    {
+        gDarkModeLibPreferred = false;
+        return;
+    }
+
+    gDarkModeLib = LoadLibraryExW(L"darkmodelib.dll", nullptr,
+                                  LOAD_LIBRARY_SEARCH_APPLICATION_DIR |
+                                      LOAD_LIBRARY_SEARCH_SYSTEM32 |
+                                      LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    if (!gDarkModeLib)
+        gDarkModeLib = LoadLibraryW(L"darkmodelib.dll");
+
+    if (!gDarkModeLib)
+        return;
+
+    gDarkModeLibApi.Initialize = reinterpret_cast<fnDarkModeLibInitialize>(GetProcAddress(gDarkModeLib, "DarkModeLibInitialize"));
+    gDarkModeLibApi.IsSupported = reinterpret_cast<fnDarkModeLibIsSupported>(GetProcAddress(gDarkModeLib, "DarkModeLibIsSupported"));
+    gDarkModeLibApi.SetEnabled = reinterpret_cast<fnDarkModeLibSetEnabled>(GetProcAddress(gDarkModeLib, "DarkModeLibSetEnabled"));
+    gDarkModeLibApi.ApplyWindow = reinterpret_cast<fnDarkModeLibApplyWindow>(GetProcAddress(gDarkModeLib, "DarkModeLibApplyWindow"));
+    gDarkModeLibApi.ApplyTree = reinterpret_cast<fnDarkModeLibApplyTree>(GetProcAddress(gDarkModeLib, "DarkModeLibApplyTree"));
+    gDarkModeLibApi.RefreshTitleBar = reinterpret_cast<fnDarkModeLibRefreshTitleBar>(GetProcAddress(gDarkModeLib, "DarkModeLibRefreshTitleBar"));
+    gDarkModeLibApi.ShouldUseDarkColors = reinterpret_cast<fnDarkModeLibShouldUseDarkColors>(GetProcAddress(gDarkModeLib, "DarkModeLibShouldUseDarkColors"));
+    gDarkModeLibApi.QueryPalette = reinterpret_cast<fnDarkModeLibQueryPalette>(GetProcAddress(gDarkModeLib, "DarkModeLibQueryPalette"));
+    gDarkModeLibApi.ThemeWindowControls = reinterpret_cast<fnDarkModeLibThemeWindowControls>(GetProcAddress(gDarkModeLib, "DarkModeLibThemeWindowControls"));
+
+    if (gDarkModeLibApi.Initialize && gDarkModeLibApi.IsSupported)
+        gDarkModeLibAvailable = gDarkModeLibApi.Initialize() && gDarkModeLibApi.IsSupported();
+}
 
 bool ControlHasCaptionButton(HWND hwnd)
 {
@@ -468,12 +523,14 @@ void EnsureInitialized()
     if (gBuildNumber < 17763)
     {
         gSupported = false;
+        InitializeDarkModeLib();
         return;
     }
 
     if (!gUxTheme)
     {
         gSupported = false;
+        InitializeDarkModeLib();
         return;
     }
 
@@ -499,35 +556,46 @@ void EnsureInitialized()
                  (gAllowDarkModeForApp != nullptr || gSetPreferredAppMode != nullptr) &&
                  gShouldAppsUseDarkMode != nullptr;
 
-    if (!gSupported)
-        return;
+    InitializeDarkModeLib();
 }
 
 } // namespace
 
+bool DarkModeLibraryIsActive()
+{
+    EnsureInitialized();
+    return gDarkModeLibAvailable && gDarkModeLibPreferred;
+}
+
 bool DarkModeInitialize()
 {
     EnsureInitialized();
-    return gSupported;
+    return gSupported || DarkModeLibraryIsActive();
 }
 
 bool DarkModeIsSupported()
 {
     EnsureInitialized();
-    return gSupported;
+    return gSupported || DarkModeLibraryIsActive();
 }
 
 void DarkModeSetEnabled(bool enabled)
 {
     EnsureInitialized();
-    if (!gSupported)
-        return;
+    const bool libraryActive = DarkModeLibraryIsActive();
 
     bool newEnabled = enabled && !IsHighContrast();
-    if (gEnabled == newEnabled)
+    if (gEnabled == newEnabled && !libraryActive)
         return;
 
     gEnabled = newEnabled;
+    gDarkModeLibPaletteValid = false;
+
+    if (libraryActive && gDarkModeLibApi.SetEnabled)
+        gDarkModeLibApi.SetEnabled(gEnabled);
+
+    if (!gSupported)
+        return;
 
     if (gAllowDarkModeForApp)
         gAllowDarkModeForApp(gEnabled);
@@ -547,6 +615,9 @@ bool DarkModeShouldUseDarkColors()
 {
     EnsureInitialized();
 
+    if (DarkModeLibraryIsActive() && gDarkModeLibApi.ShouldUseDarkColors)
+        return gDarkModeLibApi.ShouldUseDarkColors();
+
     if (ShouldUseDarkColorsInternal())
         return true;
 
@@ -560,29 +631,57 @@ bool DarkModeShouldUseDarkColors()
 void DarkModeApplyWindow(HWND hwnd)
 {
     EnsureInitialized();
-    if (!gSupported || hwnd == NULL)
+    if (hwnd == NULL)
+        return;
+
+    const bool libraryActive = DarkModeLibraryIsActive();
+    if (libraryActive)
+    {
+        if (gDarkModeLibApi.ApplyWindow)
+            gDarkModeLibApi.ApplyWindow(hwnd);
+        if (gDarkModeLibApi.ThemeWindowControls)
+            gDarkModeLibApi.ThemeWindowControls(hwnd);
+    }
+
+    if (!gSupported)
         return;
 
     if (gAllowDarkModeForWindow)
         gAllowDarkModeForWindow(hwnd, gEnabled);
 
-    ApplyControlTheme(hwnd);
+    if (!libraryActive)
+        ApplyControlTheme(hwnd);
 }
 
 void DarkModeApplyTree(HWND hwnd)
 {
     EnsureInitialized();
-    if (!gSupported || hwnd == NULL)
+    if (hwnd == NULL)
         return;
 
+    const bool libraryActive = DarkModeLibraryIsActive();
+    if (libraryActive && gDarkModeLibApi.ApplyTree)
+    {
+        gDarkModeLibApi.ApplyTree(hwnd);
+        return;
+    }
+
     DarkModeApplyWindow(hwnd);
-    EnumChildWindows(hwnd, ApplyTreeCallback, 0);
+
+    if (gSupported)
+        EnumChildWindows(hwnd, ApplyTreeCallback, 0);
 }
 
 void DarkModeRefreshTitleBar(HWND hwnd)
 {
     EnsureInitialized();
-    if (!gSupported || hwnd == NULL)
+    if (hwnd == NULL)
+        return;
+
+    if (DarkModeLibraryIsActive() && gDarkModeLibApi.RefreshTitleBar)
+        gDarkModeLibApi.RefreshTitleBar(hwnd);
+
+    if (!gSupported)
         return;
 
     BOOL useDark = FALSE;
@@ -603,7 +702,8 @@ void DarkModeRefreshTitleBar(HWND hwnd)
 bool DarkModeHandleSettingChange(UINT message, LPARAM lParam)
 {
     EnsureInitialized();
-    if (!gSupported)
+    const bool libraryActive = DarkModeLibraryIsActive();
+    if (!gSupported && !libraryActive)
         return false;
 
     if (message != WM_SETTINGCHANGE)
@@ -614,19 +714,24 @@ bool DarkModeHandleSettingChange(UINT message, LPARAM lParam)
     {
         if (CompareStringOrdinal(reinterpret_cast<LPCWSTR>(lParam), -1, L"ImmersiveColorSet", -1, TRUE) == CSTR_EQUAL)
         {
-            RefreshColorPolicy();
+            if (gSupported)
+                RefreshColorPolicy();
             isColor = true;
         }
         else if (CompareStringOrdinal(reinterpret_cast<LPCWSTR>(lParam), -1, L"WindowsThemeElement", -1, TRUE) == CSTR_EQUAL)
         {
-            RefreshColorPolicy();
+            if (gSupported)
+                RefreshColorPolicy();
             isColor = true;
         }
     }
-    else
+    else if (gSupported)
     {
         RefreshColorPolicy();
     }
+
+    if (isColor)
+        gDarkModeLibPaletteValid = false;
 
     return isColor;
 }
@@ -662,6 +767,44 @@ COLORREF DarkModeGetDialogBackgroundColor()
 COLORREF DarkModeEnsureReadableForeground(COLORREF foreground, COLORREF background)
 {
     return ResolveReadableForeground(foreground, background);
+}
+
+bool DarkModeQueryPreferredPalette(COLORREF* textColor, COLORREF* backgroundColor, COLORREF* accentColor)
+{
+    EnsureInitialized();
+
+    if (!DarkModeLibraryIsActive() || gDarkModeLibApi.QueryPalette == nullptr)
+        return false;
+
+    if (gDarkModeLibPaletteValid)
+    {
+        if (textColor)
+            *textColor = gDarkModeLibPaletteText;
+        if (backgroundColor)
+            *backgroundColor = gDarkModeLibPaletteBackground;
+        if (accentColor)
+            *accentColor = gDarkModeLibPaletteAccent;
+        return true;
+    }
+
+    COLORREF libraryText = 0;
+    COLORREF libraryBackground = 0;
+    COLORREF libraryAccent = 0;
+    if (!gDarkModeLibApi.QueryPalette(&libraryText, &libraryBackground, &libraryAccent))
+        return false;
+
+    gDarkModeLibPaletteText = libraryText;
+    gDarkModeLibPaletteBackground = libraryBackground;
+    gDarkModeLibPaletteAccent = libraryAccent;
+    gDarkModeLibPaletteValid = true;
+
+    if (textColor)
+        *textColor = libraryText;
+    if (backgroundColor)
+        *backgroundColor = libraryBackground;
+    if (accentColor)
+        *accentColor = libraryAccent;
+    return true;
 }
 
 void DarkModeUpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors)

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -5,6 +5,9 @@
 
 #include <windows.h>
 
+// Returns true when a darkmodelib runtime is present and initialized.
+bool DarkModeLibraryIsActive();
+
 // Initializes the dark mode helpers. Safe to call multiple times.
 bool DarkModeInitialize();
 
@@ -47,6 +50,7 @@ HBRUSH DarkModeGetPanelFrameBrush();
 COLORREF DarkModeGetDialogTextColor();
 COLORREF DarkModeGetDialogBackgroundColor();
 COLORREF DarkModeEnsureReadableForeground(COLORREF foreground, COLORREF background);
+bool DarkModeQueryPreferredPalette(COLORREF* textColor, COLORREF* backgroundColor, COLORREF* accentColor);
 void DarkModeUpdateListViewColors(HWND listView);
 void DarkModeUpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors);
 

--- a/src/darkmodelib.h
+++ b/src/darkmodelib.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <windows.h>
+
+// Minimal adapter for the optional darkmodelib runtime. The library is loaded
+// dynamically at startup and used only when present. All calls gracefully fall
+// back to the built-in helpers when the DLL is missing or fails to initialize.
+//
+// The API mirrors the responsibilities of our dark-mode pipeline:
+//  * opt-in / opt-out control (DarkModeLibSetEnabled)
+//  * window and tree registration (DarkModeLibApplyWindow/ApplyTree)
+//  * title bar refresh (DarkModeLibRefreshTitleBar)
+//  * palette discovery including accent colors (DarkModeLibQueryPalette)
+//  * optional automatic control retheming (DarkModeLibThemeWindowControls)
+//  * query for whether dark colors should be used (DarkModeLibShouldUseDarkColors)
+//
+// None of these functions are required for a functional build—the adapter is
+// designed to be robust against absent or partial implementations.
+
+using fnDarkModeLibInitialize = bool(WINAPI*)();
+using fnDarkModeLibIsSupported = bool(WINAPI*)();
+using fnDarkModeLibSetEnabled = bool(WINAPI*)(bool enabled);
+using fnDarkModeLibApplyWindow = void(WINAPI*)(HWND hwnd);
+using fnDarkModeLibApplyTree = void(WINAPI*)(HWND hwnd);
+using fnDarkModeLibRefreshTitleBar = void(WINAPI*)(HWND hwnd);
+using fnDarkModeLibShouldUseDarkColors = bool(WINAPI*)();
+using fnDarkModeLibQueryPalette = bool(WINAPI*)(COLORREF* text, COLORREF* background, COLORREF* accent);
+using fnDarkModeLibThemeWindowControls = void(WINAPI*)(HWND hwnd);
+
+struct DarkModeLibApi
+{
+    fnDarkModeLibInitialize Initialize = nullptr;
+    fnDarkModeLibIsSupported IsSupported = nullptr;
+    fnDarkModeLibSetEnabled SetEnabled = nullptr;
+    fnDarkModeLibApplyWindow ApplyWindow = nullptr;
+    fnDarkModeLibApplyTree ApplyTree = nullptr;
+    fnDarkModeLibRefreshTitleBar RefreshTitleBar = nullptr;
+    fnDarkModeLibShouldUseDarkColors ShouldUseDarkColors = nullptr;
+    fnDarkModeLibQueryPalette QueryPalette = nullptr;
+    fnDarkModeLibThemeWindowControls ThemeWindowControls = nullptr;
+};
+

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -2279,6 +2279,9 @@ void CMainWindow::SaveConfig(HWND parent)
                     scheme = 2;
                 else if (CurrentColors == NavigatorColors)
                     scheme = 3;
+                // Color-scheme handling: persist the logical palette selection and
+                // whether the Windows dark-mode path (and optional darkmodelib
+                // helpers) should be reapplied during ColorsChanged().
                 SetValue(actKey, SALAMANDER_CLRSCHEME_REG, REG_DWORD, &scheme, sizeof(DWORD));
 
                 DWORD useWinDark = Configuration.UseWindowsDarkMode ? 1U : 0U;

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -375,19 +375,40 @@ static void UpdateMenuAndDialogBrushes(bool preferDarkMode)
 
 static void BuildWindowsDarkPalette(SALCOLOR* target, SALCOLOR* viewerTarget)
 {
-    const COLORREF accent = GetSysColor(COLOR_HIGHLIGHT);
-    const COLORREF accentText = GetSysColor(COLOR_HIGHLIGHTTEXT);
-    const COLORREF panelBg = RGB(32, 32, 32);
-    const COLORREF panelAlt = RGB(48, 48, 48);
-    const COLORREF panelHot = RGB(56, 56, 56);
-    const COLORREF text = RGB(220, 220, 220);
-    const COLORREF dimText = RGB(160, 160, 160);
-    const COLORREF overlay = RGB(192, 192, 192);
-    const COLORREF progressBg = RGB(64, 64, 64);
-    const COLORREF inactiveCaptionBg = RGB(45, 45, 48);
-    const COLORREF inactiveCaptionFg = RGB(190, 190, 190);
-    const COLORREF hotActive = RGB(0, 0, 0);
-    const COLORREF thumbnailFrame = RGB(94, 94, 94);
+    COLORREF accent = GetSysColor(COLOR_HIGHLIGHT);
+    COLORREF accentText = GetSysColor(COLOR_HIGHLIGHTTEXT);
+    COLORREF panelBg = RGB(32, 32, 32);
+    COLORREF panelAlt = RGB(48, 48, 48);
+    COLORREF panelHot = RGB(56, 56, 56);
+    COLORREF text = RGB(220, 220, 220);
+    COLORREF dimText = RGB(160, 160, 160);
+    COLORREF overlay = RGB(192, 192, 192);
+    COLORREF progressBg = RGB(64, 64, 64);
+    COLORREF inactiveCaptionBg = RGB(45, 45, 48);
+    COLORREF inactiveCaptionFg = RGB(190, 190, 190);
+    COLORREF hotActive = RGB(0, 0, 0);
+    COLORREF thumbnailFrame = RGB(94, 94, 94);
+
+    COLORREF libraryText = 0;
+    COLORREF libraryBackground = 0;
+    COLORREF libraryAccent = 0;
+    if (DarkModeQueryPreferredPalette(&libraryText, &libraryBackground, &libraryAccent))
+    {
+        text = libraryText;
+        dimText = DarkenColor(text, 60);
+
+        panelBg = libraryBackground;
+        panelAlt = LightenColor(panelBg, 16);
+        panelHot = LightenColor(panelBg, 24);
+        progressBg = DarkenColor(panelBg, 16);
+
+        accent = libraryAccent;
+        accentText = DarkModeEnsureReadableForeground(text, accent);
+    }
+    else
+    {
+        accentText = DarkModeEnsureReadableForeground(accentText, accent);
+    }
 
     auto setColor = [](SALCOLOR& entry, COLORREF color) {
         entry = RGBF(GetRValue(color), GetGValue(color), GetBValue(color), 0);
@@ -3261,6 +3282,12 @@ void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons)
 {
     CALL_STACK_MESSAGE2("ColorsChanged(%d)", refresh);
 
+    // Dark-mode pipeline responsibilities:
+    //  * Toggle native integration (including the optional darkmodelib shim).
+    //  * Rebuild the Salamander palette and menu/dialog brushes.
+    //  * Re-apply window opt-in flags and refresh non-client rendering.
+    //  * Notify children, plug-ins, and the viewer so list views and titles
+    //    repaint with the current theme.
     const bool windowsDarkEnabled = Configuration.UseWindowsDarkMode != FALSE;
     DarkModeSetEnabled(windowsDarkEnabled);
 


### PR DESCRIPTION
## Summary
- load an optional darkmodelib runtime and route dark-mode toggling, window opt-in, and title-bar refresh through it when present
- prefer library-provided palette colors in the Windows dark scheme while retaining the existing fallback pipeline and color handling notes
- document how to enable or disable the new dependency and where to place the DLL

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fcaf411848329a4c08ba021d3c02b)