### PR TITLE
Stop PrismSharp Text Viewer from opening CSV files

### DIFF
--- a/src/plugins/textviewer/textviewer.cpp
+++ b/src/plugins/textviewer/textviewer.cpp
@@ -195,7 +195,6 @@ void WINAPI CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* s
         "php",
         "md",
         "markdown",
-        "csv",
         "bat",
         "cmd",
         "ps1",
@@ -284,7 +283,6 @@ void WINAPI CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* s
         "cshtml",
         "csp",
         "css",
-        "csv",
         "cypher",
         "d",
         "dart",
@@ -749,7 +747,7 @@ BOOL WINAPI CPluginInterfaceForViewer::CanViewFile(const char* name)
 
     static const char* const kExtensions[] = {
         ".txt", ".log", ".ini", ".cfg", ".json", ".yaml", ".yml", ".xml", ".html", ".htm", ".md",
-        ".csv", ".cs", ".cpp", ".c", ".h", ".hpp", ".py", ".js", ".ts", ".css", ".sql", ".bat", ".ps1",
+        ".cs", ".cpp", ".c", ".h", ".hpp", ".py", ".js", ".ts", ".css", ".sql", ".bat", ".ps1",
         ".php"
     };
 


### PR DESCRIPTION
#180

### Motivation
- Prevent the PrismSharp Text Viewer .NET plugin from claiming CSV files so other viewers/plugins (e.g., a dedicated CSV viewer) can handle them.
- User-visible behavior change: CSV files should no longer be opened by the PrismSharp viewer by default.

### Description
- Removed `"csv"` from the plugin's base extension registration list in `src/plugins/textviewer/textviewer.cpp`.
- Removed `"csv"` from the Prism language/extension registration list in the same file.
- Removed `".csv"` from the `CanViewFile` extension checks so the viewer will not report it as viewable.
- Changes are limited to `src/plugins/textviewer/textviewer.cpp` and affect registration/association only.

### Testing
- Ran `rg` to locate CSV occurrences in the textviewer sources and confirm removal; the search completed successfully.
- Ran `git diff -- src/plugins/textviewer/textviewer.cpp` to verify the exact edit; the diff shows the `csv` entries removed and succeeded.
- Committed the change with `git commit` which completed successfully and a PR entry was created via `make_pr`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb93eaa98832988a6c5974166e497)