### PR TITLE
Fix UI freeze when opening managed viewer plugins

### DIFF
--- a/src/plugins/jsonviewer/jsonviewer.cpp
+++ b/src/plugins/jsonviewer/jsonviewer.cpp
@@ -255,7 +255,7 @@ BOOL WINAPI CPluginInterfaceForViewer::ViewFile(const char* name, int left, int 
         return TRUE;
     }
 
-    return ManagedBridge_ViewJsonFile(parent, name, placement, showCmd, alwaysOnTop, NULL, false);
+    return ManagedBridge_ViewJsonFile(parent, name, placement, showCmd, alwaysOnTop, NULL, true);
 }
 
 BOOL WINAPI CPluginInterfaceForViewer::CanViewFile(const char* name)

--- a/src/plugins/jsonviewer/managed/ViewerHost.cs
+++ b/src/plugins/jsonviewer/managed/ViewerHost.cs
@@ -41,16 +41,6 @@ internal static class ViewerHost
             return 1;
         }
 
-        if (asynchronous && parsed.CloseHandle == IntPtr.Zero)
-        {
-            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
-                "The native host did not provide a synchronization handle for the viewer.",
-                "JSON Viewer .NET Plugin",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Error);
-            return 1;
-        }
-
         ViewerSession session;
         try
         {

--- a/src/plugins/textviewer/managed/ViewerHost.cs
+++ b/src/plugins/textviewer/managed/ViewerHost.cs
@@ -45,16 +45,6 @@ internal static class ViewerHost
             return 1;
         }
 
-        if (asynchronous && parsed.CloseHandle == IntPtr.Zero)
-        {
-            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
-                "The native host did not provide a synchronization handle for the viewer.",
-                "PrismSharp Text Viewer .NET Plugin",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Error);
-            return 1;
-        }
-
         ViewerSession session;
         try
         {

--- a/src/plugins/textviewer/textviewer.cpp
+++ b/src/plugins/textviewer/textviewer.cpp
@@ -733,7 +733,7 @@ BOOL WINAPI CPluginInterfaceForViewer::ViewFile(const char* name, int left, int 
         return TRUE;
     }
 
-    return ManagedBridge_ViewTextFile(parent, name, placement, showCmd, alwaysOnTop, NULL, false);
+    return ManagedBridge_ViewTextFile(parent, name, placement, showCmd, alwaysOnTop, NULL, true);
 }
 
 BOOL WINAPI CPluginInterfaceForViewer::CanViewFile(const char* name)

--- a/src/plugins/webview2renderviewer/managed/ViewerHost.cs
+++ b/src/plugins/webview2renderviewer/managed/ViewerHost.cs
@@ -40,16 +40,6 @@ internal static class ViewerHost
             return 1;
         }
 
-        if (asynchronous && parsed.CloseHandle == IntPtr.Zero)
-        {
-            MessageBox.Show(parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null,
-                "The native host did not provide a synchronization handle for the viewer.",
-                "WebView2 Render Viewer .NET Plugin",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Error);
-            return 1;
-        }
-
         ViewerSession session;
         try
         {

--- a/src/plugins/webview2renderviewer/webview2renderviewer.cpp
+++ b/src/plugins/webview2renderviewer/webview2renderviewer.cpp
@@ -332,7 +332,7 @@ BOOL WINAPI CPluginInterfaceForViewer::ViewFile(const char* name, int left, int 
         return TRUE;
     }
 
-    return ManagedBridge_ViewDocument(parent, name, placement, showCmd, alwaysOnTop, NULL, false);
+    return ManagedBridge_ViewDocument(parent, name, placement, showCmd, alwaysOnTop, NULL, true);
 }
 
 BOOL WINAPI CPluginInterfaceForViewer::CanViewFile(const char* name)


### PR DESCRIPTION
### Motivation
- Opening managed viewers from the native `ViewFile` non-locking path could launch them synchronously, blocking the main Salamander UI and causing the application to hang while viewer windows were open.
- The managed launch code also rejected asynchronous launches when no close handle was provided, which prevented using an async show for the common non-locking case.

### Description
- Changed the native non-locking `ViewFile` path to always request an asynchronous managed launch by passing the async flag `true` for `jsonviewer`, `textviewer`, and `webview2renderviewer` (`src/plugins/*/*viewer.cpp`).
- Relaxed managed-side validation by removing the strict check that returned an error for async launches without a close handle in each plugin's `ViewerHost.cs` so non-locking opens are accepted and handled asynchronously.
- Preserved the locking/open-with-handle behavior (the `returnLock` path still creates and hands back a file lock and continues to signal lifetime via the provided handle).
- Affected files: `src/plugins/jsonviewer/jsonviewer.cpp`, `src/plugins/textviewer/textviewer.cpp`, `src/plugins/webview2renderviewer/webview2renderviewer.cpp`, `src/plugins/jsonviewer/managed/ViewerHost.cs`, `src/plugins/textviewer/managed/ViewerHost.cs`, and `src/plugins/webview2renderviewer/managed/ViewerHost.cs`.

### Testing
- Ran repository verification with `git diff -- <files>` to confirm the intended edits to the six modified files, and the diff matched the planned changes (succeeded).
- Ran `git status --short` to verify working-tree updates and that the expected files were modified (succeeded).
- Created the PR metadata via the repository `make_pr` helper to record the change (succeeded).
- No automated unit or integration test suite was run as part of this change; a build/test pass is recommended in CI to validate runtime behavior on target platforms.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbef83a108329986e73be3cb2ea26)