### PR TITLE
Adjust LeftTabWindow position/width to account for LeftPanel tree view reserved width

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -7804,10 +7804,21 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
 
             if (LeftTabWindow != NULL && LeftTabWindow->HWindow != NULL)
             {
+                int leftTabX = 1;
+                int leftTabWidth = leftWidth;
+                if (LeftPanel != NULL)
+                {
+                    int treeReservedWidth = LeftPanel->GetTreeViewReservedWidth(leftWidth);
+                    leftTabX += treeReservedWidth;
+                    leftTabWidth -= treeReservedWidth;
+                    if (leftTabWidth < 0)
+                        leftTabWidth = 0;
+                }
+
                 UINT flags = SWP_NOACTIVATE | SWP_NOZORDER;
                 flags |= leftTabsVisible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW;
                 hdwp = HANDLES(DeferWindowPos(hdwp, LeftTabWindow->HWindow, NULL,
-                                              1, TopRebarHeight, leftWidth, leftTabHeight,
+                                              leftTabX, TopRebarHeight, leftTabWidth, leftTabHeight,
                                               flags));
             }
 


### PR DESCRIPTION
### Motivation
- Prevent the left tab area from overlapping the left panel's reserved tree view space by accounting for the tree width when laying out controls.

### Description
- Compute `treeReservedWidth` via `LeftPanel->GetTreeViewReservedWidth(leftWidth)`, then adjust `leftTabX` and `leftTabWidth` (clamped to >= 0) and pass those to `DeferWindowPos` for the `LeftTabWindow` instead of the previous fixed `1` and `leftWidth` values.

### Testing
- Project was built and the existing automated test suite was run and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1115c26bf083298695f12ec28975fd)