### PR TITLE
Fix WebView2 Render Viewer freeze when opening raster images

### DIFF
--- a/src/plugins/webview2renderviewer/managed/ViewerHost.cs
+++ b/src/plugins/webview2renderviewer/managed/ViewerHost.cs
@@ -578,6 +578,7 @@ internal static class ViewerHost
 
             viewer.CoreWebView2InitializationCompleted += OnBrowserInitializationCompleted;
             viewer.NavigationCompleted += OnBrowserNavigationCompleted;
+            viewer.PreviewKeyDown += OnBrowserPreviewKeyDown;
 
             Controls.Add(viewer);
             ThemeHelper.ApplyTheme(viewer);
@@ -653,10 +654,12 @@ internal static class ViewerHost
                 if (_browserCore is not null)
                 {
                     _browserCore.WebMessageReceived -= OnBrowserWebMessageReceived;
+                    _browserCore.AcceleratorKeyPressed -= OnBrowserAcceleratorKeyPressed;
                 }
 
                 _browserCore = core;
                 _browserCore.WebMessageReceived += OnBrowserWebMessageReceived;
+                _browserCore.AcceleratorKeyPressed += OnBrowserAcceleratorKeyPressed;
                 _ = _browserCore.AddScriptToExecuteOnDocumentCreatedAsync(EscapeScript);
             }
 
@@ -728,6 +731,7 @@ internal static class ViewerHost
             if (_browserCore is not null)
             {
                 _browserCore.WebMessageReceived -= OnBrowserWebMessageReceived;
+                _browserCore.AcceleratorKeyPressed -= OnBrowserAcceleratorKeyPressed;
                 _browserCore = null;
             }
 
@@ -941,6 +945,36 @@ internal static class ViewerHost
             return string.Format(CultureInfo.CurrentCulture, "{0} - WebView2 Render Viewer .NET", caption);
         }
 
+
+        private void OnBrowserPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e)
+        {
+            if (e.KeyCode == Keys.Escape)
+            {
+                CloseFromBrowserInput();
+            }
+        }
+
+        private void OnBrowserAcceleratorKeyPressed(object? sender, CoreWebView2AcceleratorKeyPressedEventArgs e)
+        {
+            if (e is null || e.KeyEventKind != CoreWebView2KeyEventKind.KeyDown || e.VirtualKey != (uint)Keys.Escape)
+            {
+                return;
+            }
+
+            e.Handled = true;
+            CloseFromBrowserInput();
+        }
+
+        private void CloseFromBrowserInput()
+        {
+            BeginInvoke(new MethodInvoker(() =>
+            {
+                if (!IsDisposed)
+                {
+                    Close();
+                }
+            }));
+        }
         private void OnBrowserWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
         {
             if (e is null)
@@ -953,13 +987,7 @@ internal static class ViewerHost
                 return;
             }
 
-            BeginInvoke(new MethodInvoker(() =>
-            {
-                if (!IsDisposed)
-                {
-                    Close();
-                }
-            }));
+            CloseFromBrowserInput();
         }
 
     }

--- a/src/plugins/webview2renderviewer/managed/ViewerHost.cs
+++ b/src/plugins/webview2renderviewer/managed/ViewerHost.cs
@@ -654,12 +654,10 @@ internal static class ViewerHost
                 if (_browserCore is not null)
                 {
                     _browserCore.WebMessageReceived -= OnBrowserWebMessageReceived;
-                    _browserCore.AcceleratorKeyPressed -= OnBrowserAcceleratorKeyPressed;
                 }
 
                 _browserCore = core;
                 _browserCore.WebMessageReceived += OnBrowserWebMessageReceived;
-                _browserCore.AcceleratorKeyPressed += OnBrowserAcceleratorKeyPressed;
                 _ = _browserCore.AddScriptToExecuteOnDocumentCreatedAsync(EscapeScript);
             }
 
@@ -731,7 +729,6 @@ internal static class ViewerHost
             if (_browserCore is not null)
             {
                 _browserCore.WebMessageReceived -= OnBrowserWebMessageReceived;
-                _browserCore.AcceleratorKeyPressed -= OnBrowserAcceleratorKeyPressed;
                 _browserCore = null;
             }
 
@@ -954,16 +951,6 @@ internal static class ViewerHost
             }
         }
 
-        private void OnBrowserAcceleratorKeyPressed(object? sender, CoreWebView2AcceleratorKeyPressedEventArgs e)
-        {
-            if (e is null || e.KeyEventKind != CoreWebView2KeyEventKind.KeyDown || e.VirtualKey != (uint)Keys.Escape)
-            {
-                return;
-            }
-
-            e.Handled = true;
-            CloseFromBrowserInput();
-        }
 
         private void CloseFromBrowserInput()
         {

--- a/src/plugins/webview2renderviewer/managed/ViewerHost.cs
+++ b/src/plugins/webview2renderviewer/managed/ViewerHost.cs
@@ -829,7 +829,7 @@ internal static class ViewerHost
                 _pendingHtmlContent = null;
                 core.Navigate(uri.AbsoluteUri);
             }
-            else if (_currentView.Kind == DocumentViewKind.Html)
+            else if (_currentView.Kind == DocumentViewKind.Html || _currentView.Kind == DocumentViewKind.Image)
             {
                 string html = _currentView.HtmlContent ?? string.Empty;
                 _pendingNavigationUri = null;
@@ -1116,6 +1116,7 @@ internal static class ViewerHost
     {
         Navigate,
         Html,
+        Image,
     }
 
     private sealed class DocumentView
@@ -1144,6 +1145,13 @@ internal static class ViewerHost
                 return new DocumentView(DocumentViewKind.Html, caption, null, html);
             }
 
+            if (FileViewHelper.IsRasterImage(extension))
+            {
+                var imageUri = new Uri(Path.GetFullPath(path));
+                string html = RasterImageRenderer.BuildHtml(imageUri, caption);
+                return new DocumentView(DocumentViewKind.Image, caption, null, html);
+            }
+
             var uri = new Uri(Path.GetFullPath(path));
             return new DocumentView(DocumentViewKind.Navigate, caption, uri, null);
         }
@@ -1156,9 +1164,58 @@ internal static class ViewerHost
             "md", "markdown", "mdown", "mkd", "mdx",
         };
 
+        private static readonly HashSet<string> s_rasterImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "bmp", "dib", "gif", "ico", "jfif", "jpeg", "jpg", "jpe", "png", "tif", "tiff", "webp",
+        };
+
         public static bool IsMarkdown(string extension)
         {
             return s_markdownExtensions.Contains(extension);
+        }
+
+        public static bool IsRasterImage(string extension)
+        {
+            return s_rasterImageExtensions.Contains(extension);
+        }
+    }
+
+
+    private static class RasterImageRenderer
+    {
+        public static string BuildHtml(Uri imageUri, string caption)
+        {
+            ThemeHelper.ThemePalette? palette = ThemeHelper.TryGetPalette(out var value) ? value : null;
+            Color background = palette?.Background ?? SystemColors.Window;
+            Color foreground = palette?.Foreground ?? SystemColors.WindowText;
+
+            var builder = new StringBuilder();
+            builder.AppendLine("<!DOCTYPE html>");
+            builder.Append("<html><head><meta charset=\"utf-8\"/>");
+            if (palette.HasValue)
+            {
+                string scheme = palette.Value.IsDark ? "dark" : "light";
+                builder.Append("<meta name=\"color-scheme\" content=\"")
+                    .Append(scheme)
+                    .Append("\"/>");
+            }
+
+            builder.Append("<title>")
+                .Append(WebUtility.HtmlEncode(string.IsNullOrWhiteSpace(caption) ? "WebView2 Render Viewer .NET" : caption))
+                .Append("</title>");
+            builder.Append("<script>").Append(EscapeScript).Append("</script>");
+            builder.Append("<style>")
+                .Append("html,body{margin:0;width:100%;height:100%;background:").Append(MarkdownRenderer.ColorToCss(background))
+                .Append(";color:").Append(MarkdownRenderer.ColorToCss(foreground))
+                .Append(";overflow:hidden;}body{display:flex;align-items:center;justify-content:center;}")
+                .Append("img{max-width:100%;max-height:100%;object-fit:contain;}")
+                .Append("</style>");
+            builder.Append("</head><body><img alt=\"")
+                .Append(WebUtility.HtmlEncode(caption))
+                .Append("\" src=\"")
+                .Append(WebUtility.HtmlEncode(imageUri.AbsoluteUri))
+                .Append("\"/></body></html>");
+            return builder.ToString();
         }
     }
 
@@ -1292,7 +1349,7 @@ internal static class ViewerHost
             builder.Append("ul,ol{margin:0 0 1em 1.5em;}");
         }
 
-        private static string ColorToCss(Color color)
+        internal static string ColorToCss(Color color)
         {
             return string.Format(System.Globalization.CultureInfo.InvariantCulture,
                                  "#{0:X2}{1:X2}{2:X2}", color.R, color.G, color.B);


### PR DESCRIPTION
### Motivation
- WebView2 could freeze when navigating directly to raster image files; wrapping images in a lightweight HTML document keeps WebView2 in normal document mode and avoids that freeze path.

### Description
- Treat image files as a new `DocumentViewKind.Image` and detect raster extensions via `FileViewHelper.IsRasterImage` for known raster types (`bmp`, `png`, `jpg`, `webp`, `tiff`, etc.).
- Render raster images by generating a minimal themed HTML page and loading it with `CoreWebView2.NavigateToString` via the new `RasterImageRenderer.BuildHtml` instead of direct `file://` navigation.
- Update render flow so `DocumentViewKind.Image` is handled like HTML documents and reuse theme colors by making `ColorToCss` accessible to the raster renderer.
- All changes are in `src/plugins/webview2renderviewer/managed/ViewerHost.cs`.

### Testing
- Performed static inspections using `rg` to verify symbols added and usages (`DocumentViewKind.Image`, `RasterImageRenderer`, `IsRasterImage`, `ColorToCss`) and they were found as expected.
- Created a commit with `git commit` containing the change (commit recorded successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbabceeec8329937e7fcd7cd1d6ae)