### PR TITLE
Avoid double recentering of split on treeview toggle

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -6249,8 +6249,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         {
             ToggleTreeView();
             IdleRefreshStates = TRUE; // on the next Idle, force a check of status variables
-            if (KeepSplitPositionCenteredOnVisiblePanes)
-                UpdateCenteredSplitPosition();
             LayoutWindows();
             break;
         }


### PR DESCRIPTION
### Motivation
- Remove a redundant recentering call so toggling the treeview does not apply two successive adjustments to the split position when `CMainWindow::ToggleTreeView()` already handles centering logic.

### Description
- Deleted the extra `UpdateCenteredSplitPosition()` call from the `CM_TOGGLETREEVIEW` handler in `src/mainwnd3.cpp` so `ToggleTreeView()` remains the single place that updates the split position.

### Testing
- Inspected relevant code paths with `rg` to find `CM_TOGGLETREEVIEW`, `ToggleTreeView`, and treeview lifecycle functions and viewed context with `sed`, which succeeded.
- Verified the change via `git diff` to confirm the redundant lines were removed and the handler now defers split positioning to `ToggleTreeView()`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd227d990832995fbf3d342b206db)