### PR TITLE
Refine Windows dark-mode policy decisions and theme-change handling

### DIFF
--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -755,7 +755,6 @@ protected:
     CHighlightMasks* SourceHighlightMasks;
 
     BOOL Dirty;
-    int SelectedSchemeId;
 
 public:
     CCfgPageColors();
@@ -770,7 +769,6 @@ protected:
     void LoadMasks();
     void StoreMasks();
     void EnableControls();
-    void OnSchemeChanged();
 };
 
 //

--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -719,6 +719,8 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         DarkModeApplyTree(HWindow);
         DarkModeRefreshTitleBar(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
 
@@ -728,6 +730,8 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             DarkModeApplyTree(HWindow);
             DarkModeRefreshTitleBar(HWindow);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            InvalidateRect(HWindow, NULL, TRUE);
         }
         break;
     }

--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -30,6 +30,7 @@
 #define WinLib_DarkMode_ApplyTitleBar DarkModeRefreshTitleBar
 #define WinLib_DarkMode_ApplyListTreeThemeRecursive DarkModeApplyTree
 #define WinLib_DarkMode_ApplyWindow DarkModeApplyWindow
+#define WinLib_DarkMode_ApplyStaticTextColors DarkModeApplyStaticTextColors
 
 static HBRUSH WinLib_DarkMode_GetDialogCtlColorBrush(UINT msg, HDC hdc, HWND hCtrl)
 {
@@ -71,6 +72,12 @@ static void WinLib_DarkMode_ApplyListTreeThemeRecursive(HWND root)
 static void WinLib_DarkMode_ApplyWindow(HWND hwnd)
 {
     UNREFERENCED_PARAMETER(hwnd);
+}
+
+static void WinLib_DarkMode_ApplyStaticTextColors(HWND hwndParent, HWND specificCtrl)
+{
+    UNREFERENCED_PARAMETER(hwndParent);
+    UNREFERENCED_PARAMETER(specificCtrl);
 }
 #endif
 
@@ -695,7 +702,7 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         TransferData(ttDataToWindow);
         WinLib_DarkMode_ApplyListTreeThemeRecursive(HWindow);
         WinLib_DarkMode_ApplyTitleBar(HWindow);
-        DarkModeApplyStaticTextColors(HWindow, NULL);
+        WinLib_DarkMode_ApplyStaticTextColors(HWindow, NULL);
         InvalidateRect(HWindow, NULL, TRUE);
         PostMessage(HWindow, WM_THEMECHANGED, 0, 0);
         return TRUE; // let DefDlgProc set the focus
@@ -774,7 +781,7 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         WinLib_DarkMode_ApplyListTreeThemeRecursive(HWindow);
         WinLib_DarkMode_ApplyTitleBar(HWindow);
-        DarkModeApplyStaticTextColors(HWindow, NULL);
+        WinLib_DarkMode_ApplyStaticTextColors(HWindow, NULL);
         InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
@@ -785,7 +792,7 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             WinLib_DarkMode_ApplyListTreeThemeRecursive(HWindow);
             WinLib_DarkMode_ApplyTitleBar(HWindow);
-            DarkModeApplyStaticTextColors(HWindow, NULL);
+            WinLib_DarkMode_ApplyStaticTextColors(HWindow, NULL);
             InvalidateRect(HWindow, NULL, TRUE);
         }
         break;

--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -643,6 +643,10 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_INITDIALOG:
     {
         TransferData(ttDataToWindow);
+        DarkModeApplyTree(HWindow);
+        DarkModeRefreshTitleBar(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
         return TRUE; // let DefDlgProc set the focus
     }
 

--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -22,7 +22,57 @@
 #include "messages.h"
 #include "handles.h"
 
+#ifdef INSIDE_SALAMANDER
 #include "../darkmode.h"
+#endif
+
+#ifdef INSIDE_SALAMANDER
+#define WinLib_DarkMode_ApplyTitleBar DarkModeRefreshTitleBar
+#define WinLib_DarkMode_ApplyListTreeThemeRecursive DarkModeApplyTree
+#define WinLib_DarkMode_ApplyWindow DarkModeApplyWindow
+
+static HBRUSH WinLib_DarkMode_GetDialogCtlColorBrush(UINT msg, HDC hdc, HWND hCtrl)
+{
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(msg, (WPARAM)hdc, (LPARAM)hCtrl, brush))
+        return (HBRUSH)brush;
+    return NULL;
+}
+
+static BOOL WinLib_DarkMode_OnSettingChange(LPARAM lParam)
+{
+    return DarkModeHandleSettingChange(WM_SETTINGCHANGE, lParam) ? TRUE : FALSE;
+}
+#else
+static HBRUSH WinLib_DarkMode_GetDialogCtlColorBrush(UINT msg, HDC hdc, HWND hCtrl)
+{
+    UNREFERENCED_PARAMETER(msg);
+    UNREFERENCED_PARAMETER(hdc);
+    UNREFERENCED_PARAMETER(hCtrl);
+    return NULL;
+}
+
+static BOOL WinLib_DarkMode_OnSettingChange(LPARAM lParam)
+{
+    UNREFERENCED_PARAMETER(lParam);
+    return FALSE;
+}
+
+static void WinLib_DarkMode_ApplyTitleBar(HWND hwnd)
+{
+    UNREFERENCED_PARAMETER(hwnd);
+}
+
+static void WinLib_DarkMode_ApplyListTreeThemeRecursive(HWND root)
+{
+    UNREFERENCED_PARAMETER(root);
+}
+
+static void WinLib_DarkMode_ApplyWindow(HWND hwnd)
+{
+    UNREFERENCED_PARAMETER(hwnd);
+}
+#endif
 
 #include "array.h"
 
@@ -273,7 +323,7 @@ void CWindow::AttachToWindow(HWND hWnd)
         SetWindowLongPtr(HWindow, GWLP_WNDPROC, (LONG_PTR)CWindowProc);
 #endif // _UNICODE
 
-    DarkModeApplyWindow(HWindow);
+    WinLib_DarkMode_ApplyWindow(HWindow);
 
     if (DefWndProc == CWindow::CWindowProc
 #ifndef _UNICODE
@@ -643,8 +693,8 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_INITDIALOG:
     {
         TransferData(ttDataToWindow);
-        DarkModeApplyTree(HWindow);
-        DarkModeRefreshTitleBar(HWindow);
+        WinLib_DarkMode_ApplyListTreeThemeRecursive(HWindow);
+        WinLib_DarkMode_ApplyTitleBar(HWindow);
         DarkModeApplyStaticTextColors(HWindow, NULL);
         InvalidateRect(HWindow, NULL, TRUE);
         PostMessage(HWindow, WM_THEMECHANGED, 0, 0);
@@ -714,16 +764,16 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORSCROLLBAR:
     case WM_CTLCOLORMSGBOX:
     {
-        LRESULT brush = 0;
-        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
-            return brush;
+        HBRUSH hBrush = WinLib_DarkMode_GetDialogCtlColorBrush(uMsg, (HDC)wParam, (HWND)lParam);
+        if (hBrush != NULL)
+            return (INT_PTR)hBrush;
         break;
     }
 
     case WM_THEMECHANGED:
     {
-        DarkModeApplyTree(HWindow);
-        DarkModeRefreshTitleBar(HWindow);
+        WinLib_DarkMode_ApplyListTreeThemeRecursive(HWindow);
+        WinLib_DarkMode_ApplyTitleBar(HWindow);
         DarkModeApplyStaticTextColors(HWindow, NULL);
         InvalidateRect(HWindow, NULL, TRUE);
         break;
@@ -731,10 +781,10 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_SETTINGCHANGE:
     {
-        if (DarkModeHandleSettingChange(uMsg, lParam))
+        if (WinLib_DarkMode_OnSettingChange(lParam))
         {
-            DarkModeApplyTree(HWindow);
-            DarkModeRefreshTitleBar(HWindow);
+            WinLib_DarkMode_ApplyListTreeThemeRecursive(HWindow);
+            WinLib_DarkMode_ApplyTitleBar(HWindow);
             DarkModeApplyStaticTextColors(HWindow, NULL);
             InvalidateRect(HWindow, NULL, TRUE);
         }
@@ -767,8 +817,8 @@ CDialog::CDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 TRACE_ET(_T("Unable to create dialog."));
                 return TRUE;
             }
-            DarkModeApplyTree(hwndDlg);
-            DarkModeRefreshTitleBar(hwndDlg);
+            WinLib_DarkMode_ApplyListTreeThemeRecursive(hwndDlg);
+            WinLib_DarkMode_ApplyTitleBar(hwndDlg);
             dlg->NotifDlgJustCreated(); // introduced as a place to adjust the dialog layout
         }
         break;

--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -647,6 +647,7 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DarkModeRefreshTitleBar(HWindow);
         DarkModeApplyStaticTextColors(HWindow, NULL);
         InvalidateRect(HWindow, NULL, TRUE);
+        PostMessage(HWindow, WM_THEMECHANGED, 0, 0);
         return TRUE; // let DefDlgProc set the focus
     }
 

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -188,6 +188,7 @@ DWORD gBuildNumber = 0;
 bool gInitialized = false;
 bool gSupported = false;
 bool gEnabled = false;
+bool gWindowsDarkSchemeSelected = false;
 bool gScrollbarsHooked = false;
 
 static COLORREF gDialogTextColor = GetSysColor(COLOR_BTNTEXT);
@@ -303,7 +304,7 @@ bool ShouldUseDarkColorsInternal()
 
 bool IsWindowsDarkSchemeSelected()
 {
-    return Configuration.UseWindowsDarkMode != FALSE;
+    return gWindowsDarkSchemeSelected;
 }
 
 bool ShouldApplyNativeDarkEnhancements()
@@ -533,6 +534,7 @@ void DarkModeSetEnabled(bool enabled)
     if (!gSupported)
         return;
 
+    gWindowsDarkSchemeSelected = enabled;
     bool newEnabled = enabled && ShouldApplyNativeDarkEnhancements();
     if (gEnabled == newEnabled)
         return;

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -190,6 +190,7 @@ bool gSupported = false;
 bool gEnabled = false;
 bool gWindowsDarkSchemeSelected = false;
 bool gScrollbarsHooked = false;
+thread_local int gThemeChangeDepth = 0;
 
 static COLORREF gDialogTextColor = GetSysColor(COLOR_BTNTEXT);
 static COLORREF gDialogBackgroundColor = GetSysColor(COLOR_BTNFACE);
@@ -426,11 +427,13 @@ void ApplyControlTheme(HWND hwnd)
     }
 
     auto notifyThemeChanged = [](HWND target) {
-        if (!gPropagatingThemeChange)
+        if (!gPropagatingThemeChange && gThemeChangeDepth == 0)
         {
+            ++gThemeChangeDepth;
             gPropagatingThemeChange = true;
             SendMessageW(target, WM_THEMECHANGED, 0, 0);
             gPropagatingThemeChange = false;
+            --gThemeChangeDepth;
         }
     };
 
@@ -451,6 +454,71 @@ void ApplyControlTheme(HWND hwnd)
             gSetWindowTheme(hwnd, nullptr, nullptr);
         notifyThemeChanged(hwnd);
     }
+}
+
+void ApplyListTreeThemeRecursive(HWND hwnd, bool wantDark)
+{
+    if (hwnd == NULL)
+        return;
+
+    wchar_t className[64];
+    if (GetClassNameW(hwnd, className, _countof(className)) == 0)
+        return;
+
+    if (gSetWindowTheme != nullptr)
+    {
+        if (wcscmp(className, L"SysListView32") == 0 || wcscmp(className, L"SysTreeView32") == 0)
+        {
+            gSetWindowTheme(hwnd, wantDark ? L"DarkMode_Explorer" : nullptr, nullptr);
+            const COLORREF bg = DarkModeGetColors().background;
+            const COLORREF fg = DarkModeGetColors().readableText;
+            if (wcscmp(className, L"SysListView32") == 0)
+            {
+                ListView_SetTextColor(hwnd, fg);
+                ListView_SetTextBkColor(hwnd, bg);
+                ListView_SetBkColor(hwnd, bg);
+            }
+            else
+            {
+                TreeView_SetTextColor(hwnd, fg);
+                TreeView_SetBkColor(hwnd, bg);
+            }
+            InvalidateRect(hwnd, NULL, TRUE);
+        }
+        else if (wcscmp(className, L"SysHeader32") == 0)
+        {
+            gSetWindowTheme(hwnd, wantDark ? L"DarkMode_Explorer" : nullptr, nullptr);
+            const COLORREF bg = DarkModeGetColors().background;
+            const COLORREF fg = DarkModeGetColors().readableText;
+            SendMessage(hwnd, HDM_SETTEXTCOLOR, 0, static_cast<LPARAM>(wantDark ? fg : CLR_DEFAULT));
+            SendMessage(hwnd, HDM_SETBKCOLOR, 0, static_cast<LPARAM>(wantDark ? bg : CLR_DEFAULT));
+            InvalidateRect(hwnd, NULL, TRUE);
+        }
+        else if (wcscmp(className, L"tooltips_class32") == 0 || wcscmp(className, L"ScrollBar") == 0)
+        {
+            gSetWindowTheme(hwnd, wantDark ? L"DarkMode_Explorer" : nullptr, nullptr);
+            InvalidateRect(hwnd, NULL, TRUE);
+        }
+        else if (wcscmp(className, L"Button") == 0)
+        {
+            const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+            if ((style & BS_GROUPBOX) == BS_GROUPBOX)
+            {
+                EnsureClassicButtonTheme(hwnd, wantDark);
+                InvalidateRect(hwnd, NULL, TRUE);
+            }
+        }
+        else if (wcscmp(className, L"Static") == 0)
+        {
+            const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+            const LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+            if ((exStyle & WS_EX_STATICEDGE) == WS_EX_STATICEDGE || (style & SS_ETCHEDFRAME) == SS_ETCHEDFRAME)
+                InvalidateRect(hwnd, NULL, TRUE);
+        }
+    }
+
+    for (HWND child = GetWindow(hwnd, GW_CHILD); child != NULL; child = GetWindow(child, GW_HWNDNEXT))
+        ApplyListTreeThemeRecursive(child, wantDark);
 }
 
 void EnsureInitialized()
@@ -589,6 +657,7 @@ void DarkModeApplyTree(HWND hwnd)
         return;
 
     DarkModeApplyWindow(hwnd);
+    ApplyListTreeThemeRecursive(hwnd, IsWindowsDarkSchemeSelected());
     EnumChildWindows(hwnd, ApplyTreeCallback, 0);
 }
 

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -241,18 +241,7 @@ bool IsButtonTypeNeedingClassicFallback(HWND hwnd)
         return false;
     LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
     LONG_PTR type = style & BS_TYPEMASK;
-    switch (type)
-    {
-    case BS_GROUPBOX:
-    case BS_AUTOCHECKBOX:
-    case BS_CHECKBOX:
-    case BS_AUTO3STATE:
-    case BS_3STATE:
-    case BS_AUTORADIOBUTTON:
-    case BS_RADIOBUTTON:
-        return true;
-    }
-    return false;
+    return type == BS_GROUPBOX;
 }
 
 void EnsureClassicButtonTheme(HWND hwnd, bool forceClassic)

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -241,7 +241,18 @@ bool IsButtonTypeNeedingClassicFallback(HWND hwnd)
         return false;
     LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
     LONG_PTR type = style & BS_TYPEMASK;
-    return type == BS_GROUPBOX;
+    switch (type)
+    {
+    case BS_GROUPBOX:
+    case BS_AUTOCHECKBOX:
+    case BS_CHECKBOX:
+    case BS_AUTO3STATE:
+    case BS_3STATE:
+    case BS_AUTORADIOBUTTON:
+    case BS_RADIOBUTTON:
+        return true;
+    }
+    return false;
 }
 
 void EnsureClassicButtonTheme(HWND hwnd, bool forceClassic)

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -194,6 +194,7 @@ bool gScrollbarsHooked = false;
 static COLORREF gDialogTextColor = GetSysColor(COLOR_BTNTEXT);
 static COLORREF gDialogBackgroundColor = GetSysColor(COLOR_BTNFACE);
 static HBRUSH gDialogBrushHandle = NULL;
+static DarkModeColors gColors = {GetSysColor(COLOR_BTNTEXT), GetSysColor(COLOR_BTNFACE), GetSysColor(COLOR_BTNTEXT), false};
 static bool gPropagatingThemeChange = false;
 
 const wchar_t* kDarkModeThemeProp = L"Salamander.DarkMode.Theme";
@@ -663,21 +664,45 @@ void DarkModeFixScrollbars()
 
 void DarkModeConfigureDialogColors(COLORREF textColor, COLORREF backgroundColor, HBRUSH dialogBrush)
 {
-    gDialogTextColor = ResolveReadableForeground(textColor, backgroundColor);
+    gDialogTextColor = textColor;
     gDialogBackgroundColor = backgroundColor;
     gDialogBrushHandle = dialogBrush;
+    gColors.text = textColor;
+    gColors.background = backgroundColor;
+    gColors.readableText = ResolveReadableForeground(textColor, backgroundColor);
+    gColors.usingSchemeColors = true;
+}
+
+void DarkModeSetConfiguredColors(COLORREF schemeTextColor, COLORREF schemeBackgroundColor,
+                                 COLORREF fallbackTextColor, COLORREF fallbackBackgroundColor)
+{
+    const COLORREF text = (schemeTextColor == CLR_INVALID) ? fallbackTextColor : schemeTextColor;
+    const COLORREF background = (schemeBackgroundColor == CLR_INVALID) ? fallbackBackgroundColor : schemeBackgroundColor;
+    gColors.text = text;
+    gColors.background = background;
+    gColors.readableText = ResolveReadableForeground(text, background);
+    gColors.usingSchemeColors = (schemeTextColor != CLR_INVALID) && (schemeBackgroundColor != CLR_INVALID);
+    gDialogTextColor = gColors.text;
+    gDialogBackgroundColor = gColors.background;
+}
+
+const DarkModeColors& DarkModeGetColors()
+{
+    EnsureInitialized();
+    gColors.readableText = ResolveReadableForeground(gColors.text, gColors.background);
+    return gColors;
 }
 
 COLORREF DarkModeGetDialogTextColor()
 {
     EnsureInitialized();
-    return ResolveReadableForeground(gDialogTextColor, gDialogBackgroundColor);
+    return DarkModeGetColors().readableText;
 }
 
 COLORREF DarkModeGetDialogBackgroundColor()
 {
     EnsureInitialized();
-    return gDialogBackgroundColor;
+    return DarkModeGetColors().background;
 }
 
 COLORREF DarkModeEnsureReadableForeground(COLORREF foreground, COLORREF background)

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -534,9 +534,17 @@ void ApplyListTreeThemeRecursive(HWND hwnd, bool wantDark)
         else if (wcscmp(className, L"Button") == 0)
         {
             const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
-            if ((style & BS_GROUPBOX) == BS_GROUPBOX)
+            const LONG_PTR type = style & BS_TYPEMASK;
+            if (type == BS_GROUPBOX)
             {
                 EnsureClassicButtonTheme(hwnd, wantDark);
+                InvalidateRect(hwnd, NULL, TRUE);
+            }
+            else if (gSetWindowTheme != nullptr &&
+                     (type == BS_AUTOCHECKBOX || type == BS_CHECKBOX || type == BS_AUTO3STATE ||
+                      type == BS_3STATE || type == BS_AUTORADIOBUTTON || type == BS_RADIOBUTTON))
+            {
+                gSetWindowTheme(hwnd, wantDark ? L"DarkMode_Explorer" : nullptr, nullptr);
                 InvalidateRect(hwnd, NULL, TRUE);
             }
         }

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -236,6 +236,9 @@ bool IsButtonTypeNeedingClassicFallback(HWND hwnd)
 {
     if (hwnd == NULL)
         return false;
+    int ctrlId = GetDlgCtrlID(hwnd);
+    if (ctrlId == IDR_RECYCLE1 || ctrlId == IDR_RECYCLE2 || ctrlId == IDR_RECYCLE3)
+        return true;
     wchar_t className[16];
     if (GetClassNameW(hwnd, className, _countof(className)) == 0 || lstrcmpiW(className, L"Button") != 0)
         return false;

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -231,6 +231,18 @@ bool ControlHasCaptionButton(HWND hwnd)
     return false;
 }
 
+bool IsButtonTypeNeedingClassicFallback(HWND hwnd)
+{
+    if (hwnd == NULL)
+        return false;
+    wchar_t className[16];
+    if (GetClassNameW(hwnd, className, _countof(className)) == 0 || lstrcmpiW(className, L"Button") != 0)
+        return false;
+    LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
+    LONG_PTR type = style & BS_TYPEMASK;
+    return type == BS_GROUPBOX;
+}
+
 void EnsureClassicButtonTheme(HWND hwnd, bool forceClassic)
 {
     if (hwnd == NULL || gSetWindowTheme == nullptr)
@@ -848,7 +860,7 @@ bool DarkModeHandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT&
         if ((message == WM_CTLCOLORSTATIC || message == WM_CTLCOLORBTN) && lParam != 0)
         {
             HWND ctrl = reinterpret_cast<HWND>(lParam);
-            if (ControlHasCaptionButton(ctrl))
+            if (IsButtonTypeNeedingClassicFallback(ctrl))
                 EnsureClassicButtonTheme(ctrl, false);
         }
         return false;
@@ -881,7 +893,7 @@ bool DarkModeHandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT&
         HWND ctrl = reinterpret_cast<HWND>(lParam);
         if (ctrl != NULL)
         {
-            if (ControlHasCaptionButton(ctrl))
+            if (IsButtonTypeNeedingClassicFallback(ctrl))
             {
                 EnsureClassicButtonTheme(ctrl, forceClassicButtons);
                 SetTextColor(hdc, textColor);
@@ -893,8 +905,14 @@ bool DarkModeHandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT&
             else
             {
                 EnsureClassicButtonTheme(ctrl, false);
-                LONG_PTR style = GetWindowLongPtr(ctrl, GWL_STYLE);
-                if ((style & (SS_ICON | SS_BITMAP | SS_BLACKRECT | SS_GRAYRECT | SS_WHITERECT)) == 0)
+                wchar_t className[16];
+                if (GetClassNameW(ctrl, className, _countof(className)) != 0 && lstrcmpiW(className, L"Static") == 0)
+                {
+                    LONG_PTR style = GetWindowLongPtr(ctrl, GWL_STYLE);
+                    if ((style & (SS_ICON | SS_BITMAP | SS_BLACKRECT | SS_GRAYRECT | SS_WHITERECT)) == 0)
+                        SetTextColor(hdc, DarkModeGetColors().readableText);
+                }
+                else
                     SetTextColor(hdc, textColor);
             }
         }
@@ -911,7 +929,7 @@ bool DarkModeHandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT&
     case WM_CTLCOLORBTN:
     {
         HWND ctrl = reinterpret_cast<HWND>(lParam);
-        if (ControlHasCaptionButton(ctrl))
+        if (IsButtonTypeNeedingClassicFallback(ctrl))
             EnsureClassicButtonTheme(ctrl, forceClassicButtons);
         else
             EnsureClassicButtonTheme(ctrl, false);
@@ -934,6 +952,40 @@ bool DarkModeHandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT&
     }
 
     return false;
+}
+
+void DarkModeApplyStaticTextColors(HWND hwndParent, HWND specificCtrl)
+{
+    EnsureInitialized();
+    if (hwndParent == NULL)
+        return;
+    const COLORREF text = DarkModeGetColors().readableText;
+    auto applyOne = [&](HWND ctrl) {
+        if (ctrl == NULL)
+            return;
+        wchar_t className[16];
+        if (GetClassNameW(ctrl, className, _countof(className)) == 0 || lstrcmpiW(className, L"Static") != 0)
+            return;
+        LONG_PTR style = GetWindowLongPtr(ctrl, GWL_STYLE);
+        if ((style & (SS_ICON | SS_BITMAP | SS_BLACKRECT | SS_GRAYRECT | SS_WHITERECT)) != 0)
+            return;
+        HDC dc = GetDC(ctrl);
+        if (dc != NULL)
+        {
+            SetTextColor(dc, text);
+            SetBkMode(dc, TRANSPARENT);
+            ReleaseDC(ctrl, dc);
+        }
+        InvalidateRect(ctrl, NULL, TRUE);
+    };
+
+    if (specificCtrl != NULL)
+        applyOne(specificCtrl);
+    else
+    {
+        for (HWND child = GetWindow(hwndParent, GW_CHILD); child != NULL; child = GetWindow(child, GW_HWNDNEXT))
+            applyOne(child);
+    }
 }
 
 HBRUSH DarkModeGetPanelFrameBrush()

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -301,6 +301,16 @@ bool ShouldUseDarkColorsInternal()
     return gShouldAppsUseDarkMode() && !IsHighContrast();
 }
 
+bool IsWindowsDarkSchemeSelected()
+{
+    return Configuration.UseWindowsDarkMode != FALSE;
+}
+
+bool ShouldApplyNativeDarkEnhancements()
+{
+    return IsWindowsDarkSchemeSelected() && !IsHighContrast();
+}
+
 BOOL CALLBACK ApplyTreeCallback(HWND hwnd, LPARAM)
 {
     DarkModeApplyTree(hwnd);
@@ -523,7 +533,7 @@ void DarkModeSetEnabled(bool enabled)
     if (!gSupported)
         return;
 
-    bool newEnabled = enabled && !IsHighContrast();
+    bool newEnabled = enabled && ShouldApplyNativeDarkEnhancements();
     if (gEnabled == newEnabled)
         return;
 
@@ -606,25 +616,34 @@ bool DarkModeHandleSettingChange(UINT message, LPARAM lParam)
     if (!gSupported)
         return false;
 
-    if (message != WM_SETTINGCHANGE)
+    if (message != WM_SETTINGCHANGE && message != WM_THEMECHANGED)
         return false;
 
-    bool isColor = false;
+    bool isColor = (message == WM_THEMECHANGED);
+    bool shouldRefresh = (message == WM_THEMECHANGED);
     if (lParam != 0)
     {
         if (CompareStringOrdinal(reinterpret_cast<LPCWSTR>(lParam), -1, L"ImmersiveColorSet", -1, TRUE) == CSTR_EQUAL)
         {
-            RefreshColorPolicy();
             isColor = true;
+            shouldRefresh = true;
         }
         else if (CompareStringOrdinal(reinterpret_cast<LPCWSTR>(lParam), -1, L"WindowsThemeElement", -1, TRUE) == CSTR_EQUAL)
         {
-            RefreshColorPolicy();
             isColor = true;
+            shouldRefresh = true;
         }
     }
     else
     {
+        shouldRefresh = true;
+    }
+
+    if (shouldRefresh)
+    {
+        const bool nativeEnhancements = ShouldApplyNativeDarkEnhancements();
+        if (gEnabled != nativeEnhancements)
+            DarkModeSetEnabled(nativeEnhancements);
         RefreshColorPolicy();
     }
 
@@ -828,4 +847,3 @@ HBRUSH DarkModeGetPanelFrameBrush()
         brush = HANDLES(CreateSolidBrush(RGB(0x38, 0x38, 0x38)));
     return brush;
 }
-

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -679,6 +679,11 @@ bool DarkModeShouldUseDarkColors()
     return ComputeLuminance(gDialogBackgroundColor) < 128;
 }
 
+BOOL DarkMode_ShouldUseDark()
+{
+    return DarkModeShouldUseDarkColors() ? TRUE : FALSE;
+}
+
 void DarkModeApplyWindow(HWND hwnd)
 {
     EnsureInitialized();

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -236,15 +236,12 @@ bool IsButtonTypeNeedingClassicFallback(HWND hwnd)
 {
     if (hwnd == NULL)
         return false;
-    int ctrlId = GetDlgCtrlID(hwnd);
-    if (ctrlId == IDR_RECYCLE1 || ctrlId == IDR_RECYCLE2 || ctrlId == IDR_RECYCLE3)
-        return true;
     wchar_t className[16];
     if (GetClassNameW(hwnd, className, _countof(className)) == 0 || lstrcmpiW(className, L"Button") != 0)
         return false;
     LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
     LONG_PTR type = style & BS_TYPEMASK;
-    return type == BS_GROUPBOX;
+    return type == BS_GROUPBOX || type == BS_AUTORADIOBUTTON || type == BS_RADIOBUTTON;
 }
 
 void EnsureClassicButtonTheme(HWND hwnd, bool forceClassic)

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1007,13 +1007,8 @@ void DarkModeApplyStaticTextColors(HWND hwndParent, HWND specificCtrl)
         LONG_PTR style = GetWindowLongPtr(ctrl, GWL_STYLE);
         if ((style & (SS_ICON | SS_BITMAP | SS_BLACKRECT | SS_GRAYRECT | SS_WHITERECT)) != 0)
             return;
-        HDC dc = GetDC(ctrl);
-        if (dc != NULL)
-        {
-            SetTextColor(dc, text);
-            SetBkMode(dc, TRANSPARENT);
-            ReleaseDC(ctrl, dc);
-        }
+        if (gSetWindowTheme != nullptr)
+            gSetWindowTheme(ctrl, IsWindowsDarkSchemeSelected() ? L"DarkMode_Explorer" : nullptr, nullptr);
         InvalidateRect(ctrl, NULL, TRUE);
     };
 

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -477,6 +477,22 @@ void ApplyListTreeThemeRecursive(HWND hwnd, bool wantDark)
     if (GetClassNameW(hwnd, className, _countof(className)) == 0)
         return;
 
+    auto invalidateParentChain = [](HWND ctrl) {
+        for (HWND p = GetParent(ctrl); p != NULL; p = GetParent(p))
+            InvalidateRect(p, NULL, TRUE);
+    };
+
+    auto applyChromeTheme = [&](HWND ctrl, const wchar_t* className) {
+        if (gSetWindowTheme == nullptr)
+            return;
+        if (wcscmp(className, L"ReBarWindow32") == 0 || wcscmp(className, L"ToolbarWindow32") == 0)
+        {
+            gSetWindowTheme(ctrl, wantDark ? L"DarkMode_Explorer" : nullptr, nullptr);
+            InvalidateRect(ctrl, NULL, TRUE);
+            invalidateParentChain(ctrl);
+        }
+    };
+
     if (gSetWindowTheme != nullptr)
     {
         if (wcscmp(className, L"SysListView32") == 0 || wcscmp(className, L"SysTreeView32") == 0)
@@ -505,6 +521,8 @@ void ApplyListTreeThemeRecursive(HWND hwnd, bool wantDark)
             SendMessage(hwnd, HDM_SETTEXTCOLOR, 0, static_cast<LPARAM>(wantDark ? fg : CLR_DEFAULT));
             SendMessage(hwnd, HDM_SETBKCOLOR, 0, static_cast<LPARAM>(wantDark ? bg : CLR_DEFAULT));
             InvalidateRect(hwnd, NULL, TRUE);
+            invalidateParentChain(hwnd);
+            SendMessage(hwnd, WM_THEMECHANGED, 0, 0);
         }
         else if (wcscmp(className, L"tooltips_class32") == 0 || wcscmp(className, L"ScrollBar") == 0)
         {
@@ -528,6 +546,7 @@ void ApplyListTreeThemeRecursive(HWND hwnd, bool wantDark)
                 InvalidateRect(hwnd, NULL, TRUE);
         }
     }
+    applyChromeTheme(hwnd, className);
 
     for (HWND child = GetWindow(hwnd, GW_CHILD); child != NULL; child = GetWindow(child, GW_HWNDNEXT))
         ApplyListTreeThemeRecursive(child, wantDark);

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -191,6 +191,7 @@ bool gEnabled = false;
 bool gWindowsDarkSchemeSelected = false;
 bool gScrollbarsHooked = false;
 thread_local int gThemeChangeDepth = 0;
+thread_local int gThemeBatchDepth = 0;
 
 static COLORREF gDialogTextColor = GetSysColor(COLOR_BTNTEXT);
 static COLORREF gDialogBackgroundColor = GetSysColor(COLOR_BTNFACE);
@@ -742,12 +743,21 @@ bool DarkModeHandleSettingChange(UINT message, LPARAM lParam)
         shouldRefresh = true;
     }
 
+    struct ThemeBatchScope
+    {
+        ThemeBatchScope() { ++gThemeBatchDepth; }
+        ~ThemeBatchScope() { --gThemeBatchDepth; }
+        bool IsRoot() const { return gThemeBatchDepth == 1; }
+    } scope;
+
     if (shouldRefresh)
     {
         const bool nativeEnhancements = ShouldApplyNativeDarkEnhancements();
         if (gEnabled != nativeEnhancements)
             DarkModeSetEnabled(nativeEnhancements);
         RefreshColorPolicy();
+        if (scope.IsRoot() && message == WM_THEMECHANGED)
+            gThemeChangeDepth = 0;
     }
 
     return isColor;

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -486,7 +486,8 @@ void ApplyListTreeThemeRecursive(HWND hwnd, bool wantDark)
     auto applyChromeTheme = [&](HWND ctrl, const wchar_t* className) {
         if (gSetWindowTheme == nullptr)
             return;
-        if (wcscmp(className, L"ReBarWindow32") == 0 || wcscmp(className, L"ToolbarWindow32") == 0)
+        if (wcscmp(className, L"ReBarWindow32") == 0 || wcscmp(className, L"ToolbarWindow32") == 0 ||
+            wcscmp(className, L"MenuBar") == 0)
         {
             gSetWindowTheme(ctrl, wantDark ? L"DarkMode_Explorer" : nullptr, nullptr);
             InvalidateRect(ctrl, NULL, TRUE);

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -24,6 +24,8 @@ void DarkModeSetEnabled(bool enabled);
 
 // Returns true if dark colors should currently be used.
 bool DarkModeShouldUseDarkColors();
+// Compatibility helper used by legacy call sites.
+BOOL DarkMode_ShouldUseDark();
 
 // Applies dark mode opt-in for the specified window (and keeps the opt-in
 // flag in sync when toggling the configuration).

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -5,6 +5,14 @@
 
 #include <windows.h>
 
+struct DarkModeColors
+{
+    COLORREF text;
+    COLORREF background;
+    COLORREF readableText;
+    bool usingSchemeColors;
+};
+
 // Initializes the dark mode helpers. Safe to call multiple times.
 bool DarkModeInitialize();
 
@@ -37,6 +45,9 @@ void DarkModeFixScrollbars();
 
 // Supplies dialog foreground/background colors and brush for WM_CTLCOLOR helpers.
 void DarkModeConfigureDialogColors(COLORREF textColor, COLORREF backgroundColor, HBRUSH dialogBrush);
+void DarkModeSetConfiguredColors(COLORREF schemeTextColor, COLORREF schemeBackgroundColor,
+                                 COLORREF fallbackTextColor, COLORREF fallbackBackgroundColor);
+const DarkModeColors& DarkModeGetColors();
 
 // Handles WM_CTLCOLOR* messages for dark mode aware parents. Returns true when
 // a dark brush was supplied and the caller should stop default processing.
@@ -49,4 +60,3 @@ COLORREF DarkModeGetDialogBackgroundColor();
 COLORREF DarkModeEnsureReadableForeground(COLORREF foreground, COLORREF background);
 void DarkModeUpdateListViewColors(HWND listView);
 void DarkModeUpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors);
-

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -60,3 +60,4 @@ COLORREF DarkModeGetDialogBackgroundColor();
 COLORREF DarkModeEnsureReadableForeground(COLORREF foreground, COLORREF background);
 void DarkModeUpdateListViewColors(HWND listView);
 void DarkModeUpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors);
+void DarkModeApplyStaticTextColors(HWND hwndParent, HWND specificCtrl);

--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -1500,8 +1500,7 @@ MENU_TEMPLATE_ITEM ProgressDialogMenu2[] =
             if (dc != NULL)
             {
                 const COLORREF background = DarkModeGetDialogBackgroundColor();
-                const COLORREF paletteText = DarkModeGetDialogTextColor();
-                const COLORREF text = DarkModeEnsureReadableForeground(paletteText, background);
+                const COLORREF text = DarkModeGetColors().readableText;
                 SetTextColor(dc, text);
                 SetBkColor(dc, background);
                 SetBkMode(dc, uMsg == WM_CTLCOLOREDIT ? OPAQUE : TRANSPARENT);
@@ -1740,9 +1739,8 @@ COverwriteDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
             if (dc != NULL)
             {
-                const COLORREF background = DarkModeGetDialogBackgroundColor();
-                const COLORREF paletteText = DarkModeGetDialogTextColor();
-                const COLORREF text = DarkModeEnsureReadableForeground(paletteText, background);
+                const COLORREF background = DarkModeGetColors().background;
+                const COLORREF text = DarkModeGetColors().readableText;
                 SetTextColor(dc, text);
                 SetBkColor(dc, background);
                 SetBkMode(dc, uMsg == WM_CTLCOLOREDIT ? OPAQUE : TRANSPARENT);
@@ -1819,9 +1817,8 @@ CHiddenOrSystemDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
             if (dc != NULL)
             {
-                const COLORREF background = DarkModeGetDialogBackgroundColor();
-                const COLORREF paletteText = DarkModeGetDialogTextColor();
-                const COLORREF text = DarkModeEnsureReadableForeground(paletteText, background);
+                const COLORREF background = DarkModeGetColors().background;
+                const COLORREF text = DarkModeGetColors().readableText;
                 SetTextColor(dc, text);
                 SetBkColor(dc, background);
                 SetBkMode(dc, uMsg == WM_CTLCOLOREDIT ? OPAQUE : TRANSPARENT);

--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -1816,6 +1816,9 @@ CHiddenOrSystemDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             TRACE_E(LOW_MEMORY);
 
         SetWindowText(GetDlgItem(HWindow, IDS_ERROR), Error);
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
 

--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -1579,6 +1579,29 @@ CFileErrorDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CFileErrorDlg::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, uMsg == WM_CTLCOLOREDIT ? OPAQUE : TRANSPARENT);
+            }
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         SetWindowText(HWindow, Caption);
@@ -1593,6 +1616,9 @@ CFileErrorDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             new CButton(HWindow, IDB_IGNORE, BTF_DROPDOWN);
 
         SetWindowText(GetDlgItem(HWindow, IDS_ERROR), Error);
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
 
@@ -1708,6 +1734,9 @@ COverwriteDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         SetWindowText(GetDlgItem(HWindow, IDS_SOURCEATTR), SourceAttr);
         SetWindowText(GetDlgItem(HWindow, IDS_TARGETATTR), TargetAttr);
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
 

--- a/src/dialogs2.cpp
+++ b/src/dialogs2.cpp
@@ -287,6 +287,11 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         else
             MultiMonCenterWindow(HWindow, NULL, FALSE);
 
+        DarkModeApplyTree(HWindow);
+        DarkModeRefreshTitleBar(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
+
         break;
     }
 

--- a/src/dialogs2.cpp
+++ b/src/dialogs2.cpp
@@ -320,6 +320,41 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         break;
     }
+
+    case WM_THEMECHANGED:
+    {
+        DarkModeApplyTree(HWindow);
+        DarkModeRefreshTitleBar(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
+        break;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            InvalidateRect(HWindow, NULL, TRUE);
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        break;
+    }
     }
 
     return CDialog::DialogProc(uMsg, wParam, lParam);

--- a/src/dialogs3.cpp
+++ b/src/dialogs3.cpp
@@ -2028,6 +2028,30 @@ CPackDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CPackDialog::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, (uMsg == WM_CTLCOLOREDIT || uMsg == WM_CTLCOLORLISTBOX) ? OPAQUE : TRANSPARENT);
+            }
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         InstallWordBreakProc(GetDlgItem(HWindow, IDE_PATH)); // install WordBreakProc into the edit line
@@ -2037,6 +2061,9 @@ CPackDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             SetWindowText(hSubject, Subject->Get());
 
         INT_PTR ret = CCommonDialog::DialogProc(uMsg, wParam, lParam);
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
         // we can select only the name without the dot and extension
         PostMessage(GetDlgItem(HWindow, IDE_PATH), CB_SETEDITSEL, 0, MAKELPARAM(0, SelectionEnd));
         return FALSE;

--- a/src/dialogs3.cpp
+++ b/src/dialogs3.cpp
@@ -37,9 +37,8 @@ LRESULT ApplyCopyMoveDialogColors(WPARAM wParam, bool transparent)
     if (dc == NULL)
         return reinterpret_cast<LRESULT>(dialogBrush);
 
-    const COLORREF background = DarkModeGetDialogBackgroundColor();
-    const COLORREF paletteText = DarkModeGetDialogTextColor();
-    const COLORREF text = DarkModeEnsureReadableForeground(paletteText, background);
+    const COLORREF background = DarkModeGetColors().background;
+    const COLORREF text = DarkModeGetColors().readableText;
     SetTextColor(dc, text);
     SetBkColor(dc, background);
     SetBkMode(dc, transparent ? TRANSPARENT : OPAQUE);
@@ -566,9 +565,8 @@ CCopyMoveDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 HDC hdc = reinterpret_cast<HDC>(wParam);
                 if (hdc != NULL)
                 {
-                    const COLORREF background = DarkModeGetDialogBackgroundColor();
-                    const COLORREF paletteText = DarkModeGetDialogTextColor();
-                    const COLORREF text = DarkModeEnsureReadableForeground(paletteText, background);
+                    const COLORREF background = DarkModeGetColors().background;
+                    const COLORREF text = DarkModeGetColors().readableText;
                     SetTextColor(hdc, text);
                     SetBkColor(hdc, background);
                     SetBkMode(hdc, TRANSPARENT);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -1355,6 +1355,26 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORSTATIC:
     case WM_CTLCOLORBTN:
     {
+        if (DarkModeShouldUseDarkColors())
+        {
+            HWND hCtl = reinterpret_cast<HWND>(lParam);
+            const int ctrlId = hCtl != NULL ? GetDlgCtrlID(hCtl) : 0;
+            if (ctrlId == IDR_RECYCLE1 || ctrlId == IDR_RECYCLE2 || ctrlId == IDR_RECYCLE3 ||
+                ctrlId == IDC_FILEMASK_HINT)
+            {
+                HDC dc = reinterpret_cast<HDC>(wParam);
+                if (dc != NULL)
+                {
+                    const DarkModeColors& colors = DarkModeGetColors();
+                    SetTextColor(dc, colors.readableText);
+                    SetBkColor(dc, colors.background);
+                    SetBkMode(dc, TRANSPARENT);
+                }
+                HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+                return reinterpret_cast<INT_PTR>(dialogBrush);
+            }
+        }
+
         LRESULT brush = 0;
         if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
             return brush;

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3838,8 +3838,6 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             Items[i] = new CColorArrowButton(HWindow, CConfigurationPage7ItemsBut[i], TRUE);
             Masks[i] = new CColorArrowButton(HWindow, CConfigurationPage7MasksBut[i], TRUE);
-            EnableWindow(GetDlgItem(HWindow, CConfigurationPage7Items[i]), TRUE);
-            EnableWindow(GetDlgItem(HWindow, CConfigurationPage7Masks[i]), TRUE);
         }
 
         EditLB = new CEditListBox(HWindow, IDC_C_LIST);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3868,6 +3868,8 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         int i;
         for (i = 0; i < 5; i++)
         {
+            new CStaticText(HWindow, CConfigurationPage7Items[i]);
+            new CStaticText(HWindow, CConfigurationPage7Masks[i]);
             Items[i] = new CColorArrowButton(HWindow, CConfigurationPage7ItemsBut[i], TRUE);
             Masks[i] = new CColorArrowButton(HWindow, CConfigurationPage7MasksBut[i], TRUE);
             // Keep color-caption labels readable in dark mode; some resource variants mark these statics

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -844,6 +844,36 @@ CCfgPageGeneral::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+            }
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
+    case WM_INITDIALOG:
+    {
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
+        break;
+    }
+
     case WM_COMMAND:
     {
         if (HIWORD(wParam) == BN_CLICKED)
@@ -1298,6 +1328,28 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CCfgPageView::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+            }
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         CMyListView* listView = new CMyListView(HWindow, IDC_VIEW_LIST);
@@ -1359,6 +1411,9 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         DarkModeUpdateListViewColors(HListView);
         DarkModeUpdateListViewColors(HListView2);
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
 
         break;
     }
@@ -2921,6 +2976,28 @@ CCfgPageHotPath::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CCfgPageHotPath::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+            }
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
     case WM_PAINT:
     {
         // Horrible mess - I need a message that arrives
@@ -2977,6 +3054,9 @@ CCfgPageHotPath::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         ElasticVerticalLayout(1, IDC_HOTPATH_LIST);
 
         DarkModeUpdateListViewColors(HListView);
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
 
         break;
     }
@@ -3193,11 +3273,36 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+            }
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         CHyperLink* hl = new CHyperLink(HWindow, IDC_FILEMASK_HINT, STF_DOTUNDERLINE);
         if (hl != NULL)
             hl->SetActionShowHint(LoadStr(IDS_MASKS_HINT));
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -20,6 +20,10 @@
 #include "gui.h"
 #include "darkmode.h"
 
+// Forward declarations: arrays are defined later in this file.
+extern int CConfigurationPage7Items[CFG_COLORS_BUTTONS];
+extern int CConfigurationPage7Masks[CFG_COLORS_BUTTONS];
+
 //****************************************************************************
 //
 // CHighlightMasksItem

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -847,6 +847,34 @@ CCfgPageGeneral::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORSTATIC:
     case WM_CTLCOLORBTN:
     {
+        if (uMsg == WM_CTLCOLORSTATIC && DarkModeShouldUseDarkColors() && lParam != 0)
+        {
+            HWND ctrl = reinterpret_cast<HWND>(lParam);
+            int ctrlId = GetDlgCtrlID(ctrl);
+            bool isColorCaption = false;
+            for (int i = 0; i < 5; i++)
+            {
+                if (ctrlId == CConfigurationPage7Items[i] || ctrlId == CConfigurationPage7Masks[i])
+                {
+                    isColorCaption = true;
+                    break;
+                }
+            }
+            if (isColorCaption)
+            {
+                HDC dc = reinterpret_cast<HDC>(wParam);
+                if (dc != NULL)
+                {
+                    const DarkModeColors& colors = DarkModeGetColors();
+                    SetTextColor(dc, colors.readableText);
+                    SetBkColor(dc, colors.background);
+                    SetBkMode(dc, TRANSPARENT);
+                }
+                HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+                return reinterpret_cast<INT_PTR>(dialogBrush);
+            }
+        }
+
         LRESULT brush = 0;
         if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
             return brush;

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -941,6 +941,28 @@ CCfgPageRegional::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+            }
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         if (IsSLGIncomplete[0] != 0)
@@ -952,6 +974,9 @@ CCfgPageRegional::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             CHyperLink* hl = new CHyperLink(HWindow, IDC_CFGREG_INCOMPLETE_URL);
             hl->SetActionOpen(IsSLGIncomplete);
         }
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
 
@@ -1839,6 +1864,28 @@ CCfgPageViewer::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CCfgPageViewer::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+            }
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         new CButton(HWindow, IDB_VIEWERFONT, BTF_RIGHTARROW);
@@ -1849,6 +1896,9 @@ CCfgPageViewer::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         CHyperLink* hl = new CHyperLink(HWindow, IDC_FILEMASK_HINT, STF_DOTUNDERLINE);
         if (hl != NULL)
             hl->SetActionShowHint(LoadStr(IDS_MASKS_HINT));
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
 
         break;
     }
@@ -2296,6 +2346,28 @@ CCfgPageUserMenu::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CCfgPageUserMenu::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+            }
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         RefreshGroupIconInUMItems();                                                          // if colors changed before first visiting the User Menu page and we did not receive WM_SYSCOLORCHANGE, handle it here
@@ -2311,6 +2383,9 @@ CCfgPageUserMenu::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         // dialog elements should stretch with the dialog size, set split controls
         ElasticVerticalLayout(1, IDL_MENUITEMS);
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
 
         break;
     }

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3632,6 +3632,19 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         LRESULT brush = 0;
         if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
             return brush;
+        if (DarkModeShouldUseDarkColors())
+        {
+            HDC dc = reinterpret_cast<HDC>(wParam);
+            if (dc != NULL)
+            {
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+            }
+            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+            return reinterpret_cast<INT_PTR>(dialogBrush);
+        }
         break;
     }
 
@@ -3655,6 +3668,9 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         // dialog elements should stretch with the dialog size, set split controls
         ElasticVerticalLayout(1, IDC_C_LIST);
+        DarkModeApplyTree(HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
+        InvalidateRect(HWindow, NULL, TRUE);
 
         break;
     }

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -923,6 +923,26 @@ CCfgPageRegional::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORSTATIC:
     case WM_CTLCOLORBTN:
     {
+        if (DarkModeShouldUseDarkColors())
+        {
+            HWND hCtl = reinterpret_cast<HWND>(lParam);
+            const int ctrlId = hCtl != NULL ? GetDlgCtrlID(hCtl) : 0;
+            if (ctrlId == IDR_RECYCLE1 || ctrlId == IDR_RECYCLE2 || ctrlId == IDR_RECYCLE3 ||
+                ctrlId == IDC_FILEMASK_HINT)
+            {
+                HDC dc = reinterpret_cast<HDC>(wParam);
+                if (dc != NULL)
+                {
+                    const DarkModeColors& colors = DarkModeGetColors();
+                    SetTextColor(dc, colors.readableText);
+                    SetBkColor(dc, colors.background);
+                    SetBkMode(dc, TRANSPARENT);
+                }
+                HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
+                return reinterpret_cast<INT_PTR>(dialogBrush);
+            }
+        }
+
         LRESULT brush = 0;
         if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
             return brush;

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3357,12 +3357,7 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 const DarkModeColors& colors = DarkModeGetColors();
 
-                HWND hCtl = reinterpret_cast<HWND>(lParam);
-                int ctrlId = hCtl != NULL ? GetDlgCtrlID(hCtl) : 0;
-                if (ctrlId == IDC_FILEMASK_HINT)
-                    SetTextColor(dc, RGB(96, 160, 255));
-                else
-                    SetTextColor(dc, colors.readableText);
+                SetTextColor(dc, colors.readableText);
 
                 SetBkColor(dc, colors.background);
                 SetBkMode(dc, TRANSPARENT);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3478,7 +3478,6 @@ CCfgPageColors::CCfgPageColors()
     HighlightMasks.Load(*SourceHighlightMasks);
 
     Dirty = FALSE;
-    SelectedSchemeId = -1;
 }
 
 void CCfgPageColors::Transfer(CTransferInfo& ti)
@@ -3490,25 +3489,9 @@ void CCfgPageColors::Transfer(CTransferInfo& ti)
         for (i = 0; i < NUMBER_OF_COLORS; i++)
             TmpColors[i] = UserColors[i];
 
-        struct SchemeEntry
-        {
-            int Id;
-            int TextResId;
-        };
-        static const SchemeEntry schemes[] = {
-            {0, IDS_COLORSCHEME_SALAMANDER},
-            {1, IDS_COLORSCHEME_EXPLORER},
-            {2, IDS_COLORSCHEME_NORTON},
-            {3, IDS_COLORSCHEME_NAVIGATOR},
-            {5, IDS_COLORSCHEME_CUSTOM},
-            {4, IDS_COLORSCHEME_WINDARK},
-        };
-        for (size_t schemeIndex = 0; schemeIndex < _countof(schemes); schemeIndex++)
-        {
-            int item = (int)SendMessage(HScheme, CB_ADDSTRING, 0, (LPARAM)LoadStr(schemes[schemeIndex].TextResId));
-            if (item != CB_ERR)
-                SendMessage(HScheme, CB_SETITEMDATA, item, schemes[schemeIndex].Id);
-        }
+        int schemes[5] = {IDS_COLORSCHEME_SALAMANDER, IDS_COLORSCHEME_EXPLORER, IDS_COLORSCHEME_NORTON, IDS_COLORSCHEME_NAVIGATOR, IDS_COLORSCHEME_CUSTOM};
+        for (i = 0; i < 5; i++)
+            SendMessage(HScheme, CB_ADDSTRING, 0, (LPARAM)LoadStr(schemes[i]));
 
         for (i = 0; i < PAGE7DATA_COUNT; i++)
             SendMessage(HItem, CB_ADDSTRING, 0, (LPARAM)LoadStr(Page7Data[i].ItemLabel));
@@ -3517,34 +3500,16 @@ void CCfgPageColors::Transfer(CTransferInfo& ti)
         for (i = 0; i < CFG_COLORS_BUTTONS; i++)
             SetDlgItemText(HWindow, CConfigurationPage7Masks[i], LoadStr(labels[i]));
 
-        int schemeId = 5; // custom
-        if (Configuration.UseWindowsDarkMode)
-            schemeId = 4;
-        else if (CurrentColors == SalamanderColors)
-            schemeId = 0;
+        int index = 4; // custom
+        if (CurrentColors == SalamanderColors)
+            index = 0;
         else if (CurrentColors == ExplorerColors)
-            schemeId = 1;
+            index = 1;
         else if (CurrentColors == NortonColors)
-            schemeId = 2;
+            index = 2;
         else if (CurrentColors == NavigatorColors)
-            schemeId = 3;
-
-        int selIndex = -1;
-        int itemCount = (int)SendMessage(HScheme, CB_GETCOUNT, 0, 0);
-        for (int item = 0; item < itemCount; item++)
-        {
-            int itemSchemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, item, 0);
-            if (itemSchemeId == schemeId)
-            {
-                selIndex = item;
-                break;
-            }
-        }
-        if (selIndex == -1)
-            selIndex = 0;
-        SendMessage(HScheme, CB_SETCURSEL, selIndex, 0);
-        int selectedSchemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, selIndex, 0);
-        SelectedSchemeId = (selectedSchemeId == CB_ERR) ? schemeId : selectedSchemeId;
+            index = 3;
+        SendMessage(HScheme, CB_SETCURSEL, index, 0);
         SendMessage(HItem, CB_SETCURSEL, 0, 0);
 
         // populate the highlight items list
@@ -3561,16 +3526,13 @@ void CCfgPageColors::Transfer(CTransferInfo& ti)
     else
     {
         int index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-        int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
-        if (schemeId == CB_ERR)
-            schemeId = SelectedSchemeId;
-        if (schemeId == 0)
+        if (index == 0)
             CurrentColors = SalamanderColors;
-        else if (schemeId == 1)
+        else if (index == 1)
             CurrentColors = ExplorerColors;
-        else if (schemeId == 2)
+        else if (index == 2)
             CurrentColors = NortonColors;
-        else if (schemeId == 3)
+        else if (index == 3)
             CurrentColors = NavigatorColors;
         else
         {
@@ -3579,8 +3541,6 @@ void CCfgPageColors::Transfer(CTransferInfo& ti)
             for (i = 0; i < NUMBER_OF_COLORS; i++)
                 UserColors[i] = TmpColors[i];
         }
-
-        Configuration.UseWindowsDarkMode = (schemeId == 4);
 
         ColorsChanged(TRUE, TRUE, FALSE); // save time, change only color-dependent items, do not reload icons
 
@@ -3598,16 +3558,13 @@ void CCfgPageColors::LoadColors()
 
     COLORREF* tmpColors;
     int index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-    int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
-    if (schemeId == CB_ERR)
-        schemeId = SelectedSchemeId;
-    if (schemeId == 0)
+    if (index == 0)
         tmpColors = SalamanderColors;
-    else if (schemeId == 1)
+    else if (index == 1)
         tmpColors = ExplorerColors;
-    else if (schemeId == 2)
+    else if (index == 2)
         tmpColors = NortonColors;
-    else if (schemeId == 3)
+    else if (index == 3)
         tmpColors = NavigatorColors;
     else
         tmpColors = TmpColors;
@@ -3738,22 +3695,6 @@ void CCfgPageColors::EnableControls()
     EnableWindow(GetDlgItem(HWindow, IDC_C_MASK5_C), validItem);
 }
 
-void CCfgPageColors::OnSchemeChanged()
-{
-    int index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-    if (index == CB_ERR)
-        return;
-
-    int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
-    if (schemeId == CB_ERR)
-        schemeId = SelectedSchemeId;
-
-    if (schemeId == 4 && SelectedSchemeId != 4)
-        WindowsDarkModeBuildPalette(reinterpret_cast<SALCOLOR*>(TmpColors), NULL);
-
-    SelectedSchemeId = schemeId;
-}
-
 void CCfgPageColors::Validate(CTransferInfo& ti)
 {
     CALL_STACK_MESSAGE1("CCfgPageColors::Validate()");
@@ -3784,28 +3725,6 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     switch (uMsg)
     {
-    case WM_CTLCOLORSTATIC:
-    case WM_CTLCOLORBTN:
-    {
-        LRESULT brush = 0;
-        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
-            return brush;
-        if (DarkModeShouldUseDarkColors())
-        {
-            HDC dc = reinterpret_cast<HDC>(wParam);
-            if (dc != NULL)
-            {
-                const DarkModeColors& colors = DarkModeGetColors();
-                SetTextColor(dc, colors.readableText);
-                SetBkColor(dc, colors.background);
-                SetBkMode(dc, TRANSPARENT);
-            }
-            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
-            return reinterpret_cast<INT_PTR>(dialogBrush);
-        }
-        break;
-    }
-
     case WM_INITDIALOG:
     {
         HScheme = GetDlgItem(HWindow, IDC_C_SCHEME);
@@ -3844,19 +3763,10 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             StoreMasks();
         }
 
-        if (HIWORD(wParam) == CBN_SELCHANGE)
+        if (HIWORD(wParam) == CBN_SELCHANGE && LOWORD(wParam) == IDC_C_SCHEME || LOWORD(wParam) == IDC_C_ITEM)
         {
-            if (LOWORD(wParam) == IDC_C_SCHEME)
-            {
-                OnSchemeChanged();
-                LoadColors();
-                break;
-            }
-            if (LOWORD(wParam) == IDC_C_ITEM)
-            {
-                LoadColors();
-                break;
-            }
+            LoadColors();
+            break;
         }
         if (HIWORD(wParam) == LBN_SELCHANGE && LOWORD(wParam) == IDC_C_LIST)
         {
@@ -3904,16 +3814,13 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 int index;
 
                 index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-                int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
-                if (schemeId == CB_ERR)
-                    schemeId = SelectedSchemeId;
-                if (schemeId == 0)
+                if (index == 0)
                     tmpColors = SalamanderColors;
-                else if (schemeId == 1)
+                else if (index == 1)
                     tmpColors = ExplorerColors;
-                else if (schemeId == 2)
+                else if (index == 2)
                     tmpColors = NortonColors;
-                else if (schemeId == 3)
+                else if (index == 3)
                     tmpColors = NavigatorColors;
                 else
                     tmpColors = TmpColors;
@@ -4059,32 +3966,22 @@ MENU_TEMPLATE_ITEM CfgPageColorsMenu3[] =
             if (cmd != 0)
             {
                 int index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-                int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
-                if (schemeId >= 0 && schemeId <= 3)
+                if (index != 4)
                 {
                     COLORREF* colors;
-                    if (schemeId == 0)
+                    if (index == 0)
                         colors = SalamanderColors;
-                    else if (schemeId == 1)
+                    else if (index == 1)
                         colors = ExplorerColors;
-                    else if (schemeId == 2)
+                    else if (index == 2)
                         colors = NortonColors;
-                    else if (schemeId == 3)
+                    else if (index == 3)
                         colors = NavigatorColors;
 
                     int i;
                     for (i = 0; i < NUMBER_OF_COLORS; i++)
                         TmpColors[i] = colors[i];
-                    int itemCount = (int)SendMessage(HScheme, CB_GETCOUNT, 0, 0);
-                    for (int item = 0; item < itemCount; item++)
-                    {
-                        if ((int)SendMessage(HScheme, CB_GETITEMDATA, item, 0) == 5)
-                        {
-                            SendMessage(HScheme, CB_SETCURSEL, item, 0);
-                            SelectedSchemeId = 5;
-                            break;
-                        }
-                    }
+                    SendMessage(HScheme, CB_SETCURSEL, 4, 0);
                 }
 
                 if (cmd == 1 || cmd == 3)

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3344,12 +3344,11 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     auto applyRecycleBinRadioTheme = [this]() {
         const int radioIds[] = {IDR_RECYCLE1, IDR_RECYCLE2, IDR_RECYCLE3, 0};
-        const bool useDark = DarkModeShouldUseDarkColors();
         for (int i = 0; radioIds[i] != 0; ++i)
         {
             HWND hRadio = GetDlgItem(HWindow, radioIds[i]);
             if (hRadio != NULL)
-                SetWindowTheme(hRadio, useDark ? L"" : nullptr, useDark ? L"" : nullptr);
+                DarkModeApplyTree(hRadio);
         }
     };
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -743,6 +743,35 @@ void CConfigurationDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    {
+        if (DarkModeShouldUseDarkColors())
+        {
+            HWND ctrl = (HWND)lParam;
+            int ctrlID = ctrl != NULL ? GetDlgCtrlID(ctrl) : 0;
+            bool isTargetLabel = false;
+            for (int i = 0; i < CFG_COLORS_BUTTONS; i++)
+            {
+                if (ctrlID == CConfigurationPage7Items[i] || ctrlID == CConfigurationPage7Masks[i])
+                {
+                    isTargetLabel = true;
+                    break;
+                }
+            }
+
+            if (isTargetLabel)
+            {
+                HDC dc = (HDC)wParam;
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+                return (INT_PTR)(HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
+            }
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         // ColorsChanged() calls a plug-in method (when colors change PLUGINEVENT_COLORSCHANGED

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3342,6 +3342,17 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
     };
 
+    auto applyRecycleBinRadioTheme = [this]() {
+        const int radioIds[] = {IDR_RECYCLE1, IDR_RECYCLE2, IDR_RECYCLE3, 0};
+        const bool useDark = DarkModeShouldUseDarkColors();
+        for (int i = 0; radioIds[i] != 0; ++i)
+        {
+            HWND hRadio = GetDlgItem(HWindow, radioIds[i]);
+            if (hRadio != NULL)
+                SetWindowTheme(hRadio, useDark ? L"" : nullptr, useDark ? L"" : nullptr);
+        }
+    };
+
     switch (uMsg)
     {
     case WM_CTLCOLORSTATIC:
@@ -3374,6 +3385,7 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (hl != NULL)
             hl->SetActionShowHint(LoadStr(IDS_MASKS_HINT));
         DarkModeApplyTree(HWindow);
+        applyRecycleBinRadioTheme();
         applyRecycleBinLabelColors();
         InvalidateRect(HWindow, NULL, TRUE);
         break;
@@ -3381,6 +3393,7 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_THEMECHANGED:
     {
+        applyRecycleBinRadioTheme();
         applyRecycleBinLabelColors();
         InvalidateRect(HWindow, NULL, TRUE);
         break;
@@ -3390,6 +3403,7 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (DarkModeHandleSettingChange(uMsg, lParam))
         {
+            applyRecycleBinRadioTheme();
             applyRecycleBinLabelColors();
             InvalidateRect(HWindow, NULL, TRUE);
         }

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3838,6 +3838,10 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             Items[i] = new CColorArrowButton(HWindow, CConfigurationPage7ItemsBut[i], TRUE);
             Masks[i] = new CColorArrowButton(HWindow, CConfigurationPage7MasksBut[i], TRUE);
+            // Keep color-caption labels readable in dark mode; some resource variants mark these statics
+            // disabled and Windows then forces gray/black text regardless of our expected palette.
+            EnableWindow(GetDlgItem(HWindow, CConfigurationPage7Items[i]), TRUE);
+            EnableWindow(GetDlgItem(HWindow, CConfigurationPage7Masks[i]), TRUE);
         }
 
         EditLB = new CEditListBox(HWindow, IDC_C_LIST);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3880,9 +3880,19 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             HWND hItemLabel = GetDlgItem(HWindow, CConfigurationPage7Items[i]);
             HWND hMaskLabel = GetDlgItem(HWindow, CConfigurationPage7Masks[i]);
             if (hItemLabel != NULL)
+            {
                 SetWindowLongPtr(hItemLabel, GWL_STYLE, GetWindowLongPtr(hItemLabel, GWL_STYLE) | SS_OWNERDRAW);
+                SetWindowPos(hItemLabel, NULL, 0, 0, 0, 0,
+                             SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+                InvalidateRect(hItemLabel, NULL, TRUE);
+            }
             if (hMaskLabel != NULL)
+            {
                 SetWindowLongPtr(hMaskLabel, GWL_STYLE, GetWindowLongPtr(hMaskLabel, GWL_STYLE) | SS_OWNERDRAW);
+                SetWindowPos(hMaskLabel, NULL, 0, 0, 0, 0,
+                             SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+                InvalidateRect(hMaskLabel, NULL, TRUE);
+            }
         }
 
         EditLB = new CEditListBox(HWindow, IDC_C_LIST);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -930,6 +930,8 @@ CCfgPageRegional::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (ctrlId == IDR_RECYCLE1 || ctrlId == IDR_RECYCLE2 || ctrlId == IDR_RECYCLE3 ||
                 ctrlId == IDC_FILEMASK_HINT)
             {
+                if (hCtl != NULL && (ctrlId == IDR_RECYCLE1 || ctrlId == IDR_RECYCLE2 || ctrlId == IDR_RECYCLE3))
+                    SetWindowTheme(hCtl, L"", L"");
                 HDC dc = reinterpret_cast<HDC>(wParam);
                 if (dc != NULL)
                 {

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3489,9 +3489,25 @@ void CCfgPageColors::Transfer(CTransferInfo& ti)
         for (i = 0; i < NUMBER_OF_COLORS; i++)
             TmpColors[i] = UserColors[i];
 
-        int schemes[5] = {IDS_COLORSCHEME_SALAMANDER, IDS_COLORSCHEME_EXPLORER, IDS_COLORSCHEME_NORTON, IDS_COLORSCHEME_NAVIGATOR, IDS_COLORSCHEME_CUSTOM};
-        for (i = 0; i < 5; i++)
-            SendMessage(HScheme, CB_ADDSTRING, 0, (LPARAM)LoadStr(schemes[i]));
+        struct SchemeEntry
+        {
+            int id;
+            int labelResId;
+        };
+        static const SchemeEntry schemes[] = {
+            {0, IDS_COLORSCHEME_SALAMANDER},
+            {1, IDS_COLORSCHEME_EXPLORER},
+            {2, IDS_COLORSCHEME_NORTON},
+            {3, IDS_COLORSCHEME_NAVIGATOR},
+            {5, IDS_COLORSCHEME_CUSTOM},
+            {4, IDS_COLORSCHEME_WINDARK},
+        };
+        for (i = 0; i < (int)_countof(schemes); i++)
+        {
+            int idx = (int)SendMessage(HScheme, CB_ADDSTRING, 0, (LPARAM)LoadStr(schemes[i].labelResId));
+            if (idx != CB_ERR)
+                SendMessage(HScheme, CB_SETITEMDATA, idx, schemes[i].id);
+        }
 
         for (i = 0; i < PAGE7DATA_COUNT; i++)
             SendMessage(HItem, CB_ADDSTRING, 0, (LPARAM)LoadStr(Page7Data[i].ItemLabel));
@@ -3500,16 +3516,28 @@ void CCfgPageColors::Transfer(CTransferInfo& ti)
         for (i = 0; i < CFG_COLORS_BUTTONS; i++)
             SetDlgItemText(HWindow, CConfigurationPage7Masks[i], LoadStr(labels[i]));
 
-        int index = 4; // custom
-        if (CurrentColors == SalamanderColors)
-            index = 0;
+        int schemeId = 5; // custom
+        if (Configuration.UseWindowsDarkMode)
+            schemeId = 4;
+        else if (CurrentColors == SalamanderColors)
+            schemeId = 0;
         else if (CurrentColors == ExplorerColors)
-            index = 1;
+            schemeId = 1;
         else if (CurrentColors == NortonColors)
-            index = 2;
+            schemeId = 2;
         else if (CurrentColors == NavigatorColors)
-            index = 3;
-        SendMessage(HScheme, CB_SETCURSEL, index, 0);
+            schemeId = 3;
+        int sel = 0;
+        int count = (int)SendMessage(HScheme, CB_GETCOUNT, 0, 0);
+        for (int j = 0; j < count; j++)
+        {
+            if ((int)SendMessage(HScheme, CB_GETITEMDATA, j, 0) == schemeId)
+            {
+                sel = j;
+                break;
+            }
+        }
+        SendMessage(HScheme, CB_SETCURSEL, sel, 0);
         SendMessage(HItem, CB_SETCURSEL, 0, 0);
 
         // populate the highlight items list
@@ -3526,13 +3554,16 @@ void CCfgPageColors::Transfer(CTransferInfo& ti)
     else
     {
         int index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-        if (index == 0)
+        int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
+        if (schemeId == CB_ERR)
+            schemeId = 5;
+        if (schemeId == 0)
             CurrentColors = SalamanderColors;
-        else if (index == 1)
+        else if (schemeId == 1)
             CurrentColors = ExplorerColors;
-        else if (index == 2)
+        else if (schemeId == 2)
             CurrentColors = NortonColors;
-        else if (index == 3)
+        else if (schemeId == 3)
             CurrentColors = NavigatorColors;
         else
         {
@@ -3542,6 +3573,7 @@ void CCfgPageColors::Transfer(CTransferInfo& ti)
                 UserColors[i] = TmpColors[i];
         }
 
+        Configuration.UseWindowsDarkMode = (schemeId == 4);
         ColorsChanged(TRUE, TRUE, FALSE); // save time, change only color-dependent items, do not reload icons
 
         SourceHighlightMasks->Load(HighlightMasks);
@@ -3558,13 +3590,16 @@ void CCfgPageColors::LoadColors()
 
     COLORREF* tmpColors;
     int index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-    if (index == 0)
+    int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
+    if (schemeId == CB_ERR)
+        schemeId = 5;
+    if (schemeId == 0)
         tmpColors = SalamanderColors;
-    else if (index == 1)
+    else if (schemeId == 1)
         tmpColors = ExplorerColors;
-    else if (index == 2)
+    else if (schemeId == 2)
         tmpColors = NortonColors;
-    else if (index == 3)
+    else if (schemeId == 3)
         tmpColors = NavigatorColors;
     else
         tmpColors = TmpColors;
@@ -3843,13 +3878,16 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 int index;
 
                 index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-                if (index == 0)
+                int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
+                if (schemeId == CB_ERR)
+                    schemeId = 5;
+                if (schemeId == 0)
                     tmpColors = SalamanderColors;
-                else if (index == 1)
+                else if (schemeId == 1)
                     tmpColors = ExplorerColors;
-                else if (index == 2)
+                else if (schemeId == 2)
                     tmpColors = NortonColors;
-                else if (index == 3)
+                else if (schemeId == 3)
                     tmpColors = NavigatorColors;
                 else
                     tmpColors = TmpColors;
@@ -3995,22 +4033,31 @@ MENU_TEMPLATE_ITEM CfgPageColorsMenu3[] =
             if (cmd != 0)
             {
                 int index = (int)SendMessage(HScheme, CB_GETCURSEL, 0, 0);
-                if (index != 4)
+                int schemeId = (int)SendMessage(HScheme, CB_GETITEMDATA, index, 0);
+                if (schemeId >= 0 && schemeId <= 3)
                 {
                     COLORREF* colors;
-                    if (index == 0)
+                    if (schemeId == 0)
                         colors = SalamanderColors;
-                    else if (index == 1)
+                    else if (schemeId == 1)
                         colors = ExplorerColors;
-                    else if (index == 2)
+                    else if (schemeId == 2)
                         colors = NortonColors;
-                    else if (index == 3)
+                    else if (schemeId == 3)
                         colors = NavigatorColors;
 
                     int i;
                     for (i = 0; i < NUMBER_OF_COLORS; i++)
                         TmpColors[i] = colors[i];
-                    SendMessage(HScheme, CB_SETCURSEL, 4, 0);
+                    int count = (int)SendMessage(HScheme, CB_GETCOUNT, 0, 0);
+                    for (int j = 0; j < count; j++)
+                    {
+                        if ((int)SendMessage(HScheme, CB_GETITEMDATA, j, 0) == 5)
+                        {
+                            SendMessage(HScheme, CB_SETCURSEL, j, 0);
+                            break;
+                        }
+                    }
                 }
 
                 if (cmd == 1 || cmd == 3)

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3876,6 +3876,13 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             // disabled and Windows then forces gray/black text regardless of our expected palette.
             EnableWindow(GetDlgItem(HWindow, CConfigurationPage7Items[i]), TRUE);
             EnableWindow(GetDlgItem(HWindow, CConfigurationPage7Masks[i]), TRUE);
+
+            HWND hItemLabel = GetDlgItem(HWindow, CConfigurationPage7Items[i]);
+            HWND hMaskLabel = GetDlgItem(HWindow, CConfigurationPage7Masks[i]);
+            if (hItemLabel != NULL)
+                SetWindowLongPtr(hItemLabel, GWL_STYLE, GetWindowLongPtr(hItemLabel, GWL_STYLE) | SS_OWNERDRAW);
+            if (hMaskLabel != NULL)
+                SetWindowLongPtr(hMaskLabel, GWL_STYLE, GetWindowLongPtr(hMaskLabel, GWL_STYLE) | SS_OWNERDRAW);
         }
 
         EditLB = new CEditListBox(HWindow, IDC_C_LIST);
@@ -4321,6 +4328,27 @@ MENU_TEMPLATE_ITEM CfgPageColorsMenu3[] =
     case WM_DRAWITEM:
     {
         int idCtrl = (int)wParam;
+        for (int i = 0; i < 5; i++)
+        {
+            if (idCtrl == CConfigurationPage7Items[i] || idCtrl == CConfigurationPage7Masks[i])
+            {
+                DRAWITEMSTRUCT* dis = reinterpret_cast<DRAWITEMSTRUCT*>(lParam);
+                if (dis != NULL)
+                {
+                    const DarkModeColors& colors = DarkModeGetColors();
+                    HBRUSH bg = CreateSolidBrush(DarkModeShouldUseDarkColors() ? colors.background : GetSysColor(COLOR_BTNFACE));
+                    FillRect(dis->hDC, &dis->rcItem, bg);
+                    DeleteObject(bg);
+                    char text[128] = {0};
+                    GetWindowText((HWND)dis->hwndItem, text, _countof(text));
+                    SetBkMode(dis->hDC, TRANSPARENT);
+                    SetTextColor(dis->hDC, DarkModeShouldUseDarkColors() ? colors.readableText : GetSysColor(COLOR_BTNTEXT));
+                    RECT r = dis->rcItem;
+                    DrawText(dis->hDC, text, -1, &r, DT_RIGHT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+                }
+                return TRUE;
+            }
+        }
         if (idCtrl == IDC_C_LIST)
         {
             EditLB->OnDrawItem(lParam);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -844,28 +844,6 @@ CCfgPageGeneral::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
-    case WM_CTLCOLORSTATIC:
-    case WM_CTLCOLORBTN:
-    {
-        LRESULT brush = 0;
-        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
-            return brush;
-        if (DarkModeShouldUseDarkColors())
-        {
-            HDC dc = reinterpret_cast<HDC>(wParam);
-            if (dc != NULL)
-            {
-                const DarkModeColors& colors = DarkModeGetColors();
-                SetTextColor(dc, colors.readableText);
-                SetBkColor(dc, colors.background);
-                SetBkMode(dc, TRANSPARENT);
-            }
-            HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
-            return reinterpret_cast<INT_PTR>(dialogBrush);
-        }
-        break;
-    }
-
     case WM_INITDIALOG:
     {
         DarkModeApplyTree(HWindow);
@@ -3848,9 +3826,6 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         // dialog elements should stretch with the dialog size, set split controls
         ElasticVerticalLayout(1, IDC_C_LIST);
-        DarkModeApplyTree(HWindow);
-        DarkModeApplyStaticTextColors(HWindow, NULL);
-        InvalidateRect(HWindow, NULL, TRUE);
 
         break;
     }

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -19,6 +19,7 @@
 #include "find.h"
 #include "gui.h"
 #include "darkmode.h"
+#include <uxtheme.h>
 
 //****************************************************************************
 //
@@ -3344,11 +3345,12 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     auto applyRecycleBinRadioTheme = [this]() {
         const int radioIds[] = {IDR_RECYCLE1, IDR_RECYCLE2, IDR_RECYCLE3, 0};
+        const bool useDark = DarkModeShouldUseDarkColors();
         for (int i = 0; radioIds[i] != 0; ++i)
         {
             HWND hRadio = GetDlgItem(HWindow, radioIds[i]);
             if (hRadio != NULL)
-                DarkModeApplyTree(hRadio);
+                SetWindowTheme(hRadio, useDark ? L"" : nullptr, useDark ? L"" : nullptr);
         }
     };
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -743,35 +743,6 @@ void CConfigurationDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
-    case WM_CTLCOLORSTATIC:
-    {
-        if (DarkModeShouldUseDarkColors())
-        {
-            HWND ctrl = (HWND)lParam;
-            int ctrlID = ctrl != NULL ? GetDlgCtrlID(ctrl) : 0;
-            bool isTargetLabel = false;
-            for (int i = 0; i < CFG_COLORS_BUTTONS; i++)
-            {
-                if (ctrlID == CConfigurationPage7Items[i] || ctrlID == CConfigurationPage7Masks[i])
-                {
-                    isTargetLabel = true;
-                    break;
-                }
-            }
-
-            if (isTargetLabel)
-            {
-                HDC dc = (HDC)wParam;
-                const DarkModeColors& colors = DarkModeGetColors();
-                SetTextColor(dc, colors.readableText);
-                SetBkColor(dc, colors.background);
-                SetBkMode(dc, TRANSPARENT);
-                return (INT_PTR)(HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
-            }
-        }
-        break;
-    }
-
     case WM_INITDIALOG:
     {
         // ColorsChanged() calls a plug-in method (when colors change PLUGINEVENT_COLORSCHANGED
@@ -3754,6 +3725,35 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    {
+        if (DarkModeShouldUseDarkColors())
+        {
+            HWND ctrl = (HWND)lParam;
+            int ctrlID = ctrl != NULL ? GetDlgCtrlID(ctrl) : 0;
+            bool isTargetLabel = false;
+            for (int i = 0; i < CFG_COLORS_BUTTONS; i++)
+            {
+                if (ctrlID == CConfigurationPage7Items[i] || ctrlID == CConfigurationPage7Masks[i])
+                {
+                    isTargetLabel = true;
+                    break;
+                }
+            }
+
+            if (isTargetLabel)
+            {
+                HDC dc = (HDC)wParam;
+                const DarkModeColors& colors = DarkModeGetColors();
+                SetTextColor(dc, colors.readableText);
+                SetBkColor(dc, colors.background);
+                SetBkMode(dc, TRANSPARENT);
+                return (INT_PTR)(HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
+            }
+        }
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         HScheme = GetDlgItem(HWindow, IDC_C_SCHEME);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3122,6 +3122,7 @@ CCfgPageHotPath::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_THEMECHANGED:
     {
         DarkModeUpdateListViewColors(HListView);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
         break;
     }
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3868,8 +3868,8 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         int i;
         for (i = 0; i < 5; i++)
         {
-            new CStaticText(HWindow, CConfigurationPage7Items[i]);
-            new CStaticText(HWindow, CConfigurationPage7Masks[i]);
+            new CStaticText(HWindow, CConfigurationPage7Items[i], 0);
+            new CStaticText(HWindow, CConfigurationPage7Masks[i], 0);
             Items[i] = new CColorArrowButton(HWindow, CConfigurationPage7ItemsBut[i], TRUE);
             Masks[i] = new CColorArrowButton(HWindow, CConfigurationPage7MasksBut[i], TRUE);
             // Keep color-caption labels readable in dark mode; some resource variants mark these statics

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3324,6 +3324,15 @@ void CCfgPageSystem::EnableControls()
 INT_PTR
 CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    static const int kRecycleBinLabelIds[] = {
+        IDC_STATIC_1,
+        IDC_STATIC_2,
+        IDC_STATIC_3,
+        IDC_STATIC_4,
+        IDC_STATIC_5,
+        IDC_FILEMASK_HINT,
+        0};
+
     switch (uMsg)
     {
     case WM_CTLCOLORSTATIC:
@@ -3338,7 +3347,14 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (dc != NULL)
             {
                 const DarkModeColors& colors = DarkModeGetColors();
-                SetTextColor(dc, colors.readableText);
+
+                HWND hCtl = reinterpret_cast<HWND>(lParam);
+                int ctrlId = hCtl != NULL ? GetDlgCtrlID(hCtl) : 0;
+                if (ctrlId == IDC_FILEMASK_HINT)
+                    SetTextColor(dc, RGB(96, 160, 255));
+                else
+                    SetTextColor(dc, colors.readableText);
+
                 SetBkColor(dc, colors.background);
                 SetBkMode(dc, TRANSPARENT);
             }
@@ -3354,8 +3370,25 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (hl != NULL)
             hl->SetActionShowHint(LoadStr(IDS_MASKS_HINT));
         DarkModeApplyTree(HWindow);
-        DarkModeApplyStaticTextColors(HWindow, NULL);
+        DarkModeApplyStaticTextColors(HWindow, kRecycleBinLabelIds);
         InvalidateRect(HWindow, NULL, TRUE);
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        DarkModeApplyStaticTextColors(HWindow, kRecycleBinLabelIds);
+        InvalidateRect(HWindow, NULL, TRUE);
+        break;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            DarkModeApplyStaticTextColors(HWindow, kRecycleBinLabelIds);
+            InvalidateRect(HWindow, NULL, TRUE);
+        }
         break;
     }
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3333,6 +3333,15 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         IDC_FILEMASK_HINT,
         0};
 
+    auto applyRecycleBinLabelColors = [this]() {
+        for (int i = 0; kRecycleBinLabelIds[i] != 0; ++i)
+        {
+            HWND hCtrl = GetDlgItem(HWindow, kRecycleBinLabelIds[i]);
+            if (hCtrl != NULL)
+                DarkModeApplyStaticTextColors(HWindow, hCtrl);
+        }
+    };
+
     switch (uMsg)
     {
     case WM_CTLCOLORSTATIC:
@@ -3370,14 +3379,14 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (hl != NULL)
             hl->SetActionShowHint(LoadStr(IDS_MASKS_HINT));
         DarkModeApplyTree(HWindow);
-        DarkModeApplyStaticTextColors(HWindow, kRecycleBinLabelIds);
+        applyRecycleBinLabelColors();
         InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
 
     case WM_THEMECHANGED:
     {
-        DarkModeApplyStaticTextColors(HWindow, kRecycleBinLabelIds);
+        applyRecycleBinLabelColors();
         InvalidateRect(HWindow, NULL, TRUE);
         break;
     }
@@ -3386,7 +3395,7 @@ CCfgPageSystem::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (DarkModeHandleSettingChange(uMsg, lParam))
         {
-            DarkModeApplyStaticTextColors(HWindow, kRecycleBinLabelIds);
+            applyRecycleBinLabelColors();
             InvalidateRect(HWindow, NULL, TRUE);
         }
         break;

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -20,10 +20,6 @@
 #include "gui.h"
 #include "darkmode.h"
 
-// Forward declarations: arrays are defined later in this file.
-extern int CConfigurationPage7Items[CFG_COLORS_BUTTONS];
-extern int CConfigurationPage7Masks[CFG_COLORS_BUTTONS];
-
 //****************************************************************************
 //
 // CHighlightMasksItem
@@ -851,34 +847,6 @@ CCfgPageGeneral::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORSTATIC:
     case WM_CTLCOLORBTN:
     {
-        if (uMsg == WM_CTLCOLORSTATIC && DarkModeShouldUseDarkColors() && lParam != 0)
-        {
-            HWND ctrl = reinterpret_cast<HWND>(lParam);
-            int ctrlId = GetDlgCtrlID(ctrl);
-            bool isColorCaption = false;
-            for (int i = 0; i < 5; i++)
-            {
-                if (ctrlId == CConfigurationPage7Items[i] || ctrlId == CConfigurationPage7Masks[i])
-                {
-                    isColorCaption = true;
-                    break;
-                }
-            }
-            if (isColorCaption)
-            {
-                HDC dc = reinterpret_cast<HDC>(wParam);
-                if (dc != NULL)
-                {
-                    const DarkModeColors& colors = DarkModeGetColors();
-                    SetTextColor(dc, colors.readableText);
-                    SetBkColor(dc, colors.background);
-                    SetBkMode(dc, TRANSPARENT);
-                }
-                HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
-                return reinterpret_cast<INT_PTR>(dialogBrush);
-            }
-        }
-
         LRESULT brush = 0;
         if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
             return brush;
@@ -3868,31 +3836,10 @@ CCfgPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         int i;
         for (i = 0; i < 5; i++)
         {
-            new CStaticText(HWindow, CConfigurationPage7Items[i], 0);
-            new CStaticText(HWindow, CConfigurationPage7Masks[i], 0);
             Items[i] = new CColorArrowButton(HWindow, CConfigurationPage7ItemsBut[i], TRUE);
             Masks[i] = new CColorArrowButton(HWindow, CConfigurationPage7MasksBut[i], TRUE);
-            // Keep color-caption labels readable in dark mode; some resource variants mark these statics
-            // disabled and Windows then forces gray/black text regardless of our expected palette.
             EnableWindow(GetDlgItem(HWindow, CConfigurationPage7Items[i]), TRUE);
             EnableWindow(GetDlgItem(HWindow, CConfigurationPage7Masks[i]), TRUE);
-
-            HWND hItemLabel = GetDlgItem(HWindow, CConfigurationPage7Items[i]);
-            HWND hMaskLabel = GetDlgItem(HWindow, CConfigurationPage7Masks[i]);
-            if (hItemLabel != NULL)
-            {
-                SetWindowLongPtr(hItemLabel, GWL_STYLE, GetWindowLongPtr(hItemLabel, GWL_STYLE) | SS_OWNERDRAW);
-                SetWindowPos(hItemLabel, NULL, 0, 0, 0, 0,
-                             SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
-                InvalidateRect(hItemLabel, NULL, TRUE);
-            }
-            if (hMaskLabel != NULL)
-            {
-                SetWindowLongPtr(hMaskLabel, GWL_STYLE, GetWindowLongPtr(hMaskLabel, GWL_STYLE) | SS_OWNERDRAW);
-                SetWindowPos(hMaskLabel, NULL, 0, 0, 0, 0,
-                             SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
-                InvalidateRect(hMaskLabel, NULL, TRUE);
-            }
         }
 
         EditLB = new CEditListBox(HWindow, IDC_C_LIST);
@@ -4338,27 +4285,6 @@ MENU_TEMPLATE_ITEM CfgPageColorsMenu3[] =
     case WM_DRAWITEM:
     {
         int idCtrl = (int)wParam;
-        for (int i = 0; i < 5; i++)
-        {
-            if (idCtrl == CConfigurationPage7Items[i] || idCtrl == CConfigurationPage7Masks[i])
-            {
-                DRAWITEMSTRUCT* dis = reinterpret_cast<DRAWITEMSTRUCT*>(lParam);
-                if (dis != NULL)
-                {
-                    const DarkModeColors& colors = DarkModeGetColors();
-                    HBRUSH bg = CreateSolidBrush(DarkModeShouldUseDarkColors() ? colors.background : GetSysColor(COLOR_BTNFACE));
-                    FillRect(dis->hDC, &dis->rcItem, bg);
-                    DeleteObject(bg);
-                    char text[128] = {0};
-                    GetWindowText((HWND)dis->hwndItem, text, _countof(text));
-                    SetBkMode(dis->hDC, TRANSPARENT);
-                    SetTextColor(dis->hDC, DarkModeShouldUseDarkColors() ? colors.readableText : GetSysColor(COLOR_BTNTEXT));
-                    RECT r = dis->rcItem;
-                    DrawText(dis->hDC, text, -1, &r, DT_RIGHT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
-                }
-                return TRUE;
-            }
-        }
         if (idCtrl == IDC_C_LIST)
         {
             EditLB->OnDrawItem(lParam);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -926,12 +926,19 @@ CCfgPageRegional::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (DarkModeShouldUseDarkColors())
         {
             HWND hCtl = reinterpret_cast<HWND>(lParam);
-            const int ctrlId = hCtl != NULL ? GetDlgCtrlID(hCtl) : 0;
-            if (ctrlId == IDR_RECYCLE1 || ctrlId == IDR_RECYCLE2 || ctrlId == IDR_RECYCLE3 ||
-                ctrlId == IDC_FILEMASK_HINT)
+            if (hCtl != NULL)
             {
-                if (hCtl != NULL && (ctrlId == IDR_RECYCLE1 || ctrlId == IDR_RECYCLE2 || ctrlId == IDR_RECYCLE3))
-                    SetWindowTheme(hCtl, L"", L"");
+                wchar_t className[16];
+                if (GetClassNameW(hCtl, className, _countof(className)) != 0 && lstrcmpiW(className, L"Button") == 0)
+                {
+                    LONG_PTR type = GetWindowLongPtr(hCtl, GWL_STYLE) & BS_TYPEMASK;
+                    if (type == BS_AUTORADIOBUTTON || type == BS_RADIOBUTTON)
+                        SetWindowTheme(hCtl, L"", L"");
+                }
+            }
+            const int ctrlId = hCtl != NULL ? GetDlgCtrlID(hCtl) : 0;
+            if (ctrlId == IDC_FILEMASK_HINT)
+            {
                 HDC dc = reinterpret_cast<HDC>(wParam);
                 if (dc != NULL)
                 {

--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -1007,6 +1007,7 @@ CPluginsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_THEMECHANGED:
     {
         ApplyTheme();
+        DarkModeApplyStaticTextColors(HWindow, NULL);
         break;
     }
 

--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -62,11 +62,8 @@ void CPluginsDlg::ApplyTheme()
     DarkModeRefreshTitleBar(HWindow);
 
     const bool useDark = ShouldUsePluginsDarkPalette();
-    const COLORREF paletteText = DarkModeGetDialogTextColor();
-    const COLORREF paletteBackground = DarkModeGetDialogBackgroundColor();
-    const COLORREF text = useDark ? DarkModeEnsureReadableForeground(paletteText, paletteBackground)
-                                  : GetSysColor(COLOR_WINDOWTEXT);
-    const COLORREF background = useDark ? paletteBackground : GetSysColor(COLOR_WINDOW);
+    const COLORREF text = useDark ? DarkModeGetColors().readableText : GetSysColor(COLOR_WINDOWTEXT);
+    const COLORREF background = useDark ? DarkModeGetColors().background : GetSysColor(COLOR_WINDOW);
 
     DarkModeUpdateListViewColors(HListView, text, background, useDark);
 
@@ -974,9 +971,8 @@ CPluginsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
                     if (dc == NULL)
                         return reinterpret_cast<LRESULT>(dialogBrush);
-                    const COLORREF paletteText = DarkModeGetDialogTextColor();
-                    const COLORREF background = DarkModeGetDialogBackgroundColor();
-                    const COLORREF text = DarkModeEnsureReadableForeground(paletteText, background);
+                    const COLORREF background = DarkModeGetColors().background;
+                    const COLORREF text = DarkModeGetColors().readableText;
                     SetTextColor(dc, text);
                     SetBkColor(dc, background);
                     SetBkMode(dc, transparent ? TRANSPARENT : OPAQUE);

--- a/src/edtlbwnd.cpp
+++ b/src/edtlbwnd.cpp
@@ -583,21 +583,30 @@ void CEditListBox::OnDrawItem(LPARAM lParam)
         else
         {
             COLORREF bkColor;
+            const bool useDark = DarkModeShouldUseDarkColors();
+            const DarkModeColors& darkColors = DarkModeGetColors();
             if (lpdis->itemState & ODS_SELECTED)
             {
                 if (lpdis->itemState & ODS_FOCUS)
-                    bkColor = COLOR_HIGHLIGHT;
+                    bkColor = useDark ? darkColors.background : COLOR_HIGHLIGHT;
                 else
-                    bkColor = COLOR_3DFACE;
+                    bkColor = useDark ? darkColors.background : COLOR_3DFACE;
             }
             else
-                bkColor = COLOR_WINDOW;
+                bkColor = useDark ? darkColors.background : COLOR_WINDOW;
 
             RECT itemRect = lpdis->rcItem;
             if (Flags & ELB_SHOWICON)
                 itemRect.left += IconSizes[ICONSIZE_16];
 
-            FillRect(lpdis->hDC, &itemRect, (HBRUSH)(UINT_PTR)(bkColor + 1));
+            if (useDark)
+            {
+                HBRUSH hBrush = HANDLES(CreateSolidBrush(bkColor));
+                FillRect(lpdis->hDC, &itemRect, hBrush);
+                HANDLES(DeleteObject(hBrush));
+            }
+            else
+                FillRect(lpdis->hDC, &itemRect, (HBRUSH)(UINT_PTR)(bkColor + 1));
             INT_PTR itemID = (INT_PTR)SendMessage(HWindow, LB_GETITEMDATA, lpdis->itemID, 0);
             if (itemID == -1)
             {
@@ -614,12 +623,12 @@ void CEditListBox::OnDrawItem(LPARAM lParam)
                 dtp.cbSize = sizeof(dtp);
                 dtp.iLeftMargin = dtp.iRightMargin = 4;
                 int oldBkMode = SetBkMode(lpdis->hDC, TRANSPARENT);
-                int color;
+                COLORREF textColor;
                 if (lpdis->itemState & ODS_SELECTED && lpdis->itemState & ODS_FOCUS)
-                    color = COLOR_HIGHLIGHTTEXT;
+                    textColor = useDark ? darkColors.readableText : GetSysColor(COLOR_HIGHLIGHTTEXT);
                 else
-                    color = COLOR_WINDOWTEXT;
-                int oldColor = SetTextColor(lpdis->hDC, GetSysColor(color));
+                    textColor = useDark ? darkColors.readableText : GetSysColor(COLOR_WINDOWTEXT);
+                int oldColor = SetTextColor(lpdis->hDC, textColor);
                 DispInfo.ToDo = edtlbGetData;
                 DispInfo.ItemID = itemID;
                 DispInfo.Index = lpdis->itemID;
@@ -637,7 +646,7 @@ void CEditListBox::OnDrawItem(LPARAM lParam)
                         // If a brush is passed to DrawIconEx as (HBRUSH)(COLOR_WINDOW + 1),
                         // under NT 4.0 US with 256 colors a black spot appears in the background;
                         // this patch fixes the problem.
-                        HBRUSH hBrush = HANDLES(CreateSolidBrush(GetSysColor(COLOR_WINDOW)));
+                        HBRUSH hBrush = HANDLES(CreateSolidBrush(useDark ? darkColors.background : GetSysColor(COLOR_WINDOW)));
                         int iconSize = IconSizes[ICONSIZE_16];
                         DrawIconEx(lpdis->hDC, lpdis->rcItem.left + 1, lpdis->rcItem.top + 1,
                                    DispInfo.HIcon, iconSize, iconSize, 0, hBrush /*(HBRUSH)(COLOR_WINDOW + 1)*/, DI_NORMAL);
@@ -648,7 +657,14 @@ void CEditListBox::OnDrawItem(LPARAM lParam)
                         // must clear the background
                         RECT r = lpdis->rcItem;
                         r.right = IconSizes[ICONSIZE_16] + 2;
-                        FillRect(lpdis->hDC, &r, (HBRUSH)(COLOR_WINDOW + 1));
+                        if (useDark)
+                        {
+                            HBRUSH hBrush = HANDLES(CreateSolidBrush(darkColors.background));
+                            FillRect(lpdis->hDC, &r, hBrush);
+                            HANDLES(DeleteObject(hBrush));
+                        }
+                        else
+                            FillRect(lpdis->hDC, &r, (HBRUSH)(COLOR_WINDOW + 1));
                     }
                 }
 

--- a/src/filesbx1.cpp
+++ b/src/filesbx1.cpp
@@ -414,12 +414,14 @@ void CFilesBox::PaintAllItems(HRGN hUpdateRgn, DWORD drawFlags)
         if (focused)
         {
             FillRect(HPrivateDC, &textR, HFocusedBkBrush);
-            newColor = GetCOLORREF(CurrentColors[ITEM_FG_FOCUSED]);
+            newColor = DarkModeEnsureReadableForeground(GetCOLORREF(CurrentColors[ITEM_FG_FOCUSED]),
+                                                        GetCOLORREF(CurrentColors[ITEM_BK_FOCUSED]));
         }
         else
         {
             FillRect(HPrivateDC, &textR, HNormalBkBrush);
-            newColor = GetCOLORREF(CurrentColors[ITEM_FG_NORMAL]);
+            newColor = DarkModeEnsureReadableForeground(GetCOLORREF(CurrentColors[ITEM_FG_NORMAL]),
+                                                        GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]));
         }
         int oldBkMode = SetBkMode(HPrivateDC, TRANSPARENT);
         int oldTextColor = SetTextColor(HPrivateDC, newColor);

--- a/src/filesbx2.cpp
+++ b/src/filesbx2.cpp
@@ -85,9 +85,8 @@ CBottomBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         RECT r;
         GetClientRect(HWindow, &r);
         r.left = r.right - GetSystemMetrics(SM_CXVSCROLL);
-        DarkModeMainFramePalette palette;
-        if (DarkMode_GetMainFramePalette(&palette))
-            FillRectWithColor(hDC, &r, palette.Fill);
+        if (DarkModeShouldUseDarkColors())
+            FillRectWithColor(hDC, &r, DarkModeGetDialogBackgroundColor());
         else
             FillRect(hDC, &r, HDialogBrush);
         HANDLES(EndPaint(HWindow, &ps));
@@ -222,9 +221,8 @@ void CHeaderLine::PaintItem(HDC hDC, int index, int x)
     else
         r.right = Width;
 
-    DarkModeMainFramePalette palette;
-    BOOL useDarkChrome = DarkMode_GetMainFramePalette(&palette);
-    COLORREF headerTextColor = useDarkChrome ? RGB(232, 232, 232) : GetSysColor(COLOR_BTNTEXT);
+    BOOL useDarkChrome = DarkModeShouldUseDarkColors();
+    COLORREF headerTextColor = useDarkChrome ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_BTNTEXT);
 
     // clear the background
     RECT r2;
@@ -232,7 +230,7 @@ void CHeaderLine::PaintItem(HDC hDC, int index, int x)
     r2.top++;
     r2.bottom--;
     if (useDarkChrome)
-        FillRectWithColor(ItemBitmap.HMemDC, &r2, palette.Fill);
+        FillRectWithColor(ItemBitmap.HMemDC, &r2, DarkModeGetDialogBackgroundColor());
     else
         FillRect(ItemBitmap.HMemDC, &r2, HDialogBrush);
 
@@ -316,7 +314,7 @@ void CHeaderLine::PaintItem(HDC hDC, int index, int x)
     if (useDarkChrome)
     {
         HGDIOBJ oldPen = SelectObject(ItemBitmap.HMemDC, GetStockObject(DC_PEN));
-        SetDCPenColor(ItemBitmap.HMemDC, palette.LineLight);
+        SetDCPenColor(ItemBitmap.HMemDC, RGB(95, 95, 95));
         MoveToEx(ItemBitmap.HMemDC, r.left, r.top, NULL);
         LineTo(ItemBitmap.HMemDC, r.right, r.top);
         if (first)
@@ -330,7 +328,7 @@ void CHeaderLine::PaintItem(HDC hDC, int index, int x)
             LineTo(ItemBitmap.HMemDC, r.left, r.bottom - 2);
         }
 
-        SetDCPenColor(ItemBitmap.HMemDC, palette.LineDark);
+        SetDCPenColor(ItemBitmap.HMemDC, RGB(70, 70, 70));
         MoveToEx(ItemBitmap.HMemDC, r.left, r.bottom - 1, NULL);
         LineTo(ItemBitmap.HMemDC, r.right, r.bottom - 1);
         if (!last)

--- a/src/filesbx2.cpp
+++ b/src/filesbx2.cpp
@@ -13,6 +13,15 @@
 #include "stswnd.h"
 #include "shellib.h"
 #include "snooper.h"
+#include "darkmode.h"
+
+static void FillRectWithColor(HDC hDC, const RECT* rect, COLORREF color)
+{
+    HGDIOBJ oldBrush = SelectObject(hDC, GetStockObject(DC_BRUSH));
+    SetDCBrushColor(hDC, color);
+    FillRect(hDC, rect, (HBRUSH)GetStockObject(DC_BRUSH));
+    SelectObject(hDC, oldBrush);
+}
 
 //****************************************************************************
 //
@@ -76,7 +85,11 @@ CBottomBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         RECT r;
         GetClientRect(HWindow, &r);
         r.left = r.right - GetSystemMetrics(SM_CXVSCROLL);
-        FillRect((HDC)hDC, &r, HDialogBrush);
+        DarkModeMainFramePalette palette;
+        if (DarkMode_GetMainFramePalette(&palette))
+            FillRectWithColor(hDC, &r, palette.Fill);
+        else
+            FillRect(hDC, &r, HDialogBrush);
         HANDLES(EndPaint(HWindow, &ps));
         return 0;
     }
@@ -209,12 +222,19 @@ void CHeaderLine::PaintItem(HDC hDC, int index, int x)
     else
         r.right = Width;
 
+    DarkModeMainFramePalette palette;
+    BOOL useDarkChrome = DarkMode_GetMainFramePalette(&palette);
+    COLORREF headerTextColor = useDarkChrome ? RGB(232, 232, 232) : GetSysColor(COLOR_BTNTEXT);
+
     // clear the background
     RECT r2;
     r2 = r;
     r2.top++;
     r2.bottom--;
-    FillRect(ItemBitmap.HMemDC, &r2, HDialogBrush);
+    if (useDarkChrome)
+        FillRectWithColor(ItemBitmap.HMemDC, &r2, palette.Fill);
+    else
+        FillRect(ItemBitmap.HMemDC, &r2, HDialogBrush);
 
     if (!last)
     {
@@ -293,29 +313,59 @@ void CHeaderLine::PaintItem(HDC hDC, int index, int x)
     }
 
     // draw the border lines
-    HPEN hOldPen = (HPEN)SelectObject(ItemBitmap.HMemDC, BtnHilightPen);
-    MoveToEx(ItemBitmap.HMemDC, r.left, r.top, NULL);
-    LineTo(ItemBitmap.HMemDC, r.right, r.top);
-    if (first)
+    if (useDarkChrome)
     {
+        HGDIOBJ oldPen = SelectObject(ItemBitmap.HMemDC, GetStockObject(DC_PEN));
+        SetDCPenColor(ItemBitmap.HMemDC, palette.LineLight);
         MoveToEx(ItemBitmap.HMemDC, r.left, r.top, NULL);
-        LineTo(ItemBitmap.HMemDC, r.left, r.bottom);
+        LineTo(ItemBitmap.HMemDC, r.right, r.top);
+        if (first)
+        {
+            MoveToEx(ItemBitmap.HMemDC, r.left, r.top, NULL);
+            LineTo(ItemBitmap.HMemDC, r.left, r.bottom);
+        }
+        else
+        {
+            MoveToEx(ItemBitmap.HMemDC, r.left, r.top + 2, NULL);
+            LineTo(ItemBitmap.HMemDC, r.left, r.bottom - 2);
+        }
+
+        SetDCPenColor(ItemBitmap.HMemDC, palette.LineDark);
+        MoveToEx(ItemBitmap.HMemDC, r.left, r.bottom - 1, NULL);
+        LineTo(ItemBitmap.HMemDC, r.right, r.bottom - 1);
+        if (!last)
+        {
+            MoveToEx(ItemBitmap.HMemDC, r.right - 1, r.top + 2, NULL);
+            LineTo(ItemBitmap.HMemDC, r.right - 1, r.bottom - 2);
+        }
+        SelectObject(ItemBitmap.HMemDC, oldPen);
     }
     else
     {
-        MoveToEx(ItemBitmap.HMemDC, r.left, r.top + 2, NULL);
-        LineTo(ItemBitmap.HMemDC, r.left, r.bottom - 2);
-    }
+        HPEN hOldPen = (HPEN)SelectObject(ItemBitmap.HMemDC, BtnHilightPen);
+        MoveToEx(ItemBitmap.HMemDC, r.left, r.top, NULL);
+        LineTo(ItemBitmap.HMemDC, r.right, r.top);
+        if (first)
+        {
+            MoveToEx(ItemBitmap.HMemDC, r.left, r.top, NULL);
+            LineTo(ItemBitmap.HMemDC, r.left, r.bottom);
+        }
+        else
+        {
+            MoveToEx(ItemBitmap.HMemDC, r.left, r.top + 2, NULL);
+            LineTo(ItemBitmap.HMemDC, r.left, r.bottom - 2);
+        }
 
-    SelectObject(ItemBitmap.HMemDC, BtnShadowPen);
-    MoveToEx(ItemBitmap.HMemDC, r.left, r.bottom - 1, NULL);
-    LineTo(ItemBitmap.HMemDC, r.right, r.bottom - 1);
-    if (!last)
-    {
-        MoveToEx(ItemBitmap.HMemDC, r.right - 1, r.top + 2, NULL);
-        LineTo(ItemBitmap.HMemDC, r.right - 1, r.bottom - 2);
+        SelectObject(ItemBitmap.HMemDC, BtnShadowPen);
+        MoveToEx(ItemBitmap.HMemDC, r.left, r.bottom - 1, NULL);
+        LineTo(ItemBitmap.HMemDC, r.right, r.bottom - 1);
+        if (!last)
+        {
+            MoveToEx(ItemBitmap.HMemDC, r.right - 1, r.top + 2, NULL);
+            LineTo(ItemBitmap.HMemDC, r.right - 1, r.bottom - 2);
+        }
+        SelectObject(ItemBitmap.HMemDC, hOldPen);
     }
-    SelectObject(ItemBitmap.HMemDC, hOldPen);
 
     if (DownVisible && DownIndex == index)
         InvertRect(ItemBitmap.HMemDC, &r);

--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -3328,6 +3328,21 @@ void CFilesWindow::OnColorsChanged()
         if (UseSystemIcons || UseThumbnails)
             WakeupIconCacheThread();
     }
+
+    if (ListBox != NULL && ListBox->HWindow != NULL)
+    {
+        // A color/theme switch can happen after the panel was already painted.
+        // Force a full panel repaint so stale light pixels are not left behind
+        // until the user moves selection or scrolls.
+        InvalidateRect(ListBox->HWindow, &ListBox->FilesRect, FALSE);
+        if (ListBox->HeaderLine.HWindow != NULL)
+            InvalidateRect(ListBox->HeaderLine.HWindow, NULL, TRUE);
+        if (ListBox->HVScrollBar != NULL)
+            InvalidateRect(ListBox->HVScrollBar, NULL, TRUE);
+        if (ListBox->HHScrollBar != NULL && ListBox->BottomBar.HWindow != NULL)
+            InvalidateRect(ListBox->BottomBar.HWindow, NULL, TRUE);
+        UpdateWindow(ListBox->HWindow);
+    }
 }
 
 CViewModeEnum

--- a/src/finddlg1.cpp
+++ b/src/finddlg1.cpp
@@ -3071,6 +3071,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (FoundFilesListView != NULL && FoundFilesListView->HWindow != NULL)
             DarkModeUpdateListViewColors(FoundFilesListView->HWindow);
+        DarkModeApplyStaticTextColors(HWindow, NULL);
         break;
     }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1133,7 +1133,12 @@ CStaticText::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 SetTextColor(hDC, RGB(0, 0, 255));
             BOOL enabled = IsWindowEnabled(HWindow);
             if (!enabled)
-                SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT));
+            {
+                if (DarkModeShouldUseDarkColors())
+                    SetTextColor(hDC, DarkModeGetColors().readableText);
+                else
+                    SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT));
+            }
 
             //        COLORREF textClr;
             //        if (Flags & STF_HYPERLINK_COLOR)

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1134,7 +1134,11 @@ CStaticText::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             BOOL enabled = IsWindowEnabled(HWindow);
             if (!enabled)
             {
-                if (DarkModeShouldUseDarkColors())
+                const COLORREF dlgText = DarkModeGetDialogTextColor();
+                const COLORREF dlgBg = DarkModeGetDialogBackgroundColor();
+                if (DarkModeShouldUseDarkColors() ||
+                    dlgText != GetSysColor(COLOR_BTNTEXT) ||
+                    dlgBg != GetSysColor(COLOR_BTNFACE))
                     SetTextColor(hDC, DarkModeGetColors().readableText);
                 else
                     SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT));

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1130,7 +1130,12 @@ CStaticText::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (hParent != NULL)
                 SendMessage(hParent, WM_CTLCOLORSTATIC, (WPARAM)hDC, (LPARAM)HWindow);
             if (Flags & STF_HYPERLINK_COLOR)
-                SetTextColor(hDC, RGB(0, 0, 255));
+            {
+                if (DarkModeShouldUseDarkColors())
+                    SetTextColor(hDC, RGB(120, 180, 255));
+                else
+                    SetTextColor(hDC, RGB(0, 0, 255));
+            }
             BOOL enabled = IsWindowEnabled(HWindow);
             if (!enabled)
             {

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1134,11 +1134,7 @@ CStaticText::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             BOOL enabled = IsWindowEnabled(HWindow);
             if (!enabled)
             {
-                const COLORREF dlgText = DarkModeGetDialogTextColor();
-                const COLORREF dlgBg = DarkModeGetDialogBackgroundColor();
-                if (DarkModeShouldUseDarkColors() ||
-                    dlgText != GetSysColor(COLOR_BTNTEXT) ||
-                    dlgBg != GetSysColor(COLOR_BTNFACE))
+                if (DarkModeShouldUseDarkColors())
                     SetTextColor(hDC, DarkModeGetColors().readableText);
                 else
                     SetTextColor(hDC, GetSysColor(COLOR_GRAYTEXT));

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -3177,6 +3177,11 @@ void CMainWindow::OnColorsChanged(BOOL reloadUMIcons)
     // main menu
     MainMenu.SetImageList(HGrayToolBarImageList, TRUE);
     MainMenu.SetHotImageList(HHotToolBarImageList, TRUE);
+    if (MenuBar != NULL && MenuBar->HWindow != NULL)
+    {
+        InvalidateRect(MenuBar->HWindow, NULL, TRUE);
+        UpdateWindow(MenuBar->HWindow);
+    }
 
     // archive menu
     ArchiveMenu.SetImageList(HGrayToolBarImageList, TRUE);
@@ -3193,6 +3198,19 @@ void CMainWindow::OnColorsChanged(BOOL reloadUMIcons)
     if (RightPanel != NULL)
     {
         RightPanel->OnColorsChanged();
+    }
+
+    if (EditWindow != NULL && EditWindow->HWindow != NULL)
+    {
+        InvalidateRect(EditWindow->HWindow, NULL, TRUE);
+        UpdateWindow(EditWindow->HWindow);
+
+        CEditLine* editLine = EditWindow->GetEditLine();
+        if (editLine != NULL && editLine->HWindow != NULL)
+        {
+            InvalidateRect(editLine->HWindow, NULL, TRUE);
+            UpdateWindow(editLine->HWindow);
+        }
     }
 }
 

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -470,6 +470,7 @@ const char* CONFIG_SHOWSPLASHSCREEN_REG = "Show Splash Screen";
 const char* CONFIG_CONVERSIONTABLE_REG = "Conversion Table";
 const char* CONFIG_TITLEBARSHOWPATH_REG = "Title bar show path";
 const char* CONFIG_TITLEBARMODE_REG = "Title bar mode";
+const char* CONFIG_THEME_MODE_REG = "Theme mode";
 const char* CONFIG_TITLEBARPREFIX_REG = "Title bar prefix";
 const char* CONFIG_TITLEBARPREFIXTEXT_REG = "Title bar prefix text";
 const char* CONFIG_MAINWINDOWICONINDEX_REG = "Main window icon index";
@@ -1850,6 +1851,8 @@ void CMainWindow::SaveConfig(HWND parent)
                          &Configuration.TitleBarShowPath, sizeof(DWORD));
                 SetValue(actKey, CONFIG_TITLEBARMODE_REG, REG_DWORD,
                          &Configuration.TitleBarMode, sizeof(DWORD));
+                SetValue(actKey, CONFIG_THEME_MODE_REG, REG_DWORD,
+                         &Configuration.ThemeMode, sizeof(DWORD));
                 SetValue(actKey, CONFIG_TITLEBARPREFIX_REG, REG_DWORD,
                          &Configuration.UseTitleBarPrefix, sizeof(DWORD));
                 SetValue(actKey, CONFIG_TITLEBARPREFIXTEXT_REG, REG_SZ,
@@ -3191,6 +3194,7 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
 
         DWORD cmdLine = 0, cmdLineFocus = 0;
         DWORD rightPanelFocused = FALSE;
+        Configuration.ThemeMode = THEME_MODE_LIGHT;
         if (OpenKey(salamander, SALAMANDER_CONFIG_REG, actKey))
         {
             if (importingOldConfig)
@@ -3404,6 +3408,10 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                      &Configuration.TitleBarShowPath, sizeof(DWORD));
             GetValue(actKey, CONFIG_TITLEBARMODE_REG, REG_DWORD,
                      &Configuration.TitleBarMode, sizeof(DWORD));
+            GetValue(actKey, CONFIG_THEME_MODE_REG, REG_DWORD,
+                     &Configuration.ThemeMode, sizeof(DWORD));
+            if (Configuration.ThemeMode < THEME_MODE_LIGHT || Configuration.ThemeMode > THEME_MODE_SYSTEM)
+                Configuration.ThemeMode = THEME_MODE_LIGHT;
             GetValue(actKey, CONFIG_TITLEBARPREFIX_REG, REG_DWORD,
                      &Configuration.UseTitleBarPrefix, sizeof(DWORD));
             GetValue(actKey, CONFIG_TITLEBARPREFIXTEXT_REG, REG_SZ,
@@ -4075,6 +4083,14 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
         lstrcpyn(DefaultDir[LowerCase[sysDefDir[0]] - 'a'], sysDefDir, MAX_PATH);
         // restore DefaultDir
         MainWindow->UpdateDefaultDir(TRUE);
+
+        // Main window is created before LoadConfig() runs; re-apply titlebar theme
+        // now that Configuration.ThemeMode is finalized from persisted settings.
+        DarkMode_SetThemeMode(Configuration.ThemeMode);
+        ColorsChanged(TRUE, FALSE, TRUE); // rebuild color-dependent resources for initial theme
+        DarkMode_ApplyTitleBar(HWindow);
+        DarkMode_ApplyToThreadTopLevelWindows(GetCurrentThreadId());
+        InvalidateRect(HWindow, NULL, TRUE);
 
         return ret;
     }

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -470,7 +470,6 @@ const char* CONFIG_SHOWSPLASHSCREEN_REG = "Show Splash Screen";
 const char* CONFIG_CONVERSIONTABLE_REG = "Conversion Table";
 const char* CONFIG_TITLEBARSHOWPATH_REG = "Title bar show path";
 const char* CONFIG_TITLEBARMODE_REG = "Title bar mode";
-const char* CONFIG_THEME_MODE_REG = "Theme mode";
 const char* CONFIG_TITLEBARPREFIX_REG = "Title bar prefix";
 const char* CONFIG_TITLEBARPREFIXTEXT_REG = "Title bar prefix text";
 const char* CONFIG_MAINWINDOWICONINDEX_REG = "Main window icon index";
@@ -1851,8 +1850,6 @@ void CMainWindow::SaveConfig(HWND parent)
                          &Configuration.TitleBarShowPath, sizeof(DWORD));
                 SetValue(actKey, CONFIG_TITLEBARMODE_REG, REG_DWORD,
                          &Configuration.TitleBarMode, sizeof(DWORD));
-                SetValue(actKey, CONFIG_THEME_MODE_REG, REG_DWORD,
-                         &Configuration.ThemeMode, sizeof(DWORD));
                 SetValue(actKey, CONFIG_TITLEBARPREFIX_REG, REG_DWORD,
                          &Configuration.UseTitleBarPrefix, sizeof(DWORD));
                 SetValue(actKey, CONFIG_TITLEBARPREFIXTEXT_REG, REG_SZ,
@@ -3194,7 +3191,6 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
 
         DWORD cmdLine = 0, cmdLineFocus = 0;
         DWORD rightPanelFocused = FALSE;
-        Configuration.ThemeMode = THEME_MODE_LIGHT;
         if (OpenKey(salamander, SALAMANDER_CONFIG_REG, actKey))
         {
             if (importingOldConfig)
@@ -3408,10 +3404,6 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                      &Configuration.TitleBarShowPath, sizeof(DWORD));
             GetValue(actKey, CONFIG_TITLEBARMODE_REG, REG_DWORD,
                      &Configuration.TitleBarMode, sizeof(DWORD));
-            GetValue(actKey, CONFIG_THEME_MODE_REG, REG_DWORD,
-                     &Configuration.ThemeMode, sizeof(DWORD));
-            if (Configuration.ThemeMode < THEME_MODE_LIGHT || Configuration.ThemeMode > THEME_MODE_SYSTEM)
-                Configuration.ThemeMode = THEME_MODE_LIGHT;
             GetValue(actKey, CONFIG_TITLEBARPREFIX_REG, REG_DWORD,
                      &Configuration.UseTitleBarPrefix, sizeof(DWORD));
             GetValue(actKey, CONFIG_TITLEBARPREFIXTEXT_REG, REG_SZ,
@@ -4083,14 +4075,6 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
         lstrcpyn(DefaultDir[LowerCase[sysDefDir[0]] - 'a'], sysDefDir, MAX_PATH);
         // restore DefaultDir
         MainWindow->UpdateDefaultDir(TRUE);
-
-        // Main window is created before LoadConfig() runs; re-apply titlebar theme
-        // now that Configuration.ThemeMode is finalized from persisted settings.
-        DarkMode_SetThemeMode(Configuration.ThemeMode);
-        ColorsChanged(TRUE, FALSE, TRUE); // rebuild color-dependent resources for initial theme
-        DarkMode_ApplyTitleBar(HWindow);
-        DarkMode_ApplyToThreadTopLevelWindows(GetCurrentThreadId());
-        InvalidateRect(HWindow, NULL, TRUE);
 
         return ret;
     }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -1082,8 +1082,10 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             return -1;
         }
 
-        // we do not want visual styles for the rebar in light mode
-        if (!DarkModeShouldUseDarkColors())
+        // explicit rebar theme selection for both modes
+        if (DarkModeShouldUseDarkColors())
+            SetWindowTheme(HTopRebar, L"DarkMode_Explorer", nullptr);
+        else
             SetWindowTheme(HTopRebar, (L" "), (L" "));
 
         DarkModeApplyWindow(HTopRebar);

--- a/src/menu3.cpp
+++ b/src/menu3.cpp
@@ -25,6 +25,24 @@ COLORREF DarkenColor(COLORREF color, int amount)
 }
 } // namespace
 
+static void FillRectWithColor(HDC hDC, const RECT* rect, COLORREF color)
+{
+    HGDIOBJ oldBrush = SelectObject(hDC, GetStockObject(DC_BRUSH));
+    COLORREF oldColor = SetDCBrushColor(hDC, color);
+    FillRect(hDC, rect, (HBRUSH)GetStockObject(DC_BRUSH));
+    SetDCBrushColor(hDC, oldColor);
+    SelectObject(hDC, oldBrush);
+}
+
+static void PatBltWithColor(HDC hDC, int left, int top, int width, int height, COLORREF color)
+{
+    HGDIOBJ oldBrush = SelectObject(hDC, GetStockObject(DC_BRUSH));
+    COLORREF oldColor = SetDCBrushColor(hDC, color);
+    PatBlt(hDC, left, top, width, height, PATCOPY);
+    SetDCBrushColor(hDC, oldColor);
+    SelectObject(hDC, oldBrush);
+}
+
 #define COLUMN_L1_L2_MARGIN 5 // space between column L1 and L2
 #define STANDARD_BITMAP_SIZE 17
 

--- a/src/menu3.cpp
+++ b/src/menu3.cpp
@@ -400,9 +400,8 @@ void CMenuPopup::DrawCheckBitmapVista(HDC hDC, CMenuItem* item, int yOffset, BOO
     if (item->HBmpItem != NULL)
     {
         // fill the entire area with the normal color
-        HBRUSH hOldBrush = (HBRUSH)SelectObject(SharedRes->CacheBitmap->HMemDC, HDialogBrush);
-        PatBlt(SharedRes->CacheBitmap->HMemDC, 0, 0, SharedRes->TextItemHeight + 1, item->Height, PATCOPY);
-        SelectObject(SharedRes->CacheBitmap->HMemDC, hOldBrush);
+        PatBltWithColor(SharedRes->CacheBitmap->HMemDC, 0, 0, SharedRes->TextItemHeight + 1, item->Height,
+                        SharedRes->NormalBkColor);
 
         // center the check mark if the line height is greater than the check mark height
         int myYOffset = 0;
@@ -564,9 +563,8 @@ void CMenuPopup::DrawCheckBitmap(HDC hDC, CMenuItem* item, int yOffset, BOOL sel
         (item->HBmpUnchecked != NULL && !(item->State & MENU_STATE_CHECKED)))
     {
         // fill the entire area with the normal color
-        HBRUSH hOldBrush = (HBRUSH)SelectObject(SharedRes->CacheBitmap->HMemDC, HDialogBrush);
-        PatBlt(SharedRes->CacheBitmap->HMemDC, 0, 0, SharedRes->TextItemHeight + 1, item->Height, PATCOPY);
-        SelectObject(SharedRes->CacheBitmap->HMemDC, hOldBrush);
+        PatBltWithColor(SharedRes->CacheBitmap->HMemDC, 0, 0, SharedRes->TextItemHeight + 1, item->Height,
+                        SharedRes->NormalBkColor);
 
         // center the check mark if the line height is greater than the check mark height
         int myYOffset = 0;
@@ -731,9 +729,8 @@ void CMenuPopup::DrawCheckImage(HDC hDC, CMenuItem* item, int yOffset, BOOL sele
 {
     CALL_STACK_MESSAGE_NONE
     // fill the entire area with the normal color
-    HBRUSH hOldBrush = (HBRUSH)SelectObject(SharedRes->CacheBitmap->HMemDC, HDialogBrush);
-    PatBlt(SharedRes->CacheBitmap->HMemDC, 0, 0, SharedRes->TextItemHeight + 1, item->Height, PATCOPY);
-    SelectObject(SharedRes->CacheBitmap->HMemDC, hOldBrush);
+    PatBltWithColor(SharedRes->CacheBitmap->HMemDC, 0, 0, SharedRes->TextItemHeight + 1, item->Height,
+                    SharedRes->NormalBkColor);
 
     // center the image if the line height is greater than the image height
     int myYOffset = 0;
@@ -903,12 +900,9 @@ void CMenuPopup::DrawItem(HDC hDC, CMenuItem* item, int yOffset, BOOL selected)
         return;
 
     // paint the background
-    HBRUSH hBkBrush;
+    COLORREF itemBkColor = SharedRes->NormalBkColor;
     if (selected && !(item->Type & MENU_TYPE_OWNERDRAW) && item->Type & MENU_TYPE_STRING)
-        hBkBrush = HMenuSelectedBkBrush;
-    else
-        hBkBrush = HDialogBrush;
-    HBRUSH hOldBrush = (HBRUSH)SelectObject(hDC, hBkBrush);
+        itemBkColor = SharedRes->SelectedBkColor;
     // to prevent flickering, if there is a check mark, shift the background fill
     int xO = 0;
     if (item->Height == SharedRes->TextItemHeight &&
@@ -917,8 +911,7 @@ void CMenuPopup::DrawItem(HDC hDC, CMenuItem* item, int yOffset, BOOL selected)
         (item->HBmpUnchecked != NULL && !(item->State & MENU_STATE_CHECKED) ||
          item->State & MENU_STATE_CHECKED || item->ImageIndex != -1 || item->HIcon != NULL))
         xO = SharedRes->TextItemHeight + 1;
-    PatBlt(hDC, xO, yOffset, Width - xO, item->Height, PATCOPY);
-    SelectObject(hDC, hOldBrush);
+    PatBltWithColor(hDC, xO, yOffset, Width - xO, item->Height, itemBkColor);
 
     if (!(item->Type & MENU_TYPE_OWNERDRAW))
     {
@@ -1255,7 +1248,7 @@ void CMenuPopup::DrawUpDownItem(HDC hDC, BOOL up)
     int yOffset = up ? 0 : 1; // move the down arrow one pixel down (for balance)
 
     // fill the rectangle
-    FillRect(hDC, &r, HDialogBrush);
+    FillRectWithColor(hDC, &r, SharedRes->NormalBkColor);
     // draw the arrow
     BitBlt(hDC, r.left + (r.right - r.left - w) / 2,
            arrowR.top + (arrowR.bottom - arrowR.top - h) / 2 + yOffset,

--- a/src/menubar.cpp
+++ b/src/menubar.cpp
@@ -16,6 +16,29 @@
 #define MENUBAR_LR_MARGIN 8 // number of points before and after the text, including the vertical line
 #define MENUBAR_TB_MARGIN 4 // number of points above and below the text, including the horizontal line
 
+static void FillRectWithColor(HDC hDC, const RECT* rect, COLORREF color)
+{
+    HGDIOBJ oldBrush = SelectObject(hDC, GetStockObject(DC_BRUSH));
+    COLORREF oldColor = SetDCBrushColor(hDC, color);
+    FillRect(hDC, rect, (HBRUSH)GetStockObject(DC_BRUSH));
+    SetDCBrushColor(hDC, oldColor);
+    SelectObject(hDC, oldBrush);
+}
+
+static COLORREF GetMenuBarBkColor(BOOL hot)
+{
+    if (!DarkMode_ShouldUseDark())
+        return GetSysColor(hot ? COLOR_HIGHLIGHT : COLOR_BTNFACE);
+    return hot ? RGB(62, 62, 64) : RGB(45, 45, 48);
+}
+
+static COLORREF GetMenuBarTextColor(BOOL hot)
+{
+    if (!DarkMode_ShouldUseDark())
+        return GetSysColor(hot ? COLOR_HIGHLIGHTTEXT : COLOR_BTNTEXT);
+    return hot ? RGB(245, 245, 245) : RGB(232, 232, 232);
+}
+
 CMenuBar::CMenuBar(CMenuPopup* menu, HWND hNotifyWindow, CObjectOrigin origin)
     : CWindow(origin)
 {
@@ -87,6 +110,8 @@ BOOL CMenuBar::CreateWnd(HWND hParent)
         return FALSE;
     }
     RefreshMinWidths();
+    InvalidateRect(HWindow, NULL, TRUE);
+    UpdateWindow(HWindow);
     return TRUE;
 }
 
@@ -110,6 +135,11 @@ void CMenuBar::SetFont()
     SelectObject(hDC, hOldFont);
     HANDLES(ReleaseDC(NULL, hDC));
     RefreshMinWidths();
+    if (HWindow != NULL)
+    {
+        InvalidateRect(HWindow, NULL, TRUE);
+        UpdateWindow(HWindow);
+    }
 }
 
 int CMenuBar::GetNeededWidth()
@@ -245,7 +275,7 @@ void CMenuBar::DrawAllItems(HDC hDC)
     RECT r;
     GetClientRect(HWindow, &r);
     r.left = x;
-    FillRect((HDC)hDC, &r, HDialogBrush);
+    FillRectWithColor(hDC, &r, GetMenuBarBkColor(FALSE));
 }
 
 void CMenuBar::RefreshMinWidths()
@@ -837,7 +867,7 @@ CMenuBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return TRUE;
         RECT r;
         GetClientRect(HWindow, &r);
-        FillRect((HDC)wParam, &r, HDialogBrush);
+        FillRectWithColor((HDC)wParam, &r, GetMenuBarBkColor(FALSE));
         return TRUE;
     }
 

--- a/src/msgbox.cpp
+++ b/src/msgbox.cpp
@@ -1045,19 +1045,22 @@ CMessageBox::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (WindowsVistaAndLater)
         {
             LRESULT brush = 0;
-            DarkModeHandleCtlColor(uMsg, wParam, lParam, brush);
+            const bool handled = DarkModeHandleCtlColor(uMsg, wParam, lParam, brush);
             HDC hdcStatic = (HDC)wParam;
             HWND hwndStatic = (HWND)lParam;
             int resID = GetWindowLong(hwndStatic, GWL_ID);
             if (resID == IDI_MSGBOX_ICON || resID == IDS_MSGBOX_TEXT || resID == IDS_MSGBOX_URL)
             {
-                COLORREF textClr = DarkModeGetDialogTextColor();
-                COLORREF bgClr = DarkModeGetDialogBackgroundColor();
+                const DarkModeColors& dmColors = DarkModeGetColors();
+                COLORREF textClr = dmColors.readableText;
+                COLORREF bgClr = dmColors.background;
                 SetTextColor(hdcStatic, textClr);
                 SetBkColor(hdcStatic, bgClr);
                 HBRUSH dialogBrush = HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE);
                 return (INT_PTR)dialogBrush;
             }
+            if (handled)
+                return brush;
             break;
         }
         else

--- a/src/plugins/dbviewer/dialogs.cpp
+++ b/src/plugins/dbviewer/dialogs.cpp
@@ -785,13 +785,17 @@ CColumnsDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     case WM_THEMECHANGED:
     case WM_SETTINGCHANGE:
-        PluginDarkMode_ApplyTitleBar(HWindow);
-        PluginDarkMode_ApplyListTreeThemeRecursive(HWindow);
+        PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam);
         break;
     case WM_CTLCOLORSTATIC:
     case WM_CTLCOLORBTN:
     case WM_CTLCOLOREDIT:
-        return reinterpret_cast<INT_PTR>(PluginDarkMode_GetDialogCtlColorBrush(reinterpret_cast<HDC>(wParam), uMsg));
+    {
+        LRESULT brush = 0;
+        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+            return brush;
+        break;
+    }
 
     case WM_SIZE:
         RecalcLayout(LOWORD(lParam), HIWORD(lParam));

--- a/src/plugins/dbviewer/dialogs.cpp
+++ b/src/plugins/dbviewer/dialogs.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "precomp.h"
+#include "..\\shared\\plugindarkmode.h"
 
 #include "data.h"
 #include "renderer.h"
@@ -782,6 +783,15 @@ CColumnsDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_SYSCOLORCHANGE:
         ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
         break;
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+        PluginDarkMode_ApplyTitleBar(HWindow);
+        PluginDarkMode_ApplyListTreeThemeRecursive(HWindow);
+        break;
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+        return reinterpret_cast<INT_PTR>(PluginDarkMode_GetDialogCtlColorBrush(reinterpret_cast<HDC>(wParam), uMsg));
 
     case WM_SIZE:
         RecalcLayout(LOWORD(lParam), HIWORD(lParam));

--- a/src/plugins/dbviewer/vcxproj/dbviewer.vcxproj
+++ b/src/plugins/dbviewer/vcxproj/dbviewer.vcxproj
@@ -125,6 +125,8 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
+    </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
     </ClCompile>
     <ClCompile Include="..\csvlib\csvlib.cpp">
@@ -172,6 +174,8 @@
     <ClInclude Include="..\..\shared\auxtools.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\plugindarkmode.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\spl_arc.h">
     </ClInclude>

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -1743,8 +1743,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_SETTINGCHANGE:
     case WM_THEMECHANGED:
     {
-        PluginDarkMode_ApplyTitleBar(HWindow);
-        PluginDarkMode_ApplyListTreeThemeRecursive(HWindow);
+        PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam);
         // the scrollbar size may have changed; ensure the combo box recalculates the button size
         RECT r;
         GetWindowRect(ComboBox->HWindow, &r);

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "precomp.h"
+#include "..\\shared\\plugindarkmode.h"
 
 using namespace std;
 
@@ -1740,7 +1741,10 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
 
     case WM_SETTINGCHANGE:
+    case WM_THEMECHANGED:
     {
+        PluginDarkMode_ApplyTitleBar(HWindow);
+        PluginDarkMode_ApplyListTreeThemeRecursive(HWindow);
         // the scrollbar size may have changed; ensure the combo box recalculates the button size
         RECT r;
         GetWindowRect(ComboBox->HWindow, &r);

--- a/src/plugins/filecomp/vcxproj/filecomp.vcxproj
+++ b/src/plugins/filecomp/vcxproj/filecomp.vcxproj
@@ -125,6 +125,8 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
+    </ClCompile>
     <ClCompile Include="..\..\shared\lukas\messages.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\lukas\str.cpp">
@@ -194,6 +196,8 @@
     <ClInclude Include="..\..\shared\auxtools.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\plugindarkmode.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\lukas\diff.h">
     </ClInclude>

--- a/src/plugins/ftp/dialogs1.cpp
+++ b/src/plugins/ftp/dialogs1.cpp
@@ -3,6 +3,7 @@
 // CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
+#include "..\\shared\\plugindarkmode.h"
 
 TIndirectArray<CDialog> ModelessDlgs(2, 2, dtNoDelete); // array of "Welcome Message" dialogs
 
@@ -28,6 +29,26 @@ CCenteredDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
         break; // Let DefDlgProc set the focus
+    }
+
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+    {
+        PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam);
+        break;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    {
+        LRESULT brush = 0;
+        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+            return brush;
+        break;
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);

--- a/src/plugins/ftp/dialogs1.cpp
+++ b/src/plugins/ftp/dialogs1.cpp
@@ -28,6 +28,7 @@ CCenteredDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // horizontal and vertical centering of the dialog relative to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
+        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
         break; // Let DefDlgProc set the focus
     }
 

--- a/src/plugins/ftp/dialogs4.cpp
+++ b/src/plugins/ftp/dialogs4.cpp
@@ -3,6 +3,7 @@
 // CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
+#include "..\\shared\\plugindarkmode.h"
 
 //
 // ****************************************************************************
@@ -1337,11 +1338,25 @@ CConfirmDeleteDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CConfirmDeleteDlg::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    {
+        LRESULT brush = 0;
+        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+            return brush;
+        break;
+    }
+
     case WM_INITDIALOG:
     {
         SetDlgItemText(HWindow, IDT_DELSUBJECT, Subject);
         SendDlgItemMessage(HWindow, IDC_DELICON, STM_SETICON,
                            (WPARAM)(Icon == NULL ? HANDLES(LoadIcon(NULL, IDI_QUESTION)) : Icon), 0);
+        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
         break;
     }
     }

--- a/src/plugins/ftp/vcxproj/ftp.vcxproj
+++ b/src/plugins/ftp/vcxproj/ftp.vcxproj
@@ -125,6 +125,8 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
+    </ClCompile>
     <ClCompile Include="..\..\shared\mhandles.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
@@ -226,6 +228,8 @@
     <ClInclude Include="..\..\shared\auxtools.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\plugindarkmode.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\mhandles.h">
     </ClInclude>

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -6,6 +6,14 @@
 
 #include <commctrl.h>
 
+#ifndef HDM_SETBKCOLOR
+#define HDM_SETBKCOLOR (HDM_FIRST + 29)
+#endif
+
+#ifndef HDM_SETTEXTCOLOR
+#define HDM_SETTEXTCOLOR (HDM_FIRST + 30)
+#endif
+
 namespace
 {
 using fnSetWindowTheme = HRESULT(WINAPI*)(HWND, LPCWSTR, LPCWSTR);

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -23,6 +23,7 @@ BOOL gHostPolicyAvailable = FALSE;
 BOOL gHostUseWindowsDarkScheme = FALSE;
 PluginDarkModeColors gHostColors = {CLR_INVALID, CLR_INVALID, CLR_INVALID};
 HBRUSH gDialogBrush = NULL;
+HBRUSH gInputBrush = NULL;
 fnSetWindowTheme gSetWindowTheme = NULL;
 fnDwmSetWindowAttribute gDwmSetWindowAttribute = NULL;
 thread_local int gThemeBatchDepth = 0;
@@ -246,10 +247,16 @@ void PluginDarkMode_ApplyListTreeThemeRecursive(HWND hwnd)
 
 HBRUSH PluginDarkMode_GetDialogCtlColorBrush(HDC dc, UINT)
 {
+    if (!PluginDarkMode_ShouldUseDark())
+        return NULL;
     PluginDarkModeColors c = PluginDarkMode_GetColors();
-    if (gDialogBrush != NULL)
-        DeleteObject(gDialogBrush);
-    gDialogBrush = CreateSolidBrush(c.background);
+    if (gDialogBrush == NULL)
+        gDialogBrush = CreateSolidBrush(c.background);
+    if (gInputBrush == NULL)
+    {
+        COLORREF inputBg = RGB(0x2A, 0x2A, 0x2A);
+        gInputBrush = CreateSolidBrush(inputBg);
+    }
     if (dc != NULL)
     {
         SetTextColor(dc, c.readableText);
@@ -286,6 +293,8 @@ BOOL PluginDarkMode_HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, L
     HWND ctrl = reinterpret_cast<HWND>(lParam);
     PluginDarkModeColors c = PluginDarkMode_GetColors();
     HBRUSH brush = PluginDarkMode_GetDialogCtlColorBrush(dc, message);
+    if (brush == NULL)
+        return FALSE;
     if (ctrl != NULL && message == WM_CTLCOLORBTN)
     {
         wchar_t cls[16] = {0};
@@ -308,7 +317,11 @@ BOOL PluginDarkMode_HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, L
         }
     }
     if (dc != NULL && (message == WM_CTLCOLOREDIT || message == WM_CTLCOLORLISTBOX))
+    {
         SetBkMode(dc, OPAQUE);
+        SetBkColor(dc, RGB(0x2A, 0x2A, 0x2A));
+        brush = gInputBrush != NULL ? gInputBrush : brush;
+    }
     else if (dc != NULL)
         SetBkMode(dc, TRANSPARENT);
     if (dc != NULL)

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -103,9 +103,13 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
     {
         const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
         const LONG_PTR type = style & BS_TYPEMASK;
-        if (type == BS_GROUPBOX && gSetWindowTheme != NULL)
+        if (gSetWindowTheme != NULL)
         {
-            gSetWindowTheme(hwnd, dark ? L"" : nullptr, nullptr);
+            if (type == BS_GROUPBOX)
+                gSetWindowTheme(hwnd, dark ? L"" : nullptr, nullptr);
+            else if (type == BS_AUTOCHECKBOX || type == BS_CHECKBOX || type == BS_AUTO3STATE ||
+                     type == BS_3STATE || type == BS_AUTORADIOBUTTON || type == BS_RADIOBUTTON)
+                gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
             InvalidateRect(hwnd, NULL, TRUE);
         }
     }
@@ -291,6 +295,16 @@ BOOL PluginDarkMode_HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, L
             LONG_PTR type = style & BS_TYPEMASK;
             if (type == BS_GROUPBOX && gSetWindowTheme != NULL)
                 gSetWindowTheme(ctrl, PluginDarkMode_ShouldUseDark() ? L"" : nullptr, nullptr);
+        }
+    }
+    if (ctrl != NULL && message == WM_CTLCOLORSTATIC)
+    {
+        wchar_t cls[16] = {0};
+        if (GetClassNameW(ctrl, cls, _countof(cls)) != 0 && lstrcmpiW(cls, L"Static") == 0)
+        {
+            LONG_PTR style = GetWindowLongPtrW(ctrl, GWL_STYLE);
+            if ((style & (SS_ICON | SS_BITMAP | SS_BLACKRECT | SS_GRAYRECT | SS_WHITERECT)) != 0)
+                return FALSE;
         }
     }
     if (dc != NULL && (message == WM_CTLCOLOREDIT || message == WM_CTLCOLORLISTBOX))

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -17,6 +17,7 @@ PluginDarkModeColors gHostColors = {CLR_INVALID, CLR_INVALID, CLR_INVALID};
 HBRUSH gDialogBrush = NULL;
 fnSetWindowTheme gSetWindowTheme = NULL;
 fnDwmSetWindowAttribute gDwmSetWindowAttribute = NULL;
+thread_local int gThemeBatchDepth = 0;
 
 COLORREF EnsureReadable(COLORREF fg, COLORREF bg)
 {
@@ -68,15 +69,90 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
         TreeView_SetBkColor(hwnd, c.background);
         InvalidateRect(hwnd, NULL, TRUE);
     }
-    else if (wcscmp(cls, L"SysHeader32") == 0 || wcscmp(cls, L"tooltips_class32") == 0 || wcscmp(cls, L"ScrollBar") == 0)
+    else if (wcscmp(cls, L"SysHeader32") == 0)
+    {
+        if (gSetWindowTheme != NULL)
+            gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        PluginDarkModeColors c = PluginDarkMode_GetColors();
+        SendMessage(hwnd, HDM_SETTEXTCOLOR, 0, static_cast<LPARAM>(dark ? c.readableText : CLR_DEFAULT));
+        SendMessage(hwnd, HDM_SETBKCOLOR, 0, static_cast<LPARAM>(dark ? c.background : CLR_DEFAULT));
+        InvalidateRect(hwnd, NULL, TRUE);
+        HWND parent = GetParent(hwnd);
+        while (parent != NULL)
+        {
+            InvalidateRect(parent, NULL, TRUE);
+            parent = GetParent(parent);
+        }
+    }
+    else if (wcscmp(cls, L"tooltips_class32") == 0 || wcscmp(cls, L"ScrollBar") == 0 ||
+             wcscmp(cls, L"ReBarWindow32") == 0 || wcscmp(cls, L"ToolbarWindow32") == 0)
     {
         if (gSetWindowTheme != NULL)
             gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
         InvalidateRect(hwnd, NULL, TRUE);
     }
+    else if (wcscmp(cls, L"Button") == 0)
+    {
+        const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+        const LONG_PTR type = style & BS_TYPEMASK;
+        if (type == BS_GROUPBOX && gSetWindowTheme != NULL)
+        {
+            gSetWindowTheme(hwnd, dark ? L"" : nullptr, nullptr);
+            InvalidateRect(hwnd, NULL, TRUE);
+        }
+    }
+    else if (wcscmp(cls, L"Static") == 0)
+    {
+        const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+        const LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+        if ((exStyle & WS_EX_STATICEDGE) == WS_EX_STATICEDGE || (style & SS_ETCHEDFRAME) == SS_ETCHEDFRAME)
+        {
+            InvalidateRect(hwnd, NULL, TRUE);
+            HWND parent = GetParent(hwnd);
+            while (parent != NULL)
+            {
+                InvalidateRect(parent, NULL, TRUE);
+                parent = GetParent(parent);
+            }
+        }
+    }
 
     for (HWND child = GetWindow(hwnd, GW_CHILD); child != NULL; child = GetWindow(child, GW_HWNDNEXT))
         ApplyRecursive(child, dark);
+}
+
+bool IsThemeChangeMessageRelevant(UINT message, LPARAM lParam)
+{
+    if (message == WM_THEMECHANGED)
+        return true;
+    if (message != WM_SETTINGCHANGE)
+        return false;
+    if (lParam == 0)
+        return true;
+    LPCWSTR key = reinterpret_cast<LPCWSTR>(lParam);
+    return CompareStringOrdinal(key, -1, L"ImmersiveColorSet", -1, TRUE) == CSTR_EQUAL ||
+           CompareStringOrdinal(key, -1, L"WindowsThemeElement", -1, TRUE) == CSTR_EQUAL;
+}
+
+struct ThemeBatchScope
+{
+    ThemeBatchScope() { ++gThemeBatchDepth; }
+    ~ThemeBatchScope() { --gThemeBatchDepth; }
+    bool Root() const { return gThemeBatchDepth == 1; }
+};
+
+void InvalidateKnownDarkArtifacts(HWND hwnd)
+{
+    if (hwnd == NULL)
+        return;
+    wchar_t cls[64] = {0};
+    if (GetClassNameW(hwnd, cls, _countof(cls)) == 0)
+        return;
+    if (wcscmp(cls, L"SysHeader32") == 0 || wcscmp(cls, L"ReBarWindow32") == 0 ||
+        wcscmp(cls, L"ToolbarWindow32") == 0 || wcscmp(cls, L"Static") == 0)
+        InvalidateRect(hwnd, NULL, TRUE);
+    for (HWND child = GetWindow(hwnd, GW_CHILD); child != NULL; child = GetWindow(child, GW_HWNDNEXT))
+        InvalidateKnownDarkArtifacts(child);
 }
 } // namespace
 
@@ -107,6 +183,13 @@ void PluginDarkMode_SetHostColors(COLORREF text, COLORREF background)
     gHostColors.text = text;
     gHostColors.background = background;
     gHostColors.readableText = EnsureReadable(text, background);
+}
+
+void PluginDarkMode_SetHostResolvedColors(COLORREF text, COLORREF background, COLORREF readableText)
+{
+    gHostColors.text = text;
+    gHostColors.background = background;
+    gHostColors.readableText = readableText;
 }
 
 BOOL PluginDarkMode_ShouldUseDark()
@@ -162,4 +245,55 @@ HBRUSH PluginDarkMode_GetDialogCtlColorBrush(HDC dc, UINT)
         SetBkMode(dc, TRANSPARENT);
     }
     return gDialogBrush;
+}
+
+BOOL PluginDarkMode_HandleThemeMessage(HWND hwnd, UINT message, LPARAM lParam)
+{
+    PluginDarkMode_EnsureApis();
+    if (!IsThemeChangeMessageRelevant(message, lParam))
+        return FALSE;
+    ThemeBatchScope scope;
+    if (!scope.Root())
+        return TRUE;
+    PluginDarkMode_ApplyTitleBar(hwnd);
+    PluginDarkMode_ApplyListTreeThemeRecursive(hwnd);
+    InvalidateKnownDarkArtifacts(hwnd);
+    InvalidateRect(hwnd, NULL, TRUE);
+    return TRUE;
+}
+
+BOOL PluginDarkMode_HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT* result)
+{
+    if (result == NULL)
+        return FALSE;
+    if (message != WM_CTLCOLORSTATIC && message != WM_CTLCOLORBTN && message != WM_CTLCOLOREDIT &&
+        message != WM_CTLCOLORLISTBOX && message != WM_CTLCOLORDLG && message != WM_CTLCOLORMSGBOX)
+        return FALSE;
+
+    HDC dc = reinterpret_cast<HDC>(wParam);
+    HWND ctrl = reinterpret_cast<HWND>(lParam);
+    PluginDarkModeColors c = PluginDarkMode_GetColors();
+    HBRUSH brush = PluginDarkMode_GetDialogCtlColorBrush(dc, message);
+    if (ctrl != NULL && message == WM_CTLCOLORBTN)
+    {
+        wchar_t cls[16] = {0};
+        if (GetClassNameW(ctrl, cls, _countof(cls)) != 0 && lstrcmpiW(cls, L"Button") == 0)
+        {
+            LONG_PTR style = GetWindowLongPtrW(ctrl, GWL_STYLE);
+            LONG_PTR type = style & BS_TYPEMASK;
+            if (type == BS_GROUPBOX && gSetWindowTheme != NULL)
+                gSetWindowTheme(ctrl, PluginDarkMode_ShouldUseDark() ? L"" : nullptr, nullptr);
+        }
+    }
+    if (dc != NULL && (message == WM_CTLCOLOREDIT || message == WM_CTLCOLORLISTBOX))
+        SetBkMode(dc, OPAQUE);
+    else if (dc != NULL)
+        SetBkMode(dc, TRANSPARENT);
+    if (dc != NULL)
+    {
+        SetTextColor(dc, c.readableText);
+        SetBkColor(dc, c.background);
+    }
+    *result = reinterpret_cast<LRESULT>(brush);
+    return TRUE;
 }

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "precomp.h"
+#include "plugindarkmode.h"
+
+#include <uxtheme.h>
+#include <dwmapi.h>
+#include <commctrl.h>
+
+namespace
+{
+BOOL gHostPolicyAvailable = FALSE;
+BOOL gHostUseWindowsDarkScheme = FALSE;
+PluginDarkModeColors gHostColors = {CLR_INVALID, CLR_INVALID, CLR_INVALID};
+HBRUSH gDialogBrush = NULL;
+
+COLORREF EnsureReadable(COLORREF fg, COLORREF bg)
+{
+    const int bl = (GetRValue(bg) * 30 + GetGValue(bg) * 59 + GetBValue(bg) * 11) / 100;
+    const int fl = (GetRValue(fg) * 30 + GetGValue(fg) * 59 + GetBValue(fg) * 11) / 100;
+    if (bl < 128 && fl < bl + 40)
+        return RGB(0xF0, 0xF0, 0xF0);
+    if (bl >= 128 && fl > bl - 40)
+        return RGB(0x20, 0x20, 0x20);
+    return fg;
+}
+
+BOOL DetectSystemDarkFallback()
+{
+    HKEY key = NULL;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                      0, KEY_READ, &key) != ERROR_SUCCESS)
+        return FALSE;
+    DWORD value = 1;
+    DWORD size = sizeof(value);
+    RegQueryValueExW(key, L"AppsUseLightTheme", NULL, NULL, reinterpret_cast<LPBYTE>(&value), &size);
+    RegCloseKey(key);
+    return value == 0 ? TRUE : FALSE;
+}
+
+void ApplyRecursive(HWND hwnd, BOOL dark)
+{
+    if (hwnd == NULL)
+        return;
+    wchar_t cls[64] = {0};
+    GetClassNameW(hwnd, cls, _countof(cls));
+    if (wcscmp(cls, L"SysListView32") == 0)
+    {
+        SetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        PluginDarkModeColors c = PluginDarkMode_GetColors();
+        ListView_SetTextColor(hwnd, c.readableText);
+        ListView_SetTextBkColor(hwnd, c.background);
+        ListView_SetBkColor(hwnd, c.background);
+        InvalidateRect(hwnd, NULL, TRUE);
+    }
+    else if (wcscmp(cls, L"SysTreeView32") == 0)
+    {
+        SetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        PluginDarkModeColors c = PluginDarkMode_GetColors();
+        TreeView_SetTextColor(hwnd, c.readableText);
+        TreeView_SetBkColor(hwnd, c.background);
+        InvalidateRect(hwnd, NULL, TRUE);
+    }
+    else if (wcscmp(cls, L"SysHeader32") == 0 || wcscmp(cls, L"tooltips_class32") == 0 || wcscmp(cls, L"ScrollBar") == 0)
+    {
+        SetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        InvalidateRect(hwnd, NULL, TRUE);
+    }
+
+    for (HWND child = GetWindow(hwnd, GW_CHILD); child != NULL; child = GetWindow(child, GW_HWNDNEXT))
+        ApplyRecursive(child, dark);
+}
+} // namespace
+
+void PluginDarkMode_SetHostPolicyAvailable(BOOL available, BOOL useWindowsDarkScheme)
+{
+    gHostPolicyAvailable = available;
+    gHostUseWindowsDarkScheme = useWindowsDarkScheme;
+}
+
+void PluginDarkMode_SetHostColors(COLORREF text, COLORREF background)
+{
+    gHostColors.text = text;
+    gHostColors.background = background;
+    gHostColors.readableText = EnsureReadable(text, background);
+}
+
+BOOL PluginDarkMode_ShouldUseDark()
+{
+    if (gHostPolicyAvailable)
+        return gHostUseWindowsDarkScheme;
+    return DetectSystemDarkFallback();
+}
+
+PluginDarkModeColors PluginDarkMode_GetColors()
+{
+    PluginDarkModeColors out = {GetSysColor(COLOR_BTNTEXT), GetSysColor(COLOR_BTNFACE), GetSysColor(COLOR_BTNTEXT)};
+    if (PluginDarkMode_ShouldUseDark())
+    {
+        out.background = RGB(32, 32, 32);
+        out.text = RGB(220, 220, 220);
+    }
+    if (gHostColors.text != CLR_INVALID)
+        out.text = gHostColors.text;
+    if (gHostColors.background != CLR_INVALID)
+        out.background = gHostColors.background;
+    out.readableText = EnsureReadable(out.text, out.background);
+    return out;
+}
+
+void PluginDarkMode_ApplyTitleBar(HWND hwnd)
+{
+    if (hwnd == NULL)
+        return;
+    const BOOL dark = PluginDarkMode_ShouldUseDark();
+    DwmSetWindowAttribute(hwnd, 20, &dark, sizeof(dark));
+}
+
+void PluginDarkMode_ApplyListTreeThemeRecursive(HWND hwnd)
+{
+    ApplyRecursive(hwnd, PluginDarkMode_ShouldUseDark());
+}
+
+HBRUSH PluginDarkMode_GetDialogCtlColorBrush(HDC dc, UINT)
+{
+    PluginDarkModeColors c = PluginDarkMode_GetColors();
+    if (gDialogBrush != NULL)
+        DeleteObject(gDialogBrush);
+    gDialogBrush = CreateSolidBrush(c.background);
+    if (dc != NULL)
+    {
+        SetTextColor(dc, c.readableText);
+        SetBkColor(dc, c.background);
+        SetBkMode(dc, TRANSPARENT);
+    }
+    return gDialogBrush;
+}

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -4,16 +4,19 @@
 #include "precomp.h"
 #include "plugindarkmode.h"
 
-#include <uxtheme.h>
-#include <dwmapi.h>
 #include <commctrl.h>
 
 namespace
 {
+using fnSetWindowTheme = HRESULT(WINAPI*)(HWND, LPCWSTR, LPCWSTR);
+using fnDwmSetWindowAttribute = HRESULT(WINAPI*)(HWND, DWORD, LPCVOID, DWORD);
+
 BOOL gHostPolicyAvailable = FALSE;
 BOOL gHostUseWindowsDarkScheme = FALSE;
 PluginDarkModeColors gHostColors = {CLR_INVALID, CLR_INVALID, CLR_INVALID};
 HBRUSH gDialogBrush = NULL;
+fnSetWindowTheme gSetWindowTheme = NULL;
+fnDwmSetWindowAttribute gDwmSetWindowAttribute = NULL;
 
 COLORREF EnsureReadable(COLORREF fg, COLORREF bg)
 {
@@ -48,7 +51,8 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
     GetClassNameW(hwnd, cls, _countof(cls));
     if (wcscmp(cls, L"SysListView32") == 0)
     {
-        SetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        if (gSetWindowTheme != NULL)
+            gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
         PluginDarkModeColors c = PluginDarkMode_GetColors();
         ListView_SetTextColor(hwnd, c.readableText);
         ListView_SetTextBkColor(hwnd, c.background);
@@ -57,7 +61,8 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
     }
     else if (wcscmp(cls, L"SysTreeView32") == 0)
     {
-        SetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        if (gSetWindowTheme != NULL)
+            gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
         PluginDarkModeColors c = PluginDarkMode_GetColors();
         TreeView_SetTextColor(hwnd, c.readableText);
         TreeView_SetBkColor(hwnd, c.background);
@@ -65,7 +70,8 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
     }
     else if (wcscmp(cls, L"SysHeader32") == 0 || wcscmp(cls, L"tooltips_class32") == 0 || wcscmp(cls, L"ScrollBar") == 0)
     {
-        SetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        if (gSetWindowTheme != NULL)
+            gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
         InvalidateRect(hwnd, NULL, TRUE);
     }
 
@@ -73,6 +79,22 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
         ApplyRecursive(child, dark);
 }
 } // namespace
+
+static void PluginDarkMode_EnsureApis()
+{
+    static bool loaded = false;
+    if (loaded)
+        return;
+    loaded = true;
+
+    HMODULE ux = LoadLibraryW(L"uxtheme.dll");
+    if (ux != NULL)
+        gSetWindowTheme = reinterpret_cast<fnSetWindowTheme>(GetProcAddress(ux, "SetWindowTheme"));
+
+    HMODULE dwm = LoadLibraryW(L"dwmapi.dll");
+    if (dwm != NULL)
+        gDwmSetWindowAttribute = reinterpret_cast<fnDwmSetWindowAttribute>(GetProcAddress(dwm, "DwmSetWindowAttribute"));
+}
 
 void PluginDarkMode_SetHostPolicyAvailable(BOOL available, BOOL useWindowsDarkScheme)
 {
@@ -89,6 +111,7 @@ void PluginDarkMode_SetHostColors(COLORREF text, COLORREF background)
 
 BOOL PluginDarkMode_ShouldUseDark()
 {
+    PluginDarkMode_EnsureApis();
     if (gHostPolicyAvailable)
         return gHostUseWindowsDarkScheme;
     return DetectSystemDarkFallback();
@@ -112,14 +135,17 @@ PluginDarkModeColors PluginDarkMode_GetColors()
 
 void PluginDarkMode_ApplyTitleBar(HWND hwnd)
 {
+    PluginDarkMode_EnsureApis();
     if (hwnd == NULL)
         return;
     const BOOL dark = PluginDarkMode_ShouldUseDark();
-    DwmSetWindowAttribute(hwnd, 20, &dark, sizeof(dark));
+    if (gDwmSetWindowAttribute != NULL)
+        gDwmSetWindowAttribute(hwnd, 20, &dark, sizeof(dark));
 }
 
 void PluginDarkMode_ApplyListTreeThemeRecursive(HWND hwnd)
 {
+    PluginDarkMode_EnsureApis();
     ApplyRecursive(hwnd, PluginDarkMode_ShouldUseDark());
 }
 

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -316,7 +316,8 @@ BOOL PluginDarkMode_HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, L
                 return FALSE;
         }
     }
-    if (dc != NULL && (message == WM_CTLCOLOREDIT || message == WM_CTLCOLORLISTBOX))
+    const bool isInput = (message == WM_CTLCOLOREDIT || message == WM_CTLCOLORLISTBOX);
+    if (dc != NULL && isInput)
     {
         SetBkMode(dc, OPAQUE);
         SetBkColor(dc, RGB(0x2A, 0x2A, 0x2A));
@@ -327,7 +328,7 @@ BOOL PluginDarkMode_HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, L
     if (dc != NULL)
     {
         SetTextColor(dc, c.readableText);
-        SetBkColor(dc, c.background);
+        SetBkColor(dc, isInput ? RGB(0x2A, 0x2A, 0x2A) : c.background);
     }
     *result = reinterpret_cast<LRESULT>(brush);
     return TRUE;

--- a/src/plugins/shared/plugindarkmode.h
+++ b/src/plugins/shared/plugindarkmode.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <windows.h>
+
+struct PluginDarkModeColors
+{
+    COLORREF text;
+    COLORREF background;
+    COLORREF readableText;
+};
+
+void PluginDarkMode_SetHostPolicyAvailable(BOOL available, BOOL useWindowsDarkScheme);
+void PluginDarkMode_SetHostColors(COLORREF text, COLORREF background);
+BOOL PluginDarkMode_ShouldUseDark();
+PluginDarkModeColors PluginDarkMode_GetColors();
+void PluginDarkMode_ApplyTitleBar(HWND hwnd);
+void PluginDarkMode_ApplyListTreeThemeRecursive(HWND hwnd);
+HBRUSH PluginDarkMode_GetDialogCtlColorBrush(HDC dc, UINT message);

--- a/src/plugins/shared/plugindarkmode.h
+++ b/src/plugins/shared/plugindarkmode.h
@@ -14,8 +14,11 @@ struct PluginDarkModeColors
 
 void PluginDarkMode_SetHostPolicyAvailable(BOOL available, BOOL useWindowsDarkScheme);
 void PluginDarkMode_SetHostColors(COLORREF text, COLORREF background);
+void PluginDarkMode_SetHostResolvedColors(COLORREF text, COLORREF background, COLORREF readableText);
 BOOL PluginDarkMode_ShouldUseDark();
 PluginDarkModeColors PluginDarkMode_GetColors();
 void PluginDarkMode_ApplyTitleBar(HWND hwnd);
 void PluginDarkMode_ApplyListTreeThemeRecursive(HWND hwnd);
 HBRUSH PluginDarkMode_GetDialogCtlColorBrush(HDC dc, UINT message);
+BOOL PluginDarkMode_HandleThemeMessage(HWND hwnd, UINT message, LPARAM lParam);
+BOOL PluginDarkMode_HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT* result);

--- a/src/plugins/shared/plugindarkmode_integration.md
+++ b/src/plugins/shared/plugindarkmode_integration.md
@@ -1,0 +1,24 @@
+# Plugin dark mode integration (short guide)
+
+Use `plugindarkmode.h` from plugin window/dialog procedures.
+
+## Messages to handle
+
+- `WM_THEMECHANGED`
+- `WM_SETTINGCHANGE` (especially `ImmersiveColorSet` / `WindowsThemeElement`)
+- `WM_CTLCOLORSTATIC`, `WM_CTLCOLORBTN`, `WM_CTLCOLOREDIT`
+
+## Recommended flow
+
+1. On plugin init (or when host config is known), call:
+   - `PluginDarkMode_SetHostPolicyAvailable(...)`
+   - `PluginDarkMode_SetHostColors(...)` (optional, preferred when host gives scheme colors)
+2. On `WM_THEMECHANGED` / `WM_SETTINGCHANGE`:
+   - call `PluginDarkMode_ApplyTitleBar(hwnd)`
+   - call `PluginDarkMode_ApplyListTreeThemeRecursive(hwnd)`
+   - invalidate/repaint if custom owner-draw controls are used
+3. On `WM_CTLCOLOR*`:
+   - return `PluginDarkMode_GetDialogCtlColorBrush((HDC)wParam, uMsg)`
+
+Host configuration (`Windows Dark Mode (experimental)`) has priority.  
+If host info is unavailable, the module safely falls back to system detection.

--- a/src/plugins/shared/winliblt.cpp
+++ b/src/plugins/shared/winliblt.cpp
@@ -11,7 +11,6 @@
 //****************************************************************************
 
 #include "precomp.h"
-#include "plugindarkmode.h"
 //#include <windows.h>
 #ifdef _MSC_VER
 #include <crtdbg.h>
@@ -489,27 +488,6 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
-    case WM_THEMECHANGED:
-    case WM_SETTINGCHANGE:
-    {
-        PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam);
-        InvalidateRect(HWindow, NULL, TRUE);
-        break;
-    }
-
-    case WM_CTLCOLORDLG:
-    case WM_CTLCOLORMSGBOX:
-    case WM_CTLCOLORSTATIC:
-    case WM_CTLCOLORBTN:
-    case WM_CTLCOLOREDIT:
-    case WM_CTLCOLORLISTBOX:
-    case WM_CTLCOLORSCROLLBAR:
-    {
-        LRESULT brush = 0;
-        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
-            return brush;
-        break;
-    }
     }
     return FALSE;
 }

--- a/src/plugins/shared/winliblt.cpp
+++ b/src/plugins/shared/winliblt.cpp
@@ -11,6 +11,7 @@
 //****************************************************************************
 
 #include "precomp.h"
+#include "plugindarkmode.h"
 //#include <windows.h>
 #ifdef _MSC_VER
 #include <crtdbg.h>
@@ -485,6 +486,28 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return TRUE;
         }
         }
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+    {
+        PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam);
+        InvalidateRect(HWindow, NULL, TRUE);
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        LRESULT brush = 0;
+        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+            return brush;
         break;
     }
     }

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -332,16 +332,21 @@ static void DestroyDarkModeBrushes()
 
 static COLORREF GetPaletteDialogTextColor()
 {
-    const COLORREF background = GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]);
-    const COLORREF text = GetCOLORREF(CurrentColors[ITEM_FG_NORMAL]);
-    return DarkModeEnsureReadableForeground(text, background);
+    const DarkModeColors& colors = DarkModeGetColors();
+    return colors.readableText;
 }
 
 static void UpdateMenuAndDialogBrushes(bool preferDarkMode)
 {
     const bool useDarkColors = preferDarkMode;
-    const COLORREF paletteBackground = GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]);
-    const COLORREF paletteText = GetPaletteDialogTextColor();
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF schemeBackground = useDarkColors ? GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]) : CLR_INVALID;
+    const COLORREF schemeText = useDarkColors ? GetCOLORREF(CurrentColors[ITEM_FG_NORMAL]) : CLR_INVALID;
+    DarkModeSetConfiguredColors(schemeText, schemeBackground, fallbackText, fallbackBackground);
+    const DarkModeColors& palette = DarkModeGetColors();
+    const COLORREF paletteBackground = palette.background;
+    const COLORREF paletteText = palette.readableText;
 
     if (useDarkColors)
     {
@@ -370,8 +375,8 @@ static void UpdateMenuAndDialogBrushes(bool preferDarkMode)
         HMenuGrayTextBrush = GetSysColorBrush(COLOR_3DSHADOW);
     }
 
-    COLORREF dialogText = useDarkColors ? paletteText : GetSysColor(COLOR_BTNTEXT);
-    COLORREF dialogBackground = useDarkColors ? paletteBackground : GetSysColor(COLOR_BTNFACE);
+    COLORREF dialogText = palette.readableText;
+    COLORREF dialogBackground = palette.background;
     DarkModeConfigureDialogColors(dialogText, dialogBackground, HDialogBrush);
 }
 

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -3319,6 +3319,11 @@ void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons)
     {
         COLORREF rebarColor = useDarkColors ? GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]) : GetSysColor(COLOR_BTNFACE);
         SendMessage(MainWindow->HTopRebar, RB_SETBKCOLOR, 0, (LPARAM)rebarColor);
+        COLORSCHEME cs;
+        cs.dwSize = sizeof(cs);
+        cs.clrBtnHighlight = useDarkColors ? DarkenColor(rebarColor, 18) : GetSysColor(COLOR_3DHILIGHT);
+        cs.clrBtnShadow = useDarkColors ? DarkenColor(rebarColor, 38) : GetSysColor(COLOR_3DSHADOW);
+        SendMessage(MainWindow->HTopRebar, RB_SETCOLORSCHEME, 0, (LPARAM)&cs);
         MainWindow->UpdateRebarVisuals();
     }
 

--- a/src/stswnd.cpp
+++ b/src/stswnd.cpp
@@ -816,7 +816,10 @@ void CStatusWindow::Paint(HDC hdc, BOOL highlightText, BOOL highlightHotTrackOnl
         textR.top++;
         textR.right--;
         textR.bottom--;
-        FillRect(dc, &textR, activeCaption ? HActiveCaptionBrush : HInactiveCaptionBrush);
+        if (useDark)
+            FillRectSolid(dc, &textR, GetStatusBkColor(activeCaption, TRUE));
+        else
+            FillRect(dc, &textR, activeCaption ? HActiveCaptionBrush : HInactiveCaptionBrush);
     }
 
     // text
@@ -1104,13 +1107,14 @@ void CStatusWindow::Paint(HDC hdc, BOOL highlightText, BOOL highlightHotTrackOnl
                 COLORREF oldColor;
                 if (isDirectoryLine && Configuration.ShowPanelCaption)
                 {
-                    oldColor = SetTextColor(dc, GetCOLORREF(CurrentColors[activeCaption ? HOT_ACTIVE : HOT_INACTIVE]));
+                    oldColor = SetTextColor(dc, GetStatusTextColor(activeCaption, TRUE, TRUE));
                 }
                 else
                 {
-                    oldColor = SetTextColor(dc, GetCOLORREF(CurrentColors[HOT_PANEL]));
+                    oldColor = SetTextColor(dc, GetStatusTextColor(activeCaption, FALSE, TRUE));
                     if (showFlashText)
-                        SetTextColor(dc, GetSysColor(COLOR_HIGHLIGHTTEXT));
+                        SetTextColor(dc, useDark ? GetStatusTextColor(activeCaption, FALSE, TRUE)
+                                                 : GetSysColor(COLOR_HIGHLIGHTTEXT));
                 }
                 HFONT hOldFont = NULL;
                 if (Configuration.SingleClick && HotItem != NULL)
@@ -2311,8 +2315,23 @@ BOOL CStatusWindow::GetFilterFrameRect(RECT* r)
 
 void CStatusWindow::OnColorsChanged()
 {
+    ItemBitmap.ReCreateForScreenDC();
+
     if (ToolBar != NULL)
+    {
         ToolBar->OnColorsChanged();
+        if (ToolBar->HWindow != NULL)
+        {
+            InvalidateRect(ToolBar->HWindow, NULL, TRUE);
+            UpdateWindow(ToolBar->HWindow);
+        }
+    }
+
+    if (HWindow != NULL)
+    {
+        InvalidateRect(HWindow, NULL, TRUE);
+        UpdateWindow(HWindow);
+    }
 }
 
 void CStatusWindow::SetFont()

--- a/src/stswnd.cpp
+++ b/src/stswnd.cpp
@@ -32,6 +32,35 @@ static COLORREF GetPanelBackgroundColor()
                                          : GetSysColor(COLOR_BTNFACE);
 }
 
+static COLORREF GetStatusBkColor(BOOL activeCaption, BOOL showPanelCaption)
+{
+    if (showPanelCaption)
+        return GetCOLORREF(CurrentColors[activeCaption ? ACTIVE_CAPTION_BK : INACTIVE_CAPTION_BK]);
+    return GetPanelBackgroundColor();
+}
+
+static COLORREF GetStatusTextColor(BOOL activeCaption, BOOL showPanelCaption, BOOL hot)
+{
+    if (hot)
+    {
+        if (showPanelCaption)
+            return GetCOLORREF(CurrentColors[activeCaption ? HOT_ACTIVE : HOT_INACTIVE]);
+        return GetCOLORREF(CurrentColors[HOT_PANEL]);
+    }
+    if (showPanelCaption)
+        return GetCOLORREF(CurrentColors[activeCaption ? ACTIVE_CAPTION_FG : INACTIVE_CAPTION_FG]);
+    return GetPanelDefaultTextColor();
+}
+
+static void FillRectSolid(HDC hDC, const RECT* rect, COLORREF color)
+{
+    HGDIOBJ oldBrush = SelectObject(hDC, GetStockObject(DC_BRUSH));
+    COLORREF oldColor = SetDCBrushColor(hDC, color);
+    FillRect(hDC, rect, (HBRUSH)GetStockObject(DC_BRUSH));
+    SetDCBrushColor(hDC, oldColor);
+    SelectObject(hDC, oldBrush);
+}
+
 //
 // ****************************************************************************
 // CStatusWindow
@@ -761,6 +790,7 @@ void CStatusWindow::Paint(HDC hdc, BOOL highlightText, BOOL highlightHotTrackOnl
     HDC dc = ItemBitmap.HMemDC;
 
     BOOL isDirectoryLine = (Border & blTop) != 0;
+    const bool useDark = DarkModeShouldUseDarkColors();
 
     RECT r;
     r.left = 0;

--- a/src/toolbar1.cpp
+++ b/src/toolbar1.cpp
@@ -6,6 +6,7 @@
 
 #include "bitmap.h"
 #include "toolbar.h"
+#include "darkmode.h"
 
 //*****************************************************************************
 //
@@ -882,7 +883,15 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return TRUE;
         RECT r;
         GetClientRect(HWindow, &r);
-        FillRect((HDC)wParam, &r, HDialogBrush);
+        if (DarkMode_ShouldUseDark())
+        {
+            HGDIOBJ oldBrush = SelectObject((HDC)wParam, GetStockObject(DC_BRUSH));
+            SetDCBrushColor((HDC)wParam, RGB(45, 45, 48));
+            FillRect((HDC)wParam, &r, (HBRUSH)GetStockObject(DC_BRUSH));
+            SelectObject((HDC)wParam, oldBrush);
+        }
+        else
+            FillRect((HDC)wParam, &r, HDialogBrush);
         return TRUE;
     }
 

--- a/src/toolbar2.cpp
+++ b/src/toolbar2.cpp
@@ -19,6 +19,20 @@
 #define TB_ICON_TB 3 // Number of points above and below the icon, including the border.
 #define TB_TEXT_TB 3
 
+static void FillRectWithColor(HDC hDC, const RECT* r, COLORREF color)
+{
+    HGDIOBJ oldBrush = SelectObject(hDC, GetStockObject(DC_BRUSH));
+    COLORREF oldColor = SetDCBrushColor(hDC, color);
+    FillRect(hDC, r, (HBRUSH)GetStockObject(DC_BRUSH));
+    SetDCBrushColor(hDC, oldColor);
+    SelectObject(hDC, oldBrush);
+}
+
+static COLORREF GetToolBarBkColor()
+{
+    return DarkMode_ShouldUseDark() ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE);
+}
+
 void CToolBar::SetFont()
 {
     CALL_STACK_MESSAGE1("CToolBar::SetFont()");

--- a/src/toolbar2.cpp
+++ b/src/toolbar2.cpp
@@ -428,6 +428,7 @@ void CToolBar::DrawItem(HDC hDC, int index)
         return;
     }
     BOOL vertical = (Style & TLB_STYLE_VERTICAL) != 0;
+    BOOL useDarkToolbar = DarkMode_ShouldUseDark();
 
     CToolBarItem* item = Items[index];
     int width = item->Width;
@@ -454,17 +455,23 @@ void CToolBar::DrawItem(HDC hDC, int index)
         r1.right = width;
         r1.bottom = Height;
     }
-    FillRect(CacheBitmap->HMemDC, &r1, HDialogBrush);
+    if (useDarkToolbar)
+        FillRectWithColor(CacheBitmap->HMemDC, &r1, GetToolBarBkColor());
+    else
+        FillRect(CacheBitmap->HMemDC, &r1, HDialogBrush);
 
     if (item->Style & TLBI_STYLE_SEPARATOR)
     {
+        COLORREF separatorDark = useDarkToolbar ? RGB(70, 70, 70) : GetSysColor(COLOR_BTNSHADOW);
+        COLORREF separatorLight = useDarkToolbar ? RGB(95, 95, 95) : GetSysColor(COLOR_BTNHIGHLIGHT);
         if (vertical)
         {
             int y = height / 2 - 1;
-            HPEN hOldPen = (HPEN)SelectObject(CacheBitmap->HMemDC, BtnShadowPen);
+            HGDIOBJ hOldPen = SelectObject(CacheBitmap->HMemDC, GetStockObject(DC_PEN));
+            SetDCPenColor(CacheBitmap->HMemDC, separatorDark);
             MoveToEx(CacheBitmap->HMemDC, 1, y, NULL);
             LineTo(CacheBitmap->HMemDC, Width - 1, y);
-            SelectObject(CacheBitmap->HMemDC, BtnHilightPen);
+            SetDCPenColor(CacheBitmap->HMemDC, separatorLight);
             MoveToEx(CacheBitmap->HMemDC, 1, y + 1, NULL);
             LineTo(CacheBitmap->HMemDC, Width - 1, y + 1);
             SelectObject(CacheBitmap->HMemDC, hOldPen);
@@ -472,10 +479,11 @@ void CToolBar::DrawItem(HDC hDC, int index)
         else
         {
             int x = width / 2 - 1;
-            HPEN hOldPen = (HPEN)SelectObject(CacheBitmap->HMemDC, BtnShadowPen);
+            HGDIOBJ hOldPen = SelectObject(CacheBitmap->HMemDC, GetStockObject(DC_PEN));
+            SetDCPenColor(CacheBitmap->HMemDC, separatorDark);
             MoveToEx(CacheBitmap->HMemDC, x, 1, NULL);
             LineTo(CacheBitmap->HMemDC, x, Height - 1);
-            SelectObject(CacheBitmap->HMemDC, BtnHilightPen);
+            SetDCPenColor(CacheBitmap->HMemDC, separatorLight);
             MoveToEx(CacheBitmap->HMemDC, x + 1, 1, NULL);
             LineTo(CacheBitmap->HMemDC, x + 1, Height - 1);
             SelectObject(CacheBitmap->HMemDC, hOldPen);
@@ -776,7 +784,10 @@ void CToolBar::DrawAllItems(HDC hDC)
                 r.top = offset;
                 r.right = Width;
                 r.bottom = offset + length;
-                FillRect(hDC, &r, HDialogBrush);
+                if (DarkMode_ShouldUseDark())
+                    FillRectWithColor(hDC, &r, GetToolBarBkColor());
+                else
+                    FillRect(hDC, &r, HDialogBrush);
             }
         }
     }
@@ -792,7 +803,10 @@ void CToolBar::DrawAllItems(HDC hDC)
                 r.top = 0;
                 r.right = offset + length;
                 r.bottom = Height;
-                FillRect(hDC, &r, HDialogBrush);
+                if (DarkMode_ShouldUseDark())
+                    FillRectWithColor(hDC, &r, GetToolBarBkColor());
+                else
+                    FillRect(hDC, &r, HDialogBrush);
             }
         }
     }

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -57,7 +57,8 @@ void ApplyViewerMenuTheme(HWND hwnd)
     info.cbSize = sizeof(info);
     info.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
 
-    const COLORREF background = DarkModeGetDialogBackgroundColor();
+    const DarkModeColors& dmColors = DarkModeGetColors();
+    const COLORREF background = dmColors.background;
     const int luminance = (GetRValue(background) * 30 + GetGValue(background) * 59 + GetBValue(background) * 11) / 100;
     const bool useDarkColors = DarkModeShouldUseDarkColors() || luminance < 128;
 

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -59,14 +59,13 @@ void ApplyViewerMenuTheme(HWND hwnd)
 
     const DarkModeColors& dmColors = DarkModeGetColors();
     const COLORREF background = dmColors.background;
-    const int luminance = (GetRValue(background) * 30 + GetGValue(background) * 59 + GetBValue(background) * 11) / 100;
-    const bool useDarkColors = DarkModeShouldUseDarkColors() || luminance < 128;
+    const bool useDarkColors = DarkModeShouldUseDarkColors();
 
     HBRUSH menuBrush = GetSysColorBrush(COLOR_MENU);
     if (useDarkColors)
     {
         HBRUSH brush = HDialogBrush;
-        if (brush == NULL || (!DarkModeShouldUseDarkColors() && luminance < 128))
+        if (brush == NULL)
         {
             brush = EnsureViewerMenuBrush(background, true);
         }


### PR DESCRIPTION
### Motivation
- Separate the decision whether the user selected the existing "Windows Dark" color scheme from the decision to apply native Windows dark-mode enhancements so native UI tweaks are only applied when appropriate. 
- Keep the existing configuration mapping and user-facing behavior unchanged (the Windows Dark scheme remains controlled via the existing scheme id / `Configuration.UseWindowsDarkMode`).
- Improve robustness of theme-change handling so native dark elements are refreshed when Windows theme-related broadcasts arrive without altering the configured color scheme.

### Description
- Added `IsWindowsDarkSchemeSelected()` which returns true when `Configuration.UseWindowsDarkMode` is active. 
- Added `ShouldApplyNativeDarkEnhancements()` which returns true only when the Windows Dark scheme is selected and High Contrast is not active. 
- Updated `DarkModeSetEnabled()` to evaluate its internal `gEnabled` state using `ShouldApplyNativeDarkEnhancements()` so the external API remains unchanged while the internal policy is explicit. 
- Enhanced `DarkModeHandleSettingChange()` to accept both `WM_SETTINGCHANGE` and `WM_THEMECHANGED`, detect `ImmersiveColorSet` and `WindowsThemeElement`, refresh color policy, and reapply native-enhancement state when theme changes occur.

### Testing
- Confirmed references and impact surface using searches with `rg` for dark-mode and theme-change symbols and verified the configuration mapping (`Configuration.UseWindowsDarkMode`) is still used; these searches completed successfully. 
- Inspected the modified `src/darkmode.cpp` with `sed` and `nl` to verify the new helper functions and updated message handling are present and wired correctly; file inspection returned the expected diffs. 
- Performed static review of call sites relying on `DarkModeShouldUseDarkColors()` and `DarkModeSetEnabled()` to ensure external behavior was preserved; checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10fff736788329befc0d0189b672c7)