### PR TITLE
Offer import of settings from Samandarin 0.1 when starting 0.2

### DIFF
--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -157,6 +157,7 @@ const DWORD THIS_CONFIG_VERSION = 104;
 const char* SalamanderConfigurationRoots[SALCFG_ROOTS_COUNT + 1] =
     {
         "Software\\Open Salamander Samandarin\\5.0-samandarin-0.2",
+        "Software\\Open Salamander Samandarin\\5.0-samandarin-0.1",
         "Software\\Altap\\Altap Salamander 4.0",
         "Software\\Altap\\Altap Salamander 4.0 beta 1 (DB177)",
         "Software\\Altap\\Altap Salamander 4.0 beta 1 (DB171)",


### PR DESCRIPTION
### Motivation
- Při upgradu z Samandarin 0.1 na 0.2 se vytvoří nový registry root (`5.0-samandarin-0.2`), takže první spuštění 0.2 nenabízelo import nastavení ze 0.1; potřeba je přidat předchozí Samandarin root mezi detekované konfigurace.

### Description
- Vložen řetězec `"Software\\Open Salamander Samandarin\\5.0-samandarin-0.1"` ihned za aktuální `5.0-samandarin-0.2` v poli `SalamanderConfigurationRoots` v souboru `src/mainwnd2.cpp` tak, aby bylo možné nabídnout import z verze 0.1 při prvním spuštění 0.2.

### Testing
- Ověřeno, že soubor `src/mainwnd2.cpp` nyní obsahuje oba kořeny v pořadí pomocí `rg -n "5.0-samandarin-0\.[12]" src/mainwnd2.cpp`, což vrátilo oba záznamy, a pomocí `nl -ba src/mainwnd2.cpp | sed -n '155,166p'` byla potvrzena správná pozice vloženého řádku.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be4ee71b88329b541fa14c0d6aba0)