### PR TITLE
Nezachytávat Ctrl+Shift zkratky větví CM_EDITLINE

### DIFF
--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -1172,7 +1172,7 @@ BOOL CFilesWindow::OnSysKeyDown(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT
         return TRUE;
     }
 
-    if (controlPressed && !altPressed &&
+    if (controlPressed && !altPressed && !shiftPressed &&
         (wParam == VK_RETURN || wParam == VK_LBRACKET || wParam == VK_RBRACKET ||
          wParam == VK_SPACE))
     {


### PR DESCRIPTION
### Motivation
- Podmínka, která přepíná do větve `CM_EDITLINE`, přijímala `Ctrl+{Enter,[,],Space}` bez ohledu na stav Shift, což mohlo vést ke kolizím se Shift-modifikovanými Ctrl zkratkami.

### Description
- Zpřesnil jsem kontrolu v `src/fileswn0.cpp` tak, že `CM_EDITLINE` nyní vyžaduje `controlPressed && !altPressed && !shiftPressed` místo původního stavu bez kontroly Shiftu.
- Změna zamezí tomu, aby `Ctrl+Shift+...` zkratky (např. budoucí přiřazení `CM_TOGGLETREEVIEW` na `Ctrl+Shift+{Enter/[ ]/Space}`) spadly do edit-line větve.
- Upravený soubor je `src/fileswn0.cpp` a ostatní akcelerační nastavení zůstávají beze změny (aktuální `CM_TOGGLETREEVIEW` je `Ctrl+Shift+Y`).

### Testing
- Provedl jsem vyhledávací kontroly pomocí `rg` k nalezení `CM_TOGGLETREEVIEW` a výskytu původní a nové podmínky v `src/fileswn0.cpp`, které proběhly úspěšně.
- Ověřil jsem obsah `src/salamand.rc` aby se potvrdilo, že `CM_TOGGLETREEVIEW` používá `VIRTKEY, SHIFT, CONTROL`, čímž nedochází ke kolizi s novou podmínkou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd180cef0832983219c9d2ebb4760)