### PR TITLE
Integrate Windows dark mode (darkmode.h + darkmodelib) into Checksum plugin

### DIFF
--- a/src/plugins/checksum/checksum.cpp
+++ b/src/plugins/checksum/checksum.cpp
@@ -60,6 +60,9 @@ HBRUSH ChecksumDarkModeDialogBrush = NULL;
 COLORREF ChecksumDarkModeDialogBrushColor = CLR_INVALID;
 BOOL ChecksumHostPolicyKnown = FALSE;
 BOOL ChecksumHostUseWindowsDarkMode = FALSE;
+COLORREF ChecksumHostSchemeText = CLR_INVALID;
+COLORREF ChecksumHostSchemeBackground = CLR_INVALID;
+DWORD ChecksumMainThreadId = 0;
 
 HBRUSH ChecksumGetDarkModeDialogBrush(COLORREF background)
 {
@@ -84,33 +87,57 @@ void ReleaseChecksumDarkModeResources()
 }
 }
 
-BOOL ChecksumShouldUseWindowsDarkMode()
+BOOL ChecksumCanQueryHostDarkMode()
 {
+    return SalamanderGeneral != NULL &&
+           ChecksumMainThreadId != 0 &&
+           GetCurrentThreadId() == ChecksumMainThreadId;
+}
+
+void RefreshChecksumDarkModeFromHost()
+{
+    // Checksum calculate/verify dialogs run on worker UI threads. Salamander host
+    // configuration APIs are main-thread-only, so worker dialogs must use this
+    // cached snapshot instead of querying the host directly.
+    if (!ChecksumCanQueryHostDarkMode())
+        return;
+
     BOOL useWindowsDarkMode = FALSE;
-    if (SalamanderGeneral != NULL &&
-        SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
-                                             &useWindowsDarkMode,
-                                             sizeof(useWindowsDarkMode),
-                                             NULL))
+    if (SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                              &useWindowsDarkMode,
+                                              sizeof(useWindowsDarkMode),
+                                              NULL))
     {
         ChecksumHostPolicyKnown = TRUE;
         ChecksumHostUseWindowsDarkMode = useWindowsDarkMode;
     }
+
+    if (ChecksumHostPolicyKnown && ChecksumHostUseWindowsDarkMode)
+    {
+        ChecksumHostSchemeText = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        ChecksumHostSchemeBackground = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+BOOL ChecksumShouldUseWindowsDarkMode()
+{
     return ChecksumHostPolicyKnown && ChecksumHostUseWindowsDarkMode;
 }
 
 void ConfigureChecksumDarkModeFromHost()
 {
+    RefreshChecksumDarkModeFromHost();
+
     const BOOL useWindowsDarkMode = ChecksumShouldUseWindowsDarkMode();
     const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
     const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
     COLORREF text = fallbackText;
     COLORREF background = fallbackBackground;
 
-    if (useWindowsDarkMode && SalamanderGeneral != NULL)
+    if (useWindowsDarkMode && ChecksumHostSchemeText != CLR_INVALID && ChecksumHostSchemeBackground != CLR_INVALID)
     {
-        text = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
-        background = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+        text = ChecksumHostSchemeText;
+        background = ChecksumHostSchemeBackground;
     }
 
     const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
@@ -213,9 +240,11 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the general Salamander interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    ChecksumMainThreadId = GetCurrentThreadId();
     SalamanderSafeFile = salamander->GetSalamanderSafeFile();
     SalamanderGUI = salamander->GetSalamanderGUI();
     SalamanderCrypt = SalamanderGeneral->GetSalamanderCrypt();
+    RefreshChecksumDarkModeFromHost();
 
     // set the help file name
     SalamanderGeneral->SetHelpFileName("checksum.chm");
@@ -329,6 +358,9 @@ OnConfiguration(HWND hParent)
                                          LoadStr(IDS_PLUGINNAME), MB_ICONINFORMATION | MB_OK);
         return IDCANCEL;
     }
+
+    RefreshChecksumDarkModeFromHost();
+    ConfigureChecksumDarkModeFromHost();
 
     bInConfiguration = true;
     CConfigurationDialog dlg(hParent);

--- a/src/plugins/checksum/checksum.cpp
+++ b/src/plugins/checksum/checksum.cpp
@@ -8,6 +8,7 @@
 #include "checksum.h"
 #include "misc.h"
 #include "dialogs.h"
+#include "../../darkmode.h"
 
 // ****************************************************************************
 
@@ -50,6 +51,109 @@ static const char* CONFIG_VERSION = "Version";
 static const char* CONFIG_HASHTYPE = "Hash Type";
 static const char* CONFIG_CALCDLGWIDTHS = "Dialog Size 1";
 static const char* CONFIG_VERDLGWIDTHS = "Dialog Size 2";
+
+// ****************************************************************************
+
+namespace
+{
+HBRUSH ChecksumDarkModeDialogBrush = NULL;
+COLORREF ChecksumDarkModeDialogBrushColor = CLR_INVALID;
+BOOL ChecksumHostPolicyKnown = FALSE;
+BOOL ChecksumHostUseWindowsDarkMode = FALSE;
+
+HBRUSH ChecksumGetDarkModeDialogBrush(COLORREF background)
+{
+    if (ChecksumDarkModeDialogBrush == NULL || ChecksumDarkModeDialogBrushColor != background)
+    {
+        if (ChecksumDarkModeDialogBrush != NULL)
+            DeleteObject(ChecksumDarkModeDialogBrush);
+        ChecksumDarkModeDialogBrush = CreateSolidBrush(background);
+        ChecksumDarkModeDialogBrushColor = background;
+    }
+    return ChecksumDarkModeDialogBrush;
+}
+
+void ReleaseChecksumDarkModeResources()
+{
+    if (ChecksumDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(ChecksumDarkModeDialogBrush);
+        ChecksumDarkModeDialogBrush = NULL;
+        ChecksumDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+}
+
+BOOL ChecksumShouldUseWindowsDarkMode()
+{
+    BOOL useWindowsDarkMode = FALSE;
+    if (SalamanderGeneral != NULL &&
+        SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                             &useWindowsDarkMode,
+                                             sizeof(useWindowsDarkMode),
+                                             NULL))
+    {
+        ChecksumHostPolicyKnown = TRUE;
+        ChecksumHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+    return ChecksumHostPolicyKnown && ChecksumHostUseWindowsDarkMode;
+}
+
+void ConfigureChecksumDarkModeFromHost()
+{
+    const BOOL useWindowsDarkMode = ChecksumShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && SalamanderGeneral != NULL)
+    {
+        text = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        background = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = ChecksumGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyChecksumDarkMode(HWND hwnd)
+{
+    ConfigureChecksumDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL ApplyChecksumDarkModeIfSelected(HWND hwnd)
+{
+    if (!ChecksumShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ApplyChecksumDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL HandleChecksumDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!ChecksumShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureChecksumDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
 
 // ****************************************************************************
 
@@ -162,7 +266,10 @@ BOOL CPluginInterface::Release(HWND parent, BOOL force)
         if (!ThreadQueue.KillAll(force) && !force)
             ret = FALSE;
         else
+        {
+            ReleaseChecksumDarkModeResources();
             ReleaseWinLib(DLLInstance);
+        }
     }
     return ret;
 }

--- a/src/plugins/checksum/checksum.h
+++ b/src/plugins/checksum/checksum.h
@@ -86,6 +86,7 @@ extern HINSTANCE HLanguage;   // handle to the SLG - language-dependent resource
 
 char* LoadStr(int resID);
 INT_PTR OnConfiguration(HWND hParent);
+void RefreshChecksumDarkModeFromHost();
 void ConfigureChecksumDarkModeFromHost();
 void ApplyChecksumDarkMode(HWND hwnd);
 BOOL ApplyChecksumDarkModeIfSelected(HWND hwnd);

--- a/src/plugins/checksum/checksum.h
+++ b/src/plugins/checksum/checksum.h
@@ -86,6 +86,10 @@ extern HINSTANCE HLanguage;   // handle to the SLG - language-dependent resource
 
 char* LoadStr(int resID);
 INT_PTR OnConfiguration(HWND hParent);
+void ConfigureChecksumDarkModeFromHost();
+void ApplyChecksumDarkMode(HWND hwnd);
+BOOL ApplyChecksumDarkModeIfSelected(HWND hwnd);
+BOOL HandleChecksumDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);
 
 #define CMD_CALCULATE 1
 #define CMD_VERIFY 2

--- a/src/plugins/checksum/dialogs.cpp
+++ b/src/plugins/checksum/dialogs.cpp
@@ -8,6 +8,7 @@
 #include "lang\lang.rh"
 #include "dialogs.h"
 #include "misc.h"
+#include "../../darkmode.h"
 
 CWindowQueue ModelessQueue("CheckSum Modeless Windows");  // list of all modeless windows
 CThreadQueue ThreadQueue("CheckSum Dialogs and Workers"); // list of all dialog and worker threads
@@ -282,7 +283,7 @@ INT_PTR CSFVMD5Dialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     CALL_STACK_MESSAGE_NONE // frequently called function
         //CALL_STACK_MESSAGE4("CSFVMD5Dialog::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
 
-        switch (uMsg)
+    switch (uMsg)
     {
     case WM_INITDIALOG:
     {
@@ -300,9 +301,44 @@ INT_PTR CSFVMD5Dialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 delete lv; // not attached = automatic deallocation will not happen
         }
 
+        ApplyChecksumDarkMode(HWindow);
+
         SetForegroundWindow(HWindow);
 
         SetTimer(HWindow, IDT_UPDATEUI, IDT_UPDATESUI_PERIOD, NULL);
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyChecksumDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureChecksumDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyChecksumDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleChecksumDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
         break;
     }
 
@@ -1201,6 +1237,8 @@ INT_PTR CCalculateDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             SetWindowLongPtr(hProgress, GWL_STYLE, style & ~PBS_MARQUEE);
         }
         SendMessage(hProgress, PBM_SETRANGE, 0, MAKELPARAM(0, 1024));
+        if (ApplyChecksumDarkModeIfSelected(HWindow))
+            RedrawWindow(hProgress, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
 
         BOOL startThread = FALSE;
         for (int i = 0; i < HT_COUNT; i++)
@@ -2236,10 +2274,44 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
+        ApplyChecksumDarkMode(HWindow);
         // Center horizontally & vertically to parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
         break; // Need DefDlgProc to set focus
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyChecksumDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureChecksumDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyChecksumDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleChecksumDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
     }
     } // switch
     return CDialog::DialogProc(uMsg, wParam, lParam);

--- a/src/plugins/checksum/dialogs.cpp
+++ b/src/plugins/checksum/dialogs.cpp
@@ -2154,6 +2154,8 @@ BOOL OpenCalculateDialog(HWND parent)
     BOOL bAlwaysOnTop = FALSE;
     // NOTE: GetConfigParameter can only be called from the main thread
     SalamanderGeneral->GetConfigParameter(SALCFG_ALWAYSONTOP, &bAlwaysOnTop, sizeof(bAlwaysOnTop), NULL);
+    RefreshChecksumDarkModeFromHost();
+    ConfigureChecksumDarkModeFromHost(); // prime darkmodelib on the main thread before the dialog worker starts
 
     CCalculateDialogThread* t = new CCalculateDialogThread(parent, bAlwaysOnTop, pFileList, _strdup(sourcePath));
     if (t != NULL)
@@ -2228,6 +2230,8 @@ BOOL OpenVerifyDialog(HWND parent)
     BOOL bAlwaysOnTop = FALSE;
     // NOTE: GetConfigParameter can only be called from the main thread
     SalamanderGeneral->GetConfigParameter(SALCFG_ALWAYSONTOP, &bAlwaysOnTop, sizeof(bAlwaysOnTop), NULL);
+    RefreshChecksumDarkModeFromHost();
+    ConfigureChecksumDarkModeFromHost(); // prime darkmodelib on the main thread before the dialog worker starts
 
     CVerifyDialogThread* t = new CVerifyDialogThread(parent, bAlwaysOnTop);
     if (t != NULL)

--- a/src/plugins/checksum/vcxproj/checksum.props
+++ b/src/plugins/checksum/vcxproj/checksum.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/checksum/vcxproj/checksum.vcxproj
+++ b/src/plugins/checksum/vcxproj/checksum.vcxproj
@@ -129,6 +129,44 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\checksum.cpp">
     </ClCompile>
     <ClCompile Include="..\dialogs.cpp">

--- a/src/plugins/checksum/vcxproj/checksum.vcxproj.filters
+++ b/src/plugins/checksum/vcxproj/checksum.vcxproj.filters
@@ -42,6 +42,39 @@
     <ClCompile Include="..\..\shared\winliblt.cpp">
       <Filter>cpp</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
     <ClCompile Include="..\wrappers.cpp">
       <Filter>cpp</Filter>
     </ClCompile>

--- a/src/plugins/ftp/dialogs.h
+++ b/src/plugins/ftp/dialogs.h
@@ -105,6 +105,7 @@ public:
 
 protected:
     virtual void NotifDlgJustCreated();
+    virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 
 //

--- a/src/plugins/ftp/dialogs1.cpp
+++ b/src/plugins/ftp/dialogs1.cpp
@@ -3,7 +3,6 @@
 // CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
-#include "..\\shared\\plugindarkmode.h"
 
 TIndirectArray<CDialog> ModelessDlgs(2, 2, dtNoDelete); // array of "Welcome Message" dialogs
 
@@ -28,14 +27,20 @@ CCenteredDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // horizontal and vertical centering of the dialog relative to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
+        ApplyFTPDarkMode(HWindow);
         break; // Let DefDlgProc set the focus
     }
 
     case WM_THEMECHANGED:
     case WM_SETTINGCHANGE:
     {
-        PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam);
+        ConfigureFTPDarkModeFromHost();
+        if (uMsg == WM_THEMECHANGED || DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyFTPDarkMode(HWindow);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return TRUE;
+        }
         break;
     }
 
@@ -46,9 +51,9 @@ CCenteredDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORDLG:
     case WM_CTLCOLORMSGBOX:
     {
-        LRESULT brush = 0;
-        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
-            return brush;
+        INT_PTR result = 0;
+        if (HandleFTPDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
         break;
     }
     }
@@ -68,6 +73,53 @@ void CCenteredDialog::NotifDlgJustCreated()
 void CCommonPropSheetPage::NotifDlgJustCreated()
 {
     SalamanderGUI->ArrangeHorizontalLines(HWindow);
+}
+
+INT_PTR
+CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+    case WM_INITDIALOG:
+    {
+        ApplyFTPDarkModeIfSelected(HWindow);
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyFTPDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureFTPDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyFTPDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleFTPDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
+    }
+    return CPropSheetPage::DialogProc(uMsg, wParam, lParam);
 }
 
 //

--- a/src/plugins/ftp/dialogs2.cpp
+++ b/src/plugins/ftp/dialogs2.cpp
@@ -893,12 +893,6 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
-    case WM_DESTROY:
-    {
-        ReleaseFTPLogsMenuTheme(HWindow);
-        break;
-    }
-
     case WM_CTLCOLORDLG:
     case WM_CTLCOLORSTATIC:
     case WM_CTLCOLORBTN:
@@ -1151,6 +1145,8 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_DESTROY:
     {
+        ReleaseFTPLogsMenuTheme(HWindow);
+
         if (HasDelayedUpdateTimer)
             KillTimer(HWindow, LOGSDLG_DELAYEDUPDATETIMER);
         HasDelayedUpdateTimer = FALSE;

--- a/src/plugins/ftp/dialogs2.cpp
+++ b/src/plugins/ftp/dialogs2.cpp
@@ -89,6 +89,149 @@ void FillFTPLogsMenuRect(HDC hdc, const RECT* rect, COLORREF color)
     }
 }
 
+
+struct CFTPLogsTopMenuItem
+{
+    DWORD Magic;
+    char Text[64];
+};
+
+const DWORD FTP_LOGS_TOP_MENU_MAGIC = 0x4C54464D; // "MFTL"
+CFTPLogsTopMenuItem FTPLogsTopMenuItems[3];
+
+void SelectFTPLogsMenuFont(HDC hdc, HFONT& oldFont, HFONT& menuFont)
+{
+    NONCLIENTMETRICS ncm;
+    memset(&ncm, 0, sizeof(ncm));
+    ncm.cbSize = sizeof(ncm);
+    if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm, 0))
+        menuFont = HANDLES(CreateFontIndirect(&ncm.lfMenuFont));
+    if (menuFont == NULL)
+        menuFont = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
+    oldFont = (HFONT)SelectObject(hdc, menuFont);
+}
+
+void RestoreFTPLogsMenuFont(HDC hdc, HFONT oldFont, HFONT menuFont)
+{
+    if (oldFont != NULL)
+        SelectObject(hdc, oldFont);
+    if (menuFont != NULL && menuFont != (HFONT)GetStockObject(DEFAULT_GUI_FONT))
+        HANDLES(DeleteObject(menuFont));
+}
+
+void SetFTPLogsTopMenuOwnerDraw(HWND hwnd, BOOL enable)
+{
+    HMENU menu = GetMenu(hwnd);
+    if (menu == NULL)
+        return;
+
+    int count = GetMenuItemCount(menu);
+    if (count > (int)_countof(FTPLogsTopMenuItems))
+        count = (int)_countof(FTPLogsTopMenuItems);
+
+    for (int i = 0; i < count; i++)
+    {
+        CFTPLogsTopMenuItem& item = FTPLogsTopMenuItems[i];
+        if (item.Text[0] == 0)
+            GetMenuString(menu, i, item.Text, (int)_countof(item.Text), MF_BYPOSITION);
+
+        MENUITEMINFO mii;
+        memset(&mii, 0, sizeof(mii));
+        mii.cbSize = sizeof(mii);
+        if (enable)
+        {
+            item.Magic = FTP_LOGS_TOP_MENU_MAGIC;
+            mii.fMask = MIIM_FTYPE | MIIM_DATA;
+            mii.fType = MFT_OWNERDRAW;
+            mii.dwItemData = (ULONG_PTR)&item;
+        }
+        else
+        {
+            item.Magic = 0;
+            mii.fMask = MIIM_FTYPE | MIIM_STRING | MIIM_DATA;
+            mii.fType = MFT_STRING;
+            mii.dwTypeData = item.Text;
+            mii.cch = (UINT)strlen(item.Text);
+            mii.dwItemData = 0;
+        }
+        SetMenuItemInfo(menu, i, TRUE, &mii);
+    }
+}
+
+CFTPLogsTopMenuItem* GetFTPLogsTopMenuItem(ULONG_PTR itemData)
+{
+    CFTPLogsTopMenuItem* item = (CFTPLogsTopMenuItem*)itemData;
+    if (item == NULL || item->Magic != FTP_LOGS_TOP_MENU_MAGIC)
+        return NULL;
+    return item;
+}
+
+BOOL MeasureFTPLogsTopMenuItem(MEASUREITEMSTRUCT* measure)
+{
+    CFTPLogsTopMenuItem* item = GetFTPLogsTopMenuItem(measure->itemData);
+    if (item == NULL)
+        return FALSE;
+
+    HDC hdc = GetDC(NULL);
+    if (hdc != NULL)
+    {
+        HFONT oldFont = NULL;
+        HFONT menuFont = NULL;
+        SelectFTPLogsMenuFont(hdc, oldFont, menuFont);
+        SIZE size;
+        if (GetTextExtentPoint32(hdc, item->Text, (int)strlen(item->Text), &size))
+            measure->itemWidth = size.cx + 16;
+        RestoreFTPLogsMenuFont(hdc, oldFont, menuFont);
+        ReleaseDC(NULL, hdc);
+    }
+    if (measure->itemWidth == 0)
+        measure->itemWidth = 64;
+    measure->itemHeight = GetSystemMetrics(SM_CYMENU);
+    return TRUE;
+}
+
+BOOL DrawFTPLogsTopMenuItem(DRAWITEMSTRUCT* draw)
+{
+    CFTPLogsTopMenuItem* item = GetFTPLogsTopMenuItem(draw->itemData);
+    if (item == NULL)
+        return FALSE;
+
+    const BOOL dark = DarkModeShouldUseDarkColors();
+    const DarkModeColors& colors = DarkModeGetColors();
+    COLORREF background = dark ? colors.background : GetSysColor(COLOR_MENU);
+    COLORREF text = dark ? colors.readableText : GetSysColor(COLOR_MENUTEXT);
+    if ((draw->itemState & ODS_SELECTED) != 0)
+        background = dark ? RGB(0x3A, 0x3A, 0x3A) : GetSysColor(COLOR_HIGHLIGHT);
+    else if ((draw->itemState & ODS_HOTLIGHT) != 0)
+        background = dark ? RGB(0x45, 0x45, 0x45) : GetSysColor(COLOR_HIGHLIGHT);
+    if ((draw->itemState & (ODS_GRAYED | ODS_DISABLED | ODS_INACTIVE)) != 0)
+        text = dark ? RGB(0x80, 0x80, 0x80) : GetSysColor(COLOR_GRAYTEXT);
+
+    FillFTPLogsMenuRect(draw->hDC, &draw->rcItem, background);
+
+    HFONT oldFont = NULL;
+    HFONT menuFont = NULL;
+    SelectFTPLogsMenuFont(draw->hDC, oldFont, menuFont);
+    int oldBkMode = SetBkMode(draw->hDC, TRANSPARENT);
+    COLORREF oldText = SetTextColor(draw->hDC, text);
+    RECT textRect = draw->rcItem;
+    InflateRect(&textRect, -8, 0);
+    UINT flags = DT_SINGLELINE | DT_VCENTER;
+    if ((draw->itemState & ODS_NOACCEL) != 0)
+        flags |= DT_HIDEPREFIX;
+    DrawText(draw->hDC, item->Text, -1, &textRect, flags);
+    SetTextColor(draw->hDC, oldText);
+    SetBkMode(draw->hDC, oldBkMode);
+    RestoreFTPLogsMenuFont(draw->hDC, oldFont, menuFont);
+    return TRUE;
+}
+
+void ReleaseFTPLogsMenuTheme(HWND hwnd)
+{
+    SetFTPLogsTopMenuOwnerDraw(hwnd, FALSE);
+    EnsureFTPLogsMenuBrush(CLR_INVALID, FALSE);
+}
+
 void ApplyFTPLogsMenuTheme(HWND hwnd)
 {
     HMENU menu = GetMenu(hwnd);
@@ -106,9 +249,11 @@ void ApplyFTPLogsMenuTheme(HWND hwnd)
         HBRUSH brush = EnsureFTPLogsMenuBrush(DarkModeGetColors().background, TRUE);
         if (brush != NULL)
             menuBrush = brush;
+        SetFTPLogsTopMenuOwnerDraw(hwnd, TRUE);
     }
     else
     {
+        SetFTPLogsTopMenuOwnerDraw(hwnd, FALSE);
         EnsureFTPLogsMenuBrush(CLR_INVALID, FALSE);
     }
 
@@ -690,6 +835,22 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
+    case WM_MEASUREITEM:
+    {
+        MEASUREITEMSTRUCT* measure = (MEASUREITEMSTRUCT*)lParam;
+        if (measure != NULL && measure->CtlType == ODT_MENU && MeasureFTPLogsTopMenuItem(measure))
+            return TRUE;
+        break;
+    }
+
+    case WM_DRAWITEM:
+    {
+        DRAWITEMSTRUCT* draw = (DRAWITEMSTRUCT*)lParam;
+        if (draw != NULL && draw->CtlType == ODT_MENU && DrawFTPLogsTopMenuItem(draw))
+            return TRUE;
+        break;
+    }
+
     case WM_UAHDRAWMENU:
     {
         if (DarkModeShouldUseDarkColors() && lParam != 0)
@@ -729,6 +890,12 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             InvalidateRect(HWindow, NULL, TRUE);
             return TRUE;
         }
+        break;
+    }
+
+    case WM_DESTROY:
+    {
+        ReleaseFTPLogsMenuTheme(HWindow);
         break;
     }
 

--- a/src/plugins/ftp/dialogs2.cpp
+++ b/src/plugins/ftp/dialogs2.cpp
@@ -4,6 +4,177 @@
 
 #include "precomp.h"
 
+
+namespace
+{
+#ifndef WM_UAHDRAWMENU
+#define WM_UAHDRAWMENU 0x0091
+#endif
+#ifndef WM_UAHDRAWMENUITEM
+#define WM_UAHDRAWMENUITEM 0x0092
+#endif
+
+typedef struct tagFTPUAHMENU
+{
+    HMENU hmenu;
+    HDC hdc;
+    DWORD dwFlags;
+} FTPUAHMENU;
+
+typedef struct tagFTPUAHMENUITEMMETRICS
+{
+    DWORD rgsizeBar[2];
+    DWORD rgsizePopup[4];
+} FTPUAHMENUITEMMETRICS;
+
+typedef struct tagFTPUAHMENUPOPUPMETRICS
+{
+    DWORD rgcx[4];
+    DWORD fUpdateMaxWidths : 2;
+} FTPUAHMENUPOPUPMETRICS;
+
+typedef struct tagFTPUAHMENUITEM
+{
+    int iPosition;
+    FTPUAHMENUITEMMETRICS umim;
+    FTPUAHMENUPOPUPMETRICS umpm;
+} FTPUAHMENUITEM;
+
+typedef struct tagFTPUAHDRAWMENUITEM
+{
+    DRAWITEMSTRUCT dis;
+    FTPUAHMENU um;
+    FTPUAHMENUITEM umi;
+} FTPUAHDRAWMENUITEM;
+
+HBRUSH EnsureFTPLogsMenuBrush(COLORREF color, BOOL enable)
+{
+    static COLORREF cachedColor = CLR_INVALID;
+    static HBRUSH cachedBrush = NULL;
+
+    if (!enable)
+    {
+        if (cachedBrush != NULL)
+        {
+            HANDLES(DeleteObject(cachedBrush));
+            cachedBrush = NULL;
+            cachedColor = CLR_INVALID;
+        }
+        return NULL;
+    }
+
+    if (cachedBrush != NULL && cachedColor != color)
+    {
+        HANDLES(DeleteObject(cachedBrush));
+        cachedBrush = NULL;
+        cachedColor = CLR_INVALID;
+    }
+
+    if (cachedBrush == NULL)
+    {
+        cachedBrush = HANDLES(CreateSolidBrush(color));
+        cachedColor = color;
+    }
+
+    return cachedBrush;
+}
+
+void FillFTPLogsMenuRect(HDC hdc, const RECT* rect, COLORREF color)
+{
+    HBRUSH brush = HANDLES(CreateSolidBrush(color));
+    if (brush != NULL)
+    {
+        FillRect(hdc, rect, brush);
+        HANDLES(DeleteObject(brush));
+    }
+}
+
+void ApplyFTPLogsMenuTheme(HWND hwnd)
+{
+    HMENU menu = GetMenu(hwnd);
+    if (menu == NULL)
+        return;
+
+    MENUINFO info;
+    memset(&info, 0, sizeof(info));
+    info.cbSize = sizeof(info);
+    info.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
+
+    HBRUSH menuBrush = GetSysColorBrush(COLOR_MENU);
+    if (DarkModeShouldUseDarkColors())
+    {
+        HBRUSH brush = EnsureFTPLogsMenuBrush(DarkModeGetColors().background, TRUE);
+        if (brush != NULL)
+            menuBrush = brush;
+    }
+    else
+    {
+        EnsureFTPLogsMenuBrush(CLR_INVALID, FALSE);
+    }
+
+    info.hbrBack = menuBrush;
+    SetMenuInfo(menu, &info);
+    DrawMenuBar(hwnd);
+}
+
+void PaintFTPLogsMenuBar(HWND hwnd, HDC hdc)
+{
+    if (hwnd == NULL || hdc == NULL || !DarkModeShouldUseDarkColors())
+        return;
+
+    MENUBARINFO mbi;
+    memset(&mbi, 0, sizeof(mbi));
+    mbi.cbSize = sizeof(mbi);
+    if (!GetMenuBarInfo(hwnd, OBJID_MENU, 0, &mbi))
+        return;
+
+    RECT wndRect;
+    GetWindowRect(hwnd, &wndRect);
+    RECT barRect = mbi.rcBar;
+    OffsetRect(&barRect, -wndRect.left, -wndRect.top);
+    barRect.top -= 1;
+
+    FillFTPLogsMenuRect(hdc, &barRect, DarkModeGetColors().background);
+}
+
+void PaintFTPLogsMenuBarItem(FTPUAHDRAWMENUITEM* item)
+{
+    if (item == NULL || !DarkModeShouldUseDarkColors())
+        return;
+
+    const DarkModeColors& colors = DarkModeGetColors();
+    COLORREF background = colors.background;
+    COLORREF text = colors.readableText;
+    if ((item->dis.itemState & ODS_SELECTED) != 0)
+        background = RGB(0x3A, 0x3A, 0x3A);
+    else if ((item->dis.itemState & ODS_HOTLIGHT) != 0)
+        background = RGB(0x45, 0x45, 0x45);
+    if ((item->dis.itemState & (ODS_GRAYED | ODS_DISABLED | ODS_INACTIVE)) != 0)
+        text = RGB(0x80, 0x80, 0x80);
+
+    FillFTPLogsMenuRect(item->um.hdc, &item->dis.rcItem, background);
+
+    char textBuf[MAX_PATH];
+    textBuf[0] = 0;
+    MENUITEMINFO mii;
+    memset(&mii, 0, sizeof(mii));
+    mii.cbSize = sizeof(mii);
+    mii.fMask = MIIM_STRING;
+    mii.dwTypeData = textBuf;
+    mii.cch = _countof(textBuf) - 1;
+    GetMenuItemInfo(item->um.hmenu, (UINT)item->umi.iPosition, TRUE, &mii);
+
+    int oldBkMode = SetBkMode(item->um.hdc, TRANSPARENT);
+    COLORREF oldText = SetTextColor(item->um.hdc, text);
+    UINT flags = DT_CENTER | DT_SINGLELINE | DT_VCENTER;
+    if ((item->dis.itemState & ODS_NOACCEL) != 0)
+        flags |= DT_HIDEPREFIX;
+    DrawText(item->um.hdc, textBuf, -1, &item->dis.rcItem, flags);
+    SetTextColor(item->um.hdc, oldText);
+    SetBkMode(item->um.hdc, oldBkMode);
+}
+} // namespace
+
 //
 // ****************************************************************************
 // CSimpleDlgControlWindow
@@ -485,6 +656,7 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         LoadListOfLogs(FALSE);
 
         ApplyFTPDarkMode(HWindow);
+        ApplyFTPLogsMenuTheme(HWindow);
 
         if (ShowLogUID != -1)
             SendMessage(HWindow, WM_APP_ACTIVATELOG, ShowLogUID, 0);
@@ -518,9 +690,31 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
+    case WM_UAHDRAWMENU:
+    {
+        if (DarkModeShouldUseDarkColors() && lParam != 0)
+        {
+            FTPUAHMENU* menu = reinterpret_cast<FTPUAHMENU*>(lParam);
+            PaintFTPLogsMenuBar(HWindow, menu->hdc);
+            return 0;
+        }
+        break;
+    }
+
+    case WM_UAHDRAWMENUITEM:
+    {
+        if (DarkModeShouldUseDarkColors() && lParam != 0)
+        {
+            PaintFTPLogsMenuBarItem(reinterpret_cast<FTPUAHDRAWMENUITEM*>(lParam));
+            return 0;
+        }
+        break;
+    }
+
     case WM_THEMECHANGED:
     {
         ApplyFTPDarkMode(HWindow);
+        ApplyFTPLogsMenuTheme(HWindow);
         RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
         return TRUE;
     }
@@ -531,6 +725,7 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (DarkModeHandleSettingChange(uMsg, lParam))
         {
             ApplyFTPDarkMode(HWindow);
+            ApplyFTPLogsMenuTheme(HWindow);
             InvalidateRect(HWindow, NULL, TRUE);
             return TRUE;
         }

--- a/src/plugins/ftp/dialogs2.cpp
+++ b/src/plugins/ftp/dialogs2.cpp
@@ -484,6 +484,8 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         LoadListOfLogs(FALSE);
 
+        ApplyFTPDarkMode(HWindow);
+
         if (ShowLogUID != -1)
             SendMessage(HWindow, WM_APP_ACTIVATELOG, ShowLogUID, 0);
 
@@ -513,6 +515,39 @@ CLogsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 SalamanderGeneral->MultiMonCenterWindow(HWindow, CenterToWnd, TRUE);
             }
         }
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyFTPDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureFTPDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyFTPDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleFTPDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
         break;
     }
 

--- a/src/plugins/ftp/dialogs4.cpp
+++ b/src/plugins/ftp/dialogs4.cpp
@@ -3,7 +3,6 @@
 // CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
-#include "..\\shared\\plugindarkmode.h"
 
 //
 // ****************************************************************************
@@ -1345,9 +1344,9 @@ CConfirmDeleteDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORDLG:
     case WM_CTLCOLORMSGBOX:
     {
-        LRESULT brush = 0;
-        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
-            return brush;
+        INT_PTR result = 0;
+        if (HandleFTPDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
         break;
     }
 
@@ -1356,7 +1355,7 @@ CConfirmDeleteDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SetDlgItemText(HWindow, IDT_DELSUBJECT, Subject);
         SendDlgItemMessage(HWindow, IDC_DELICON, STM_SETICON,
                            (WPARAM)(Icon == NULL ? HANDLES(LoadIcon(NULL, IDI_QUESTION)) : Icon), 0);
-        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
+        ApplyFTPDarkMode(HWindow);
         break;
     }
     }

--- a/src/plugins/ftp/dialogs6.cpp
+++ b/src/plugins/ftp/dialogs6.cpp
@@ -3,7 +3,6 @@
 // CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
-#include "..\\shared\\plugindarkmode.h"
 
 //
 // ****************************************************************************
@@ -38,7 +37,7 @@ COperationDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
-        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
+        ApplyFTPDarkMode(HWindow);
         BOOL preventSystemFromSettingFocus = FALSE;
         GetDlgItemText(HWindow, IDB_PAUSERESUME, PauseButtonPauseText, 50);
         GetDlgItemText(HWindow, IDB_OPCONSPAUSERESUME, ConPauseButtonPauseText, 50);
@@ -349,6 +348,8 @@ COperationDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // FIXME: once we have the operations queue window we can make Hide visible again (and remove "disabled" from the resources)
         // also restore the text in the resources:  IDS_OPERDLGCONFIRMCANCEL, "Do you really want to cancel operation?\n\nNote: use Hide button to close window without cancelling operation."
         ShowWindow(GetDlgItem(HWindow, IDB_HIDE), SW_HIDE);
+
+        ApplyFTPDarkModeIfSelected(HWindow);
 
         if (preventSystemFromSettingFocus)
         {
@@ -1044,16 +1045,27 @@ COperationDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_SYSCOLORCHANGE:
     {
-        DWORD color = GetSysColor(COLOR_WINDOW);
+        const COLORREF color = DarkModeShouldUseDarkColors() ? DarkModeGetColors().background : GetSysColor(COLOR_WINDOW);
+        const COLORREF text = DarkModeShouldUseDarkColors() ? DarkModeGetColors().readableText : GetSysColor(COLOR_WINDOWTEXT);
         ListView_SetBkColor(ConsListView, color);
+        ListView_SetTextBkColor(ConsListView, color);
+        ListView_SetTextColor(ConsListView, text);
         ListView_SetBkColor(ItemsListView, color);
+        ListView_SetTextBkColor(ItemsListView, color);
+        ListView_SetTextColor(ItemsListView, text);
         break;
     }
 
     case WM_THEMECHANGED:
     case WM_SETTINGCHANGE:
     {
-        PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam);
+        ConfigureFTPDarkModeFromHost();
+        if (uMsg == WM_THEMECHANGED || DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyFTPDarkMode(HWindow);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return TRUE;
+        }
         break;
     }
 
@@ -1081,9 +1093,9 @@ COperationDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORDLG:
     case WM_CTLCOLORMSGBOX:
     {
-        LRESULT brush = 0;
-        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
-            return brush;
+        INT_PTR result = 0;
+        if (HandleFTPDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
 
         if (uMsg != WM_CTLCOLORBTN)
             break;

--- a/src/plugins/ftp/fs1.cpp
+++ b/src/plugins/ftp/fs1.cpp
@@ -320,6 +320,8 @@ void CPluginInterfaceForFS::ExecuteChangeDriveMenuItem(int panel)
 
 void ConnectFTPServer(HWND parent, int panel) // called in Alt+F1/F2 and in Drive bars and from the plugin menu
 {
+    RefreshFTPDarkModeFromHost();
+    ConfigureFTPDarkModeFromHost();
     CConnectDlg dlg(parent);
     if (dlg.IsGood())
     {
@@ -369,6 +371,8 @@ void ConnectFTPServer(HWND parent, int panel) // called in Alt+F1/F2 and in Driv
 
 void OrganizeBookmarks(HWND parent) // called in Alt+F1/F2 and in Drive bars and from the plugin menu
 {
+    RefreshFTPDarkModeFromHost();
+    ConfigureFTPDarkModeFromHost();
     CConnectDlg dlg(parent, 1);
     if (dlg.IsGood())
         dlg.Execute();

--- a/src/plugins/ftp/ftp.cpp
+++ b/src/plugins/ftp/ftp.cpp
@@ -232,6 +232,134 @@ char TargetPanelPath[MAX_PATH] = "";
 
 char UserDefinedSuffix[100] = ""; // preloaded string for marking user-defined "server type"
 
+
+namespace
+{
+HBRUSH FTPDarkModeDialogBrush = NULL;
+COLORREF FTPDarkModeDialogBrushColor = CLR_INVALID;
+BOOL FTPHostPolicyKnown = FALSE;
+BOOL FTPHostUseWindowsDarkMode = FALSE;
+COLORREF FTPHostSchemeText = CLR_INVALID;
+COLORREF FTPHostSchemeBackground = CLR_INVALID;
+DWORD FTPMainThreadId = 0;
+
+HBRUSH FTPGetDarkModeDialogBrush(COLORREF background)
+{
+    if (FTPDarkModeDialogBrush == NULL || FTPDarkModeDialogBrushColor != background)
+    {
+        if (FTPDarkModeDialogBrush != NULL)
+            DeleteObject(FTPDarkModeDialogBrush);
+        FTPDarkModeDialogBrush = CreateSolidBrush(background);
+        FTPDarkModeDialogBrushColor = background;
+    }
+    return FTPDarkModeDialogBrush;
+}
+
+void ReleaseFTPDarkModeResources()
+{
+    if (FTPDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(FTPDarkModeDialogBrush);
+        FTPDarkModeDialogBrush = NULL;
+        FTPDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+}
+
+BOOL FTPCanQueryHostDarkMode()
+{
+    return SalamanderGeneral != NULL &&
+           FTPMainThreadId != 0 &&
+           GetCurrentThreadId() == FTPMainThreadId;
+}
+
+void RefreshFTPDarkModeFromHost()
+{
+    // FTP owns several modeless UI threads. Salamander host configuration APIs
+    // are main-thread-only, so worker dialogs use this cached snapshot.
+    if (!FTPCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                              &useWindowsDarkMode,
+                                              sizeof(useWindowsDarkMode),
+                                              NULL))
+    {
+        FTPHostPolicyKnown = TRUE;
+        FTPHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (FTPHostPolicyKnown && FTPHostUseWindowsDarkMode)
+    {
+        FTPHostSchemeText = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        FTPHostSchemeBackground = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+BOOL FTPShouldUseWindowsDarkMode()
+{
+    return FTPHostPolicyKnown && FTPHostUseWindowsDarkMode;
+}
+
+void ConfigureFTPDarkModeFromHost()
+{
+    RefreshFTPDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = FTPShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && FTPHostSchemeText != CLR_INVALID && FTPHostSchemeBackground != CLR_INVALID)
+    {
+        text = FTPHostSchemeText;
+        background = FTPHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = FTPGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyFTPDarkMode(HWND hwnd)
+{
+    ConfigureFTPDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL ApplyFTPDarkModeIfSelected(HWND hwnd)
+{
+    if (!FTPShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ApplyFTPDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL HandleFTPDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!FTPShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureFTPDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     if (fdwReason == DLL_PROCESS_ATTACH)
@@ -302,7 +430,9 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // get the general interface of Salamander
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    FTPMainThreadId = GetCurrentThreadId();
     SalZLIB = SalamanderGeneral->GetSalamanderZLIB();
+    RefreshFTPDarkModeFromHost();
 
     // set the help file name
     SalamanderGeneral->SetHelpFileName("ftp.chm");
@@ -410,6 +540,7 @@ BOOL CPluginInterface::Release(HWND parent, BOOL force)
 
         ReleaseSockets();
         FreeSSL();
+        ReleaseFTPDarkModeResources();
         Config.ReleaseDataFromSalamanderGeneral();
     }
     return ret;
@@ -890,6 +1021,8 @@ void CPluginInterface::SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRe
 void CPluginInterface::Configuration(HWND parent)
 {
     CALL_STACK_MESSAGE1("CPluginInterface::Configuration()");
+    RefreshFTPDarkModeFromHost();
+    ConfigureFTPDarkModeFromHost();
     CConfigDlg(parent).Execute();
 }
 
@@ -991,6 +1124,12 @@ void RefreshValuesOfPanelCtrlCon()
 
 void CPluginInterface::Event(int event, DWORD param)
 {
+    if (event == PLUGINEVENT_COLORSCHANGED || event == PLUGINEVENT_CONFIGURATIONCHANGED || event == PLUGINEVENT_SETTINGCHANGE)
+    {
+        RefreshFTPDarkModeFromHost();
+        ConfigureFTPDarkModeFromHost();
+    }
+
     if (event == PLUGINEVENT_CONFIGURATIONCHANGED)
     {
         SalamanderGeneral->GetConfigParameter(SALCFG_SORTBYEXTDIRSASFILES, &SortByExtDirsAsFiles,

--- a/src/plugins/ftp/ftp.h
+++ b/src/plugins/ftp/ftp.h
@@ -128,6 +128,12 @@ extern int GlobalDisconnectPanel; // panel for which disconnect is called (-1 ==
 
 extern CThreadQueue AuxThreadQueue; // queue of all auxiliary threads
 
+void RefreshFTPDarkModeFromHost();
+void ConfigureFTPDarkModeFromHost();
+void ApplyFTPDarkMode(HWND hwnd);
+BOOL ApplyFTPDarkModeIfSelected(HWND hwnd);
+BOOL HandleFTPDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);
+
 extern BOOL WindowsVistaAndLater; // Windows Vista or later from the NT line
 
 // global variables for the FTPCMD_CHANGETGTPANELPATH command

--- a/src/plugins/ftp/precomp.h
+++ b/src/plugins/ftp/precomp.h
@@ -38,6 +38,7 @@
 #include "arraylt.h"
 #include "winliblt.h"
 #include "auxtools.h"
+#include "../../darkmode.h"
 #include "ftp.rh"
 #include "ftp.rh2"
 #include "lang\lang.rh"

--- a/src/plugins/ftp/vcxproj/ftp.props
+++ b/src/plugins/ftp/vcxproj/ftp.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>WSOCK32.LIB;Crypt32.lib;Cryptui.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/plugins/ftp/vcxproj/ftp.vcxproj
+++ b/src/plugins/ftp/vcxproj/ftp.vcxproj
@@ -125,9 +125,45 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
-    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
-    </ClCompile>
     <ClCompile Include="..\..\shared\mhandles.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
     </ClCompile>
@@ -228,8 +264,6 @@
     <ClInclude Include="..\..\shared\auxtools.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
-    </ClInclude>
-    <ClInclude Include="..\..\shared\plugindarkmode.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\mhandles.h">
     </ClInclude>

--- a/src/plugins/ftp/vcxproj/ftp.vcxproj.filters
+++ b/src/plugins/ftp/vcxproj/ftp.vcxproj.filters
@@ -153,6 +153,39 @@
     <ClCompile Include="..\..\shared\mhandles.cpp">
       <Filter>shared</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <Filter>shared</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
       <Filter>shared</Filter>
     </ClCompile>

--- a/src/plugins/renamer/dialogs.cpp
+++ b/src/plugins/renamer/dialogs.cpp
@@ -226,6 +226,7 @@ ComDlgHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
     {
         // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // we do not do this for Windows common dialogs
         SG->MultiMonCenterWindow(hdlg, GetParent(hdlg), FALSE);
+        ApplyRenamerDarkModeIfSelected(hdlg);
         return 1;
     }
     return 0;
@@ -887,7 +888,41 @@ CProgressDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DialogStackPush(HWindow);
         Progress = SalGUI->AttachProgressBar(HWindow, IDS_PROGRESS);
         SG->MultiMonCenterWindow(HWindow, Parent, FALSE);
+        ApplyRenamerDarkMode(HWindow);
         NextUpdate = GetTickCount();
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyRenamerDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureRenamerDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyRenamerDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleRenamerDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
         break;
     }
 
@@ -980,6 +1015,40 @@ CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SalGUI->ChangeToArrowButton(HWindow, IDB_INITDIRHELP);
         SalGUI->AttachButton(HWindow, IDB_FONT, BTF_RIGHTARROW);
         SG->MultiMonCenterWindow(HWindow, Parent, FALSE);
+        ApplyRenamerDarkMode(HWindow);
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyRenamerDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureRenamerDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyRenamerDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleRenamerDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
         break;
     }
 

--- a/src/plugins/renamer/menu.cpp
+++ b/src/plugins/renamer/menu.cpp
@@ -28,6 +28,8 @@ BOOL CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstrac
     case MID_RENAME:
     {
         SG->GetConfigParameter(SALCFG_ALWAYSONTOP, &AlwaysOnTop, sizeof(AlwaysOnTop), NULL);
+        RefreshRenamerDarkModeFromHost();
+        ConfigureRenamerDarkModeFromHost();
         if (SG->GetPanelSelection(PANEL_SOURCE, NULL, NULL))
         {
             CRenamerDialogThread* t = new CRenamerDialogThread();

--- a/src/plugins/renamer/precomp.h
+++ b/src/plugins/renamer/precomp.h
@@ -33,6 +33,7 @@
 #include "arraylt.h"
 #include "winliblt.h"
 #include "auxtools.h"
+#include "mhandles.h"
 #include "../../darkmode.h"
 
 #include "renamer.rh"

--- a/src/plugins/renamer/precomp.h
+++ b/src/plugins/renamer/precomp.h
@@ -8,6 +8,7 @@
 #include <windows.h>
 #include <CommDlg.h>
 #include <ShellAPI.h>
+#include <shlobj.h>
 #include <crtdbg.h>
 #include <ostream>
 #include <stdio.h>

--- a/src/plugins/renamer/precomp.h
+++ b/src/plugins/renamer/precomp.h
@@ -33,7 +33,7 @@
 #include "arraylt.h"
 #include "winliblt.h"
 #include "auxtools.h"
-#include "plugindarkmode.h"
+#include "../../darkmode.h"
 
 #include "renamer.rh"
 #include "renamer.rh2"

--- a/src/plugins/renamer/preview.cpp
+++ b/src/plugins/renamer/preview.cpp
@@ -344,9 +344,9 @@ BOOL CPreviewWindow::CustomDraw(LPNMLVCUSTOMDRAW cd, LRESULT& result)
             break;
         }
 
-        if (PluginDarkMode_ShouldUseDark())
+        if (DarkModeShouldUseDarkColors())
         {
-            PluginDarkModeColors colors = PluginDarkMode_GetColors();
+            const DarkModeColors& colors = DarkModeGetColors();
             cd->clrTextBk = colors.background;
             if (subItem == CI_NEWNAME &&
                 strcmp(GetItemText(item, CI_OLDNAME), GetItemText(item, CI_NEWNAME)) == 0)
@@ -664,6 +664,7 @@ void CPreviewWindow::SetItemCount(int count, DWORD flags, int state)
 
             HFONT font = (HFONT)SendMessage(HWindow, WM_GETFONT, 0, 0);
             SendMessage(Static, WM_SETFONT, WPARAM(font), 0);
+            ApplyRenamerDarkModeIfSelected(HWindow);
         }
         else
         {
@@ -689,12 +690,31 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         wParam, lParam);
     switch (uMsg)
     {
+    case WM_THEMECHANGED:
+    {
+        ApplyRenamerDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureRenamerDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyRenamerDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
     case WM_CTLCOLORSTATIC:
         if (HWND(lParam) == Static)
         {
-            LRESULT brush = 0;
-            if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
-                return brush;
+            INT_PTR result = 0;
+            if (HandleRenamerDarkCtlColor(uMsg, wParam, lParam, &result))
+                return result;
             SetTextColor((HDC)wParam, GetSysColor(COLOR_WINDOWTEXT));
             return (LRESULT)GetSysColorBrush(COLOR_WINDOW);
         }

--- a/src/plugins/renamer/preview.cpp
+++ b/src/plugins/renamer/preview.cpp
@@ -664,7 +664,12 @@ void CPreviewWindow::SetItemCount(int count, DWORD flags, int state)
 
             HFONT font = (HFONT)SendMessage(HWindow, WM_GETFONT, 0, 0);
             SendMessage(Static, WM_SETFONT, WPARAM(font), 0);
-            ApplyRenamerDarkModeIfSelected(HWindow);
+            if (DarkModeShouldUseDarkColors())
+            {
+                DarkModeApplyWindow(Static);
+                DarkModeApplyStaticTextColors(HWindow, Static);
+                RedrawWindow(Static, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
+            }
         }
         else
         {
@@ -690,25 +695,6 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         wParam, lParam);
     switch (uMsg)
     {
-    case WM_THEMECHANGED:
-    {
-        ApplyRenamerDarkMode(HWindow);
-        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
-        return TRUE;
-    }
-
-    case WM_SETTINGCHANGE:
-    {
-        ConfigureRenamerDarkModeFromHost();
-        if (DarkModeHandleSettingChange(uMsg, lParam))
-        {
-            ApplyRenamerDarkMode(HWindow);
-            InvalidateRect(HWindow, NULL, TRUE);
-            return TRUE;
-        }
-        break;
-    }
-
     case WM_CTLCOLORSTATIC:
         if (HWND(lParam) == Static)
         {

--- a/src/plugins/renamer/renamer.cpp
+++ b/src/plugins/renamer/renamer.cpp
@@ -314,6 +314,8 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     // set SalamanderVersion for "spl_com.h"
     SalamanderVersion = salamander->GetVersion();
 
+    HANDLES_CAN_USE_TRACE();
+
     CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
 
 #ifdef DUMP_MEM

--- a/src/plugins/renamer/renamer.cpp
+++ b/src/plugins/renamer/renamer.cpp
@@ -49,6 +49,135 @@ CThreadQueue ThreadQueue("Renamer Dialogs");
 CWindowQueueEx WindowQueue;
 BOOL AlwaysOnTop = FALSE;
 
+
+namespace
+{
+HBRUSH RenamerDarkModeDialogBrush = NULL;
+COLORREF RenamerDarkModeDialogBrushColor = CLR_INVALID;
+BOOL RenamerHostPolicyKnown = FALSE;
+BOOL RenamerHostUseWindowsDarkMode = FALSE;
+COLORREF RenamerHostSchemeText = CLR_INVALID;
+COLORREF RenamerHostSchemeBackground = CLR_INVALID;
+DWORD RenamerMainThreadId = 0;
+
+HBRUSH RenamerGetDarkModeDialogBrush(COLORREF background)
+{
+    if (RenamerDarkModeDialogBrush == NULL || RenamerDarkModeDialogBrushColor != background)
+    {
+        if (RenamerDarkModeDialogBrush != NULL)
+            DeleteObject(RenamerDarkModeDialogBrush);
+        RenamerDarkModeDialogBrush = CreateSolidBrush(background);
+        RenamerDarkModeDialogBrushColor = background;
+    }
+    return RenamerDarkModeDialogBrush;
+}
+
+void ReleaseRenamerDarkModeResources()
+{
+    if (RenamerDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(RenamerDarkModeDialogBrush);
+        RenamerDarkModeDialogBrush = NULL;
+        RenamerDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+}
+
+BOOL RenamerCanQueryHostDarkMode()
+{
+    return SG != NULL &&
+           RenamerMainThreadId != 0 &&
+           GetCurrentThreadId() == RenamerMainThreadId;
+}
+
+void RefreshRenamerDarkModeFromHost()
+{
+    // The Batch Rename UI runs on its own UI thread. Salamander host
+    // configuration/color APIs are main-thread-only, so worker dialogs consume
+    // this main-thread snapshot instead of querying the host directly.
+    if (!RenamerCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SG->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                               &useWindowsDarkMode,
+                               sizeof(useWindowsDarkMode),
+                               NULL))
+    {
+        RenamerHostPolicyKnown = TRUE;
+        RenamerHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (RenamerHostPolicyKnown && RenamerHostUseWindowsDarkMode)
+    {
+        RenamerHostSchemeText = SG->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        RenamerHostSchemeBackground = SG->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+BOOL RenamerShouldUseWindowsDarkMode()
+{
+    return RenamerHostPolicyKnown && RenamerHostUseWindowsDarkMode;
+}
+
+void ConfigureRenamerDarkModeFromHost()
+{
+    RefreshRenamerDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = RenamerShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && RenamerHostSchemeText != CLR_INVALID && RenamerHostSchemeBackground != CLR_INVALID)
+    {
+        text = RenamerHostSchemeText;
+        background = RenamerHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = RenamerGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyRenamerDarkMode(HWND hwnd)
+{
+    ConfigureRenamerDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL ApplyRenamerDarkModeIfSelected(HWND hwnd)
+{
+    if (!RenamerShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ApplyRenamerDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL HandleRenamerDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!RenamerShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureRenamerDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     CALL_STACK_MESSAGE_NONE
@@ -207,7 +336,9 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the Salamander general interface
     SG = salamander->GetSalamanderGeneral();
+    RenamerMainThreadId = GetCurrentThreadId();
     SalGUI = salamander->GetSalamanderGUI();
+    RefreshRenamerDarkModeFromHost();
 
     // set the help file name
     SG->SetHelpFileName("renamer.chm");
@@ -265,6 +396,7 @@ BOOL CPluginInterface::Release(HWND parent, BOOL force)
             ret = FALSE;
         else
         {
+            ReleaseRenamerDarkModeResources();
             ReleaseDialogs();
 
 #ifdef DUMP_MEM
@@ -421,6 +553,9 @@ void OnConfiguration(HWND hParent)
         SG->SalMessageBox(hParent, LoadStr(IDS_CFG_CONFLICT), LoadStr(IDS_PLUGINNAME), MB_ICONINFORMATION | MB_OK);
         return;
     }
+    RefreshRenamerDarkModeFromHost();
+    ConfigureRenamerDarkModeFromHost();
+
     InConfiguration = TRUE;
 
     if (CConfigDialog(hParent).Execute() == IDOK)
@@ -477,8 +612,10 @@ void CPluginInterface::Event(int event, DWORD param)
     {
     case PLUGINEVENT_COLORSCHANGED:
     {
+        RefreshRenamerDarkModeFromHost();
+        ConfigureRenamerDarkModeFromHost();
         // HSymbolsImageList must not be NULL, otherwise the entry point would return an error
-        COLORREF bkColor = GetSysColor(COLOR_WINDOW);
+        COLORREF bkColor = DarkModeShouldUseDarkColors() ? DarkModeGetColors().background : GetSysColor(COLOR_WINDOW);
         if (ImageList_GetBkColor(HSymbolsImageList) != bkColor)
             ImageList_SetBkColor(HSymbolsImageList, bkColor);
         break;
@@ -486,6 +623,8 @@ void CPluginInterface::Event(int event, DWORD param)
 
     case PLUGINEVENT_CONFIGURATIONCHANGED:
     {
+        RefreshRenamerDarkModeFromHost();
+        ConfigureRenamerDarkModeFromHost();
         // load confirmations from the configuration
         Silent = 0;
         BOOL b;
@@ -500,6 +639,8 @@ void CPluginInterface::Event(int event, DWORD param)
 
     case PLUGINEVENT_SETTINGCHANGE:
     {
+        RefreshRenamerDarkModeFromHost();
+        ConfigureRenamerDarkModeFromHost();
         WindowQueue.BroadcastMessage(WM_USER_SETTINGCHANGE, 0, 0);
         break;
     }

--- a/src/plugins/renamer/renamer.h
+++ b/src/plugins/renamer/renamer.h
@@ -64,6 +64,11 @@ BOOL ErrorL(int lastError, int error, ...);
 int SalPrintf(char* buffer, unsigned count, const char* format, ...);
 
 void OnConfiguration(HWND hParent);
+void RefreshRenamerDarkModeFromHost();
+void ConfigureRenamerDarkModeFromHost();
+void ApplyRenamerDarkMode(HWND hwnd);
+BOOL ApplyRenamerDarkModeIfSelected(HWND hwnd);
+BOOL HandleRenamerDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);
 
 // ****************************************************************************
 //

--- a/src/plugins/renamer/rendlg.cpp
+++ b/src/plugins/renamer/rendlg.cpp
@@ -31,41 +31,6 @@ char* CommandHistory[MAX_HISTORY_ENTRIES];
 // CRenamerDialog
 //
 
-namespace
-{
-int RenamerColorLuminance(COLORREF color)
-{
-    return (GetRValue(color) * 30 + GetGValue(color) * 59 + GetBValue(color) * 11) / 100;
-}
-
-void ConfigureRenamerDarkModeFromHost()
-{
-    BOOL useWindowsDarkMode = FALSE;
-    BOOL hasHostPolicy = SG != NULL && SG->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
-                                                              &useWindowsDarkMode,
-                                                              sizeof(useWindowsDarkMode),
-                                                              NULL);
-    PluginDarkMode_SetHostPolicyAvailable(hasHostPolicy, useWindowsDarkMode);
-
-    if (hasHostPolicy && useWindowsDarkMode && SG != NULL)
-    {
-        COLORREF text = SG->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
-        COLORREF background = SG->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
-        COLORREF readable = text;
-        const int bgLum = RenamerColorLuminance(background);
-        const int fgLum = RenamerColorLuminance(text);
-        if (bgLum < 128 && fgLum < bgLum + 40)
-            readable = RGB(0xF0, 0xF0, 0xF0);
-        else if (bgLum >= 128 && fgLum > bgLum - 40)
-            readable = RGB(0x20, 0x20, 0x20);
-        PluginDarkMode_SetHostResolvedColors(text, background, readable);
-    }
-    else
-    {
-        PluginDarkMode_SetHostResolvedColors(GetSysColor(COLOR_BTNTEXT), GetSysColor(COLOR_BTNFACE), GetSysColor(COLOR_BTNTEXT));
-    }
-}
-}
 
 MENU_TEMPLATE_ITEM MenuTemplate[] =
     {
@@ -1673,20 +1638,20 @@ CRenamerDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DialogStackPush(HWindow);
         if (!Init())
             PostMessage(HWindow, WM_CLOSE, 0, 0);
-        PluginDarkMode_HandleThemeMessage(HWindow, WM_THEMECHANGED, 0);
+        ApplyRenamerDarkMode(HWindow);
         RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
         return TRUE;
     }
 
     case WM_ERASEBKGND:
     {
-        if (PluginDarkMode_ShouldUseDark())
+        if (DarkModeShouldUseDarkColors())
         {
             RECT r;
             GetClientRect(HWindow, &r);
-            HBRUSH brush = PluginDarkMode_GetDialogCtlColorBrush(NULL, WM_CTLCOLORDLG);
-            if (brush != NULL)
-                FillRect((HDC)wParam, &r, brush);
+            INT_PTR result = 0;
+            if (HandleRenamerDarkCtlColor(WM_CTLCOLORDLG, wParam, (LPARAM)HWindow, &result))
+                FillRect((HDC)wParam, &r, (HBRUSH)result);
             return TRUE;
         }
         break;
@@ -1698,10 +1663,11 @@ CRenamerDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CTLCOLORLISTBOX:
     case WM_CTLCOLORDLG:
     case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
     {
-        LRESULT brush = 0;
-        if (PluginDarkMode_HandleCtlColor(uMsg, wParam, lParam, &brush))
-            return brush;
+        INT_PTR result = 0;
+        if (HandleRenamerDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
         break;
     }
 
@@ -1709,8 +1675,9 @@ CRenamerDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_SETTINGCHANGE:
     {
         ConfigureRenamerDarkModeFromHost();
-        if (PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam))
+        if (uMsg == WM_THEMECHANGED || DarkModeHandleSettingChange(uMsg, lParam))
         {
+            ApplyRenamerDarkMode(HWindow);
             if (MenuBar != NULL)
                 InvalidateRect(MenuBar->GetHWND(), NULL, TRUE);
             RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
@@ -2287,11 +2254,13 @@ CRenamerDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_USER_CFGCHNG:
     {
         UpdateManualModeFont();
+        ApplyRenamerDarkMode(HWindow);
         return 0;
     }
 
     case WM_USER_SETTINGCHANGE:
     {
+        ApplyRenamerDarkMode(HWindow);
         if (MenuBar != NULL)
             MenuBar->SetFont();
         return 0;

--- a/src/plugins/renamer/vcxproj/renamer.props
+++ b/src/plugins/renamer/vcxproj/renamer.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\shared\lukas;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;DECLARE_REGIFACE_FUNCTIONS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\shared\lukas;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;DECLARE_REGIFACE_FUNCTIONS;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/renamer/vcxproj/renamer.vcxproj
+++ b/src/plugins/renamer/vcxproj/renamer.vcxproj
@@ -127,7 +127,43 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\lukas\str.cpp">
     </ClCompile>
-    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
     </ClCompile>
@@ -174,8 +210,6 @@
     <ClInclude Include="..\..\shared\dbg.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\lukas\str.h">
-    </ClInclude>
-    <ClInclude Include="..\..\shared\plugindarkmode.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\spl_base.h">
     </ClInclude>

--- a/src/plugins/renamer/vcxproj/renamer.vcxproj
+++ b/src/plugins/renamer/vcxproj/renamer.vcxproj
@@ -127,6 +127,8 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\lukas\str.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+    </ClCompile>
     <ClCompile Include="..\..\..\darkmode.cpp" />
     <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
@@ -210,6 +212,8 @@
     <ClInclude Include="..\..\shared\dbg.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\lukas\str.h">
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\spl_base.h">
     </ClInclude>

--- a/src/plugins/renamer/vcxproj/renamer.vcxproj.filters
+++ b/src/plugins/renamer/vcxproj/renamer.vcxproj.filters
@@ -73,7 +73,37 @@
     <ClCompile Include="..\..\shared\dbg.cpp">
       <Filter>common</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
       <Filter>common</Filter>
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
@@ -124,9 +154,6 @@
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
-      <Filter>common</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\shared\plugindarkmode.h">
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\shared\spl_base.h">

--- a/src/plugins/renamer/vcxproj/renamer.vcxproj.filters
+++ b/src/plugins/renamer/vcxproj/renamer.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClCompile Include="..\..\shared\dbg.cpp">
       <Filter>common</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\darkmode.cpp">
       <Filter>common</Filter>
     </ClCompile>
@@ -154,6 +157,9 @@
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\shared\spl_base.h">


### PR DESCRIPTION
### Motivation
- The Checksum plugin used inconsistent lightweight plugin dark-mode helpers and left dialogs using light controls when Salamander's "Windows Dark Mode (experimental)" scheme was selected, so the plugin must follow the host `src/darkmode.h` API and the existing `win32-darkmodelib` backend like PictView does.
- Use the host-configured colors/brush and native apply calls so dialogs/list/progress controls follow the same scheme as Salamander Configuration → Colors → Scheme.

### Description
- Added Checksum-specific dark-mode helpers and state in `src/plugins/checksum/checksum.cpp` and exported the API in `src/plugins/checksum/checksum.h`: `ConfigureChecksumDarkModeFromHost`, `ApplyChecksumDarkMode`, `ApplyChecksumDarkModeIfSelected`, `HandleChecksumDarkCtlColor`, `ChecksumShouldUseWindowsDarkMode`, and `ReleaseChecksumDarkModeResources`.
- Integrated host `darkmode.h` calls into dialog flow in `src/plugins/checksum/dialogs.cpp` so dialogs call `ApplyChecksumDarkMode` on `WM_INITDIALOG`, handle `WM_THEMECHANGED` / `WM_SETTINGCHANGE`, and route `WM_CTLCOLOR*` through `DarkModeHandleCtlColor`, and re-apply dark-mode to newly created progress controls after marquee mode is removed.
- Ensure plugin releases its dark-mode brush on shutdown by calling `ReleaseChecksumDarkModeResources` from the plugin `Release` path.
- Added host dark-mode sources and win32-darkmodelib backend into the Checksum project: compile `darkmode.cpp`, `darkmode_backend_darkmodelib.cpp` and vendored darkmodelib sources, and updated `checksum.props` to add the darkmodelib include path and `USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG` preprocessor defines, and added corresponding entries to the `.vcxproj` and `.filters` files so the Checksum project builds the same backend as PictView.

### Testing
- Ran `git diff --check` to validate there are no whitespace/merge issues, which passed.
- Parsed the modified project XML files with Python `xml.etree.ElementTree` using the snippet: `python3 - <<'PY'\nimport xml.etree.ElementTree as ET\nfor f in ['src/plugins/checksum/vcxproj/checksum.props','src/plugins/checksum/vcxproj/checksum.vcxproj','src/plugins/checksum/vcxproj/checksum.vcxproj.filters']:\n    ET.parse(f)\n    print('ok', f)\nPY`, which succeeded for all three files.
- Attempted to run the Visual Studio build tool check (`command -v msbuild`), but MSBuild is not available in this Linux environment so a full Windows build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6b624fb483299c171ff04e0914be)