### PR TITLE
Fix Samandarin updater freeze after saving configuration

### DIFF
--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -19,7 +19,6 @@ namespace OpenSalamander.Samandarin;
 public static class EntryPoint
 {
     private static bool _visualsEnabled;
-    private static SynchronizationContext? _syncContext;
 
     [STAThread]
     public static int Dispatch(string? argument)
@@ -28,8 +27,6 @@ public static class EntryPoint
         try
         {
             EnsureApplicationInitialized();
-            _syncContext ??= SynchronizationContext.Current;
-
             var parts = (argument ?? string.Empty).Split(new[] { ';' }, 3);
             var command = parts.Length > 0 ? parts[0] : string.Empty;
             parentHandle = ParseHandle(parts.Length > 1 ? parts[1] : string.Empty);
@@ -54,7 +51,7 @@ public static class EntryPoint
 
     private static int Initialize(IntPtr parent, string currentVersion)
     {
-        UpdateCoordinator.Initialize(currentVersion, _syncContext, parent);
+        UpdateCoordinator.Initialize(currentVersion, parent);
         return 0;
     }
 
@@ -134,7 +131,6 @@ internal static class UpdateCoordinator
     private static readonly HttpClient HttpClient;
     private static readonly object UiThreadLock = new();
 
-    private static SynchronizationContext? SyncContext;
     private static UpdateSettings Settings;
     private static string CurrentVersion = string.Empty;
     private static Timer? UpdateTimer;
@@ -161,15 +157,11 @@ internal static class UpdateCoordinator
         HttpClient.DefaultRequestHeaders.UserAgent.ParseAdd("SamandarinUpdateNotifier/1.0");
     }
 
-    public static void Initialize(string currentVersion, SynchronizationContext? context, IntPtr parent)
+    public static void Initialize(string currentVersion, IntPtr parent)
     {
         lock (SyncRoot)
         {
             CurrentVersion = (currentVersion ?? string.Empty).Trim();
-            if (context != null)
-            {
-                SyncContext = context;
-            }
             ScheduleTimer_NoLock();
         }
 
@@ -603,44 +595,29 @@ internal static class UpdateCoordinator
 
     private static void RunOnUiThread(Action action)
     {
-        var context = SyncContext;
-        if (context is null)
+        EnsureUiThread();
+
+        var queue = UiQueue;
+        if (queue is null)
         {
-            EnsureUiThread();
-
-            var queue = UiQueue;
-            if (queue is null)
-            {
-                action();
-                return;
-            }
-
-            if (Thread.CurrentThread == UiThread)
-            {
-                action();
-                return;
-            }
-
-            try
-            {
-                queue.Add(action);
-            }
-            catch (InvalidOperationException)
-            {
-                // The queue has been marked complete during shutdown; run inline as a best effort.
-                action();
-            }
+            action();
+            return;
         }
-        else
+
+        if (Thread.CurrentThread == UiThread)
         {
-            if (ReferenceEquals(SynchronizationContext.Current, context))
-            {
-                action();
-            }
-            else
-            {
-                context.Post(static state => ((Action)state!)(), action);
-            }
+            action();
+            return;
+        }
+
+        try
+        {
+            queue.Add(action);
+        }
+        catch (InvalidOperationException)
+        {
+            // The queue has been marked complete during shutdown; run inline as a best effort.
+            action();
         }
     }
 


### PR DESCRIPTION
### Motivation
- The Samandarin update notifier could freeze the main application when UI work was posted to an ambient `SynchronizationContext` that stopped pumping after the configuration dialog closed. 
- The intent is to ensure notifier UI interactions always complete and do not rely on a transient context that may no longer process `Post` callbacks. 

### Description
- Removed the stored `SynchronizationContext` and the code paths that captured/used `SynchronizationContext.Current` during initialization, and simplified `EntryPoint.Initialize` to no longer accept a context. 
- Ensured all notifier UI work is routed through a dedicated STA worker thread and queue (`EnsureUiThread`, `UiQueue`, `UiThread`) by changing `RunOnUiThread` to always use that queue. 
- Kept `ShowMessageAsync` / `RunOnUiThreadAsync` semantics but made them invoke UI actions via the dedicated UI thread so awaited UI tasks reliably complete; these changes are in `src/plugins/samandarin/managed/EntryPoint.cs`. 

### Testing
- Attempted a local managed build with `dotnet build src/plugins/samandarin/managed/Samandarin.Managed.csproj`, but the environment lacks the `dotnet` SDK so the build could not be run (`/bin/bash: dotnet: command not found`). 
- Ran repository checks and committed the change (`git status --short` and commit created with message `Fix Samandarin updater UI thread deadlock after config save`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc0aafe348329ae8e5ea04cb0c118)