### PR TITLE
Apply dark-mode theming to panel TreeView to fix scrollbar colors

### DIFF
--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -1598,6 +1598,7 @@ void CFilesWindow::CreateTreeView()
         }
         if (appIsThemed)
             SetWindowTheme(HTreeView, (L" "), (L" "));
+        DarkModeApplyWindow(HTreeView);
 
         SHFILEINFO sfi;
         memset(&sfi, 0, sizeof(sfi));


### PR DESCRIPTION
### Motivation
- Ensure the panel `TreeView` opts into the native dark-mode theming so scrollbars follow the selected color scheme (including `Windows Dark Mode (experimental)`).

### Description
- In `src/fileswn2.cpp` call `DarkModeApplyWindow(HTreeView)` immediately after `SetWindowTheme` in `CFilesWindow::CreateTreeView` so the newly created `SysTreeView32` control receives the dark-mode theme mapping. 

### Testing
- No automated tests were run for this small UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bda0aade88329946cdef5acf3ba01)