### PR TITLE
Enable dark mode styling in PictView

### DIFF
--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -121,7 +121,7 @@ void ApplyTree(HWND hwnd)
             // tear down any hooks left from a previous Windows Dark Mode session.
             RemoveWindowAndChildSubclasses(hwnd);
         }
-        dmlib::setDarkTitleBar(hwnd, dark);
+        dmlib::setDarkTitleBar(hwnd);
     }
 #else
     (void)hwnd;
@@ -170,8 +170,8 @@ bool HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT& result,
                     {
                         // Follow darkmodelib demo behavior expectation: button labels in dark mode
                         // must stay high-contrast (light) regardless of host palette drift.
-                        textColor = dmlib::isDarkTheme() ? RGB(0xF0, 0xF0, 0xF0)
-                                                         : EnsureReadableForBackground(colors.readableText, colors.background);
+                        textColor = DarkMode_ShouldUseDark() ? RGB(0xF0, 0xF0, 0xF0)
+                                                              : EnsureReadableForBackground(colors.readableText, colors.background);
                     }
                 }
             }

--- a/src/plugins/pictview/dialogs.cpp
+++ b/src/plugins/pictview/dialogs.cpp
@@ -32,6 +32,16 @@ void ApplyPictViewDarkMode(HWND hwnd)
     }
 }
 
+bool ApplyPictViewDarkModeIfSelected(HWND hwnd)
+{
+    ConfigurePictViewDarkModeFromHost();
+    if (!PictViewShouldUseWindowsDarkMode())
+        return false;
+
+    ApplyPictViewDarkMode(hwnd);
+    return true;
+}
+
 void RedrawPictViewConfigPage(HWND hwnd)
 {
     if (hwnd == NULL)
@@ -162,7 +172,8 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
-        ApplyPictViewDarkMode(HWindow);
+        ApplyPictViewDarkModeIfSelected(HWindow);
+        QueuePictViewConfigPageRedraw(HWindow);
         break;
     }
 
@@ -177,9 +188,7 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (wParam != FALSE)
         {
-            ConfigurePictViewDarkModeFromHost();
-            if (PictViewShouldUseWindowsDarkMode())
-                ApplyPictViewDarkMode(HWindow);
+            ApplyPictViewDarkModeIfSelected(HWindow);
             QueuePictViewConfigPageRedraw(HWindow);
         }
         break;
@@ -231,7 +240,8 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 void CCommonPropSheetPage::NotifDlgJustCreated()
 {
     SalamanderGUI->ArrangeHorizontalLines(HWindow);
-    ApplyPictViewDarkMode(HWindow);
+    ApplyPictViewDarkModeIfSelected(HWindow);
+    QueuePictViewConfigPageRedraw(HWindow);
 }
 
 //****************************************************************************
@@ -803,7 +813,7 @@ protected:
         {
         case WM_CREATE:
         {
-            ApplyPictViewDarkMode(HWindow);
+            ApplyPictViewDarkModeIfSelected(HWindow);
             break;
         }
 
@@ -901,7 +911,7 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
 {
     if (uMsg == PSCB_INITIALIZED) // attach to the dialog
     {
-        ApplyPictViewDarkMode(HWindow);
+        BOOL keepAttached = ApplyPictViewDarkModeIfSelected(HWindow) ? TRUE : FALSE;
         CCenteredPropertyWindow* wnd = new CCenteredPropertyWindow;
         if (wnd != NULL)
         {
@@ -910,9 +920,14 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
                 delete wnd; // the window is not attached, destroy it right here
             else
             {
-                // Keep the subclass attached for the lifetime of the property sheet.
-                // It handles dark CTLCOLOR/theme messages for the tab and button area
-                // outside individual property pages and redraws pages when switching tabs.
+                if (!keepAttached)
+                    PostMessage(wnd->HWindow, WM_USER_CFGDLGDETACH, 0, 0); // light mode: detach after centering like the original dialog
+                else
+                {
+                    // Keep the subclass attached for the lifetime of the property sheet.
+                    // It handles dark CTLCOLOR/theme messages for the tab and button area
+                    // outside individual property pages and redraws pages when switching tabs.
+                }
             }
         }
     }

--- a/src/plugins/pictview/dialogs.cpp
+++ b/src/plugins/pictview/dialogs.cpp
@@ -19,6 +19,8 @@
 
 namespace
 {
+const UINT WM_USER_CFGPAGE_REDRAW = WM_APP + 3252;
+
 void ApplyPictViewDarkMode(HWND hwnd)
 {
     ConfigurePictViewDarkModeFromHost();
@@ -28,6 +30,23 @@ void ApplyPictViewDarkMode(HWND hwnd)
         DarkModeRefreshTitleBar(hwnd);
         DarkModeApplyTree(hwnd);
     }
+}
+
+void RedrawPictViewConfigPage(HWND hwnd)
+{
+    if (hwnd == NULL)
+        return;
+
+    HWND parent = GetParent(hwnd);
+    if (parent != NULL)
+        RedrawWindow(parent, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+    RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
+}
+
+void QueuePictViewConfigPageRedraw(HWND hwnd)
+{
+    if (hwnd != NULL)
+        PostMessage(hwnd, WM_USER_CFGPAGE_REDRAW, 0, 0);
 }
 
 bool HandlePictViewDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR& result)
@@ -158,10 +177,18 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (wParam != FALSE)
         {
-            ApplyPictViewDarkMode(HWindow);
-            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+            ConfigurePictViewDarkModeFromHost();
+            if (PictViewShouldUseWindowsDarkMode())
+                ApplyPictViewDarkMode(HWindow);
+            QueuePictViewConfigPageRedraw(HWindow);
         }
         break;
+    }
+
+    case WM_USER_CFGPAGE_REDRAW:
+    {
+        RedrawPictViewConfigPage(HWindow);
+        return TRUE;
     }
 
     case WM_SETTINGCHANGE:
@@ -173,6 +200,14 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             InvalidateRect(HWindow, NULL, TRUE);
             return TRUE;
         }
+        break;
+    }
+
+    case WM_NOTIFY:
+    {
+        LPNMHDR hdr = (LPNMHDR)lParam;
+        if (hdr != NULL && hdr->code == PSN_SETACTIVE)
+            QueuePictViewConfigPageRedraw(HWindow);
         break;
     }
 
@@ -809,8 +844,14 @@ protected:
         {
             LPNMHDR hdr = (LPNMHDR)lParam;
             if (hdr != NULL && hdr->code == TCN_SELCHANGE)
-                RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+                QueuePictViewConfigPageRedraw((HWND)SendMessage(HWindow, PSM_GETCURRENTPAGEHWND, 0, 0));
             break;
+        }
+
+        case WM_USER_CFGPAGE_REDRAW:
+        {
+            RedrawPictViewConfigPage((HWND)SendMessage(HWindow, PSM_GETCURRENTPAGEHWND, 0, 0));
+            return 0;
         }
 
         case WM_WINDOWPOSCHANGING:

--- a/src/plugins/pictview/dialogs.cpp
+++ b/src/plugins/pictview/dialogs.cpp
@@ -3,6 +3,8 @@
 
 #include "precomp.h"
 
+#include "../../darkmode.h"
+
 #include "lib/pvw32dll.h"
 #include "renderer.h"
 #include "pictview.h"
@@ -13,6 +15,31 @@
 #include "exif/exif.h"
 #include "exif/libexif/exif-tag.h"
 #include "utils.h"
+
+
+namespace
+{
+void ApplyPictViewDarkMode(HWND hwnd)
+{
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+bool HandlePictViewDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR& result)
+{
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        result = (INT_PTR)brush;
+        return true;
+    }
+    return false;
+}
+}
 
 // Enforces ANSI variant
 #define ListView_SetItemTextA(hwndLV, i, iSubItem_, pszText_) \
@@ -53,10 +80,43 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
+        ApplyPictViewDarkMode(HWindow);
         // horizontal and vertical centering of the dialog to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
         break; // want the focus from DefDlgProc
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyPictViewDarkMode(HWindow);
+        InvalidateRect(HWindow, NULL, TRUE);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyPictViewDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandlePictViewDarkCtlColor(uMsg, wParam, lParam, result))
+            return result;
+        break;
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -65,6 +125,7 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 void CCommonDialog::NotifDlgJustCreated()
 {
     SalamanderGUI->ArrangeHorizontalLines(HWindow);
+    ApplyPictViewDarkMode(HWindow);
 }
 
 // ****************************************************************************
@@ -72,9 +133,56 @@ void CCommonDialog::NotifDlgJustCreated()
 // CCommonPropSheetPage
 //
 
+INT_PTR
+CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+    case WM_INITDIALOG:
+    {
+        ApplyPictViewDarkMode(HWindow);
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyPictViewDarkMode(HWindow);
+        InvalidateRect(HWindow, NULL, TRUE);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyPictViewDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandlePictViewDarkCtlColor(uMsg, wParam, lParam, result))
+            return result;
+        break;
+    }
+    }
+    return CPropSheetPage::DialogProc(uMsg, wParam, lParam);
+}
+
 void CCommonPropSheetPage::NotifDlgJustCreated()
 {
     SalamanderGUI->ArrangeHorizontalLines(HWindow);
+    ApplyPictViewDarkMode(HWindow);
 }
 
 //****************************************************************************
@@ -640,6 +748,12 @@ protected:
     {
         switch (uMsg)
         {
+        case WM_CREATE:
+        {
+            ApplyPictViewDarkMode(HWindow);
+            break;
+        }
+
         case WM_WINDOWPOSCHANGING:
         {
             WINDOWPOS* pos = (WINDOWPOS*)lParam;
@@ -686,6 +800,7 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
 {
     if (uMsg == PSCB_INITIALIZED) // attach to the dialog
     {
+        ApplyPictViewDarkMode(HWindow);
         CCenteredPropertyWindow* wnd = new CCenteredPropertyWindow;
         if (wnd != NULL)
         {
@@ -1579,6 +1694,7 @@ CExifDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DWORD exFlags = LVS_EX_FULLROWSELECT;
         DWORD origFlags = ListView_GetExtendedListViewStyle(HListView);
         ListView_SetExtendedListViewStyle(HListView, origFlags | exFlags); // 4.71
+        DarkModeUpdateListViewColors(HListView);
 
         InitListView();
 
@@ -1801,7 +1917,15 @@ CExifDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     // cd->iSubItem == 1 &&
                     if (GetHighlightIndex(Items[(int)cd->nmcd.lItemlParam].Tag) != -1)
                     {
-                        cd->clrTextBk = RGB(255, 255, 0);
+                        if (DarkModeShouldUseDarkColors())
+                        {
+                            cd->clrText = DarkModeGetDialogTextColor();
+                            cd->clrTextBk = RGB(0x5A, 0x50, 0x00);
+                        }
+                        else
+                        {
+                            cd->clrTextBk = RGB(255, 255, 0);
+                        }
                         SetWindowLongPtr(HWindow, DWLP_MSGRESULT, CDRF_NEWFONT);
                         return TRUE;
                     }

--- a/src/plugins/pictview/dialogs.cpp
+++ b/src/plugins/pictview/dialogs.cpp
@@ -172,8 +172,8 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
-        ApplyPictViewDarkModeIfSelected(HWindow);
-        QueuePictViewConfigPageRedraw(HWindow);
+        if (ApplyPictViewDarkModeIfSelected(HWindow))
+            QueuePictViewConfigPageRedraw(HWindow);
         break;
     }
 
@@ -188,8 +188,8 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (wParam != FALSE)
         {
-            ApplyPictViewDarkModeIfSelected(HWindow);
-            QueuePictViewConfigPageRedraw(HWindow);
+            if (ApplyPictViewDarkModeIfSelected(HWindow))
+                QueuePictViewConfigPageRedraw(HWindow);
         }
         break;
     }
@@ -215,7 +215,7 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_NOTIFY:
     {
         LPNMHDR hdr = (LPNMHDR)lParam;
-        if (hdr != NULL && hdr->code == PSN_SETACTIVE)
+        if (hdr != NULL && hdr->code == PSN_SETACTIVE && PictViewShouldUseWindowsDarkMode())
             QueuePictViewConfigPageRedraw(HWindow);
         break;
     }
@@ -240,8 +240,8 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 void CCommonPropSheetPage::NotifDlgJustCreated()
 {
     SalamanderGUI->ArrangeHorizontalLines(HWindow);
-    ApplyPictViewDarkModeIfSelected(HWindow);
-    QueuePictViewConfigPageRedraw(HWindow);
+    if (ApplyPictViewDarkModeIfSelected(HWindow))
+        QueuePictViewConfigPageRedraw(HWindow);
 }
 
 //****************************************************************************

--- a/src/plugins/pictview/dialogs.cpp
+++ b/src/plugins/pictview/dialogs.cpp
@@ -34,7 +34,6 @@ void ApplyPictViewDarkMode(HWND hwnd)
 
 bool ApplyPictViewDarkModeIfSelected(HWND hwnd)
 {
-    ConfigurePictViewDarkModeFromHost();
     if (!PictViewShouldUseWindowsDarkMode())
         return false;
 
@@ -61,6 +60,9 @@ void QueuePictViewConfigPageRedraw(HWND hwnd)
 
 bool HandlePictViewDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR& result)
 {
+    if (!PictViewShouldUseWindowsDarkMode())
+        return false;
+
     ConfigurePictViewDarkModeFromHost();
     LRESULT brush = 0;
     if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
@@ -803,35 +805,44 @@ void CConfigPageAdvanced::Transfer(CTransferInfo& ti)
 class CCenteredPropertyWindow : public CWindow
 {
 public:
-    CCenteredPropertyWindow() : Centered(FALSE) {}
+    CCenteredPropertyWindow(BOOL darkModeAttached) : Centered(FALSE), DarkModeAttached(darkModeAttached) {}
 
 protected:
     BOOL Centered;
+    BOOL DarkModeAttached;
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         switch (uMsg)
         {
         case WM_CREATE:
         {
-            ApplyPictViewDarkModeIfSelected(HWindow);
+            if (DarkModeAttached)
+                ApplyPictViewDarkMode(HWindow);
             break;
         }
 
         case WM_THEMECHANGED:
         {
-            ApplyPictViewDarkMode(HWindow);
-            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
-            return 0;
-        }
-
-        case WM_SETTINGCHANGE:
-        {
-            ConfigurePictViewDarkModeFromHost();
-            if (DarkModeHandleSettingChange(uMsg, lParam))
+            if (DarkModeAttached)
             {
                 ApplyPictViewDarkMode(HWindow);
                 RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
                 return 0;
+            }
+            break;
+        }
+
+        case WM_SETTINGCHANGE:
+        {
+            if (DarkModeAttached)
+            {
+                ConfigurePictViewDarkModeFromHost();
+                if (DarkModeHandleSettingChange(uMsg, lParam))
+                {
+                    ApplyPictViewDarkMode(HWindow);
+                    RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+                    return 0;
+                }
             }
             break;
         }
@@ -844,24 +855,34 @@ protected:
         case WM_CTLCOLORMSGBOX:
         case WM_CTLCOLORSCROLLBAR:
         {
-            INT_PTR result = 0;
-            if (HandlePictViewDarkCtlColor(uMsg, wParam, lParam, result))
-                return result;
+            if (DarkModeAttached)
+            {
+                INT_PTR result = 0;
+                if (HandlePictViewDarkCtlColor(uMsg, wParam, lParam, result))
+                    return result;
+            }
             break;
         }
 
         case WM_NOTIFY:
         {
-            LPNMHDR hdr = (LPNMHDR)lParam;
-            if (hdr != NULL && hdr->code == TCN_SELCHANGE)
-                QueuePictViewConfigPageRedraw((HWND)SendMessage(HWindow, PSM_GETCURRENTPAGEHWND, 0, 0));
+            if (DarkModeAttached)
+            {
+                LPNMHDR hdr = (LPNMHDR)lParam;
+                if (hdr != NULL && hdr->code == TCN_SELCHANGE)
+                    QueuePictViewConfigPageRedraw((HWND)SendMessage(HWindow, PSM_GETCURRENTPAGEHWND, 0, 0));
+            }
             break;
         }
 
         case WM_USER_CFGPAGE_REDRAW:
         {
-            RedrawPictViewConfigPage((HWND)SendMessage(HWindow, PSM_GETCURRENTPAGEHWND, 0, 0));
-            return 0;
+            if (DarkModeAttached)
+            {
+                RedrawPictViewConfigPage((HWND)SendMessage(HWindow, PSM_GETCURRENTPAGEHWND, 0, 0));
+                return 0;
+            }
+            break;
         }
 
         case WM_WINDOWPOSCHANGING:
@@ -912,7 +933,7 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
     if (uMsg == PSCB_INITIALIZED) // attach to the dialog
     {
         BOOL keepAttached = ApplyPictViewDarkModeIfSelected(HWindow) ? TRUE : FALSE;
-        CCenteredPropertyWindow* wnd = new CCenteredPropertyWindow;
+        CCenteredPropertyWindow* wnd = new CCenteredPropertyWindow(keepAttached);
         if (wnd != NULL)
         {
             wnd->AttachToWindow(HWindow);

--- a/src/plugins/pictview/dialogs.cpp
+++ b/src/plugins/pictview/dialogs.cpp
@@ -21,6 +21,7 @@ namespace
 {
 void ApplyPictViewDarkMode(HWND hwnd)
 {
+    ConfigurePictViewDarkModeFromHost();
     if (hwnd != NULL)
     {
         DarkModeApplyWindow(hwnd);
@@ -31,6 +32,7 @@ void ApplyPictViewDarkMode(HWND hwnd)
 
 bool HandlePictViewDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR& result)
 {
+    ConfigurePictViewDarkModeFromHost();
     LRESULT brush = 0;
     if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
     {
@@ -90,12 +92,13 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_THEMECHANGED:
     {
         ApplyPictViewDarkMode(HWindow);
-        InvalidateRect(HWindow, NULL, TRUE);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
         return TRUE;
     }
 
     case WM_SETTINGCHANGE:
     {
+        ConfigurePictViewDarkModeFromHost();
         if (DarkModeHandleSettingChange(uMsg, lParam))
         {
             ApplyPictViewDarkMode(HWindow);
@@ -147,12 +150,23 @@ CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_THEMECHANGED:
     {
         ApplyPictViewDarkMode(HWindow);
-        InvalidateRect(HWindow, NULL, TRUE);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
         return TRUE;
+    }
+
+    case WM_SHOWWINDOW:
+    {
+        if (wParam != FALSE)
+        {
+            ApplyPictViewDarkMode(HWindow);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+        }
+        break;
     }
 
     case WM_SETTINGCHANGE:
     {
+        ConfigurePictViewDarkModeFromHost();
         if (DarkModeHandleSettingChange(uMsg, lParam))
         {
             ApplyPictViewDarkMode(HWindow);
@@ -743,7 +757,11 @@ void CConfigPageAdvanced::Transfer(CTransferInfo& ti)
 // helper object for centering the configuration dialog to the parent
 class CCenteredPropertyWindow : public CWindow
 {
+public:
+    CCenteredPropertyWindow() : Centered(FALSE) {}
+
 protected:
+    BOOL Centered;
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         switch (uMsg)
@@ -754,14 +772,56 @@ protected:
             break;
         }
 
+        case WM_THEMECHANGED:
+        {
+            ApplyPictViewDarkMode(HWindow);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return 0;
+        }
+
+        case WM_SETTINGCHANGE:
+        {
+            ConfigurePictViewDarkModeFromHost();
+            if (DarkModeHandleSettingChange(uMsg, lParam))
+            {
+                ApplyPictViewDarkMode(HWindow);
+                RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+                return 0;
+            }
+            break;
+        }
+
+        case WM_CTLCOLORDLG:
+        case WM_CTLCOLORSTATIC:
+        case WM_CTLCOLORBTN:
+        case WM_CTLCOLOREDIT:
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLORMSGBOX:
+        case WM_CTLCOLORSCROLLBAR:
+        {
+            INT_PTR result = 0;
+            if (HandlePictViewDarkCtlColor(uMsg, wParam, lParam, result))
+                return result;
+            break;
+        }
+
+        case WM_NOTIFY:
+        {
+            LPNMHDR hdr = (LPNMHDR)lParam;
+            if (hdr != NULL && hdr->code == TCN_SELCHANGE)
+                RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+            break;
+        }
+
         case WM_WINDOWPOSCHANGING:
         {
             WINDOWPOS* pos = (WINDOWPOS*)lParam;
-            if (pos->flags & SWP_SHOWWINDOW)
+            if (!Centered && (pos->flags & SWP_SHOWWINDOW))
             {
                 HWND hParent = GetParent(HWindow);
                 if (hParent != NULL)
                     SalamanderGeneral->MultiMonCenterWindow(HWindow, hParent, TRUE);
+                Centered = TRUE;
             }
             break;
         }
@@ -809,7 +869,9 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
                 delete wnd; // the window is not attached, destroy it right here
             else
             {
-                PostMessage(wnd->HWindow, WM_USER_CFGDLGDETACH, 0, 0); // to detach CCenteredPropertyWindow from the dialog
+                // Keep the subclass attached for the lifetime of the property sheet.
+                // It handles dark CTLCOLOR/theme messages for the tab and button area
+                // outside individual property pages and redraws pages when switching tabs.
             }
         }
     }
@@ -1691,6 +1753,7 @@ CExifDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             Highlights.ResetState();
 
         HListView = GetDlgItem(HWindow, IDC_IMGEXIF_LIST);
+        ApplyPictViewDarkMode(HWindow);
         DWORD exFlags = LVS_EX_FULLROWSELECT;
         DWORD origFlags = ListView_GetExtendedListViewStyle(HListView);
         ListView_SetExtendedListViewStyle(HListView, origFlags | exFlags); // 4.71

--- a/src/plugins/pictview/dialogs.h
+++ b/src/plugins/pictview/dialogs.h
@@ -42,6 +42,7 @@ public:
         : CPropSheetPage(title, modul, resID, helpID, flags, icon, origin) {}
 
 protected:
+    virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
     virtual void NotifDlgJustCreated();
 };
 

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -3,6 +3,8 @@
 
 #include "precomp.h"
 
+#include "../../darkmode.h"
+
 #include <share.h>
 #include <string>
 #include <limits>
@@ -3149,6 +3151,7 @@ void CViewerWindow::ToggleStatusBar()
             StatusBar = NULL;
             return;
         }
+        DarkModeApplyTree(StatusBar->HWindow);
         G.StatusbarVisible = TRUE;
     }
     else
@@ -3371,17 +3374,22 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         RECT r;
         GetClientRect(HWindow, &r);
+        DWORD rebarStyle = WS_VISIBLE | /*WS_BORDER |  */ WS_CHILD |
+                            WS_CLIPCHILDREN | WS_CLIPSIBLINGS |
+                            RBS_VARHEIGHT | CCS_NODIVIDER | CCS_NOPARENTALIGN |
+                            RBS_AUTOSIZE;
+        if (!DarkModeShouldUseDarkColors())
+            rebarStyle |= RBS_BANDBORDERS;
+
         HRebar = CreateWindowEx(WS_EX_TOOLWINDOW, REBARCLASSNAME, _T(""),
-                                WS_VISIBLE | /*WS_BORDER |  */ WS_CHILD |
-                                    WS_CLIPCHILDREN | WS_CLIPSIBLINGS |
-                                    RBS_VARHEIGHT | CCS_NODIVIDER |
-                                    RBS_BANDBORDERS | CCS_NOPARENTALIGN |
-                                    RBS_AUTOSIZE,
+                                rebarStyle,
                                 0, 0, r.right, r.bottom, // dummy
                                 HWindow, (HMENU)0, DLLInstance, NULL);
 
-        // we do not want visual styles for the rebar
-        SalamanderGUI->DisableWindowVisualStyles(HRebar);
+        // we do not want visual styles for the rebar in light mode; dark mode
+        // needs native themed drawing to avoid light rebar bands.
+        if (!DarkModeShouldUseDarkColors())
+            SalamanderGUI->DisableWindowVisualStyles(HRebar);
 
         Renderer.CreateEx(/*WS_EX_STATICEDGE*/ WS_EX_CLIENTEDGE,
                           CWINDOW_CLASSNAME2,
@@ -3403,6 +3411,10 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             ToggleToolBar();
         if (G.StatusbarVisible)
             ToggleStatusBar();
+
+        DarkModeApplyWindow(HWindow);
+        DarkModeRefreshTitleBar(HWindow);
+        DarkModeApplyTree(HWindow);
 
         SetFocus(Renderer.HWindow);
 
@@ -3597,6 +3609,14 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_ERASEBKGND:
     {
+        if (DarkModeShouldUseDarkColors())
+        {
+            RECT r;
+            GetClientRect(HWindow, &r);
+            HBRUSH brush = CreateSolidBrush(DarkModeGetDialogBackgroundColor());
+            FillRect((HDC)wParam, &r, brush);
+            DeleteObject(brush);
+        }
         return 1;
     }
 
@@ -3621,6 +3641,28 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_SIZE:
     {
         OnSize();
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        DarkModeApplyWindow(HWindow);
+        DarkModeRefreshTitleBar(HWindow);
+        DarkModeApplyTree(HWindow);
+        InvalidateRect(HWindow, NULL, TRUE);
+        return 0;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            DarkModeApplyWindow(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeApplyTree(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return 0;
+        }
         break;
     }
 

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -389,6 +389,8 @@ namespace
 {
 HBRUSH PictViewDarkModeDialogBrush = NULL;
 COLORREF PictViewDarkModeDialogBrushColor = CLR_INVALID;
+BOOL PictViewHostPolicyKnown = FALSE;
+BOOL PictViewHostUseWindowsDarkMode = FALSE;
 
 int PictViewColorLuminance(COLORREF color)
 {
@@ -432,13 +434,16 @@ void ReleasePictViewDarkModeResources()
 BOOL PictViewShouldUseWindowsDarkMode()
 {
     BOOL useWindowsDarkMode = FALSE;
-    if (SalamanderGeneral == NULL)
-        return FALSE;
-    return SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
-                                                &useWindowsDarkMode,
-                                                sizeof(useWindowsDarkMode),
-                                                NULL) &&
-           useWindowsDarkMode;
+    if (SalamanderGeneral != NULL &&
+        SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                             &useWindowsDarkMode,
+                                             sizeof(useWindowsDarkMode),
+                                             NULL))
+    {
+        PictViewHostPolicyKnown = TRUE;
+        PictViewHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+    return PictViewHostPolicyKnown && PictViewHostUseWindowsDarkMode;
 }
 
 void ConfigurePictViewDarkModeFromHost()

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -385,21 +385,101 @@ CButtonData ToolBarButtons[] =
         {IDX_TB_FULLSCREEN, IDS_TT_FULL_SCREEN, CMD_FULLSCREEN, vweFileOpened /*vweNotLoading*/},
         {IDX_TB_TERMINATOR}};
 
+namespace
+{
+HBRUSH PictViewDarkModeDialogBrush = NULL;
+COLORREF PictViewDarkModeDialogBrushColor = CLR_INVALID;
+
+int PictViewColorLuminance(COLORREF color)
+{
+    return (GetRValue(color) * 30 + GetGValue(color) * 59 + GetBValue(color) * 11) / 100;
+}
+
+COLORREF PictViewEnsureReadableForeground(COLORREF foreground, COLORREF background)
+{
+    const int bgLum = PictViewColorLuminance(background);
+    const int fgLum = PictViewColorLuminance(foreground);
+    if (bgLum < 128 && fgLum < bgLum + 40)
+        return RGB(0xF0, 0xF0, 0xF0);
+    if (bgLum >= 128 && fgLum > bgLum - 40)
+        return RGB(0x20, 0x20, 0x20);
+    return foreground;
+}
+
+HBRUSH PictViewGetDarkModeDialogBrush(COLORREF background)
+{
+    if (PictViewDarkModeDialogBrush == NULL || PictViewDarkModeDialogBrushColor != background)
+    {
+        if (PictViewDarkModeDialogBrush != NULL)
+            DeleteObject(PictViewDarkModeDialogBrush);
+        PictViewDarkModeDialogBrush = CreateSolidBrush(background);
+        PictViewDarkModeDialogBrushColor = background;
+    }
+    return PictViewDarkModeDialogBrush;
+}
+
+void ReleasePictViewDarkModeResources()
+{
+    if (PictViewDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(PictViewDarkModeDialogBrush);
+        PictViewDarkModeDialogBrush = NULL;
+        PictViewDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+}
+
+BOOL PictViewShouldUseWindowsDarkMode()
+{
+    BOOL useWindowsDarkMode = FALSE;
+    if (SalamanderGeneral == NULL)
+        return FALSE;
+    return SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                                &useWindowsDarkMode,
+                                                sizeof(useWindowsDarkMode),
+                                                NULL) &&
+           useWindowsDarkMode;
+}
+
+void ConfigurePictViewDarkModeFromHost()
+{
+    const BOOL useWindowsDarkMode = PictViewShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && SalamanderGeneral != NULL)
+    {
+        text = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        background = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+
+    const COLORREF readableText = PictViewEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = PictViewGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
 // sets colors for the entries defined by vceCount
 void RebuildColors(SALCOLOR* colors)
 {
+    const BOOL useWindowsDarkMode = PictViewShouldUseWindowsDarkMode();
+    const COLORREF darkBackground = useWindowsDarkMode ? DarkModeGetDialogBackgroundColor() : CLR_INVALID;
     if (GetFValue(colors[vceBackground]) & SCF_DEFAULT)
-        SetRGBPart(&colors[vceBackground], GetSysColor(COLOR_APPWORKSPACE));
+        SetRGBPart(&colors[vceBackground], useWindowsDarkMode ? darkBackground : GetSysColor(COLOR_APPWORKSPACE));
     if (GetFValue(colors[vceTransparent]) & SCF_DEFAULT)
-        SetRGBPart(&colors[vceTransparent], GetSysColor(COLOR_WINDOW));
+        SetRGBPart(&colors[vceTransparent], useWindowsDarkMode ? darkBackground : GetSysColor(COLOR_WINDOW));
     if (GetFValue(colors[vceFSBackground]) & SCF_DEFAULT)
         SetRGBPart(&colors[vceFSBackground], RGB(0, 0, 0));
     if (GetFValue(colors[vceFSTransparent]) & SCF_DEFAULT)
-        SetRGBPart(&colors[vceFSTransparent], GetSysColor(COLOR_WINDOW));
+        SetRGBPart(&colors[vceFSTransparent], useWindowsDarkMode ? RGB(0, 0, 0) : GetSysColor(COLOR_WINDOW));
 }
 
 void InitGlobalGUIParameters(void)
 {
+    ConfigurePictViewDarkModeFromHost();
     G.rgbPanelBackground = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
 
     RebuildColors(G.Colors);
@@ -470,6 +550,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
             DestroyAcceleratorTable(G.HAccel);
         if (G.CaptureAtomID != 0)
             GlobalDeleteAtom(G.CaptureAtomID);
+        ReleasePictViewDarkModeResources();
     }
 
     return TRUE; // DLL can be loaded
@@ -3151,6 +3232,7 @@ void CViewerWindow::ToggleStatusBar()
             StatusBar = NULL;
             return;
         }
+        ConfigurePictViewDarkModeFromHost();
         DarkModeApplyTree(StatusBar->HWindow);
         G.StatusbarVisible = TRUE;
     }
@@ -3374,6 +3456,8 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         RECT r;
         GetClientRect(HWindow, &r);
+        ConfigurePictViewDarkModeFromHost();
+
         DWORD rebarStyle = WS_VISIBLE | /*WS_BORDER |  */ WS_CHILD |
                             WS_CLIPCHILDREN | WS_CLIPSIBLINGS |
                             RBS_VARHEIGHT | CCS_NODIVIDER | CCS_NOPARENTALIGN |
@@ -3412,6 +3496,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (G.StatusbarVisible)
             ToggleStatusBar();
 
+        ConfigurePictViewDarkModeFromHost();
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
         DarkModeApplyTree(HWindow);
@@ -3609,6 +3694,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_ERASEBKGND:
     {
+        ConfigurePictViewDarkModeFromHost();
         if (DarkModeShouldUseDarkColors())
         {
             RECT r;
@@ -3646,6 +3732,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_THEMECHANGED:
     {
+        ConfigurePictViewDarkModeFromHost();
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
         DarkModeApplyTree(HWindow);
@@ -3655,6 +3742,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_SETTINGCHANGE:
     {
+        ConfigurePictViewDarkModeFromHost();
         if (DarkModeHandleSettingChange(uMsg, lParam))
         {
             DarkModeApplyWindow(HWindow);

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -468,6 +468,35 @@ void ConfigurePictViewDarkModeFromHost()
 }
 
 // sets colors for the entries defined by vceCount
+namespace
+{
+COLORREF PictViewGetEffectiveRendererColor(SALCOLOR color, COLORREF lightDefault, COLORREF darkDefault)
+{
+    if (PictViewShouldUseWindowsDarkMode())
+    {
+        const COLORREF rgb = GetCOLORREF(color);
+        if ((GetFValue(color) & SCF_DEFAULT) || rgb == lightDefault || rgb == RGB(0xFF, 0xFF, 0xFF))
+            return darkDefault;
+    }
+
+    return GetCOLORREF(color);
+}
+}
+
+COLORREF PictViewGetRendererBackgroundColor(BOOL fullScreen)
+{
+    return PictViewGetEffectiveRendererColor(G.Colors[fullScreen ? vceFSBackground : vceBackground],
+                                             fullScreen ? RGB(0, 0, 0) : GetSysColor(COLOR_APPWORKSPACE),
+                                             fullScreen ? RGB(0, 0, 0) : DarkModeGetDialogBackgroundColor());
+}
+
+COLORREF PictViewGetRendererTransparentColor(BOOL fullScreen)
+{
+    return PictViewGetEffectiveRendererColor(G.Colors[fullScreen ? vceFSTransparent : vceTransparent],
+                                             GetSysColor(COLOR_WINDOW),
+                                             fullScreen ? RGB(0, 0, 0) : DarkModeGetDialogBackgroundColor());
+}
+
 void RebuildColors(SALCOLOR* colors)
 {
     const BOOL useWindowsDarkMode = PictViewShouldUseWindowsDarkMode();
@@ -3254,6 +3283,23 @@ BOOL CViewerWindow::IsFullScreen()
     return FullScreen;
 }
 
+void CViewerWindow::UpdateRendererFrameForTheme()
+{
+    if (Renderer.HWindow == NULL)
+        return;
+
+    const BOOL wantClientEdge = !FullScreen && !DarkModeShouldUseDarkColors();
+    LONG_PTR exStyle = GetWindowLongPtr(Renderer.HWindow, GWL_EXSTYLE);
+    LONG_PTR newExStyle = wantClientEdge ? (exStyle | WS_EX_CLIENTEDGE) : (exStyle & ~WS_EX_CLIENTEDGE);
+    if (newExStyle != exStyle)
+    {
+        SetWindowLongPtr(Renderer.HWindow, GWL_EXSTYLE, newExStyle);
+        SetWindowPos(Renderer.HWindow, NULL, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+        InvalidateRect(Renderer.HWindow, NULL, TRUE);
+    }
+}
+
 void CViewerWindow::ToggleFullScreen()
 {
     if (Renderer.Loading)
@@ -3282,9 +3328,7 @@ void CViewerWindow::ToggleFullScreen()
 
         SetWindowLong(HWindow, GWL_STYLE, style);
 
-        style = GetWindowLong(Renderer.HWindow, GWL_EXSTYLE);
-        style |= WS_EX_CLIENTEDGE;
-        SetWindowLong(Renderer.HWindow, GWL_EXSTYLE, style);
+        UpdateRendererFrameForTheme();
         ShowWindow(HRebar, SW_SHOW);
         if (StatusBar != NULL)
             ShowWindow(StatusBar->HWindow, SW_SHOW);
@@ -3302,7 +3346,7 @@ void CViewerWindow::ToggleFullScreen()
         }
 
         if (Renderer.PVHandle)
-            PVW32DLL.PVSetBkHandle(Renderer.PVHandle, GetCOLORREF(G.Colors[vceTransparent]));
+            PVW32DLL.PVSetBkHandle(Renderer.PVHandle, PictViewGetRendererTransparentColor(FALSE));
     }
     else
     {
@@ -3324,9 +3368,7 @@ void CViewerWindow::ToggleFullScreen()
         style = WS_POPUP | WS_VISIBLE | WS_OVERLAPPED | WS_CLIPSIBLINGS | WS_SYSMENU;
         SetWindowLong(HWindow, GWL_STYLE, style);
 
-        style = GetWindowLong(Renderer.HWindow, GWL_EXSTYLE);
-        style &= ~WS_EX_CLIENTEDGE;
-        SetWindowLong(Renderer.HWindow, GWL_EXSTYLE, style);
+        UpdateRendererFrameForTheme();
 
         ShowWindow(HRebar, SW_HIDE);
         if (StatusBar != NULL)
@@ -3353,7 +3395,7 @@ void CViewerWindow::ToggleFullScreen()
                      0);
 
         if (Renderer.PVHandle)
-            PVW32DLL.PVSetBkHandle(Renderer.PVHandle, GetCOLORREF(G.Colors[vceFSTransparent]));
+            PVW32DLL.PVSetBkHandle(Renderer.PVHandle, PictViewGetRendererTransparentColor(TRUE));
     }
     LockWindowUpdate(NULL);
 }
@@ -3480,7 +3522,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (!DarkModeShouldUseDarkColors())
             SalamanderGUI->DisableWindowVisualStyles(HRebar);
 
-        Renderer.CreateEx(/*WS_EX_STATICEDGE*/ WS_EX_CLIENTEDGE,
+        Renderer.CreateEx(DarkModeShouldUseDarkColors() ? 0 : /*WS_EX_STATICEDGE*/ WS_EX_CLIENTEDGE,
                           CWINDOW_CLASSNAME2,
                           _T(""),
                           WS_VISIBLE | WS_CHILD | /*WS_VSCROLL | WS_HSCROLL | */ WS_CLIPSIBLINGS,
@@ -3505,6 +3547,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
         DarkModeApplyTree(HWindow);
+        UpdateRendererFrameForTheme();
 
         SetFocus(Renderer.HWindow);
 
@@ -3659,6 +3702,9 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_VIEWERCFGCHNG:
     {
+        ConfigurePictViewDarkModeFromHost();
+        RebuildColors(G.Colors);
+        UpdateRendererFrameForTheme();
         if (Renderer.HWindow != NULL)
             SendMessage(Renderer.HWindow, uMsg, wParam, lParam);
         return 0;
@@ -3738,9 +3784,13 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_THEMECHANGED:
     {
         ConfigurePictViewDarkModeFromHost();
+        RebuildColors(G.Colors);
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
         DarkModeApplyTree(HWindow);
+        UpdateRendererFrameForTheme();
+        if (Renderer.HWindow != NULL)
+            SendMessage(Renderer.HWindow, WM_USER_VIEWERCFGCHNG, 0, 0);
         InvalidateRect(HWindow, NULL, TRUE);
         return 0;
     }
@@ -3750,9 +3800,13 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         ConfigurePictViewDarkModeFromHost();
         if (DarkModeHandleSettingChange(uMsg, lParam))
         {
+            RebuildColors(G.Colors);
             DarkModeApplyWindow(HWindow);
             DarkModeRefreshTitleBar(HWindow);
             DarkModeApplyTree(HWindow);
+            UpdateRendererFrameForTheme();
+            if (Renderer.HWindow != NULL)
+                SendMessage(Renderer.HWindow, WM_USER_VIEWERCFGCHNG, 0, 0);
             InvalidateRect(HWindow, NULL, TRUE);
             return 0;
         }

--- a/src/plugins/pictview/pictview.h
+++ b/src/plugins/pictview/pictview.h
@@ -399,6 +399,7 @@ protected:
     BOOL InsertMenuBand();
     BOOL InsertToolBarBand();
     void LayoutWindows();
+    void UpdateRendererFrameForTheme();
     void EnsureNoTopmost();
 };
 
@@ -507,6 +508,8 @@ void FillMenuHistory(CGUIMenuPopupAbstract* popup, int cmdFirst, BOOL filesHisto
 void InitGlobalGUIParameters(void);
 void ConfigurePictViewDarkModeFromHost();
 BOOL PictViewShouldUseWindowsDarkMode();
+COLORREF PictViewGetRendererBackgroundColor(BOOL fullScreen);
+COLORREF PictViewGetRendererTransparentColor(BOOL fullScreen);
 void RebuildColors(SALCOLOR* colors);
 
 int ShowOneTimeMessage(HWND HParent, int msg, BOOL* pChecked, int flags = MSGBOXEX_YESNO | MSGBOXEX_SILENT,

--- a/src/plugins/pictview/pictview.h
+++ b/src/plugins/pictview/pictview.h
@@ -505,6 +505,8 @@ void FillMenuHistory(CGUIMenuPopupAbstract* popup, int cmdFirst, BOOL filesHisto
 
 // refreshes G.rgbXXX items
 void InitGlobalGUIParameters(void);
+void ConfigurePictViewDarkModeFromHost();
+BOOL PictViewShouldUseWindowsDarkMode();
 void RebuildColors(SALCOLOR* colors);
 
 int ShowOneTimeMessage(HWND HParent, int msg, BOOL* pChecked, int flags = MSGBOXEX_YESNO | MSGBOXEX_SILENT,

--- a/src/plugins/pictview/precomp.h
+++ b/src/plugins/pictview/precomp.h
@@ -52,6 +52,7 @@
 #include "dbg.h"
 #include "arraylt.h"
 #include "winliblt.h"
+#include "mhandles.h"
 #include "auxtools.h"
 #include "lukas\gdi.h"
 

--- a/src/plugins/pictview/render1.cpp
+++ b/src/plugins/pictview/render1.cpp
@@ -425,7 +425,7 @@ BOOL CRendererWindow::OpenFile(LPCTSTR name, int showCmd, HBITMAP hBmp)
     if (PVHandle)
     {
         CALL_STACK_MESSAGE1("PVW32DLL.PVSetBkHandle");
-        PVW32DLL.PVSetBkHandle(PVHandle, GetCOLORREF(G.Colors[Viewer->IsFullScreen() ? vceFSTransparent : vceTransparent]));
+        PVW32DLL.PVSetBkHandle(PVHandle, PictViewGetRendererTransparentColor(Viewer->IsFullScreen()));
     }
     WMSize();
     UpdateInfos();
@@ -1224,7 +1224,7 @@ PVCODE SimplifyImageSequence(LPPVHandle hPVImage, HDC dc, int ScreenWidth, int S
 void CRendererWindow::SimplifyImageSequence(HDC dc)
 {
     int ScreenWidth, ScreenHeight;
-    COLORREF bgColor(GetCOLORREF(G.Colors[Viewer->IsFullScreen() ? vceFSBackground : vceBackground]));
+    COLORREF bgColor(PictViewGetRendererBackgroundColor(Viewer->IsFullScreen()));
 
     if (pvii.Format == PVF_GIF)
     {
@@ -1492,7 +1492,7 @@ LRESULT CRendererWindow::OnPaint()
 
     if (HAreaBrush == NULL)
     {
-        HAreaBrush = CreateSolidBrush(GetCOLORREF(G.Colors[Viewer->IsFullScreen() ? vceFSBackground : vceBackground]));
+        HAreaBrush = CreateSolidBrush(PictViewGetRendererBackgroundColor(Viewer->IsFullScreen()));
     }
 
     if (ImageLoaded || Loading)
@@ -1972,7 +1972,7 @@ LRESULT CRendererWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         if (PVHandle)
         {
-            PVW32DLL.PVSetBkHandle(PVHandle, GetCOLORREF(G.Colors[Viewer->FullScreen ? vceFSTransparent : vceTransparent]));
+            PVW32DLL.PVSetBkHandle(PVHandle, PictViewGetRendererTransparentColor(Viewer->FullScreen));
             SetTitle(); // add/remove full path from title
         }
         InvalidateRect(HWindow, NULL, TRUE);

--- a/src/plugins/pictview/render2.cpp
+++ b/src/plugins/pictview/render2.cpp
@@ -193,7 +193,7 @@ void CRendererWindow::ScreenCapture()
     if (wndRgnType == COMPLEXREGION) // clip only non-rectangular windows
     {
         // fill "transparent" background
-        HBRUSH hBrush = CreateSolidBrush(GetCOLORREF(G.Colors[vceTransparent]));
+        HBRUSH hBrush = CreateSolidBrush(PictViewGetRendererTransparentColor(FALSE));
         RECT fillR = {0, 0, width, height};
         FillRect(hMemDC, &fillR, hBrush);
         DeleteObject(hBrush);

--- a/src/plugins/pictview/statsbar.cpp
+++ b/src/plugins/pictview/statsbar.cpp
@@ -212,6 +212,7 @@ void CViewerWindow::InitProgressBar()
                                          PBS_SMOOTH | WS_CHILD | WS_VISIBLE, r.left, r.top,
                                          r.right - r.left, r.bottom - r.top,
                                          StatusBar->HWindow, NULL, DLLInstance, NULL);
+    ConfigurePictViewDarkModeFromHost();
     DarkModeApplyTree(StatusBar->HWindow);
 
     SendMessage(StatusBar->hProgBar, PBM_SETRANGE, 0, MAKELPARAM(0, 100));

--- a/src/plugins/pictview/statsbar.cpp
+++ b/src/plugins/pictview/statsbar.cpp
@@ -3,6 +3,8 @@
 
 #include "precomp.h"
 
+#include "../../darkmode.h"
+
 #include "lib\\pvw32dll.h"
 #include "renderer.h"
 #include "pictview.h"
@@ -210,6 +212,7 @@ void CViewerWindow::InitProgressBar()
                                          PBS_SMOOTH | WS_CHILD | WS_VISIBLE, r.left, r.top,
                                          r.right - r.left, r.bottom - r.top,
                                          StatusBar->HWindow, NULL, DLLInstance, NULL);
+    DarkModeApplyTree(StatusBar->HWindow);
 
     SendMessage(StatusBar->hProgBar, PBM_SETRANGE, 0, MAKELPARAM(0, 100));
     SendMessage(StatusBar->hProgBar, PBM_SETPOS, 0, 0);

--- a/src/plugins/pictview/vcxproj/pictview.props
+++ b/src/plugins/pictview/vcxproj/pictview.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\exif;..\exif\libexif;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\exif;..\exif\libexif;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/pictview/vcxproj/pictview.vcxproj
+++ b/src/plugins/pictview/vcxproj/pictview.vcxproj
@@ -125,6 +125,8 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+    </ClCompile>
     <ClCompile Include="..\..\shared\lukas\gdi.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">

--- a/src/plugins/pictview/vcxproj/pictview.vcxproj
+++ b/src/plugins/pictview/vcxproj/pictview.vcxproj
@@ -129,6 +129,8 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
     <ClCompile Include="..\dialogs.cpp">
     </ClCompile>
     <ClCompile Include="..\histwnd.cpp">

--- a/src/plugins/pictview/vcxproj/pictview.vcxproj
+++ b/src/plugins/pictview/vcxproj/pictview.vcxproj
@@ -133,30 +133,39 @@
     <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\dialogs.cpp">
     </ClCompile>

--- a/src/plugins/pictview/vcxproj/pictview.vcxproj
+++ b/src/plugins/pictview/vcxproj/pictview.vcxproj
@@ -131,6 +131,33 @@
     </ClCompile>
     <ClCompile Include="..\..\..\darkmode.cpp" />
     <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\dialogs.cpp">
     </ClCompile>
     <ClCompile Include="..\histwnd.cpp">

--- a/src/plugins/pictview/vcxproj/pictview.vcxproj.filters
+++ b/src/plugins/pictview/vcxproj/pictview.vcxproj.filters
@@ -72,6 +72,12 @@
     <ClCompile Include="..\..\shared\winliblt.cpp">
       <Filter>Shared</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
     <ClCompile Include="..\wiawrap.cpp">
       <Filter>cpp</Filter>
     </ClCompile>

--- a/src/plugins/pictview/vcxproj/pictview.vcxproj.filters
+++ b/src/plugins/pictview/vcxproj/pictview.vcxproj.filters
@@ -78,6 +78,33 @@
     <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
       <Filter>Shared</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <Filter>Shared</Filter>
+    </ClCompile>
     <ClCompile Include="..\wiawrap.cpp">
       <Filter>cpp</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- PictView dialogs and viewer windows showed light UI parts when the user selected the "Windows Dark Mode (experimental)" scheme, so dialogs, status/progress bars and listviews must follow the shared dark-mode helpers to provide a consistent dark UI.
- The project already includes a shared dark-mode integration (`darkmode.cpp` / `darkmode_backend_darkmodelib.cpp`), so reuse those helpers instead of bespoke per-dialog fixes.

### Description
- Added use of the shared dark-mode API by including `darkmode.h` and a small local wrapper (`ApplyPictViewDarkMode` / `HandlePictViewDarkCtlColor`) in `src/plugins/pictview/dialogs.cpp` to apply dark mode to dialogs and handle `WM_CTLCOLOR*` messages.
- Extended `CCommonDialog::DialogProc` and `CCommonPropSheetPage::DialogProc` to call `DarkModeApplyWindow`/`DarkModeRefreshTitleBar`/`DarkModeApplyTree`, handle `WM_THEMECHANGED`/`WM_SETTINGCHANGE` and forward control-color handling to `DarkModeHandleCtlColor`; also call the helper from `NotifDlgJustCreated` (files: `dialogs.cpp`, `dialogs.h`).
- Updated the PictView viewer window to opt into dark mode on creation and to refresh on theme/setting changes, adjusted rebar style handling to avoid light band borders in dark mode, and painted the background with the configured dialog background when dark colors are active (file: `pictview.cpp`).
- Ensured status bar and progress bar child controls get dark-mode treatment by invoking `DarkModeApplyTree` when they are created, and applied dark-mode listview colors for the EXIF dialog including adjusted highlight color for dark mode (files: `statsbar.cpp`, `dialogs.cpp`).
- Added the shared dark-mode sources to the PictView project file so the plugin is compiled with the same dark-mode integration (`src/plugins/pictview/vcxproj/pictview.vcxproj` and `.filters` now include `darkmode.cpp` and `darkmode_backend_darkmodelib.cpp`).

### Testing
- Parsed the modified project XML with `python3`/`xml.etree.ElementTree` to validate the edited `.vcxproj` and `.filters` files (succeeded).
- Searched repository references with `rg` to confirm new dark-mode hooks were inserted (`DarkModeApplyTree`, `DarkModeHandleCtlColor`, `DarkModeUpdateListViewColors`, etc.) (succeeded).
- Ran `git diff --check` to verify no whitespace/conflict markers (succeeded).
- Changes were committed locally as `Enable dark mode styling in PictView` and verified in the working tree (`git status`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e29d396608329b7654e3bffb56be0)