### PR TITLE
Enable File Comparator dark mode integration

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1220,6 +1220,15 @@ void DarkModeApplyTree(HWND hwnd)
     EnumChildWindows(hwnd, ApplyTreeCallback, 0);
 }
 
+void DarkModeApplyMenuBar(HWND hwnd)
+{
+#if USE_DARKMODELIB
+    DarkModeBackendDarkModelib::ApplyMenuBar(hwnd, DarkModeShouldUseDarkColors());
+#else
+    (void)hwnd;
+#endif
+}
+
 void DarkModeRefreshTitleBar(HWND hwnd)
 {
     EnsureInitialized();

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -8,6 +8,7 @@
 #include <delayimp.h>
 #include <uxtheme.h>
 #include <commctrl.h>
+#include <algorithm>
 
 #ifndef HDM_SETBKCOLOR
 #define HDM_SETBKCOLOR (HDM_FIRST + 29)
@@ -390,11 +391,11 @@ void PaintDarkChoiceButton(HWND hwnd, HDC hdc)
     const BOOL enabled = IsWindowEnabled(hwnd);
     const LRESULT checkState = SendMessage(hwnd, BM_GETCHECK, 0, 0);
     const LRESULT buttonState = SendMessage(hwnd, BM_GETSTATE, 0, 0);
-    const int glyphSize = max(13, GetSystemMetrics(SM_CXMENUCHECK));
+    const int glyphSize = (std::max)(13, GetSystemMetrics(SM_CXMENUCHECK));
     RECT glyph = rc;
     glyph.left += 1;
     glyph.right = glyph.left + glyphSize;
-    glyph.top = rc.top + max(0, (rc.bottom - rc.top - glyphSize) / 2);
+    glyph.top = rc.top + (std::max)(0, (rc.bottom - rc.top - glyphSize) / 2);
     glyph.bottom = glyph.top + glyphSize;
 
     LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
@@ -632,7 +633,7 @@ void PaintDarkStatusBar(HWND hwnd, HDC hdc)
         if (i + 1 < count)
         {
             RECT edge = part;
-            edge.left = edge.right - max(1, borders[2]);
+            edge.left = edge.right - (std::max)(1, borders[2]);
             FillRectWithColor(hdc, edge, RGB(0x4A, 0x4A, 0x4A));
         }
 
@@ -641,7 +642,7 @@ void PaintDarkStatusBar(HWND hwnd, HDC hdc)
 
         const LRESULT textLen = SendMessage(hwnd, SB_GETTEXTLENGTH, i, 0);
         const DWORD flags = HIWORD(textLen);
-        const int len = min(static_cast<int>(LOWORD(textLen)), 1023);
+        const int len = (std::min)(static_cast<int>(LOWORD(textLen)), 1023);
         TCHAR text[1024];
         text[0] = 0;
         const LRESULT itemData = SendMessage(hwnd, SB_GETTEXT, i, reinterpret_cast<LPARAM>(text));

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -8,7 +8,6 @@
 #include <delayimp.h>
 #include <uxtheme.h>
 #include <commctrl.h>
-#include <algorithm>
 
 #ifndef HDM_SETBKCOLOR
 #define HDM_SETBKCOLOR (HDM_FIRST + 29)
@@ -391,11 +390,13 @@ void PaintDarkChoiceButton(HWND hwnd, HDC hdc)
     const BOOL enabled = IsWindowEnabled(hwnd);
     const LRESULT checkState = SendMessage(hwnd, BM_GETCHECK, 0, 0);
     const LRESULT buttonState = SendMessage(hwnd, BM_GETSTATE, 0, 0);
-    const int glyphSize = (std::max)(13, GetSystemMetrics(SM_CXMENUCHECK));
+    const int menuCheckWidth = GetSystemMetrics(SM_CXMENUCHECK);
+    const int glyphSize = menuCheckWidth > 13 ? menuCheckWidth : 13;
+    const int glyphTopOffset = static_cast<int>((rc.bottom - rc.top - glyphSize) / 2);
     RECT glyph = rc;
     glyph.left += 1;
     glyph.right = glyph.left + glyphSize;
-    glyph.top = rc.top + (std::max)(0, (rc.bottom - rc.top - glyphSize) / 2);
+    glyph.top = rc.top + (glyphTopOffset > 0 ? glyphTopOffset : 0);
     glyph.bottom = glyph.top + glyphSize;
 
     LONG_PTR style = GetWindowLongPtr(hwnd, GWL_STYLE);
@@ -633,7 +634,7 @@ void PaintDarkStatusBar(HWND hwnd, HDC hdc)
         if (i + 1 < count)
         {
             RECT edge = part;
-            edge.left = edge.right - (std::max)(1, borders[2]);
+            edge.left = edge.right - (borders[2] > 1 ? borders[2] : 1);
             FillRectWithColor(hdc, edge, RGB(0x4A, 0x4A, 0x4A));
         }
 
@@ -642,7 +643,8 @@ void PaintDarkStatusBar(HWND hwnd, HDC hdc)
 
         const LRESULT textLen = SendMessage(hwnd, SB_GETTEXTLENGTH, i, 0);
         const DWORD flags = HIWORD(textLen);
-        const int len = (std::min)(static_cast<int>(LOWORD(textLen)), 1023);
+        const int rawTextLen = static_cast<int>(LOWORD(textLen));
+        const int len = rawTextLen < 1023 ? rawTextLen : 1023;
         TCHAR text[1024];
         text[0] = 0;
         const LRESULT itemData = SendMessage(hwnd, SB_GETTEXT, i, reinterpret_cast<LPARAM>(text));

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -34,6 +34,9 @@ void DarkModeApplyWindow(HWND hwnd);
 // Applies dark mode opt-in to the specified window and all of its descendants.
 void DarkModeApplyTree(HWND hwnd);
 
+// Applies or removes dark custom drawing for a native window menu bar.
+void DarkModeApplyMenuBar(HWND hwnd);
+
 // Refreshes the non-client area/title bar to match the current dark mode
 // preference and system state.
 void DarkModeRefreshTitleBar(HWND hwnd);

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -113,6 +113,7 @@ void ApplyTree(HWND hwnd)
         {
             dmlib::setDarkWndNotifySafe(hwnd);
             dmlib::setChildCtrlsSubclassAndTheme(hwnd);
+            ApplyMenuBar(hwnd, true);
         }
         else
         {
@@ -120,11 +121,30 @@ void ApplyTree(HWND hwnd)
             // darkmodelib to apply even its light-mode themes/subclasses here; just
             // tear down any hooks left from a previous Windows Dark Mode session.
             RemoveWindowAndChildSubclasses(hwnd);
+            ApplyMenuBar(hwnd, false);
         }
         dmlib::setDarkTitleBar(hwnd);
     }
 #else
     (void)hwnd;
+#endif
+}
+
+
+void ApplyMenuBar(HWND hwnd, bool enableDark)
+{
+#if USE_DARKMODELIB
+    if (hwnd != NULL)
+    {
+        if (enableDark)
+            dmlib::setWindowMenuBarSubclass(hwnd);
+        else
+            dmlib::removeWindowMenuBarSubclass(hwnd);
+        DrawMenuBar(hwnd);
+    }
+#else
+    (void)hwnd;
+    (void)enableDark;
 #endif
 }
 

--- a/src/darkmode_backend_darkmodelib.h
+++ b/src/darkmode_backend_darkmodelib.h
@@ -14,6 +14,7 @@ bool IsAvailable();
 
 // Backend mirrors of selected darkmode APIs used by the host implementation.
 void ApplyTree(HWND hwnd);
+void ApplyMenuBar(HWND hwnd, bool enableDark);
 void ApplyCheckboxOrRadioButton(HWND hwnd, bool enableDark);
 bool HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT& result,
                     const DarkModeColors& colors, HBRUSH dialogBrush);

--- a/src/plugins/filecomp/controls.cpp
+++ b/src/plugins/filecomp/controls.cpp
@@ -13,6 +13,31 @@ HFONT EnvFont;     // environment font (edit, toolbar, header, status)
 int EnvFontHeight; // font height
 HBRUSH HDitheredBrush = NULL;
 
+namespace
+{
+COLORREF FileCompGetFaceColor()
+{
+    return DarkModeShouldUseDarkColors() ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE);
+}
+
+COLORREF FileCompGetTextColor()
+{
+    return DarkModeShouldUseDarkColors() ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_WINDOWTEXT);
+}
+
+void FillFileCompFaceRect(HDC dc, const RECT* rect)
+{
+    if (DarkModeShouldUseDarkColors())
+    {
+        HBRUSH brush = CreateSolidBrush(DarkModeGetDialogBackgroundColor());
+        FillRect(dc, rect, brush);
+        DeleteObject(brush);
+    }
+    else
+        FillRect(dc, rect, (HBRUSH)(COLOR_BTNFACE + 1));
+}
+}
+
 // ****************************************************************************
 //
 // CFileHeaderWindow
@@ -329,14 +354,14 @@ CSplitBarWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         GetClientRect(HWindow, &r);
         if (Tracking && HDitheredBrush)
         {
-            COLORREF oldBk = SetBkColor(dc, GetSysColor(COLOR_BTNFACE));
-            COLORREF oldText = SetTextColor(dc, GetSysColor(COLOR_3DDKSHADOW));
+            COLORREF oldBk = SetBkColor(dc, FileCompGetFaceColor());
+            COLORREF oldText = SetTextColor(dc, DarkModeShouldUseDarkColors() ? DarkModeGetColors().readableText : GetSysColor(COLOR_3DDKSHADOW));
             FillRect(dc, &r, HDitheredBrush);
             SetBkColor(dc, oldBk);
             SetTextColor(dc, oldText);
         }
         else
-            FillRect(dc, &r, (HBRUSH)(COLOR_BTNFACE + 1));
+            FillFileCompFaceRect(dc, &r);
         EndPaint(HWindow, &ps);
         return 0;
     }
@@ -391,10 +416,14 @@ CToolTipWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         HDC hDC = (HDC)wParam;
         RECT r;
         GetClientRect(HWindow, &r);
-        FillRect(hDC, &r, (HBRUSH)(COLOR_INFOBK + 1));
+        COLORREF tipBkColor = DarkModeShouldUseDarkColors() ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_INFOBK);
+        COLORREF tipTextColor = DarkModeShouldUseDarkColors() ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_INFOTEXT);
+        HBRUSH tipBrush = CreateSolidBrush(tipBkColor);
+        FillRect(hDC, &r, tipBrush);
+        DeleteObject(tipBrush);
         HFONT hOldFont = (HFONT)SelectObject(hDC, EnvFont);
-        COLORREF oldTextColor = SetTextColor(hDC, GetSysColor(COLOR_INFOTEXT));
-        COLORREF oldBkColor = SetBkColor(hDC, GetSysColor(COLOR_INFOBK));
+        COLORREF oldTextColor = SetTextColor(hDC, tipTextColor);
+        COLORREF oldBkColor = SetBkColor(hDC, tipBkColor);
         ExtTextOut(hDC, 2, 1, ETO_OPAQUE, &r, Text, TextLen, NULL);
         SetBkColor(hDC, oldBkColor);
         SetTextColor(hDC, oldTextColor);
@@ -508,7 +537,7 @@ CComboBoxEdit::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 CComboBox::CComboBox()
 {
     CALL_STACK_MESSAGE1("CComboBox::CComboBox()");
-    BtnFacePen = CreatePen(PS_SOLID, 0, GetSysColor(COLOR_BTNFACE));
+    BtnFacePen = CreatePen(PS_SOLID, 0, FileCompGetFaceColor());
     BtnShadowPen = CreatePen(PS_SOLID, 0, GetSysColor(COLOR_BTNSHADOW));
     BtnHilightPen = CreatePen(PS_SOLID, 0, GetSysColor(COLOR_BTNHIGHLIGHT));
     Tracking = FALSE;
@@ -534,7 +563,7 @@ void CComboBox::ChangeColors()
         DeleteObject(BtnShadowPen);
     if (BtnHilightPen)
         DeleteObject(BtnHilightPen);
-    BtnFacePen = CreatePen(PS_SOLID, 0, GetSysColor(COLOR_BTNFACE));
+    BtnFacePen = CreatePen(PS_SOLID, 0, FileCompGetFaceColor());
     BtnShadowPen = CreatePen(PS_SOLID, 0, GetSysColor(COLOR_BTNSHADOW));
     BtnHilightPen = CreatePen(PS_SOLID, 0, GetSysColor(COLOR_BTNHIGHLIGHT));
 }
@@ -572,6 +601,9 @@ CComboBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_CTLCOLORSTATIC:
     {
+        INT_PTR result = 0;
+        if (HandleFileCompDarkCtlColor(WM_CTLCOLORSTATIC, wParam, lParam, &result))
+            return result;
         SetBkColor((HDC)wParam, GetSysColor(COLOR_WINDOW));
         SetTextColor((HDC)wParam, GetSysColor(COLOR_WINDOWTEXT));
         return (LRESULT)GetSysColorBrush(COLOR_WINDOW);
@@ -825,19 +857,22 @@ CRebar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 // draw our own text
                 HDC hdc = GetDC(HWindow);
                 HFONT oldFont = (HFONT)SelectObject(hdc, (HFONT)EnvFont);
-                SetBkColor(hdc, GetSysColor(COLOR_BTNFACE));
+                COLORREF oldBkColor = SetBkColor(hdc, FileCompGetFaceColor());
+                COLORREF oldTextColor = SetTextColor(hdc, FileCompGetTextColor());
                 DrawText(hdc, text, -1, &r, DT_SINGLELINE | DT_TOP);
 
                 // line under the text
                 r.top += EnvFontHeight;
-                FillRect(hdc, &r, (HBRUSH)(COLOR_BTNFACE + 1));
+                FillFileCompFaceRect(hdc, &r);
                 r.top -= EnvFontHeight;
 
                 // area behind the text
                 r.left = r.right;
                 r.right += 13;
-                FillRect(hdc, &r, (HBRUSH)(COLOR_BTNFACE + 1));
+                FillFileCompFaceRect(hdc, &r);
 
+                SetTextColor(hdc, oldTextColor);
+                SetBkColor(hdc, oldBkColor);
                 SelectObject(hdc, oldFont);
                 ReleaseDC(HWindow, hdc);
             }
@@ -848,6 +883,9 @@ CRebar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_CTLCOLORSTATIC:
     {
+        INT_PTR result = 0;
+        if (HandleFileCompDarkCtlColor(WM_CTLCOLORSTATIC, wParam, lParam, &result))
+            return result;
         //SetBkColor((HDC)wParam, GetSysColor(COLOR_WINDOW));
         SetTextColor((HDC)wParam, GetSysColor(COLOR_WINDOWTEXT));
         //return 0;

--- a/src/plugins/filecomp/controls.cpp
+++ b/src/plugins/filecomp/controls.cpp
@@ -76,7 +76,7 @@ CFileHeaderWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_CREATE:
     {
-        BkColor = SG->GetCurrentColor(SALCOL_INACTIVE_CAPTION_BK);
+        BkColor = FileCompGetHostColor(SALCOL_INACTIVE_CAPTION_BK, GetSysColor(COLOR_INACTIVECAPTION));
         BkgndBrush = CreateSolidBrush(BkColor);
 
         return 0;
@@ -90,7 +90,7 @@ CFileHeaderWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         // make sure we always have the current brush color
         COLORREF oldBk = BkColor;
-        BkColor = SG->GetCurrentColor(SALCOL_INACTIVE_CAPTION_BK);
+        BkColor = FileCompGetHostColor(SALCOL_INACTIVE_CAPTION_BK, GetSysColor(COLOR_INACTIVECAPTION));
         if (BkColor != oldBk)
         {
             if (BkgndBrush)
@@ -98,8 +98,8 @@ CFileHeaderWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             BkgndBrush = CreateSolidBrush(BkColor);
         }
 
-        COLORREF oldBkColor = SetBkColor(dc, SG->GetCurrentColor(SALCOL_INACTIVE_CAPTION_BK));
-        COLORREF oldTexColor = SetTextColor(dc, SG->GetCurrentColor(SALCOL_INACTIVE_CAPTION_FG));
+        COLORREF oldBkColor = SetBkColor(dc, BkColor);
+        COLORREF oldTexColor = SetTextColor(dc, FileCompGetHostColor(SALCOL_INACTIVE_CAPTION_FG, GetSysColor(COLOR_INACTIVECAPTIONTEXT)));
         RECT r;
         GetClientRect(HWindow, &r);
         FillRect(dc, &r, BkgndBrush);
@@ -604,8 +604,8 @@ CComboBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         INT_PTR result = 0;
         if (HandleFileCompDarkCtlColor(WM_CTLCOLORSTATIC, wParam, lParam, &result))
             return result;
-        SetBkColor((HDC)wParam, GetSysColor(COLOR_WINDOW));
-        SetTextColor((HDC)wParam, GetSysColor(COLOR_WINDOWTEXT));
+        SetBkColor((HDC)wParam, DarkModeShouldUseDarkColors() ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_WINDOW));
+        SetTextColor((HDC)wParam, DarkModeShouldUseDarkColors() ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_WINDOWTEXT));
         return (LRESULT)GetSysColorBrush(COLOR_WINDOW);
     }
 
@@ -887,7 +887,7 @@ CRebar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (HandleFileCompDarkCtlColor(WM_CTLCOLORSTATIC, wParam, lParam, &result))
             return result;
         //SetBkColor((HDC)wParam, GetSysColor(COLOR_WINDOW));
-        SetTextColor((HDC)wParam, GetSysColor(COLOR_WINDOWTEXT));
+        SetTextColor((HDC)wParam, DarkModeShouldUseDarkColors() ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_WINDOWTEXT));
         //return 0;
         return (LRESULT)GetSysColorBrush(COLOR_WINDOW);
     }

--- a/src/plugins/filecomp/controls.cpp
+++ b/src/plugins/filecomp/controls.cpp
@@ -823,62 +823,80 @@ CRebar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         lParam);
     switch (uMsg)
     {
+    case WM_ERASEBKGND:
+    {
+        RECT r;
+        GetClientRect(HWindow, &r);
+        FillFileCompFaceRect((HDC)wParam, &r);
+        return TRUE;
+    }
+
     case WM_PAINT:
     {
-        int bandCount = int(SendMessage(HWindow, RB_GETBANDCOUNT, 0, 0));
-        // make sure the underline is drawn for text with a prefix (e.g. &Differences)
-        int i;
-        for (i = 0; i < bandCount; i++)
+        LRESULT ret = CWindow::WindowProc(uMsg, wParam, lParam);
+
+        HDC hdc = GetDC(HWindow);
+        if (hdc != NULL)
         {
-            char text[512];
-            *text = 0;
-            REBARBANDINFO rbbi;
-            rbbi.cbSize = sizeof(REBARBANDINFO);
-            rbbi.fMask = RBBIM_TEXT | RBBIM_HEADERSIZE;
-            rbbi.lpText = text;
-            rbbi.cch = 512;
-            SendMessage(HWindow, RB_GETBANDINFO, i, (LPARAM)&rbbi);
+            RECT client;
+            GetClientRect(HWindow, &client);
+            RECT gap = client;
+            gap.top = LONG(SendMessage(HWindow, RB_GETBARHEIGHT, 0, 0));
+            if (gap.top < gap.bottom)
+                FillFileCompFaceRect(hdc, &gap);
 
-            if (*text)
+            int bandCount = int(SendMessage(HWindow, RB_GETBANDCOUNT, 0, 0));
+            // make sure the underline is drawn for text with a prefix (e.g. &Differences)
+            int i;
+            for (i = 0; i < bandCount; i++)
             {
-                RECT r;
-                SendMessage(HWindow, RB_GETRECT, i, (LPARAM)&r);
-                //SendMessage(HWindow, RB_GETBANDBORDERS, i, (LPARAM)&borders);
+                char text[512];
+                *text = 0;
+                REBARBANDINFO rbbi;
+                rbbi.cbSize = sizeof(REBARBANDINFO);
+                rbbi.fMask = RBBIM_TEXT | RBBIM_HEADERSIZE;
+                rbbi.lpText = text;
+                rbbi.cch = 512;
+                SendMessage(HWindow, RB_GETBANDINFO, i, (LPARAM)&rbbi);
 
-                r.left += 9;
-                r.right = r.left + rbbi.cxHeader;
-                r.top = r.top + (r.bottom - r.top - EnvFontHeight) / 2 - 1;
-                r.bottom = r.top + EnvFontHeight + 1;
+                if (*text)
+                {
+                    RECT r;
+                    SendMessage(HWindow, RB_GETRECT, i, (LPARAM)&r);
+                    //SendMessage(HWindow, RB_GETBANDBORDERS, i, (LPARAM)&borders);
 
-                // make sure our text is not wiped during painting
-                ValidateRect(HWindow, &r);
-                r.right -= 13;
+                    r.left += 9;
+                    r.right = r.left + rbbi.cxHeader;
+                    r.top = r.top + (r.bottom - r.top - EnvFontHeight) / 2 - 1;
+                    r.bottom = r.top + EnvFontHeight + 1;
 
-                // draw our own text
-                HDC hdc = GetDC(HWindow);
-                HFONT oldFont = (HFONT)SelectObject(hdc, (HFONT)EnvFont);
-                COLORREF oldBkColor = SetBkColor(hdc, FileCompGetFaceColor());
-                COLORREF oldTextColor = SetTextColor(hdc, FileCompGetTextColor());
-                DrawText(hdc, text, -1, &r, DT_SINGLELINE | DT_TOP);
+                    r.right -= 13;
 
-                // line under the text
-                r.top += EnvFontHeight;
-                FillFileCompFaceRect(hdc, &r);
-                r.top -= EnvFontHeight;
+                    // draw our own text
+                    HFONT oldFont = (HFONT)SelectObject(hdc, (HFONT)EnvFont);
+                    COLORREF oldBkColor = SetBkColor(hdc, FileCompGetFaceColor());
+                    COLORREF oldTextColor = SetTextColor(hdc, FileCompGetTextColor());
+                    DrawText(hdc, text, -1, &r, DT_SINGLELINE | DT_TOP);
 
-                // area behind the text
-                r.left = r.right;
-                r.right += 13;
-                FillFileCompFaceRect(hdc, &r);
+                    // line under the text
+                    r.top += EnvFontHeight;
+                    FillFileCompFaceRect(hdc, &r);
+                    r.top -= EnvFontHeight;
 
-                SetTextColor(hdc, oldTextColor);
-                SetBkColor(hdc, oldBkColor);
-                SelectObject(hdc, oldFont);
-                ReleaseDC(HWindow, hdc);
+                    // area behind the text
+                    r.left = r.right;
+                    r.right += 13;
+                    FillFileCompFaceRect(hdc, &r);
+
+                    SetTextColor(hdc, oldTextColor);
+                    SetBkColor(hdc, oldBkColor);
+                    SelectObject(hdc, oldFont);
+                }
             }
+            ReleaseDC(HWindow, hdc);
         }
 
-        break;
+        return ret;
     }
 
     case WM_CTLCOLORSTATIC:

--- a/src/plugins/filecomp/dialogs.cpp
+++ b/src/plugins/filecomp/dialogs.cpp
@@ -3,6 +3,28 @@
 
 #include "precomp.h"
 
+namespace
+{
+const UINT WM_USER_FILECOMP_CFGPAGE_REDRAW = WM_APP + 3252;
+
+void RedrawFileCompConfigPage(HWND hwnd)
+{
+    if (hwnd == NULL)
+        return;
+
+    HWND parent = GetParent(hwnd);
+    if (parent != NULL)
+        RedrawWindow(parent, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+    RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
+}
+
+void QueueFileCompConfigPageRedraw(HWND hwnd)
+{
+    if (hwnd != NULL)
+        PostMessage(hwnd, WM_USER_FILECOMP_CFGPAGE_REDRAW, 0, 0);
+}
+}
+
 UINT_PTR CALLBACK
 ComDlgHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -10,6 +32,7 @@ ComDlgHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
                         lParam);
     if (uiMsg == WM_INITDIALOG)
     {
+        ApplyFileCompDarkModeIfSelected(hdlg);
         // SalamanderGUI->ArrangeHorizontalLines(hdlg);  // we do not do this for Windows common dialogs
         CenterWindow(hdlg);
         return 1;
@@ -294,7 +317,80 @@ CCompareFilesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CCommonPropSheetPage
 //
 
+INT_PTR
+CCommonPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+    case WM_INITDIALOG:
+    {
+        if (ApplyFileCompDarkModeIfSelected(HWindow))
+            QueueFileCompConfigPageRedraw(HWindow);
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyFileCompDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SHOWWINDOW:
+    {
+        if (wParam != FALSE)
+        {
+            if (ApplyFileCompDarkModeIfSelected(HWindow))
+                QueueFileCompConfigPageRedraw(HWindow);
+        }
+        break;
+    }
+
+    case WM_USER_FILECOMP_CFGPAGE_REDRAW:
+    {
+        RedrawFileCompConfigPage(HWindow);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureFileCompDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyFileCompDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_NOTIFY:
+    {
+        LPNMHDR hdr = (LPNMHDR)lParam;
+        if (hdr != NULL && hdr->code == PSN_SETACTIVE && FileCompShouldUseWindowsDarkMode())
+            QueueFileCompConfigPageRedraw(HWindow);
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleFileCompDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
+    }
+    return CPropSheetPage::DialogProc(uMsg, wParam, lParam);
+}
+
 void CCommonPropSheetPage::NotifDlgJustCreated()
 {
     SalGUI->ArrangeHorizontalLines(HWindow);
+    ApplyFileCompDarkMode(HWindow);
 }

--- a/src/plugins/filecomp/dialogs.h
+++ b/src/plugins/filecomp/dialogs.h
@@ -53,6 +53,7 @@ public:
         : CPropSheetPage(title, modul, resID, helpID, flags, icon, origin) {}
 
 protected:
+    virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
     virtual void NotifDlgJustCreated();
 };
 

--- a/src/plugins/filecomp/dialogs2.cpp
+++ b/src/plugins/filecomp/dialogs2.cpp
@@ -366,6 +366,25 @@ CPropPageColors::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             Preview2->SetFont(PageGeneral->GetCurrentFont());
             break;
         }
+        break;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureFileCompDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyFileCompDarkMode(HWindow);
+            LRESULT i = SendMessage(GetDlgItem(HWindow, IDC_ITEMS), CB_GETCURSEL, 0, 0);
+            UpdateColors(int(i));
+            if (Preview1 != NULL)
+                Preview1->RePaint();
+            if (Preview2 != NULL)
+                Preview2->RePaint();
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
     }
 
     case WM_SYSCOLORCHANGE:

--- a/src/plugins/filecomp/dialogs4.cpp
+++ b/src/plugins/filecomp/dialogs4.cpp
@@ -202,9 +202,19 @@ CPropPageGeneral::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CConfigurationDialog
 //
 
-// helper object for centering the configuration dialog over its parent
+// helper object for centering and darkening the configuration property sheet
 class CCenteredPropertyWindow : public CWindow
 {
+public:
+    void ApplyDarkMode()
+    {
+        ApplyFileCompDarkMode(HWindow);
+
+        HWND tab = PropSheet_GetTabControl(HWindow);
+        if (tab != NULL)
+            DarkModeApplyWindow(tab);
+    }
+
 protected:
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
@@ -218,11 +228,58 @@ protected:
             break;
         }
 
-        case WM_APP + 1000: // detach from the dialog after centering
+        case WM_APP + 1000: // deferred dark-mode apply/redraw after the property sheet creates its children
         {
-            DetachWindow();
-            delete this; // a bit of a hack, but nothing will touch 'this' anymore so it's fine
+            ApplyDarkMode();
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
             return 0;
+        }
+
+        case WM_THEMECHANGED:
+        {
+            ApplyDarkMode();
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return 0;
+        }
+
+        case WM_SETTINGCHANGE:
+        {
+            ConfigureFileCompDarkModeFromHost();
+            if (DarkModeHandleSettingChange(uMsg, lParam))
+            {
+                ApplyDarkMode();
+                RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+                return 0;
+            }
+            break;
+        }
+
+        case WM_ERASEBKGND:
+        {
+            if (DarkModeShouldUseDarkColors())
+            {
+                RECT r;
+                GetClientRect(HWindow, &r);
+                HBRUSH brush = CreateSolidBrush(DarkModeGetDialogBackgroundColor());
+                FillRect((HDC)wParam, &r, brush);
+                DeleteObject(brush);
+                return TRUE;
+            }
+            break;
+        }
+
+        case WM_CTLCOLORDLG:
+        case WM_CTLCOLORSTATIC:
+        case WM_CTLCOLORBTN:
+        case WM_CTLCOLOREDIT:
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLORMSGBOX:
+        case WM_CTLCOLORSCROLLBAR:
+        {
+            INT_PTR result = 0;
+            if (HandleFileCompDarkCtlColor(uMsg, wParam, lParam, &result))
+                return result;
+            break;
         }
         }
         return CWindow::WindowProc(uMsg, wParam, lParam);
@@ -261,7 +318,8 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
                 delete wnd; // the window is not attached, delete it right here
             else
             {
-                PostMessage(wnd->HWindow, WM_APP + 1000, 0, 0); // detach CCenteredPropertyWindow from the dialog
+                wnd->ApplyDarkMode();
+                PostMessage(wnd->HWindow, WM_APP + 1000, 0, 0); // deferred redraw after the property sheet creates its children
             }
         }
     }

--- a/src/plugins/filecomp/dlg_com.cpp
+++ b/src/plugins/filecomp/dlg_com.cpp
@@ -278,7 +278,7 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
 
     // text colors of the displayed file contents
     if (GetFValue(colors[TEXT_FG_NORMAL]) & SCF_DEFAULT)
-        SetRGBPart(&colors[TEXT_FG_NORMAL], SG->GetCurrentColor(SALCOL_VIEWER_FG_NORMAL));
+        SetRGBPart(&colors[TEXT_FG_NORMAL], FileCompGetHostColor(SALCOL_VIEWER_FG_NORMAL, GetSysColor(COLOR_WINDOWTEXT)));
     if (GetFValue(colors[TEXT_FG_LEFT_FOCUSED]) & SCF_DEFAULT)
         SetRGBPart(&colors[TEXT_FG_LEFT_FOCUSED], GetCOLORREF(colors[TEXT_FG_NORMAL]));
     if (GetFValue(colors[TEXT_FG_RIGHT_FOCUSED]) & SCF_DEFAULT)
@@ -294,7 +294,7 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
 
     // background colors of the displayed file contents
     if (GetFValue(colors[TEXT_BK_NORMAL]) & SCF_DEFAULT)
-        SetRGBPart(&colors[TEXT_BK_NORMAL], SG->GetCurrentColor(SALCOL_VIEWER_BK_NORMAL));
+        SetRGBPart(&colors[TEXT_BK_NORMAL], FileCompGetHostColor(SALCOL_VIEWER_BK_NORMAL, GetSysColor(COLOR_WINDOW)));
     if (GetFValue(colors[TEXT_BK_LEFT_FOCUSED]) & SCF_DEFAULT)
     {
         SetRGBPart(&colors[TEXT_BK_LEFT_FOCUSED],
@@ -386,14 +386,14 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     if (GetFValue(colors[TEXT_FG_SELECTION]) & SCF_DEFAULT)
     {
         if (GetFValue(colors[TEXT_FG_NORMAL]) & SCF_DEFAULT)
-            SetRGBPart(&colors[TEXT_FG_SELECTION], SG->GetCurrentColor(SALCOL_VIEWER_FG_SELECTED));
+            SetRGBPart(&colors[TEXT_FG_SELECTION], FileCompGetHostColor(SALCOL_VIEWER_FG_SELECTED, GetSysColor(COLOR_HIGHLIGHTTEXT)));
         else
             SetRGBPart(&colors[TEXT_FG_SELECTION], GetCOLORREF(colors[TEXT_BK_NORMAL]));
     }
     if (GetFValue(colors[TEXT_BK_SELECTION]) & SCF_DEFAULT)
     {
         if (GetFValue(colors[TEXT_BK_NORMAL]) & SCF_DEFAULT)
-            SetRGBPart(&colors[TEXT_BK_SELECTION], SG->GetCurrentColor(SALCOL_VIEWER_BK_SELECTED));
+            SetRGBPart(&colors[TEXT_BK_SELECTION], FileCompGetHostColor(SALCOL_VIEWER_BK_SELECTED, GetSysColor(COLOR_HIGHLIGHT)));
         else
             SetRGBPart(&colors[TEXT_BK_SELECTION], GetCOLORREF(colors[TEXT_FG_NORMAL]));
     }

--- a/src/plugins/filecomp/dlg_com.cpp
+++ b/src/plugins/filecomp/dlg_com.cpp
@@ -86,9 +86,43 @@ CCommonDialog::CCommonDialog(int resID, HWND hParent, CObjectOrigin origin)
     {
     case WM_INITDIALOG:
     {
+        ApplyFileCompDarkMode(HWindow);
         // horizontal and vertical centering of the dialog over the parent
         CenterWindow(HWindow);
         break; // let DefDlgProc set the focus
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyFileCompDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureFileCompDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyFileCompDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleFileCompDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -97,6 +131,7 @@ CCommonDialog::CCommonDialog(int resID, HWND hParent, CObjectOrigin origin)
 void CCommonDialog::NotifDlgJustCreated()
 {
     SalGUI->ArrangeHorizontalLines(HWindow);
+    ApplyFileCompDarkMode(HWindow);
 }
 
 // ****************************************************************************
@@ -160,6 +195,9 @@ COLORREF
 GetScrollbarColor()
 {
     CALL_STACK_MESSAGE_NONE
+    if (DarkModeShouldUseDarkColors())
+        return DarkModeGetDialogBackgroundColor();
+
     if (GetSysColor(COLOR_BTNFACE) != GetSysColor(COLOR_3DHILIGHT))
     {
         return GetAverageColor(GetSysColor(COLOR_SCROLLBAR), 1,
@@ -201,7 +239,7 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     CALL_STACK_MESSAGE1("UpdateDefaultColors(, )");
     // text colors in the column with line numbers
     if (GetFValue(colors[LINENUM_FG_NORMAL]) & SCF_DEFAULT)
-        SetRGBPart(&colors[LINENUM_FG_NORMAL], GetSysColor(COLOR_WINDOWTEXT));
+        SetRGBPart(&colors[LINENUM_FG_NORMAL], DarkModeShouldUseDarkColors() ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_WINDOWTEXT));
     //if (GetFValue(colors[LINENUM_FG_FOCUSED]) & SCF_DEFAULT)
     //  SetRGBPart(&colors[LINENUM_FG_FOCUSED], GetCOLORREF(colors[LINENUM_FG_NORMAL]));
 
@@ -224,11 +262,11 @@ void UpdateDefaultColors(SALCOLOR* colors, HPALETTE& palette)
     if (GetFValue(colors[LINENUM_BK_RIGHT_CHANGE]) & SCF_DEFAULT)
         SetRGBPart(&colors[LINENUM_BK_RIGHT_CHANGE], GetCOLORREF(colors[LINENUM_BK_NORMAL]));
     if (GetFValue(colors[LINENUM_BK_LEFT_CHANGE_FOCUSED]) & SCF_DEFAULT)
-        SetRGBPart(&colors[LINENUM_BK_LEFT_CHANGE_FOCUSED], GetSysColor(COLOR_BTNFACE));
+        SetRGBPart(&colors[LINENUM_BK_LEFT_CHANGE_FOCUSED], DarkModeShouldUseDarkColors() ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE));
     //GetAverageColor(GetCOLORREF(colors[LINENUM_BK_LEFT_CHANGE]), 9,
     //                GetCOLORREF(colors[LINENUM_FG_LEFT_CHANGE]), 1));
     if (GetFValue(colors[LINENUM_BK_RIGHT_CHANGE_FOCUSED]) & SCF_DEFAULT)
-        SetRGBPart(&colors[LINENUM_BK_RIGHT_CHANGE_FOCUSED], GetSysColor(COLOR_BTNFACE));
+        SetRGBPart(&colors[LINENUM_BK_RIGHT_CHANGE_FOCUSED], DarkModeShouldUseDarkColors() ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE));
     //GetAverageColor(GetCOLORREF(colors[LINENUM_BK_RIGHT_CHANGE]), 9,
     //                GetCOLORREF(colors[LINENUM_FG_RIGHT_CHANGE]), 1));
 
@@ -442,7 +480,7 @@ BOOL InitDialogs()
             CS_DBLCLKS, 0, 0, DLLInstance,
             NULL,
             LoadCursor(DLLInstance, MAKEINTRESOURCE(IDC_SPLIT_VERT)),
-            (HBRUSH)(COLOR_WINDOW + 1),
+            NULL,
             NULL, SPLITBARWINDOW_CLASSNAME, NULL))
     {
         TRACE_E("RegisterUniversalClass has failed, last error:" << GetLastError());
@@ -459,7 +497,7 @@ BOOL InitDialogs()
     windowClass.hInstance = DLLInstance;
     windowClass.hIcon = NULL;
     windowClass.hCursor = HArrowCursor;
-    windowClass.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    windowClass.hbrBackground = NULL;
     windowClass.lpszMenuName = NULL;
     windowClass.lpszClassName = FILEVIEWWINDOW_CLASSNAME;
     windowClass.hIconSm = NULL;

--- a/src/plugins/filecomp/filecomp.cpp
+++ b/src/plugins/filecomp/filecomp.cpp
@@ -51,6 +51,134 @@ const char* CONFIG_INPUTENCTABLE1 = "InputEnc Table 1";
 
 BOOL LoadOnStart;
 
+namespace
+{
+HBRUSH FileCompDarkModeDialogBrush = NULL;
+COLORREF FileCompDarkModeDialogBrushColor = CLR_INVALID;
+BOOL FileCompHostPolicyKnown = FALSE;
+BOOL FileCompHostUseWindowsDarkMode = FALSE;
+COLORREF FileCompHostSchemeText = CLR_INVALID;
+COLORREF FileCompHostSchemeBackground = CLR_INVALID;
+DWORD FileCompMainThreadId = 0;
+
+HBRUSH FileCompGetDarkModeDialogBrush(COLORREF background)
+{
+    if (FileCompDarkModeDialogBrush == NULL || FileCompDarkModeDialogBrushColor != background)
+    {
+        if (FileCompDarkModeDialogBrush != NULL)
+            DeleteObject(FileCompDarkModeDialogBrush);
+        FileCompDarkModeDialogBrush = CreateSolidBrush(background);
+        FileCompDarkModeDialogBrushColor = background;
+    }
+    return FileCompDarkModeDialogBrush;
+}
+}
+
+BOOL FileCompCanQueryHostDarkMode()
+{
+    return SG != NULL &&
+           FileCompMainThreadId != 0 &&
+           GetCurrentThreadId() == FileCompMainThreadId;
+}
+
+void RefreshFileCompDarkModeFromHost()
+{
+    // File Comparator windows/dialogs can run outside Salamander's main UI thread.
+    // Host configuration/color APIs are main-thread-only, so non-main UI consumes
+    // this cached snapshot.
+    if (!FileCompCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SG->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                               &useWindowsDarkMode,
+                               sizeof(useWindowsDarkMode),
+                               NULL))
+    {
+        FileCompHostPolicyKnown = TRUE;
+        FileCompHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (FileCompHostPolicyKnown && FileCompHostUseWindowsDarkMode)
+    {
+        FileCompHostSchemeText = SG->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        FileCompHostSchemeBackground = SG->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+BOOL FileCompShouldUseWindowsDarkMode()
+{
+    return FileCompHostPolicyKnown && FileCompHostUseWindowsDarkMode;
+}
+
+void ConfigureFileCompDarkModeFromHost()
+{
+    RefreshFileCompDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = FileCompShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && FileCompHostSchemeText != CLR_INVALID && FileCompHostSchemeBackground != CLR_INVALID)
+    {
+        text = FileCompHostSchemeText;
+        background = FileCompHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = FileCompGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyFileCompDarkMode(HWND hwnd)
+{
+    ConfigureFileCompDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL ApplyFileCompDarkModeIfSelected(HWND hwnd)
+{
+    if (!FileCompShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ApplyFileCompDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL HandleFileCompDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!FileCompShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureFileCompDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+void ReleaseFileCompDarkModeResources()
+{
+    if (FileCompDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(FileCompDarkModeDialogBrush);
+        FileCompDarkModeDialogBrush = NULL;
+        FileCompDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+
 #ifdef DUMP_MEM
 _CrtMemState ___CrtMemState;
 #endif //DUMP_MEM
@@ -73,6 +201,10 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
         return NULL;
 
     CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
+
+    FileCompMainThreadId = GetCurrentThreadId();
+    RefreshFileCompDarkModeFromHost();
+    ConfigureFileCompDarkModeFromHost();
 
     SG->SetHelpFileName("filecomp.chm");
 
@@ -155,6 +287,7 @@ BOOL CPluginInterface::Release(HWND parent, BOOL force)
                 //SG->CallLoadOrSaveConfiguration(FALSE, LoadOrSaveConfiguration, parent);
 
                 ReleaseDialogs();
+                ReleaseFileCompDarkModeResources();
                 ReleaseLCUtils();
                 MappedFontFactory.Free();
                 if (hNormalizDll)

--- a/src/plugins/filecomp/filecomp.cpp
+++ b/src/plugins/filecomp/filecomp.cpp
@@ -59,6 +59,12 @@ BOOL FileCompHostPolicyKnown = FALSE;
 BOOL FileCompHostUseWindowsDarkMode = FALSE;
 COLORREF FileCompHostSchemeText = CLR_INVALID;
 COLORREF FileCompHostSchemeBackground = CLR_INVALID;
+COLORREF FileCompHostInactiveCaptionText = CLR_INVALID;
+COLORREF FileCompHostInactiveCaptionBackground = CLR_INVALID;
+COLORREF FileCompHostViewerText = CLR_INVALID;
+COLORREF FileCompHostViewerBackground = CLR_INVALID;
+COLORREF FileCompHostViewerSelectionText = CLR_INVALID;
+COLORREF FileCompHostViewerSelectionBackground = CLR_INVALID;
 DWORD FileCompMainThreadId = 0;
 
 HBRUSH FileCompGetDarkModeDialogBrush(COLORREF background)
@@ -99,16 +105,47 @@ void RefreshFileCompDarkModeFromHost()
         FileCompHostUseWindowsDarkMode = useWindowsDarkMode;
     }
 
-    if (FileCompHostPolicyKnown && FileCompHostUseWindowsDarkMode)
-    {
-        FileCompHostSchemeText = SG->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
-        FileCompHostSchemeBackground = SG->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
-    }
+    FileCompHostSchemeText = SG->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+    FileCompHostSchemeBackground = SG->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    FileCompHostInactiveCaptionText = SG->GetCurrentColor(SALCOL_INACTIVE_CAPTION_FG);
+    FileCompHostInactiveCaptionBackground = SG->GetCurrentColor(SALCOL_INACTIVE_CAPTION_BK);
+    FileCompHostViewerText = SG->GetCurrentColor(SALCOL_VIEWER_FG_NORMAL);
+    FileCompHostViewerBackground = SG->GetCurrentColor(SALCOL_VIEWER_BK_NORMAL);
+    FileCompHostViewerSelectionText = SG->GetCurrentColor(SALCOL_VIEWER_FG_SELECTED);
+    FileCompHostViewerSelectionBackground = SG->GetCurrentColor(SALCOL_VIEWER_BK_SELECTED);
 }
 
 BOOL FileCompShouldUseWindowsDarkMode()
 {
     return FileCompHostPolicyKnown && FileCompHostUseWindowsDarkMode;
+}
+
+COLORREF FileCompGetHostColor(int salamanderColor, COLORREF fallback)
+{
+    // Salamander color APIs are safe only on the host main thread. FileComp owns
+    // worker UI threads for the compare dialog/window, so those windows consume
+    // the cached main-thread snapshot refreshed from plugin events.
+    switch (salamanderColor)
+    {
+    case SALCOL_ITEM_FG_NORMAL:
+        return FileCompHostSchemeText != CLR_INVALID ? FileCompHostSchemeText : fallback;
+    case SALCOL_ITEM_BK_NORMAL:
+        return FileCompHostSchemeBackground != CLR_INVALID ? FileCompHostSchemeBackground : fallback;
+    case SALCOL_INACTIVE_CAPTION_FG:
+        return FileCompHostInactiveCaptionText != CLR_INVALID ? FileCompHostInactiveCaptionText : fallback;
+    case SALCOL_INACTIVE_CAPTION_BK:
+        return FileCompHostInactiveCaptionBackground != CLR_INVALID ? FileCompHostInactiveCaptionBackground : fallback;
+    case SALCOL_VIEWER_FG_NORMAL:
+        return FileCompHostViewerText != CLR_INVALID ? FileCompHostViewerText : fallback;
+    case SALCOL_VIEWER_BK_NORMAL:
+        return FileCompHostViewerBackground != CLR_INVALID ? FileCompHostViewerBackground : fallback;
+    case SALCOL_VIEWER_FG_SELECTED:
+        return FileCompHostViewerSelectionText != CLR_INVALID ? FileCompHostViewerSelectionText : fallback;
+    case SALCOL_VIEWER_BK_SELECTED:
+        return FileCompHostViewerSelectionBackground != CLR_INVALID ? FileCompHostViewerSelectionBackground : fallback;
+    default:
+        return fallback;
+    }
 }
 
 void ConfigureFileCompDarkModeFromHost()
@@ -584,13 +621,18 @@ void CPluginInterface::Event(int event, DWORD param) // FIXME_X64 - is a 32-bit 
     {
     case PLUGINEVENT_COLORSCHANGED:
     {
+        RefreshFileCompDarkModeFromHost();
+        ConfigureFileCompDarkModeFromHost();
         // the text color may have changed
         MainWindowQueue.BroadcastMessage(WM_USER_CFGCHNG, CC_COLORS, 0);
+        MainWindowQueue.BroadcastMessage(WM_THEMECHANGED, 0, 0);
         break;
     }
 
     case PLUGINEVENT_CONFIGURATIONCHANGED:
     {
+        RefreshFileCompDarkModeFromHost();
+        ConfigureFileCompDarkModeFromHost();
         // Cache the value for use in Config dialog
         SG->GetConfigParameter(SALCFG_VIEWERFONT, &::Configuration.InternalViewerFont, sizeof(LOGFONT), NULL);
         // the viewer font may have changed
@@ -599,6 +641,15 @@ void CPluginInterface::Event(int event, DWORD param) // FIXME_X64 - is a 32-bit 
             ::Configuration.FileViewLogFont = ::Configuration.InternalViewerFont;
             MainWindowQueue.BroadcastMessage(WM_USER_CFGCHNG, CC_FONT, 0);
         }
+        break;
+    }
+
+    case PLUGINEVENT_SETTINGCHANGE:
+    {
+        RefreshFileCompDarkModeFromHost();
+        ConfigureFileCompDarkModeFromHost();
+        MainWindowQueue.BroadcastMessage(WM_USER_CFGCHNG, CC_COLORS, 0);
+        MainWindowQueue.BroadcastMessage(WM_THEMECHANGED, 0, 0);
         break;
     }
     }
@@ -734,6 +785,8 @@ BOOL CPluginInterfaceForMenu::ExecuteMenuItem(CSalamanderForOperationsAbstract* 
 
         BOOL doNotSwapNames = secondFromSource || SG->GetSourcePanel() == PANEL_LEFT;
         SG->GetConfigParameter(SALCFG_ALWAYSONTOP, &AlwaysOnTop, sizeof(AlwaysOnTop), NULL);
+        RefreshFileCompDarkModeFromHost();
+        ConfigureFileCompDarkModeFromHost();
         CFilecompThread* d = new CFilecompThread(doNotSwapNames ? file1 : file2, doNotSwapNames ? file2 : file1, FALSE, "");
         if (!d)
             return Error((HWND)-1, IDS_LOWMEM);

--- a/src/plugins/filecomp/filecomp.h
+++ b/src/plugins/filecomp/filecomp.h
@@ -20,6 +20,7 @@ extern BOOL LoadOnStart;
 BOOL FileCompCanQueryHostDarkMode();
 void RefreshFileCompDarkModeFromHost();
 BOOL FileCompShouldUseWindowsDarkMode();
+COLORREF FileCompGetHostColor(int salamanderColor, COLORREF fallback);
 void ConfigureFileCompDarkModeFromHost();
 void ApplyFileCompDarkMode(HWND hwnd);
 BOOL ApplyFileCompDarkModeIfSelected(HWND hwnd);

--- a/src/plugins/filecomp/filecomp.h
+++ b/src/plugins/filecomp/filecomp.h
@@ -17,6 +17,15 @@ extern BOOL AlwaysOnTop;
 
 extern BOOL LoadOnStart;
 
+BOOL FileCompCanQueryHostDarkMode();
+void RefreshFileCompDarkModeFromHost();
+BOOL FileCompShouldUseWindowsDarkMode();
+void ConfigureFileCompDarkModeFromHost();
+void ApplyFileCompDarkMode(HWND hwnd);
+BOOL ApplyFileCompDarkModeIfSelected(HWND hwnd);
+BOOL HandleFileCompDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);
+void ReleaseFileCompDarkModeResources();
+
 // ****************************************************************************
 //
 // Plugin interface

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -2177,7 +2177,9 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (wParam & CC_COLORS)
         {
+            ApplyFileCompDarkMode(HWindow);
             UpdateDefaultColors(Colors, Palette);
+            ComboBox->ChangeColors();
             if (UsePalette)
             {
                 HDC dc = GetDC(HWindow);
@@ -2186,6 +2188,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 SelectPalette(dc, oldPalette, FALSE);
                 ReleaseDC(HWindow, dc);
             }
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
         }
 
         if (DataValid)

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -19,6 +19,33 @@ CBandParams BandsParams[2];
 
 const char* MAINWINDOW_CLASSNAME = "SFC Window Class";
 
+namespace
+{
+void ApplyFileCompMainWindowChrome(HWND hwnd, HWND toolbar, HWND rebar)
+{
+    const bool dark = DarkModeShouldUseDarkColors();
+    const COLORREF background = dark ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE);
+    const COLORREF text = dark ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_BTNTEXT);
+
+    if (toolbar != NULL)
+    {
+        SendMessage(toolbar, TB_SETBKCOLOR, 0, background);
+        SendMessage(toolbar, TB_SETTEXTCOLOR, 0, text);
+        InvalidateRect(toolbar, NULL, TRUE);
+    }
+
+    if (rebar != NULL)
+    {
+        SendMessage(rebar, RB_SETBKCOLOR, 0, background);
+        SendMessage(rebar, RB_SETTEXTCOLOR, 0, text);
+        InvalidateRect(rebar, NULL, TRUE);
+    }
+
+    DarkModeApplyMenuBar(hwnd);
+    DrawMenuBar(hwnd);
+}
+}
+
 CMainWindow::CMainWindow(char* path1, char* path2, CCompareOptions* options, UINT showCmd)
 {
     CALL_STACK_MESSAGE1("CMainWindow::CMainWindow(, , )");
@@ -218,6 +245,7 @@ BOOL CMainWindow::Init()
     RestoreRebarLayout();
 
     RebarHeight = LONG(SendMessage(Rebar->HWindow, RB_GETBARHEIGHT, 0, 0)) + 4 + REBAR_BORDER;
+    ApplyFileCompMainWindowChrome(HWindow, HToolbar, Rebar->HWindow);
 
     // create the window caption
     LeftHeader = new CFileHeaderWindow("");
@@ -314,6 +342,7 @@ BOOL CMainWindow::Init()
     Initialized = TRUE;
 
     ApplyFileCompDarkMode(HWindow);
+    ApplyFileCompMainWindowChrome(HWindow, HToolbar, Rebar != NULL ? Rebar->HWindow : NULL);
 
     // ensure the worker thread gets started
     PostMessage(HWindow, WM_COMMAND, CM_RECOMPARE, 0);
@@ -1661,6 +1690,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             case RBN_HEIGHTCHANGE:
             {
                 RebarHeight = LONG(SendMessage(Rebar->HWindow, RB_GETBARHEIGHT, 0, 0)) + 4 + REBAR_BORDER;
+                ApplyFileCompMainWindowChrome(HWindow, HToolbar, Rebar->HWindow);
                 if (Initialized)
                     LayoutChilds();
                 return 0;
@@ -1754,6 +1784,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_THEMECHANGED:
     {
         ApplyFileCompDarkMode(HWindow);
+        ApplyFileCompMainWindowChrome(HWindow, HToolbar, Rebar != NULL ? Rebar->HWindow : NULL);
         UpdateDefaultColors(Colors, Palette);
         ComboBox->ChangeColors();
         if (DataValid)
@@ -2178,6 +2209,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (wParam & CC_COLORS)
         {
             ApplyFileCompDarkMode(HWindow);
+            ApplyFileCompMainWindowChrome(HWindow, HToolbar, Rebar != NULL ? Rebar->HWindow : NULL);
             UpdateDefaultColors(Colors, Palette);
             ComboBox->ChangeColors();
             if (UsePalette)

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -29,8 +29,14 @@ void ApplyFileCompMainWindowChrome(HWND hwnd, HWND toolbar, HWND rebar)
 
     if (toolbar != NULL)
     {
-        SendMessage(toolbar, TB_SETBKCOLOR, 0, background);
-        SendMessage(toolbar, TB_SETTEXTCOLOR, 0, text);
+#ifdef TB_SETCOLORSCHEME
+        COLORSCHEME scheme;
+        memset(&scheme, 0, sizeof(scheme));
+        scheme.dwSize = sizeof(scheme);
+        scheme.clrBtnHighlight = background;
+        scheme.clrBtnShadow = background;
+        SendMessage(toolbar, TB_SETCOLORSCHEME, 0, (LPARAM)&scheme);
+#endif
         InvalidateRect(toolbar, NULL, TRUE);
     }
 

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "precomp.h"
-#include "..\\shared\\plugindarkmode.h"
 
 using namespace std;
 
@@ -98,7 +97,7 @@ BOOL CMainWindow::Init()
     }
     COLORMAP cm;
     cm.from = 0x00FF00FF;
-    cm.to = GetSysColor(COLOR_BTNFACE);
+    cm.to = DarkModeShouldUseDarkColors() ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE);
     HToolbar = CreateToolbarEx(HWindow,
                                WS_VISIBLE | WS_CHILD |
                                    WS_CLIPCHILDREN | WS_CLIPSIBLINGS |
@@ -313,6 +312,8 @@ BOOL CMainWindow::Init()
         DragAcceptFiles(HWindow, TRUE);
 
     Initialized = TRUE;
+
+    ApplyFileCompDarkMode(HWindow);
 
     // ensure the worker thread gets started
     PostMessage(HWindow, WM_COMMAND, CM_RECOMPARE, 0);
@@ -1047,11 +1048,14 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         r3.bottom = RebarHeight;
         r3.left = 0;
         r3.right = r1.right;
-        FillRect(dc, &r3, (HBRUSH)(COLOR_BTNFACE + 1));
+        HBRUSH faceBrush = DarkModeShouldUseDarkColors() ? CreateSolidBrush(DarkModeGetDialogBackgroundColor()) : NULL;
+        FillRect(dc, &r3, faceBrush != NULL ? faceBrush : (HBRUSH)(COLOR_BTNFACE + 1));
         // draw the gap between the header and the text window
         r3.top = RebarHeight + r2.bottom + 2;
         r3.bottom = r3.top + 2;
-        FillRect(dc, &r3, (HBRUSH)(COLOR_BTNFACE + 1));
+        FillRect(dc, &r3, faceBrush != NULL ? faceBrush : (HBRUSH)(COLOR_BTNFACE + 1));
+        if (faceBrush != NULL)
+            DeleteObject(faceBrush);
 
         EndPaint(HWindow, &ps);
         return 0;
@@ -1741,9 +1745,22 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
 
     case WM_SETTINGCHANGE:
+    {
+        ConfigureFileCompDarkModeFromHost();
+        if (!DarkModeHandleSettingChange(uMsg, lParam))
+            break;
+        // fall through
+    }
     case WM_THEMECHANGED:
     {
-        PluginDarkMode_HandleThemeMessage(HWindow, uMsg, lParam);
+        ApplyFileCompDarkMode(HWindow);
+        UpdateDefaultColors(Colors, Palette);
+        ComboBox->ChangeColors();
+        if (DataValid)
+        {
+            FileView[fviLeft]->ReloadConfiguration(CC_COLORS, TRUE);
+            FileView[fviRight]->ReloadConfiguration(CC_COLORS, TRUE);
+        }
         // the scrollbar size may have changed; ensure the combo box recalculates the button size
         RECT r;
         GetWindowRect(ComboBox->HWindow, &r);
@@ -1754,7 +1771,22 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SetWindowPos(ComboBox->HWindow, 0, 0, 0,
                      r.right - r.left, r.bottom - r.top,
                      SWP_FRAMECHANGED | SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOMOVE);
-        break;
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        if (HToolbar != NULL)
+            RedrawWindow(HToolbar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
+        if (Rebar != NULL && Rebar->HWindow != NULL)
+            RedrawWindow(Rebar->HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        if (LeftHeader != NULL && LeftHeader->HWindow != NULL)
+            RedrawWindow(LeftHeader->HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
+        if (RightHeader != NULL && RightHeader->HWindow != NULL)
+            RedrawWindow(RightHeader->HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
+        if (LeftFileViewHWnd != NULL)
+            RedrawWindow(LeftFileViewHWnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
+        if (RightFileViewHWnd != NULL)
+            RedrawWindow(RightFileViewHWnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
+        if (SplitBar != NULL && SplitBar->HWindow != NULL)
+            RedrawWindow(SplitBar->HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
+        return TRUE;
     }
 
     case WM_QUERYNEWPALETTE:

--- a/src/plugins/filecomp/precomp.h
+++ b/src/plugins/filecomp/precomp.h
@@ -8,6 +8,7 @@
 #include <windows.h>
 #include <CommDlg.h>
 #include <ShellAPI.h>
+#include <oleidl.h> // IDropTarget used by shared mhandles.h
 #include <crtdbg.h>
 #include <tchar.h>
 #include <sys/stat.h>

--- a/src/plugins/filecomp/precomp.h
+++ b/src/plugins/filecomp/precomp.h
@@ -42,6 +42,8 @@
 #include "arraylt.h"
 #include "winliblt.h"
 #include "auxtools.h"
+#include "mhandles.h"
+#include "../../darkmode.h"
 
 // get rid of some annoying warnings
 #pragma warning(disable : 4661)

--- a/src/plugins/filecomp/vcxproj/filecomp.props
+++ b/src/plugins/filecomp/vcxproj/filecomp.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\shared\lukas;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\shared\lukas;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/plugins/filecomp/vcxproj/filecomp.vcxproj
+++ b/src/plugins/filecomp/vcxproj/filecomp.vcxproj
@@ -125,7 +125,45 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
-    <ClCompile Include="..\..\shared\plugindarkmode.cpp">
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\shared\lukas\messages.cpp">
     </ClCompile>
@@ -197,7 +235,7 @@
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
     </ClInclude>
-    <ClInclude Include="..\..\shared\plugindarkmode.h">
+    <ClInclude Include="..\..\shared\mhandles.h">
     </ClInclude>
     <ClInclude Include="..\..\shared\lukas\diff.h">
     </ClInclude>

--- a/src/plugins/filecomp/vcxproj/filecomp.vcxproj.filters
+++ b/src/plugins/filecomp/vcxproj/filecomp.vcxproj.filters
@@ -115,6 +115,42 @@
     <ClCompile Include="..\..\shared\lukas\utilbase.cpp">
       <Filter>lukas-shared</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\controls.h">
@@ -181,6 +217,9 @@
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\shared\dbg.h">
+      <Filter>common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\shared\mhandles.h">
       <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\shared\spl_base.h">


### PR DESCRIPTION
### Motivation
- Replace the legacy per-plugin lightweight dark-mode helper with the shared host dark-mode API so File Comparator follows host policy and scheme colors. 
- Make dialogs, property pages, previews and custom controls dark-mode aware to avoid visual glitches and to respect the host scheme. 
- Avoid synchronous property-sheet redraw cycles (flicker/recursive apply) by using a deferred private redraw message for config pages.

### Description
- Added shared host dark-mode includes to FileComp precompiled header by adding `mhandles.h` and `../../darkmode.h` to `src/plugins/filecomp/precomp.h`.
- Implemented a FileComp dark-mode manager in `src/plugins/filecomp/filecomp.cpp` with a cached main-thread ID, host dark-mode policy/colors, dialog brush lifecycle, and helpers: `RefreshFileCompDarkModeFromHost`, `ConfigureFileCompDarkModeFromHost`, `ApplyFileCompDarkMode`, `ApplyFileCompDarkModeIfSelected`, `HandleFileCompDarkCtlColor`, and `ReleaseFileCompDarkModeResources`; declarations added to `src/plugins/filecomp/filecomp.h`.
- In `SalamanderPluginEntry` (in `filecomp.cpp`) capture the main-thread ID and load initial host snapshot; call `ReleaseFileCompDarkModeResources` during plugin shutdown in `CPluginInterface::Release`.
- Replaced legacy `plugindarkmode` usage in `src/plugins/filecomp/mainwnd.cpp` with shared helpers, applied `ApplyFileCompDarkMode(HWindow)` on init, and on theme/setting changes use `ConfigureFileCompDarkModeFromHost`/`ApplyFileCompDarkMode` and perform targeted invalidation/redraw of main window and relevant children.
- Integrated dark-mode handling into FileComp dialogs and property pages: `src/plugins/filecomp/dialogs.cpp`, `dlg_com.cpp`, `dialogs2.cpp`, `dialogs3.cpp`, `dialogs4.cpp` and compare dialogs, adding `WM_USER_FILECOMP_CFGPAGE_REDRAW` deferred redraw for property pages to avoid synchronous tab-switch redraw cycles.
- Replaced hardcoded `COLOR_WINDOW`, `COLOR_WINDOWTEXT`, `COLOR_BTNFACE` and similar usages in `src/plugins/filecomp/controls.cpp`, `dlg_com.cpp`, `dialogs2.cpp`, `mainwnd.cpp`, and preview/custom view code with dark-mode aware helpers (`DarkModeShouldUseDarkColors()`, `DarkModeGetDialogBackgroundColor()`, `DarkModeGetDialogTextColor()`, `DarkModeGetColors()` and `HandleFileCompDarkCtlColor`).
- Updated FileComp MSVC project files (`src/plugins/filecomp/vcxproj/filecomp.props`, `filecomp.vcxproj`, and `.filters`) to:
  - add `..\..\..\third_party\darkmodelib\include` to include path and preprocessor defines `USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG` in `filecomp.props`; 
  - remove `plugindarkmode.cpp/.h` entries and instead add `..\..\shared\mhandles.cpp`, `..\..\..\darkmode.cpp`, `..\..\..\darkmode_backend_darkmodelib.cpp` and the vendored `third_party/darkmodelib/src/*.cpp` files (configured to compile without PCH and with `UNICODE;_UNICODE`).

### Testing
- Project XML validation: parsed `src/plugins/filecomp/vcxproj/filecomp.props`, `filecomp.vcxproj` and `filecomp.vcxproj.filters` via `xml.etree.ElementTree` successfully and verified expected dark-mode source/include entries (succeeded).
- Basic repository checks: ran `git diff --check` and other repository consistency checks (no whitespace/errors reported).
- Visual Studio build: attempted `msbuild` for Win32/x64 Debug/Release but `msbuild` is not available in this Linux environment so full Windows builds were not run here (tool unavailable).
- Note: runtime/manual functional verification inside Salamander (compare window, dialogs, property pages, preview and custom controls under the "Windows Dark Mode (experimental)" scheme) must be performed on Windows; this environment cannot run those interactive checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb6d748248329b2e592babccb7cdb)