### PR TITLE
Avoid plugin custom-column probing during panel refresh

### DIFF
--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -4296,6 +4296,15 @@ void CFilesWindow::RefreshListBox(int suggestedXOffset,
                     break;
                 case COLUMN_ID_CUSTOM:
                 {
+                    // For plugin panels we avoid repeated callback probing during refresh.
+                    // Some plugins keep stale transfer pointers and can crash when queried while idling.
+                    // Keep at least the previous width and let drawing-time callbacks provide text.
+                    if (PanelType == ptPluginFS)
+                    {
+                        column->Width = max(column->MinWidth, column->Width);
+                        break;
+                    }
+
                     TransferActCustomData = column->CustomData;
                     int columnMaxWidth = column->MinWidth;
                     // ask the plugin


### PR DESCRIPTION
### Motivation
- Crash dumps showed periodic access-violation writes to `0x0` originating from `CFilesWindow::RefreshListBox` while the Hyper-V plugin was loaded, implicating repeated `column->GetText()` callbacks during idle refresh. 
- To eliminate the risky refresh-time probing path (which can hit stale plugin pointers) we must avoid querying plugin custom-column callbacks during automatic width recalculation.

### Description
- Added an early-path in `CFilesWindow::RefreshListBox` (`src/fileswn2.cpp`) for `COLUMN_ID_CUSTOM` that, when `PanelType == ptPluginFS`, skips per-row `column->GetText()` probing and preserves the existing `column->Width` (bounded by `column->MinWidth`).
- The previous per-row measuring logic remains unchanged for non-plugin panels so only plugin FS panels are affected.
- This minimizes the window where plugins might be probed while idle, deferring plugin text callbacks to draw time and reducing the chance of null-pointer crashes.
- The change is localized to a small edit in `src/fileswn2.cpp` (inserted safeguard checks before the plugin probing loop).

### Testing
- Ran targeted code searches (`rg`) and inspected relevant source ranges with `sed` to verify the insertion site and logic, and those checks succeeded. 
- Verified the working tree with `git status --short`, confirmed the diff with `git diff -- src/fileswn2.cpp`, and committed the change with message `Avoid plugin custom-column probing during refresh`, and the commit succeeded. 
- No automated runtime/unit tests were executed against the binary in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1057ffc254832982bb951110120101)