### PR TITLE
Allow archive and plugin-FS drag when shell-extension shared memory is available

### DIFF
--- a/src/shellsup.cpp
+++ b/src/shellsup.cpp
@@ -1204,12 +1204,15 @@ void ShellAction(CFilesWindow* panel, CShellAction action, BOOL useSelection,
     }
 
     BOOL dragFiles = action == saLeftDragFiles || action == saRightDragFiles;
+    BOOL canCreateFakeDragData = SalShExtSharedMemView != NULL;
     if (panel->Is(ptZIPArchive) && action != saContextMenu &&
-        (!dragFiles && action != saCopyToClipboard || !SalShExtRegistered))
+        ((!dragFiles && action != saCopyToClipboard) ||
+         (dragFiles && !canCreateFakeDragData) ||
+         (action == saCopyToClipboard && !SalShExtRegistered)))
     {
-        if (dragFiles && !SalShExtRegistered)
+        if (dragFiles && !canCreateFakeDragData)
         {
-            TRACE_E("Drag&drop from archives is not possible, shell extension utils\\salextx86.dll or utils\\salextx64.dll is missing!");
+            TRACE_E("Drag&drop from archives is not possible, shell extension shared memory is not available!");
         }
         if (action == saCopyToClipboard && !SalShExtRegistered)
             TRACE_E("Copy&paste from archives is not possible, shell extension utils\\salextx86.dll or utils\\salextx64.dll is missing!");
@@ -1217,13 +1220,13 @@ void ShellAction(CFilesWindow* panel, CShellAction action, BOOL useSelection,
         return;
     }
     if (panel->Is(ptPluginFS) && dragFiles &&
-        (!SalShExtRegistered ||
+        (!canCreateFakeDragData ||
          !panel->GetPluginFS()->NotEmpty() ||
          !panel->GetPluginFS()->IsServiceSupported(FS_SERVICE_MOVEFROMFS) &&    // FS umi "move from FS"
              !panel->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMFS))) // FS umi "copy from FS"
     {
-        if (!SalShExtRegistered)
-            TRACE_E("Drag&drop from file-systems is not possible, shell extension utils\\salextx86.dll or utils\\salextx64.dll is missing!");
+        if (!canCreateFakeDragData)
+            TRACE_E("Drag&drop from file-systems is not possible, shell extension shared memory is not available!");
         if (!panel->GetPluginFS()->NotEmpty())
             TRACE_E("Unexpected situation in ShellAction(): panel->GetPluginFS() is empty!");
         return;
@@ -1267,7 +1270,7 @@ void ShellAction(CFilesWindow* panel, CShellAction action, BOOL useSelection,
     targetPath[0] = 0;
     char realDraggedPath[2 * MAX_PATH];
     realDraggedPath[0] = 0;
-    if (panel->Is(ptZIPArchive) && SalShExtRegistered)
+    if (panel->Is(ptZIPArchive) && (dragFiles ? canCreateFakeDragData : SalShExtRegistered))
     {
         if (dragFiles)
         {
@@ -1538,7 +1541,7 @@ void ShellAction(CFilesWindow* panel, CShellAction action, BOOL useSelection,
             }
             else
             {
-                if (dragFiles && SalShExtRegistered &&
+                if (dragFiles && canCreateFakeDragData &&
                     panel->GetPluginFS()->NotEmpty() &&
                     (panel->GetPluginFS()->IsServiceSupported(FS_SERVICE_MOVEFROMFS) || // FS umi "move from FS"
                      panel->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMFS)))  // FS umi "copy from FS"


### PR DESCRIPTION
### Motivation
- Drag-and-drop from archive (ZIP) panels and plugin file-systems failed to start because the code required the shell extension to be registered even when shared-memory-based fake drag data could be created; this prevented drag actions from beginning.

### Description
- Change in `src/shellsup.cpp`: introduce `canCreateFakeDragData = SalShExtSharedMemView != NULL` and use it to gate drag startup for archives and plugin FS instead of `SalShExtRegistered` where appropriate.
- Allow archive/ZIP and plugin-FS drag flows to proceed when the shared-memory copy-hook mechanism is available, while keeping clipboard copy/paste from archives still gated by `SalShExtRegistered`.
- Update the conditions that decide whether to build a fake drag data object and to call `DoDragFromArchiveOrFS` so plugin FS and archive tabs can enter the drag flow when fake drag data can be created.

### Testing
- Ran `git diff --check` to ensure no whitespace/format issues, and it succeeded.
- Changes committed locally (`git commit`) and verified the modified file is `src/shellsup.cpp` with the intended conditional changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f18fdaec88329b0b23edcd3fd4f92)