### PR TITLE
Apply dark mode to tab control overflow buttons

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1389,6 +1389,28 @@ void DarkModeUpdateListViewColors(HWND listView, COLORREF textColor, COLORREF ba
     InvalidateRect(listView, NULL, TRUE);
 }
 
+void DarkModeUpdateTabControlOverflowButtons(HWND tabControl)
+{
+    EnsureInitialized();
+    if (tabControl == NULL)
+        return;
+
+    const bool enableDark = DarkModeShouldUseDarkColors();
+#if USE_DARKMODELIB
+    DarkModeBackendDarkModelib::UpdateTabControlOverflowButtons(tabControl, enableDark);
+#endif
+
+    HWND upDown = NULL;
+    while ((upDown = FindWindowEx(tabControl, upDown, UPDOWN_CLASS, NULL)) != NULL)
+    {
+        if (gSupported)
+            DarkModeApplyWindow(upDown);
+        if (gSetWindowTheme != nullptr)
+            gSetWindowTheme(upDown, enableDark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        InvalidateRect(upDown, NULL, TRUE);
+    }
+}
+
 void DarkModeUpdateListViewColors(HWND listView)
 {
     EnsureInitialized();

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -77,3 +77,4 @@ COLORREF DarkModeEnsureReadableForeground(COLORREF foreground, COLORREF backgrou
 void DarkModeUpdateListViewColors(HWND listView);
 void DarkModeUpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors);
 void DarkModeApplyStaticTextColors(HWND hwndParent, HWND specificCtrl);
+void DarkModeUpdateTabControlOverflowButtons(HWND tabControl);

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -208,6 +208,33 @@ void ApplyStaticTextColors(HWND hwndParent, HWND specificCtrl, const DarkModeCol
 #endif
 }
 
+void UpdateTabControlOverflowButtons(HWND tabControl, bool enableDark)
+{
+#if USE_DARKMODELIB
+    if (tabControl != NULL)
+    {
+        if (enableDark)
+            dmlib::setTabCtrlUpDownSubclass(tabControl);
+        else
+            dmlib::removeTabCtrlUpDownSubclass(tabControl);
+
+        HWND upDown = NULL;
+        while ((upDown = FindWindowEx(tabControl, upDown, UPDOWN_CLASS, NULL)) != NULL)
+        {
+            if (enableDark)
+                dmlib::setUpDownCtrlSubclass(upDown);
+            else
+                dmlib::removeUpDownCtrlSubclass(upDown);
+
+            InvalidateRect(upDown, NULL, TRUE);
+        }
+    }
+#else
+    (void)tabControl;
+    (void)enableDark;
+#endif
+}
+
 void UpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors)
 {
 #if USE_DARKMODELIB

--- a/src/darkmode_backend_darkmodelib.h
+++ b/src/darkmode_backend_darkmodelib.h
@@ -19,4 +19,5 @@ bool HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT& result,
                     const DarkModeColors& colors, HBRUSH dialogBrush);
 void ApplyStaticTextColors(HWND hwndParent, HWND specificCtrl, const DarkModeColors& colors);
 void UpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors);
+void UpdateTabControlOverflowButtons(HWND tabControl, bool enableDark);
 } // namespace DarkModeBackendDarkModelib

--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -585,12 +585,21 @@ void CTabWindow::EnsureNewTabButton()
     }
 
     UpdateNewTabButtonWidth();
+    UpdateOverflowButtonColors();
 }
 
 void CTabWindow::RefreshLayout()
 {
     CALL_STACK_MESSAGE_NONE
     UpdateNewTabButtonWidth();
+    UpdateOverflowButtonColors();
+}
+
+void CTabWindow::UpdateOverflowButtonColors()
+{
+    CALL_STACK_MESSAGE_NONE
+    if (HWindow != NULL)
+        DarkModeUpdateTabControlOverflowButtons(HWindow);
 }
 
 bool CTabWindow::HandleMouseWheel(WPARAM wParam)
@@ -1449,6 +1458,7 @@ void CTabWindow::ScrollTabsByWheelSteps(int steps)
         TabCtrl_SetCurSel(HWindow, oldSel);
     }
 
+    UpdateOverflowButtonColors();
     InvalidateRect(HWindow, NULL, FALSE);
 }
 
@@ -1868,6 +1878,16 @@ LRESULT CTabWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE4("CTabWindow::WindowProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_SIZE:
+    case WM_THEMECHANGED:
+        UpdateOverflowButtonColors();
+        break;
+
+    case WM_PARENTNOTIFY:
+        if (LOWORD(wParam) == WM_CREATE)
+            UpdateOverflowButtonColors();
+        break;
+
     case WM_PAINT:
     {
         if (HWindow == NULL)

--- a/src/tabwnd.h
+++ b/src/tabwnd.h
@@ -54,6 +54,7 @@ private:
     int GetNewTabButtonIndex() const;
     BOOL IsNewTabButtonIndex(int index) const;
     void UpdateNewTabButtonWidth();
+    void UpdateOverflowButtonColors();
     bool IsReorderableIndex(int index) const;
     void StartDragTracking(int index, const POINT& pt);
     void UpdateDragTracking(const POINT& pt);


### PR DESCRIPTION
### Motivation

- Ensure the tab-strip overflow (the up/down arrows created as an internal `UPDOWN_CLASS` child of `SysTabControl32`) follows the selected color scheme when `Windows Dark Mode (experimental)` is chosen, because those arrows were remaining light and visually inconsistent in dark schemes.

### Description

- Add `DarkModeUpdateTabControlOverflowButtons(HWND)` (declared in `src/darkmode.h`, implemented in `src/darkmode.cpp`) which applies dark/native theming to a tab control's overflow up/down child windows and invalidates them.
- Implement backend support `DarkModeBackendDarkModelib::UpdateTabControlOverflowButtons(HWND, bool)` in `src/darkmode_backend_darkmodelib.h/.cpp` to call `dmlib::setTabCtrlUpDownSubclass`/`dmlib::setUpDownCtrlSubclass` when `USE_DARKMODELIB` is enabled and to invalidate the `updown` children.
- Integrate overflow updates into the tab panel by adding `CTabWindow::UpdateOverflowButtonColors()` (declared in `src/tabwnd.h`, implemented and invoked in `src/tabwnd.cpp`) and calling it after layout changes (`EnsureNewTabButton`, `RefreshLayout`), after simulating overflow scroll clicks (`ScrollTabsByWheelSteps`), and on `WM_SIZE`, `WM_THEMECHANGED` and `WM_PARENTNOTIFY` (child `WM_CREATE`) so the overflow buttons get themed/updated when created or when theme/layout changes.
- Also apply native dark theming and `DarkModeApplyWindow` to discovered up/down child windows from the common code path, ensuring both the `darkmodelib` subclassing and native `SetWindowTheme` are used when available.

### Testing

- Ran `git diff --check` to validate whitespace and trivial issues, which reported no problems.
- Checked for Windows build tooling (`msbuild`) but it is not available in this Linux container so a native Windows build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ceb3b722c83299ac69f094ac6d017)