### PR TITLE
Remove duplicated ShouldUsePluginsDarkPalette in dialogs5.cpp

### DIFF
--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -34,19 +34,6 @@ bool ShouldUsePluginsDarkPalette()
 }
 }
 
-namespace
-{
-bool ShouldUsePluginsDarkPalette()
-{
-    if (DarkModeShouldUseDarkColors())
-        return true;
-
-    COLORREF background = DarkModeGetDialogBackgroundColor();
-    int luminance = (GetRValue(background) * 30 + GetGValue(background) * 59 + GetBValue(background) * 11) / 100;
-    return luminance < 128;
-}
-}
-
 //
 // ****************************************************************************
 // CPluginsDlg


### PR DESCRIPTION
### Motivation
- Fix compilation errors (MSVC C2084 redefinition and subsequent parser/type errors) caused by an accidental duplicated anonymous-namespace implementation introduced during a rebase.

### Description
- Removed the second duplicated anonymous-namespace `ShouldUsePluginsDarkPalette()` implementation in `src/dialogs5.cpp` so only one definition remains.

### Testing
- Ran `rg -n "ShouldUsePluginsDarkPalette" src/dialogs5.cpp` to confirm a single occurrence and committed the change with `git commit`, and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb7cb6ebc83299d2774f33d9fc260)