### PR TITLE
Integrate PictView with shared plugin dark-mode support

### DIFF
--- a/src/plugins/pictview/dialogs.cpp
+++ b/src/plugins/pictview/dialogs.cpp
@@ -53,10 +53,48 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
+        ConfigurePictViewDarkModeFromHost();
+        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
         // horizontal and vertical centering of the dialog to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
         break; // want the focus from DefDlgProc
+    }
+
+    case WM_ERASEBKGND:
+    {
+        if (PluginDarkMode_ShouldUseDark())
+        {
+            RECT r;
+            GetClientRect(HWindow, &r);
+            HBRUSH brush = PluginDarkMode_GetDialogCtlColorBrush(NULL, WM_CTLCOLORDLG);
+            if (brush != NULL)
+                FillRect((HDC)wParam, &r, brush);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    {
+        LRESULT brush = 0;
+        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+            return brush;
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+    {
+        ConfigurePictViewDarkModeFromHost();
+        if (PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam))
+            return TRUE;
+        break;
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -71,6 +109,53 @@ void CCommonDialog::NotifDlgJustCreated()
 //
 // CCommonPropSheetPage
 //
+
+INT_PTR
+CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+    case WM_INITDIALOG:
+        ConfigurePictViewDarkModeFromHost();
+        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
+        break;
+
+    case WM_ERASEBKGND:
+    {
+        if (PluginDarkMode_ShouldUseDark())
+        {
+            RECT r;
+            GetClientRect(HWindow, &r);
+            HBRUSH brush = PluginDarkMode_GetDialogCtlColorBrush(NULL, WM_CTLCOLORDLG);
+            if (brush != NULL)
+                FillRect((HDC)wParam, &r, brush);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    {
+        LRESULT brush = 0;
+        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+            return brush;
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+        ConfigurePictViewDarkModeFromHost();
+        if (PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam))
+            return TRUE;
+        break;
+    }
+    return CPropSheetPage::DialogProc(uMsg, wParam, lParam);
+}
 
 void CCommonPropSheetPage::NotifDlgJustCreated()
 {
@@ -645,6 +730,8 @@ protected:
             WINDOWPOS* pos = (WINDOWPOS*)lParam;
             if (pos->flags & SWP_SHOWWINDOW)
             {
+                ConfigurePictViewDarkModeFromHost();
+                PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
                 HWND hParent = GetParent(HWindow);
                 if (hParent != NULL)
                     SalamanderGeneral->MultiMonCenterWindow(HWindow, hParent, TRUE);
@@ -652,11 +739,48 @@ protected:
             break;
         }
 
-        case WM_USER_CFGDLGDETACH: // we should detach from the dialog (already centered)
+        case WM_ERASEBKGND:
         {
+            if (PluginDarkMode_ShouldUseDark())
+            {
+                RECT r;
+                GetClientRect(HWindow, &r);
+                HBRUSH brush = PluginDarkMode_GetDialogCtlColorBrush(NULL, WM_CTLCOLORDLG);
+                if (brush != NULL)
+                    FillRect((HDC)wParam, &r, brush);
+                return TRUE;
+            }
+            break;
+        }
+
+        case WM_CTLCOLORSTATIC:
+        case WM_CTLCOLORBTN:
+        case WM_CTLCOLOREDIT:
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLORDLG:
+        case WM_CTLCOLORMSGBOX:
+        {
+            LRESULT brush = 0;
+            if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+                return brush;
+            break;
+        }
+
+        case WM_THEMECHANGED:
+        case WM_SETTINGCHANGE:
+            ConfigurePictViewDarkModeFromHost();
+            if (PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam))
+                return TRUE;
+            break;
+
+        case WM_NCDESTROY:
+        {
+            HWND hwnd = HWindow;
+            WNDPROC defWndProc = (WNDPROC)DefWndProc;
             DetachWindow();
-            delete this; // a bit hacky, but nobody touches 'this' anymore so it's fine
-            return 0;
+            LRESULT ret = CallWindowProc(defWndProc, hwnd, uMsg, wParam, lParam);
+            delete this;
+            return ret;
         }
         }
         return CWindow::WindowProc(uMsg, wParam, lParam);
@@ -694,7 +818,8 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
                 delete wnd; // the window is not attached, destroy it right here
             else
             {
-                PostMessage(wnd->HWindow, WM_USER_CFGDLGDETACH, 0, 0); // to detach CCenteredPropertyWindow from the dialog
+                ConfigurePictViewDarkModeFromHost();
+                PluginDarkMode_HandleThemeMessage(wnd->HWindow, WM_THEMECHANGED, 0);
             }
         }
     }
@@ -1801,7 +1926,16 @@ CExifDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     // cd->iSubItem == 1 &&
                     if (GetHighlightIndex(Items[(int)cd->nmcd.lItemlParam].Tag) != -1)
                     {
+                        cd->clrText = RGB(0, 0, 0);
                         cd->clrTextBk = RGB(255, 255, 0);
+                        SetWindowLongPtr(HWindow, DWLP_MSGRESULT, CDRF_NEWFONT);
+                        return TRUE;
+                    }
+                    if (PluginDarkMode_ShouldUseDark())
+                    {
+                        PluginDarkModeColors colors = PluginDarkMode_GetColors();
+                        cd->clrText = colors.readableText;
+                        cd->clrTextBk = colors.background;
                         SetWindowLongPtr(HWindow, DWLP_MSGRESULT, CDRF_NEWFONT);
                         return TRUE;
                     }

--- a/src/plugins/pictview/dialogs.h
+++ b/src/plugins/pictview/dialogs.h
@@ -42,6 +42,7 @@ public:
         : CPropSheetPage(title, modul, resID, helpID, flags, icon, origin) {}
 
 protected:
+    virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
     virtual void NotifDlgJustCreated();
 };
 

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -1191,10 +1191,12 @@ void CPluginInterface::Event(int event, DWORD param)
     {
     case PLUGINEVENT_COLORSCHANGED:
         InitGlobalGUIParameters();
+        ConfigurePictViewDarkModeFromHost();
         ViewerWindowQueue.BroadcastMessage(WM_USER_VIEWERCFGCHNG, 0, 0);
         break;
 
     case PLUGINEVENT_SETTINGCHANGE:
+        ConfigurePictViewDarkModeFromHost();
         ViewerWindowQueue.BroadcastMessage(WM_USER_SETTINGCHANGE, 0, 0);
         break;
 
@@ -3632,6 +3634,14 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_VIEWERCFGCHNG:
     {
+        ConfigurePictViewDarkModeFromHost();
+        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
+        if (MenuBar != NULL)
+            InvalidateRect(MenuBar->GetHWND(), NULL, TRUE);
+        if (HRebar != NULL)
+            InvalidateRect(HRebar, NULL, TRUE);
+        if (StatusBar != NULL && StatusBar->HWindow != NULL)
+            InvalidateRect(StatusBar->HWindow, NULL, TRUE);
         if (Renderer.HWindow != NULL)
             SendMessage(Renderer.HWindow, uMsg, wParam, lParam);
         return 0;
@@ -3639,10 +3649,19 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_SETTINGCHANGE:
     {
+        ConfigurePictViewDarkModeFromHost();
+        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
         if (MenuBar != NULL)
+        {
             MenuBar->SetFont();
+            InvalidateRect(MenuBar->GetHWND(), NULL, TRUE);
+        }
         if (ToolBar != NULL)
             ToolBar->SetFont();
+        if (HRebar != NULL)
+            InvalidateRect(HRebar, NULL, TRUE);
+        if (StatusBar != NULL && StatusBar->HWindow != NULL)
+            InvalidateRect(StatusBar->HWindow, NULL, TRUE);
         if (HHistogramWindow != NULL)
             SendMessage(HHistogramWindow, WM_USER_SETTINGCHANGE, wParam, lParam);
         return 0;

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -142,6 +142,45 @@ int SalamanderVersion = 0;
 // interface providing customized Windows controls used in Salamander
 CSalamanderGUIAbstract* SalamanderGUI = NULL;
 
+namespace
+{
+int PictViewColorLuminance(COLORREF color)
+{
+    return (GetRValue(color) * 30 + GetGValue(color) * 59 + GetBValue(color) * 11) / 100;
+}
+}
+
+void ConfigurePictViewDarkModeFromHost()
+{
+    BOOL useWindowsDarkMode = FALSE;
+    BOOL hasHostPolicy = SalamanderGeneral != NULL &&
+                         SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                                                &useWindowsDarkMode,
+                                                                sizeof(useWindowsDarkMode),
+                                                                NULL);
+    PluginDarkMode_SetHostPolicyAvailable(hasHostPolicy, useWindowsDarkMode);
+
+    if (hasHostPolicy && useWindowsDarkMode && SalamanderGeneral != NULL)
+    {
+        COLORREF text = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        COLORREF background = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+        COLORREF readable = text;
+        const int bgLum = PictViewColorLuminance(background);
+        const int fgLum = PictViewColorLuminance(text);
+        if (bgLum < 128 && fgLum < bgLum + 40)
+            readable = RGB(0xF0, 0xF0, 0xF0);
+        else if (bgLum >= 128 && fgLum > bgLum - 40)
+            readable = RGB(0x20, 0x20, 0x20);
+        PluginDarkMode_SetHostResolvedColors(text, background, readable);
+    }
+    else
+    {
+        PluginDarkMode_SetHostResolvedColors(GetSysColor(COLOR_BTNTEXT),
+                                             GetSysColor(COLOR_BTNFACE),
+                                             GetSysColor(COLOR_BTNTEXT));
+    }
+}
+
 CWindowQueue ViewerWindowQueue("PictView Viewers"); // list of all viewer windows
 CThreadQueue ThreadQueue("PictView Viewers");       // list of all window threads
 
@@ -515,6 +554,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the general Salamander interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    ConfigurePictViewDarkModeFromHost();
 
     // set the help file name
     SalamanderGeneral->SetHelpFileName("pictview.chm");
@@ -3149,6 +3189,7 @@ void CViewerWindow::ToggleStatusBar()
             StatusBar = NULL;
             return;
         }
+        PluginDarkMode_ApplyListTreeThemeRecursive(StatusBar->HWindow);
         G.StatusbarVisible = TRUE;
     }
     else
@@ -3360,6 +3401,8 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_CREATE:
     {
+        ConfigurePictViewDarkModeFromHost();
+        PluginDarkMode_ApplyTitleBar(HWindow);
         InitializeGraphics();
         MainMenu = SalamanderGUI->CreateMenuPopup();
         if (MainMenu == NULL)
@@ -3403,6 +3446,8 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             ToggleToolBar();
         if (G.StatusbarVisible)
             ToggleStatusBar();
+
+        PluginDarkMode_ApplyListTreeThemeRecursive(HWindow);
 
         SetFocus(Renderer.HWindow);
 
@@ -3552,6 +3597,36 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             DestroyIcon(hIcon);
 
         PostQuitMessage(0);
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+    {
+        ConfigurePictViewDarkModeFromHost();
+        if (PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam))
+        {
+            if (MenuBar != NULL)
+                InvalidateRect(MenuBar->GetHWND(), NULL, TRUE);
+            if (HRebar != NULL)
+                InvalidateRect(HRebar, NULL, TRUE);
+            if (StatusBar != NULL && StatusBar->HWindow != NULL)
+                InvalidateRect(StatusBar->HWindow, NULL, TRUE);
+            return 0;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    {
+        LRESULT brush = 0;
+        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+            return brush;
         break;
     }
 

--- a/src/plugins/pictview/pictview.h
+++ b/src/plugins/pictview/pictview.h
@@ -522,6 +522,8 @@ extern HINSTANCE HLanguage;   // handle to the SLG - language-dependent resource
 
 extern CSalamanderGeneralAbstract* SalamanderGeneral;
 extern CSalamanderGUIAbstract* SalamanderGUI;
+
+void ConfigurePictViewDarkModeFromHost();
 extern CPVW32DLL PVW32DLL;
 
 extern HINSTANCE EXIFLibrary;

--- a/src/plugins/pictview/precomp.h
+++ b/src/plugins/pictview/precomp.h
@@ -54,6 +54,7 @@
 #include "winliblt.h"
 #include "auxtools.h"
 #include "lukas\gdi.h"
+#include "..\shared\plugindarkmode.h"
 
 // When we have an old version of windowsx.h
 #ifndef GET_Y_LPARAM

--- a/src/plugins/pictview/saveas.cpp
+++ b/src/plugins/pictview/saveas.cpp
@@ -463,6 +463,8 @@ UINT_PTR CALLBACK SaveAsDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
     switch (uMsg)
     {
     case WM_INITDIALOG:
+        ConfigurePictViewDarkModeFromHost();
+        PluginDarkMode_HandleThemeMessage(hDlg, WM_THEMECHANGED, 0);
         // SalamanderGUI->ArrangeHorizontalLines(hDlg);  // not used for Windows common dialogs
         PositionControls(hDlg);
 
@@ -503,6 +505,35 @@ UINT_PTR CALLBACK SaveAsDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
         break;
     case WM_COMMAND:
         OnSaveAsCommand(hDlg, wParam, lParam);
+        break;
+    case WM_ERASEBKGND:
+        if (PluginDarkMode_ShouldUseDark())
+        {
+            RECT r;
+            GetClientRect(hDlg, &r);
+            HBRUSH brush = PluginDarkMode_GetDialogCtlColorBrush(NULL, WM_CTLCOLORDLG);
+            if (brush != NULL)
+                FillRect((HDC)wParam, &r, brush);
+            return TRUE;
+        }
+        break;
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    {
+        LRESULT brush = 0;
+        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
+            return brush;
+        break;
+    }
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+        ConfigurePictViewDarkModeFromHost();
+        if (PluginDarkMode_HandleThemeMessage(hDlg, uMsg, lParam))
+            return TRUE;
         break;
     case WM_DESTROY:
         psai = (SAVEAS_INFO_PTR)((OPENFILENAME*)GetWindowLongPtr(hDlg, GWLP_USERDATA))->lCustData;

--- a/src/plugins/pictview/vcxproj/pictview.vcxproj
+++ b/src/plugins/pictview/vcxproj/pictview.vcxproj
@@ -125,6 +125,8 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
+    </ClCompile>
     <ClCompile Include="..\..\shared\lukas\gdi.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
@@ -170,6 +172,8 @@
     <ClInclude Include="..\..\shared\auxtools.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\plugindarkmode.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\lukas\gdi.h">
     </ClInclude>

--- a/src/plugins/pictview/vcxproj/pictview.vcxproj.filters
+++ b/src/plugins/pictview/vcxproj/pictview.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="..\..\shared\dbg.cpp">
       <Filter>Shared</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\shared\lukas\gdi.cpp">
       <Filter>Shared</Filter>
     </ClCompile>
@@ -117,6 +120,9 @@
       <Filter>Shared</Filter>
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
+      <Filter>Shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\plugindarkmode.h">
       <Filter>Shared</Filter>
     </ClInclude>
     <ClInclude Include="..\..\shared\lukas\gdi.h">

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -44,6 +44,7 @@ void ResetPluginBrushes()
 
 const UINT_PTR PLUGIN_DARKMODE_HEADER_SUBCLASS_ID = 0x50444844; // "PDHD"
 const UINT_PTR PLUGIN_DARKMODE_STATUS_SUBCLASS_ID = 0x50445342; // "PDSB"
+const UINT_PTR PLUGIN_DARKMODE_TAB_SUBCLASS_ID = 0x50445442;    // "PDTB"
 
 void FillPluginColorRect(HDC hdc, const RECT* rect, COLORREF color)
 {
@@ -308,6 +309,127 @@ void EnsurePluginDarkStatusBarSubclass(HWND hwnd, BOOL dark)
     InvalidateRect(hwnd, NULL, TRUE);
 }
 
+void PaintPluginDarkTabControl(HWND hwnd, HDC hdc)
+{
+    if (hwnd == NULL || hdc == NULL)
+        return;
+
+    PluginDarkModeColors colors = PluginDarkMode_GetColors();
+    RECT client;
+    GetClientRect(hwnd, &client);
+    FillPluginColorRect(hdc, &client, colors.background);
+
+    HFONT font = reinterpret_cast<HFONT>(SendMessage(hwnd, WM_GETFONT, 0, 0));
+    HGDIOBJ oldFont = font != NULL ? SelectObject(hdc, font) : NULL;
+    COLORREF oldText = SetTextColor(hdc, colors.readableText);
+    int oldBkMode = SetBkMode(hdc, TRANSPARENT);
+
+    HPEN borderPen = CreatePen(PS_SOLID, 1, RGB(0x55, 0x55, 0x55));
+    HPEN oldPen = borderPen != NULL ? reinterpret_cast<HPEN>(SelectObject(hdc, borderPen)) : NULL;
+
+    const int count = TabCtrl_GetItemCount(hwnd);
+    const int selected = TabCtrl_GetCurSel(hwnd);
+    for (int i = 0; i < count; ++i)
+    {
+        RECT item;
+        if (!TabCtrl_GetItemRect(hwnd, i, &item))
+            continue;
+
+        const BOOL isSelected = i == selected;
+        FillPluginColorRect(hdc, &item, isSelected ? RGB(0x3A, 0x3A, 0x3A) : colors.background);
+        if (borderPen != NULL)
+        {
+            MoveToEx(hdc, item.left, item.bottom - 1, NULL);
+            LineTo(hdc, item.left, item.top);
+            LineTo(hdc, item.right - 1, item.top);
+            LineTo(hdc, item.right - 1, item.bottom);
+        }
+
+        TCHAR text[256] = {0};
+        TCITEM tci = {0};
+        tci.mask = TCIF_TEXT;
+        tci.pszText = text;
+        tci.cchTextMax = _countof(text);
+        SendMessage(hwnd, TCM_GETITEM, i, reinterpret_cast<LPARAM>(&tci));
+
+        RECT textRect = item;
+        textRect.left += 8;
+        textRect.right -= 8;
+        DrawText(hdc, text, -1, &textRect, DT_SINGLELINE | DT_VCENTER | DT_CENTER | DT_END_ELLIPSIS);
+    }
+
+    if (oldPen != NULL)
+        SelectObject(hdc, oldPen);
+    if (borderPen != NULL)
+        DeleteObject(borderPen);
+    SetBkMode(hdc, oldBkMode);
+    SetTextColor(hdc, oldText);
+    if (oldFont != NULL)
+        SelectObject(hdc, oldFont);
+}
+
+LRESULT CALLBACK PluginDarkTabSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+                                       UINT_PTR subclassId, DWORD_PTR)
+{
+    if (subclassId != PLUGIN_DARKMODE_TAB_SUBCLASS_ID)
+        return DefSubclassProc(hwnd, msg, wParam, lParam);
+
+    switch (msg)
+    {
+    case WM_NCDESTROY:
+        RemoveWindowSubclass(hwnd, PluginDarkTabSubclass, PLUGIN_DARKMODE_TAB_SUBCLASS_ID);
+        break;
+
+    case WM_ERASEBKGND:
+        if (PluginDarkMode_ShouldUseDark())
+            return TRUE;
+        break;
+
+    case WM_PAINT:
+        if (PluginDarkMode_ShouldUseDark())
+        {
+            PAINTSTRUCT ps;
+            HDC hdc = BeginPaint(hwnd, &ps);
+            PaintPluginDarkTabControl(hwnd, hdc);
+            EndPaint(hwnd, &ps);
+            return 0;
+        }
+        break;
+
+    case WM_PRINTCLIENT:
+        if (PluginDarkMode_ShouldUseDark())
+        {
+            PaintPluginDarkTabControl(hwnd, reinterpret_cast<HDC>(wParam));
+            return 0;
+        }
+        break;
+
+    case TCM_INSERTITEM:
+    case TCM_DELETEITEM:
+    case TCM_DELETEALLITEMS:
+    case TCM_SETCURSEL:
+    case TCM_SETITEM:
+    case WM_SETTEXT:
+    case WM_SIZE:
+    case WM_THEMECHANGED:
+        InvalidateRect(hwnd, NULL, TRUE);
+        break;
+    }
+
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+void EnsurePluginDarkTabSubclass(HWND hwnd, BOOL dark)
+{
+    if (hwnd == NULL)
+        return;
+    if (dark)
+        SetWindowSubclass(hwnd, PluginDarkTabSubclass, PLUGIN_DARKMODE_TAB_SUBCLASS_ID, 0);
+    else
+        RemoveWindowSubclass(hwnd, PluginDarkTabSubclass, PLUGIN_DARKMODE_TAB_SUBCLASS_ID);
+    InvalidateRect(hwnd, NULL, TRUE);
+}
+
 COLORREF EnsureReadable(COLORREF fg, COLORREF bg)
 {
     const int bl = (GetRValue(bg) * 30 + GetGValue(bg) * 59 + GetBValue(bg) * 11) / 100;
@@ -392,8 +514,14 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
         EnsurePluginDarkStatusBarSubclass(hwnd, dark);
         InvalidateRect(hwnd, NULL, TRUE);
     }
-    else if (wcscmp(cls, L"SysTabControl32") == 0 || wcscmp(cls, L"msctls_progress32") == 0 ||
-             wcscmp(cls, L"msctls_updown32") == 0)
+    else if (wcscmp(cls, L"SysTabControl32") == 0)
+    {
+        if (gSetWindowTheme != NULL)
+            gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        EnsurePluginDarkTabSubclass(hwnd, dark);
+        InvalidateRect(hwnd, NULL, TRUE);
+    }
+    else if (wcscmp(cls, L"msctls_progress32") == 0 || wcscmp(cls, L"msctls_updown32") == 0)
     {
         if (gSetWindowTheme != NULL)
             gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
@@ -423,6 +551,8 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
                 gSetWindowTheme(hwnd, dark ? L"" : nullptr, nullptr);
             else if (type == BS_AUTOCHECKBOX || type == BS_CHECKBOX || type == BS_AUTO3STATE ||
                      type == BS_3STATE || type == BS_AUTORADIOBUTTON || type == BS_RADIOBUTTON)
+                gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+            else
                 gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
             InvalidateRect(hwnd, NULL, TRUE);
         }

--- a/src/plugins/shared/plugindarkmode.cpp
+++ b/src/plugins/shared/plugindarkmode.cpp
@@ -43,6 +43,7 @@ void ResetPluginBrushes()
 }
 
 const UINT_PTR PLUGIN_DARKMODE_HEADER_SUBCLASS_ID = 0x50444844; // "PDHD"
+const UINT_PTR PLUGIN_DARKMODE_STATUS_SUBCLASS_ID = 0x50445342; // "PDSB"
 
 void FillPluginColorRect(HDC hdc, const RECT* rect, COLORREF color)
 {
@@ -168,6 +169,145 @@ void EnsurePluginDarkHeaderSubclass(HWND hwnd, BOOL dark)
     InvalidateRect(hwnd, NULL, TRUE);
 }
 
+
+void PaintPluginDarkStatusBar(HWND hwnd, HDC hdc)
+{
+    if (hwnd == NULL || hdc == NULL)
+        return;
+
+    RECT client;
+    GetClientRect(hwnd, &client);
+    PluginDarkModeColors colors = PluginDarkMode_GetColors();
+    FillPluginColorRect(hdc, &client, colors.background);
+
+    HFONT font = reinterpret_cast<HFONT>(SendMessage(hwnd, WM_GETFONT, 0, 0));
+    HGDIOBJ oldFont = font != NULL ? SelectObject(hdc, font) : NULL;
+    COLORREF oldText = SetTextColor(hdc, colors.readableText);
+    int oldBkMode = SetBkMode(hdc, TRANSPARENT);
+
+    int borders[3] = {0, 0, 0};
+    SendMessage(hwnd, SB_GETBORDERS, 0, reinterpret_cast<LPARAM>(borders));
+    const int partCount = static_cast<int>(SendMessage(hwnd, SB_GETPARTS, 0, 0));
+    const int count = partCount > 0 ? partCount : 1;
+
+    for (int i = 0; i < count; ++i)
+    {
+        RECT part = client;
+        if (partCount > 0)
+            SendMessage(hwnd, SB_GETRECT, i, reinterpret_cast<LPARAM>(&part));
+
+        if (i + 1 < count)
+        {
+            RECT edge = part;
+            edge.left = edge.right - (borders[2] > 0 ? borders[2] : 1);
+            FillPluginColorRect(hdc, &edge, RGB(0x4A, 0x4A, 0x4A));
+        }
+
+        part.left += borders[2] + 2;
+        part.right -= borders[0] + 2;
+
+        HICON icon = reinterpret_cast<HICON>(SendMessage(hwnd, SB_GETICON, i, 0));
+        if (icon != NULL)
+        {
+            const int iconSize = GetSystemMetrics(SM_CXSMICON);
+            const int y = part.top + ((part.bottom - part.top) - iconSize) / 2;
+            DrawIconEx(hdc, part.left, y, icon, iconSize, iconSize, 0, NULL, DI_NORMAL);
+            part.left += iconSize + 4;
+        }
+
+        const LRESULT textLen = SendMessage(hwnd, SB_GETTEXTLENGTH, i, 0);
+        const DWORD flags = HIWORD(textLen);
+        const int len = LOWORD(textLen) < 1023 ? LOWORD(textLen) : 1023;
+        TCHAR text[1024];
+        text[0] = 0;
+        const LRESULT itemData = SendMessage(hwnd, SB_GETTEXT, i, reinterpret_cast<LPARAM>(text));
+
+        if ((flags & SBT_OWNERDRAW) != 0 && len == 0)
+        {
+            const UINT id = static_cast<UINT>(GetDlgCtrlID(hwnd));
+            DRAWITEMSTRUCT dis = {0};
+            dis.CtlType = ODT_STATIC;
+            dis.CtlID = id;
+            dis.itemID = static_cast<UINT>(i);
+            dis.itemAction = ODA_DRAWENTIRE;
+            dis.hwndItem = hwnd;
+            dis.hDC = hdc;
+            dis.rcItem = part;
+            dis.itemData = static_cast<ULONG_PTR>(itemData);
+            SendMessage(GetParent(hwnd), WM_DRAWITEM, id, reinterpret_cast<LPARAM>(&dis));
+        }
+        else
+        {
+            text[len] = 0;
+            DrawText(hdc, text, -1, &part, DT_SINGLELINE | DT_VCENTER | DT_LEFT | DT_NOPREFIX | DT_PATH_ELLIPSIS);
+        }
+    }
+
+    SetBkMode(hdc, oldBkMode);
+    SetTextColor(hdc, oldText);
+    if (oldFont != NULL)
+        SelectObject(hdc, oldFont);
+}
+
+LRESULT CALLBACK PluginDarkStatusBarSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+                                             UINT_PTR subclassId, DWORD_PTR)
+{
+    if (subclassId != PLUGIN_DARKMODE_STATUS_SUBCLASS_ID)
+        return DefSubclassProc(hwnd, msg, wParam, lParam);
+
+    switch (msg)
+    {
+    case WM_NCDESTROY:
+        RemoveWindowSubclass(hwnd, PluginDarkStatusBarSubclass, PLUGIN_DARKMODE_STATUS_SUBCLASS_ID);
+        break;
+
+    case WM_ERASEBKGND:
+        if (PluginDarkMode_ShouldUseDark())
+            return TRUE;
+        break;
+
+    case WM_PAINT:
+        if (PluginDarkMode_ShouldUseDark())
+        {
+            PAINTSTRUCT ps;
+            HDC hdc = BeginPaint(hwnd, &ps);
+            PaintPluginDarkStatusBar(hwnd, hdc);
+            EndPaint(hwnd, &ps);
+            return 0;
+        }
+        break;
+
+    case WM_PRINTCLIENT:
+        if (PluginDarkMode_ShouldUseDark())
+        {
+            PaintPluginDarkStatusBar(hwnd, reinterpret_cast<HDC>(wParam));
+            return 0;
+        }
+        break;
+
+    case SB_SETTEXT:
+    case SB_SETPARTS:
+    case WM_SETTEXT:
+    case WM_SIZE:
+    case WM_THEMECHANGED:
+        InvalidateRect(hwnd, NULL, TRUE);
+        break;
+    }
+
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+void EnsurePluginDarkStatusBarSubclass(HWND hwnd, BOOL dark)
+{
+    if (hwnd == NULL)
+        return;
+    if (dark)
+        SetWindowSubclass(hwnd, PluginDarkStatusBarSubclass, PLUGIN_DARKMODE_STATUS_SUBCLASS_ID, 0);
+    else
+        RemoveWindowSubclass(hwnd, PluginDarkStatusBarSubclass, PLUGIN_DARKMODE_STATUS_SUBCLASS_ID);
+    InvalidateRect(hwnd, NULL, TRUE);
+}
+
 COLORREF EnsureReadable(COLORREF fg, COLORREF bg)
 {
     const int bl = (GetRValue(bg) * 30 + GetGValue(bg) * 59 + GetBValue(bg) * 11) / 100;
@@ -242,6 +382,22 @@ void ApplyRecursive(HWND hwnd, BOOL dark)
             InvalidateRect(parent, NULL, TRUE);
             parent = GetParent(parent);
         }
+    }
+    else if (wcscmp(cls, L"msctls_statusbar32") == 0)
+    {
+        if (gSetWindowTheme != NULL)
+            gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        PluginDarkModeColors c = PluginDarkMode_GetColors();
+        SendMessage(hwnd, SB_SETBKCOLOR, 0, static_cast<LPARAM>(dark ? c.background : CLR_DEFAULT));
+        EnsurePluginDarkStatusBarSubclass(hwnd, dark);
+        InvalidateRect(hwnd, NULL, TRUE);
+    }
+    else if (wcscmp(cls, L"SysTabControl32") == 0 || wcscmp(cls, L"msctls_progress32") == 0 ||
+             wcscmp(cls, L"msctls_updown32") == 0)
+    {
+        if (gSetWindowTheme != NULL)
+            gSetWindowTheme(hwnd, dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        InvalidateRect(hwnd, NULL, TRUE);
     }
     else if (wcscmp(cls, L"Edit") == 0 || wcscmp(cls, L"ComboBox") == 0 || wcscmp(cls, L"ComboBoxEx32") == 0 ||
              wcscmp(cls, L"ListBox") == 0)
@@ -320,8 +476,10 @@ void InvalidateKnownDarkArtifacts(HWND hwnd)
         return;
     if (wcscmp(cls, L"SysHeader32") == 0 || wcscmp(cls, L"ReBarWindow32") == 0 ||
         wcscmp(cls, L"ToolbarWindow32") == 0 || wcscmp(cls, L"Static") == 0 ||
-        wcscmp(cls, L"Edit") == 0 || wcscmp(cls, L"ComboBox") == 0 ||
-        wcscmp(cls, L"ComboBoxEx32") == 0 || wcscmp(cls, L"ListBox") == 0)
+        wcscmp(cls, L"msctls_statusbar32") == 0 || wcscmp(cls, L"SysTabControl32") == 0 ||
+        wcscmp(cls, L"msctls_progress32") == 0 || wcscmp(cls, L"Edit") == 0 ||
+        wcscmp(cls, L"ComboBox") == 0 || wcscmp(cls, L"ComboBoxEx32") == 0 ||
+        wcscmp(cls, L"ListBox") == 0)
         InvalidateRect(hwnd, NULL, TRUE);
     for (HWND child = GetWindow(hwnd, GW_CHILD); child != NULL; child = GetWindow(child, GW_HWNDNEXT))
         InvalidateKnownDarkArtifacts(child);


### PR DESCRIPTION
### Motivation
- PictView dialogs and viewer windows were not following the host-selected "Windows Dark Mode (experimental)" scheme, producing mixed light/dark UI components; the goal is to make PictView respect the host dark-mode policy and use resolved host colors so all plugin UI becomes consistent in dark mode.

### Description
- Wire PictView into the shared plugin dark-mode helpers by adding `plugindarkmode.h` to PictView precompiled header and calling a new `ConfigurePictViewDarkModeFromHost()` helper that resolves host colors and policy.  
- Add dark-mode handling to the viewer main window: apply title-bar dark attribute, call `PluginDarkMode_ApplyListTreeThemeRecursive()` when windows/widgets are created, and handle `WM_THEMECHANGED`, `WM_SETTINGCHANGE` and `WM_CTLCOLOR*` to return plugin brushes.  
- Update all PictView dialog flows (common dialogs, property sheet pages, Save As hook, EXIF/Image Properties, About, Configuration, etc.) to initialize dark-mode, handle `WM_ERASEBKGND` and `WM_CTLCOLOR*`, and react to theme/setting changes; also adjust EXIF list custom draw to use dark-mode text/background and keep highlight legible.  
- Extend shared plugin dark-mode helpers (`plugindarkmode.cpp`) with status-bar painting/subclass support (paint icons + text, handle SB messages) and add theming support for a few extra common controls used by PictView.  
- Add `plugindarkmode.cpp`/`.h` to the PictView Visual Studio project (`pictview.vcxproj` / filters) so the helper compiles into the plugin.

### Testing
- Ran `git diff --check` to ensure no trivial whitespace/merge errors (passed).  
- Verified Visual Studio project XML parses for modified files with `python3 xml.etree.ElementTree.parse()` (both `pictview.vcxproj` and `.filters` parsed OK).  
- Performed repository static checks (balanced braces count and quick grep for new symbols); modifications committed successfully.  
- Note: a full Windows/MSBuild build was not executed in this environment (`msbuild` not available), so runtime validation on Windows is still required (expected next step: build + manual smoke test of PictView windows in dark scheme).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e1bd4056c8329bf7124017272dfdc)