### PR TITLE
Add dark mode support to Undelete plugin dialogs

### DIFF
--- a/src/plugins/undelete/dialogs.cpp
+++ b/src/plugins/undelete/dialogs.cpp
@@ -19,6 +19,50 @@
 
 #pragma comment(lib, "UxTheme.lib")
 
+
+namespace
+{
+BOOL HandleUndeleteDarkDialogMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    switch (uMsg)
+    {
+    case WM_THEMECHANGED:
+        ApplyUndeleteDarkMode(hwnd);
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        *result = TRUE;
+        return TRUE;
+
+    case WM_SETTINGCHANGE:
+        ConfigureUndeleteDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyUndeleteDarkMode(hwnd);
+            InvalidateRect(hwnd, NULL, TRUE);
+            *result = TRUE;
+            return TRUE;
+        }
+        break;
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+        return HandleUndeleteDarkCtlColor(uMsg, wParam, lParam, result);
+    }
+    return FALSE;
+}
+
+void ApplyUndeleteDarkModeToDialogChild(HWND hwnd, int controlID)
+{
+    HWND child = GetDlgItem(hwnd, controlID);
+    if (child != NULL)
+        DarkModeApplyWindow(child);
+}
+}
+
 // ****************************************************************************
 //
 //  CSnapshotProgressDlg
@@ -73,6 +117,10 @@ BOOL CSnapshotProgressDlg::GetWantCancel()
 
 INT_PTR CSnapshotProgressDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    INT_PTR darkResult = 0;
+    if (HandleUndeleteDarkDialogMessage(HWindow, uMsg, wParam, lParam, &darkResult))
+        return darkResult;
+
     CALL_STACK_MESSAGE4("CSnapshotProgressDlg::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
@@ -84,6 +132,8 @@ INT_PTR CSnapshotProgressDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam
             DestroyWindow(HWindow);
             return FALSE;
         }
+        ApplyUndeleteDarkMode(HWindow);
+        ApplyUndeleteDarkModeToDialogChild(HWindow, IDC_PROGRESSBAR);
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
         break; // we want focus from DefDlgProc
@@ -205,6 +255,10 @@ BOOL CCopyProgressDlg::GetWantCancel()
 
 INT_PTR CCopyProgressDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    INT_PTR darkResult = 0;
+    if (HandleUndeleteDarkDialogMessage(HWindow, uMsg, wParam, lParam, &darkResult))
+        return darkResult;
+
     CALL_STACK_MESSAGE4("CCopyProgressDlg::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
@@ -219,6 +273,11 @@ INT_PTR CCopyProgressDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             DestroyWindow(HWindow);
             return FALSE;
         }
+        ApplyUndeleteDarkMode(HWindow);
+        ApplyUndeleteDarkModeToDialogChild(HWindow, IDC_PROGRESS_FILE);
+        ApplyUndeleteDarkModeToDialogChild(HWindow, IDC_PROGRESS_TOTAL);
+        ApplyUndeleteDarkModeToDialogChild(HWindow, IDC_LABEL_SOURCE);
+        ApplyUndeleteDarkModeToDialogChild(HWindow, IDC_LABEL_DEST);
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
         break; // let DefDlgProc set the focus
@@ -478,6 +537,9 @@ void CConnectDialog::InitDrives()
         selectIndex = 0;
     ListView_SetItemState(hList, selectIndex, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
     ListView_EnsureVisible(hList, selectIndex, FALSE);
+
+    if (ApplyUndeleteDarkModeIfSelected(hList))
+        DarkModeUpdateListViewColors(hList);
 }
 
 BOOL CConnectDialog::OnDialogOK()
@@ -558,11 +620,18 @@ void CConnectDialog::OnImageBrowse()
         ret = GetOpenFileName(&openInfo);
     }
     if (ret)
+    {
         SetDlgItemText(HWindow, IDC_EDIT_IMAGE, Volume);
+        ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_EDIT_IMAGE));
+    }
 }
 
 INT_PTR CConnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    INT_PTR darkResult = 0;
+    if (HandleUndeleteDarkDialogMessage(HWindow, uMsg, wParam, lParam, &darkResult))
+        return darkResult;
+
     CALL_STACK_MESSAGE4("CConnectDialog::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
@@ -573,6 +642,9 @@ INT_PTR CConnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (IsAppThemed())
             SetWindowTheme(GetDlgItem(HWindow, IDC_LIST_VOLUMES), L"explorer", NULL);
         InitDrives();
+        ApplyUndeleteDarkMode(HWindow);
+        if (ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_LIST_VOLUMES)))
+            DarkModeUpdateListViewColors(GetDlgItem(HWindow, IDC_LIST_VOLUMES));
         break;
     }
 
@@ -601,6 +673,9 @@ INT_PTR CConnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             EnableWindow(GetDlgItem(HWindow, IDC_LIST_VOLUMES), !checked);
             EnableWindow(GetDlgItem(HWindow, IDC_EDIT_IMAGE), checked);
             EnableWindow(GetDlgItem(HWindow, IDC_BUTTON_BROWSE), checked);
+            ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_LIST_VOLUMES));
+            ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_EDIT_IMAGE));
+            ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_BUTTON_BROWSE));
             return TRUE;
         }
 
@@ -634,14 +709,20 @@ void CFileNameDialog::Transfer(CTransferInfo& ti)
 
 INT_PTR CFileNameDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    INT_PTR darkResult = 0;
+    if (HandleUndeleteDarkDialogMessage(HWindow, uMsg, wParam, lParam, &darkResult))
+        return darkResult;
+
     CALL_STACK_MESSAGE4("CFileNameDialog::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
     case WM_INITDIALOG:
     {
+        ApplyUndeleteDarkMode(HWindow);
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
         TransferData(ttDataToWindow);
+        ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_EDIT_FILENAME));
         SetFocus(GetDlgItem(HWindow, IDC_EDIT_FILENAME));
         SendDlgItemMessage(HWindow, IDC_EDIT_FILENAME, EM_SETSEL, 0, 1);
         AllPressed = FALSE;
@@ -687,11 +768,16 @@ void CConfigDialog::Transfer(CTransferInfo& ti)
 
 INT_PTR CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    INT_PTR darkResult = 0;
+    if (HandleUndeleteDarkDialogMessage(HWindow, uMsg, wParam, lParam, &darkResult))
+        return darkResult;
+
     CALL_STACK_MESSAGE4("CConfigDialog::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
     case WM_INITDIALOG:
     {
+        ApplyUndeleteDarkMode(HWindow);
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
         break;
@@ -709,6 +795,7 @@ INT_PTR CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                                   String<char>::LoadStr(IDS_CHOOSETEMPDIR),
                                                   path, FALSE, path);
             SetDlgItemText(HWindow, IDC_EDIT_TEMPPATH, path);
+            ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_EDIT_TEMPPATH));
             return TRUE;
         }
         }
@@ -730,17 +817,23 @@ CRestoreDialog::CRestoreDialog(HWND parent)
 
 INT_PTR CRestoreDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    INT_PTR darkResult = 0;
+    if (HandleUndeleteDarkDialogMessage(HWindow, uMsg, wParam, lParam, &darkResult))
+        return darkResult;
+
     CALL_STACK_MESSAGE4("CRestoreDialog::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     char path[MAX_PATH + 300];
     switch (uMsg)
     {
     case WM_INITDIALOG:
     {
+        ApplyUndeleteDarkMode(HWindow);
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
 
         SalamanderGeneral->GetPanelPath(PANEL_TARGET, path, MAX_PATH, NULL, NULL);
         SetDlgItemText(HWindow, IDC_EDIT_TARGET, path);
+        ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_EDIT_TARGET));
 
         int files, dirs;
         char text1[200], text2[MAX_PATH + 100];
@@ -775,6 +868,7 @@ INT_PTR CRestoreDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             _snprintf_s(path, _TRUNCATE, text1, text2);
             SetDlgItemText(HWindow, IDC_LABEL_SOURCE, path);
         }
+        ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_LABEL_SOURCE));
         break;
     }
 
@@ -790,6 +884,7 @@ INT_PTR CRestoreDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             SalamanderGeneral->GetTargetDirectory(HWindow, HWindow, title, String<char>::LoadStr(IDS_CHOOSETARGET),
                                                   path, FALSE, path);
             SetDlgItemText(HWindow, IDC_EDIT_TARGET, path);
+            ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_EDIT_TARGET));
             return TRUE;
         }
 
@@ -812,11 +907,16 @@ INT_PTR CRestoreDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 INT_PTR CRestoreProgressDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    INT_PTR darkResult = 0;
+    if (HandleUndeleteDarkDialogMessage(HWindow, uMsg, wParam, lParam, &darkResult))
+        return darkResult;
+
     CALL_STACK_MESSAGE4("CRestoreProgressDlg::DialogProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     if (uMsg == WM_INITDIALOG)
     {
         SetDlgItemText(HWindow, IDC_LABEL_UNDELETING, String<char>::LoadStr(IDS_RESTORING));
         SetWindowText(HWindow, String<char>::LoadStr(IDS_RESTORE));
+        ApplyUndeleteDarkModeIfSelected(GetDlgItem(HWindow, IDC_LABEL_UNDELETING));
         /*HWND hLabel = GetDlgItem(HWindow, IDC_LABEL_UNDELETING);
     SetWindowLong(hLabel, GWL_STYLE, GetWindowLong(hLabel, GWL_STYLE) | SS_RIGHT);*/
     }

--- a/src/plugins/undelete/library/precomp.h
+++ b/src/plugins/undelete/library/precomp.h
@@ -37,6 +37,7 @@
 #include "spl_vers.h"
 #include "dbg.h"
 #include "mhandles.h"
+#include "../../../darkmode.h"
 
 #include "arraylt.h"
 

--- a/src/plugins/undelete/undelete.cpp
+++ b/src/plugins/undelete/undelete.cpp
@@ -68,6 +68,134 @@ int SalamanderVersion = 0;
 
 CLUSTER_MAP_I cluster_map;
 
+namespace
+{
+HBRUSH UndeleteDarkModeDialogBrush = NULL;
+COLORREF UndeleteDarkModeDialogBrushColor = CLR_INVALID;
+BOOL UndeleteHostPolicyKnown = FALSE;
+BOOL UndeleteHostUseWindowsDarkMode = FALSE;
+COLORREF UndeleteHostSchemeText = CLR_INVALID;
+COLORREF UndeleteHostSchemeBackground = CLR_INVALID;
+DWORD UndeleteMainThreadId = 0;
+
+HBRUSH UndeleteGetDarkModeDialogBrush(COLORREF background)
+{
+    if (UndeleteDarkModeDialogBrush == NULL || UndeleteDarkModeDialogBrushColor != background)
+    {
+        if (UndeleteDarkModeDialogBrush != NULL)
+            DeleteObject(UndeleteDarkModeDialogBrush);
+        UndeleteDarkModeDialogBrush = CreateSolidBrush(background);
+        UndeleteDarkModeDialogBrushColor = background;
+    }
+    return UndeleteDarkModeDialogBrush;
+}
+
+BOOL UndeleteCanQueryHostDarkMode()
+{
+    return SalamanderGeneral != NULL &&
+           UndeleteMainThreadId != 0 &&
+           GetCurrentThreadId() == UndeleteMainThreadId;
+}
+
+BOOL UndeleteShouldUseWindowsDarkMode()
+{
+    return UndeleteHostPolicyKnown && UndeleteHostUseWindowsDarkMode;
+}
+}
+
+void ReleaseUndeleteDarkModeResources()
+{
+    if (UndeleteDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(UndeleteDarkModeDialogBrush);
+        UndeleteDarkModeDialogBrush = NULL;
+        UndeleteDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+
+void RefreshUndeleteDarkModeFromHost()
+{
+    // Some Undelete dialogs can be driven by worker UI loops. Salamander host
+    // configuration APIs are main-thread-only, so those dialogs reuse this
+    // cached snapshot instead of querying the host directly.
+    if (!UndeleteCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                              &useWindowsDarkMode,
+                                              sizeof(useWindowsDarkMode),
+                                              NULL))
+    {
+        UndeleteHostPolicyKnown = TRUE;
+        UndeleteHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (UndeleteHostPolicyKnown && UndeleteHostUseWindowsDarkMode)
+    {
+        UndeleteHostSchemeText = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        UndeleteHostSchemeBackground = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+void ConfigureUndeleteDarkModeFromHost()
+{
+    RefreshUndeleteDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = UndeleteShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && UndeleteHostSchemeText != CLR_INVALID && UndeleteHostSchemeBackground != CLR_INVALID)
+    {
+        text = UndeleteHostSchemeText;
+        background = UndeleteHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = UndeleteGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyUndeleteDarkMode(HWND hwnd)
+{
+    ConfigureUndeleteDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL ApplyUndeleteDarkModeIfSelected(HWND hwnd)
+{
+    if (!UndeleteShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ApplyUndeleteDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL HandleUndeleteDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!UndeleteShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureUndeleteDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 // ****************************************************************************
 //
 //  CTopIndexMem
@@ -236,8 +364,10 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // get Salamander interfaces
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    UndeleteMainThreadId = GetCurrentThreadId();
     SalamanderSafeFile = salamander->GetSalamanderSafeFile();
     SalamanderGUI = salamander->GetSalamanderGUI();
+    RefreshUndeleteDarkModeFromHost();
 
     // set help file name
     SalamanderGeneral->SetHelpFileName("undelete.chm");
@@ -298,6 +428,7 @@ BOOL WINAPI CPluginInterface::Release(HWND parent, BOOL force)
     CALL_STACK_MESSAGE2("CPluginInterface::Release(, %d)", force);
     ReleaseFS();
     OS<char>::OS_ReleaseLibraryData();
+    ReleaseUndeleteDarkModeResources();
     ReleaseWinLib(DLLInstance);
     /*if (ret && InterfaceForFS.GetActiveFSCount() != 0)
   {

--- a/src/plugins/undelete/undelete.h
+++ b/src/plugins/undelete/undelete.h
@@ -15,6 +15,13 @@ extern CSalamanderGUIAbstract* SalamanderGUI;
 BOOL InitFS();
 void ReleaseFS();
 
+void RefreshUndeleteDarkModeFromHost();
+void ConfigureUndeleteDarkModeFromHost();
+void ApplyUndeleteDarkMode(HWND hwnd);
+BOOL ApplyUndeleteDarkModeIfSelected(HWND hwnd);
+BOOL HandleUndeleteDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);
+void ReleaseUndeleteDarkModeResources();
+
 // FS-name assigned by Salamander after plugin is loaded
 extern char AssignedFSName[MAX_PATH];
 

--- a/src/plugins/undelete/vcxproj/undelete.props
+++ b/src/plugins/undelete/vcxproj/undelete.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\library;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\library;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/undelete/vcxproj/undelete.vcxproj
+++ b/src/plugins/undelete/vcxproj/undelete.vcxproj
@@ -129,6 +129,44 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\dialogs.cpp">
     </ClCompile>
     <ClCompile Include="..\fs1.cpp">

--- a/src/plugins/undelete/vcxproj/undelete.vcxproj.filters
+++ b/src/plugins/undelete/vcxproj/undelete.vcxproj.filters
@@ -68,6 +68,39 @@
     <ClCompile Include="..\..\shared\winliblt.cpp">
       <Filter>sal</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\dialogs.h">


### PR DESCRIPTION
### Motivation
- Bring the Undelete plugin in line with other plugins by integrating host-driven Windows Dark Mode so Undelete dialogs use the host color scheme and darkmode helpers.
- Ensure dialogs created or modified after initialization (progress bars, listviews, child controls) also get dark-mode styling and CTLCOLOR handling.

### Description
- Include the shared dark-mode host API by adding `#include "../../../darkmode.h"` to `src/plugins/undelete/library/precomp.h` so all Undelete translation units can use the helpers.
- Declare the new per-plugin dark-mode helpers in `src/plugins/undelete/undelete.h` (`RefreshUndeleteDarkModeFromHost`, `ConfigureUndeleteDarkModeFromHost`, `ApplyUndeleteDarkMode`, `ApplyUndeleteDarkModeIfSelected`, `HandleUndeleteDarkCtlColor`, `ReleaseUndeleteDarkModeResources`).
- Implement per-plugin dark-mode state and helpers in `src/plugins/undelete/undelete.cpp`, including cached main-thread ID, cached host policy/colors, dialog brush management, `Refresh*`/`Configure*`/`Apply*` helpers, CTLCOLOR routing via `HandleUndeleteDarkCtlColor`, and `ReleaseUndeleteDarkModeResources` cleanup.
- Capture `GetCurrentThreadId()` and prime initial host snapshot in `SalamanderPluginEntry`, and call `ReleaseUndeleteDarkModeResources` from `CPluginInterface::Release` to free brushes/resources on unload.
- Update `src/plugins/undelete/dialogs.cpp` to route `WM_THEMECHANGED`/`WM_SETTINGCHANGE`/`WM_CTLCOLOR*` to the new handler, apply dark mode at `WM_INITDIALOG`, and re-apply to child controls created/changed after init using `ApplyUndeleteDarkModeIfSelected` / `DarkModeUpdateListViewColors` so dynamic controls do not stay light.
- Wire darkmode build inputs into the Undelete Visual Studio project: add `..
..\..\third_party\darkmodelib\include` to `AdditionalIncludeDirectories` and add `USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG` to preprocessor defines in `src/plugins/undelete/vcxproj/undelete.props`.
- Add `darkmode.cpp`, `darkmode_backend_darkmodelib.cpp`, and vendored `third_party/darkmodelib/src/*.cpp` to `src/plugins/undelete/vcxproj/undelete.vcxproj` and to the `.filters`, marking darkmodelib `.cpp` files as `PrecompiledHeader=NotUsing` and adding `UNICODE;_UNICODE` where required, while keeping `mhandles.cpp` in the project.

### Testing
- Parsed and validated `undelete.props`, `undelete.vcxproj`, and `undelete.vcxproj.filters` with Python `xml.etree.ElementTree` to ensure the modified project XML is well-formed (`ET.parse(...)`), and the parse succeeded.
- Verified that all files referenced by the updated vcxproj/vcxproj.filters exist after normalizing paths using a small Python check against the project `Include` entries, and confirmed the referenced sources are present.
- Ran `rg` checks to confirm the new dark-mode helpers and integration points are present in `src/plugins/undelete/*` and that project entries for `darkmode`/`darkmodelib` and `mhandles.cpp` were added as expected.
- Could not perform native Windows builds or manual UI verification of Win32/x64 Debug/Release `undelete.vcxproj` because MSBuild/Visual Studio / Windows GUI are not available in this Linux container; the PR includes project changes needed for those builds and manual testing was requested to be performed on Windows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb3da17a48329bedd8d5e581189c6)