### PR TITLE
Fix duplicate resource IDs for tree controls

### DIFF
--- a/src/resource.rh2
+++ b/src/resource.rh2
@@ -367,8 +367,8 @@
 #define IDC_DIRTEXT         957
 #define IDC_LEFTTABCTRL     958
 #define IDC_RIGHTTABCTRL    959
-#define IDC_TREEVIEW        958
-#define IDC_TREESPLIT       959
+#define IDC_TREEVIEW        966
+#define IDC_TREESPLIT       970
 
 // icons
 #define IDI_SALAMANDER       960


### PR DESCRIPTION
### Motivation
- Remove ID collisions between tab controls and tree controls in `src/resource.rh2` to prevent control lookup/routing conflicts at runtime.

### Description
- Update `src/resource.rh2` to set `#define IDC_TREEVIEW` to `966` and `#define IDC_TREESPLIT` to `970`, leaving `IDC_LEFTTABCTRL` (`958`) and `IDC_RIGHTTABCTRL` (`959`) unchanged.

### Testing
- Verified the modification by inspecting the updated file and running a file diff to confirm the new `#define` lines are present and unique; automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc9124d188329b8f32b1f71531474)