### PR TITLE
Fix Samandarin version label shown in update notifications/settings

### DIFF
--- a/src/plugins/samandarin/managed_bridge.cpp
+++ b/src/plugins/samandarin/managed_bridge.cpp
@@ -70,8 +70,16 @@ void ShowLoadError(HWND parent, const wchar_t* text)
 
 std::wstring BuildCurrentVersion()
 {
-    const char* version = VERSINFO_SALAMANDER_VERSION;
-    int required = MultiByteToWideChar(CP_UTF8, 0, version, -1, nullptr, 0);
+    std::string version = VERSINFO_SALAMANDER_VERSION;
+    const size_t platformSuffix = version.find(" (");
+    if (platformSuffix != std::string::npos)
+    {
+        version.resize(platformSuffix);
+    }
+
+    version += VERSINFO_SAMANDARIN_SUFFIX;
+
+    int required = MultiByteToWideChar(CP_UTF8, 0, version.c_str(), -1, nullptr, 0);
     if (required <= 0)
     {
         return std::wstring();
@@ -79,7 +87,7 @@ std::wstring BuildCurrentVersion()
 
     std::wstring result;
     result.resize(static_cast<size_t>(required));
-    int converted = MultiByteToWideChar(CP_UTF8, 0, version, -1, result.data(), required);
+    int converted = MultiByteToWideChar(CP_UTF8, 0, version.c_str(), -1, result.data(), required);
     if (converted <= 0)
     {
         return std::wstring();


### PR DESCRIPTION
### Motivation
- The managed update UI received only the Salamander host version (e.g. `5.0 (x64)`), causing incorrect messages and settings entries instead of the full Samandarin release tag (e.g. `5.0-samandarin-0.1`).

### Description
- Changed `BuildCurrentVersion()` in `src/plugins/samandarin/managed_bridge.cpp` to remove the platform suffix from `VERSINFO_SALAMANDER_VERSION` and append `VERSINFO_SAMANDARIN_SUFFIX` so the managed UI receives the full Samandarin version string.
- Switched to a `std::string` and used `version.c_str()` for the `MultiByteToWideChar` conversion to handle the constructed version string correctly.
- The update notifier and settings UI will now display versions like `5.0-samandarin-0.1` / `5.0-samandarin-0.2` consistent with release tags.

### Testing
- Ran `git diff -- src/plugins/samandarin/managed_bridge.cpp` and inspected the patch to verify the intended changes were applied (succeeded).
- Ran `git status --short` and committed the change via `git commit`, confirming the file was updated and committed (succeeded).
- No unit or runtime build tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd646bd9c8329acf110f952aa75f9)