### PR TITLE
Defer tab initialization work during panel config load

### DIFF
--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -216,6 +216,22 @@ BOOL CFilesWindowAncestor::GetGeneralPath(char* buf, int bufSize, BOOL convertFS
     return ret;
 }
 
+void CFilesWindowAncestor::SetPathForDeferredRestore(const char* path)
+{
+    CALL_STACK_MESSAGE2("CFilesWindowAncestor::SetPathForDeferredRestore(%s)", path);
+    DetachDirectory((CFilesWindow*)this);
+    strcpy(Path, path);
+
+    if (MainWindow != NULL)
+        MainWindow->UpdatePanelTabTitle((CFilesWindow*)this);
+
+    FileBasedCompression = FALSE;
+    FileBasedEncryption = FALSE;
+    SupportACLS = FALSE;
+    MonitorChanges = FALSE;
+    DriveType = DRIVE_UNKNOWN;
+}
+
 void CFilesWindowAncestor::SetPath(const char* path)
 {
     CALL_STACK_MESSAGE2("CFilesWindowAncestor::SetPath(%s)", path);

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -573,6 +573,7 @@ public:
     BOOL GetSuppressAutoRefresh() { return SuppressAutoRefresh; }
 
     void SetPath(const char* path);
+    void SetPathForDeferredRestore(const char* path);
     void SetMonitorChanges(BOOL monitorChanges) { MonitorChanges = monitorChanges; }
     void SetPanelType(CPanelType type) { PanelType = type; }
     void SetZIPPath(const char* path);

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -555,7 +555,7 @@ public:
     void FocusPanel(CFilesWindow* focus, BOOL testIfMainWndActive = FALSE); // clears EditMode because focus is put into the panel
     void FocusLeftPanel();                                                  // calls FocusPanel for the left panel
 
-    CFilesWindow* AddPanelTab(CPanelSide side, int index = -1);
+    CFilesWindow* AddPanelTab(CPanelSide side, int index = -1, bool activateTab = true);
     bool InsertPanelTabInstance(CPanelSide side, int index, CFilesWindow* panel, bool preserveLockState);
     void SwitchPanelTab(CFilesWindow* panel);
     void ClosePanelTab(CFilesWindow* panel, bool storeForReopen = true);

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -1609,10 +1609,8 @@ static void PrepareInactivePanelPathFromConfig(CMainWindow* mainWnd, CFilesWindo
 
     if (IsDiskOrUNCPath(path))
     {
-        panel->SetPath(path);
+        panel->SetPathForDeferredRestore(path);
         panel->NeedsRefreshOnActivation = TRUE;
-        if (mainWnd != NULL)
-            mainWnd->UpdatePanelTabTitle(panel);
     }
     else
         RestorePanelPathFromConfig(mainWnd, panel, path);

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -1602,6 +1602,22 @@ static BOOL RestorePanelPathFromConfig(CMainWindow* mainWnd, CFilesWindow* panel
     return FALSE;
 }
 
+static void PrepareInactivePanelPathFromConfig(CMainWindow* mainWnd, CFilesWindow* panel, const char* path)
+{
+    if (panel == NULL || path == NULL || path[0] == 0)
+        return;
+
+    if (IsDiskOrUNCPath(path))
+    {
+        panel->SetPath(path);
+        panel->NeedsRefreshOnActivation = TRUE;
+        if (mainWnd != NULL)
+            mainWnd->UpdatePanelTabTitle(panel);
+    }
+    else
+        RestorePanelPathFromConfig(mainWnd, panel, path);
+}
+
 void CMainWindow::SavePanelConfig(CPanelSide side, HKEY hSalamander, const char* reg)
 {
     HKEY actKey;
@@ -2729,7 +2745,7 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
 
     if (tabs.Count == 0)
     {
-        CFilesWindow* panel = AddPanelTab(side, 0);
+        CFilesWindow* panel = AddPanelTab(side, 0, false);
         if (panel != NULL)
         {
             DWORD style = WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
@@ -2764,7 +2780,7 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
     while (tabs.Count < tabCount)
     {
         CFilesWindow* previous = (side == cpsLeft) ? LeftPanel : RightPanel;
-        CFilesWindow* panel = AddPanelTab(side, tabs.Count);
+        CFilesWindow* panel = AddPanelTab(side, tabs.Count, false);
         if (panel == NULL)
             break;
 
@@ -2850,7 +2866,11 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
         if (Configuration.WorkDirsHistoryScope == wdhsPerTab)
             UpdateDirectoryLineHistoryState(panel);
 
-        BOOL restored = RestorePanelPathFromConfig(this, panel, path);
+        BOOL restored = FALSE;
+        if (i == activeIndex)
+            restored = RestorePanelPathFromConfig(this, panel, path);
+        else
+            PrepareInactivePanelPathFromConfig(this, panel, path);
         if (i == activeIndex)
         {
             activeRestored = restored;

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -94,7 +94,7 @@ namespace
     constexpr size_t kMaxStoredClosedTabs = 10;
 }
 
-CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side, int index)
+CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side, int index, bool activateTab)
 {
     CALL_STACK_MESSAGE2("CMainWindow::AddPanelTab(%d)", side);
     CFilesWindow* panel = new CFilesWindow(this, side);
@@ -107,7 +107,8 @@ CFilesWindow* CMainWindow::AddPanelTab(CPanelSide side, int index)
         return NULL;
     }
 
-    SwitchPanelTab(panel);
+    if (activateTab)
+        SwitchPanelTab(panel);
     return panel;
 }
 


### PR DESCRIPTION
### Motivation
- Startup was slowed by creating tabs that immediately activated and performed expensive refresh/path-restore work for every persisted tab during `LoadPanelConfig`, especially on slow or remote paths.

### Description
- Added an `activateTab` parameter to `CMainWindow::AddPanelTab` so callers can create tabs without immediately switching to them (changed in `src/mainwnd.h` and `src/mainwnd3.cpp`).
- Updated `LoadPanelConfig` to create tabs with `activateTab = false` while rebuilding persisted tab sets to avoid repeated `SwitchPanelTab`/refresh work (`src/mainwnd2.cpp`).
- Introduced `PrepareInactivePanelPathFromConfig` to set paths and mark `NeedsRefreshOnActivation` for inactive disk/UNC tabs, and retained full `RestorePanelPathFromConfig` behavior for the active tab only (`src/mainwnd2.cpp`).

### Testing
- Performed static checks with `rg` to verify `AddPanelTab` call sites were updated and no unintended activations remain, which succeeded.
- Ran `git diff --check` to validate there are no whitespace/diff issues, which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48c2390a083298c29f0c14bb44a14)