### PR TITLE
Fix tree view splitter color in dark mode

### DIFF
--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -3322,6 +3322,8 @@ void CFilesWindow::OnColorsChanged()
         StatusLine->OnColorsChanged();
     }
 
+    UpdateTreeViewColors();
+
     if (IconCache != NULL)
     {
         SleepIconCacheThread();

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -164,14 +164,12 @@ BOOL CFilesWindow::IsTreeViewHost()
 
 CFilesWindow* CFilesWindow::GetTreeViewSourcePanel()
 {
-    if (MainWindow != NULL)
-    {
-        CFilesWindow* activePanel = MainWindow->GetActivePanel();
-        if (activePanel != NULL)
-            return activePanel;
-        if (MainWindow->LeftPanel != NULL)
-            return MainWindow->LeftPanel;
-    }
+    // The tree view is anchored to the left side of the main window, so it must
+    // always mirror the currently selected left tab.  Do not use the globally
+    // active panel here; focus can be on the right panel while the user switches
+    // or refreshes left-side tabs.
+    if (MainWindow != NULL && MainWindow->LeftPanel != NULL)
+        return MainWindow->LeftPanel;
     return this;
 }
 

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -74,6 +74,22 @@ static LRESULT CALLBACK TreeViewSplitSubclassProc(HWND hwnd, UINT message, WPARA
 
     switch (message)
     {
+    case WM_ERASEBKGND:
+        return TRUE;
+
+    case WM_PAINT:
+    {
+        PAINTSTRUCT ps;
+        HDC hdc = BeginPaint(hwnd, &ps);
+        RECT r;
+        GetClientRect(hwnd, &r);
+
+        HBRUSH hBrush = DarkModeShouldUseDarkColors() ? DarkModeGetPanelFrameBrush() : GetSysColorBrush(COLOR_BTNFACE);
+        FillRect(hdc, &r, hBrush);
+        EndPaint(hwnd, &ps);
+        return 0;
+    }
+
     case WM_SETCURSOR:
         SetCursor(LoadCursor(NULL, IDC_SIZEWE));
         return TRUE;
@@ -203,6 +219,8 @@ void CFilesWindow::UpdateTreeViewColors()
     TreeView_SetBkColor(HTreeView, GetTreeViewBkColor());
     TreeView_SetLineColor(HTreeView, GetTreeViewTextColor());
     InvalidateRect(HTreeView, NULL, FALSE);
+    if (HTreeSplit != NULL)
+        InvalidateRect(HTreeSplit, NULL, TRUE);
 }
 
 void CFilesWindow::SetTreeViewWidth(int width)

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -164,12 +164,17 @@ BOOL CFilesWindow::IsTreeViewHost()
 
 CFilesWindow* CFilesWindow::GetTreeViewSourcePanel()
 {
-    // The tree view is anchored to the left side of the main window, so it must
-    // always mirror the currently selected left tab.  Do not use the globally
-    // active panel here; focus can be on the right panel while the user switches
-    // or refreshes left-side tabs.
-    if (MainWindow != NULL && MainWindow->LeftPanel != NULL)
-        return MainWindow->LeftPanel;
+    // The tree view window is hosted on the left side, but its content must
+    // follow the currently active panel/tab, regardless of whether it is on the
+    // left or right side.
+    if (MainWindow != NULL)
+    {
+        CFilesWindow* activePanel = MainWindow->GetActivePanel();
+        if (activePanel != NULL)
+            return activePanel;
+        if (MainWindow->LeftPanel != NULL)
+            return MainWindow->LeftPanel;
+    }
     return this;
 }
 

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -225,10 +225,18 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
     if (GetPanelTabIndex(side, panel) < 0)
         return;
 
+    CFilesWindow* previousPanel = (side == cpsLeft) ? LeftPanel : RightPanel;
+
     if (side == cpsLeft)
         LeftPanel = panel;
     else
         RightPanel = panel;
+
+    if (side == cpsLeft && previousPanel != NULL && previousPanel != panel)
+    {
+        previousPanel->TreeViewActive = FALSE;
+        previousPanel->DestroyTreeView();
+    }
 
     panel->SetPanelSide(side);
 
@@ -614,6 +622,11 @@ void CMainWindow::UpdatePanelTabVisibility(CPanelSide side)
             continue;
         BOOL show = (panel == active);
         ShowWindow(panel->HWindow, show ? SW_SHOW : SW_HIDE);
+        if (side == cpsLeft && !show)
+        {
+            panel->TreeViewActive = FALSE;
+            panel->DestroyTreeView();
+        }
         if (show)
             panel->NeedsRefreshOnActivation = FALSE;
         else if (panel->Is(ptDisk) || panel->Is(ptZIPArchive))
@@ -7576,8 +7589,26 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 return notifyResult;
         }
 
-        // Handle treeview notifications (treeview is now a child of the main window)
+        // Handle treeview notifications (treeview is now a child of the main window).
+        // The visible tree belongs to the currently selected left tab, but hidden
+        // tabs can still send cleanup notifications while their stale tree window
+        // is being destroyed.  Resolve the owner by HWND so those notifications
+        // are not ignored.
+        CFilesWindow* treePanel = NULL;
         if (LeftPanel != NULL && lphdr != NULL && lphdr->hwndFrom == LeftPanel->HTreeView)
+            treePanel = LeftPanel;
+        else if (lphdr != NULL)
+        {
+            for (int i = 0; i < LeftPanelTabs.Count; i++)
+            {
+                if (LeftPanelTabs[i] != NULL && lphdr->hwndFrom == LeftPanelTabs[i]->HTreeView)
+                {
+                    treePanel = LeftPanelTabs[i];
+                    break;
+                }
+            }
+        }
+        if (treePanel != NULL)
         {
             if (lphdr->code == TVN_DELETEITEM)
             {
@@ -7593,7 +7624,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 return 0;
             }
 
-            if (LeftPanel->TreeViewDisableNotify)
+            if (treePanel->TreeViewDisableNotify)
                 return 0;
 
             switch (lphdr->code)
@@ -7606,18 +7637,18 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
 
                 if (pnmcd->nmcd.dwDrawStage == CDDS_ITEMPREPAINT)
                 {
-                    pnmcd->clrText = LeftPanel->GetTreeViewTextColor();
-                    pnmcd->clrTextBk = LeftPanel->GetTreeViewBkColor();
+                    pnmcd->clrText = treePanel->GetTreeViewTextColor();
+                    pnmcd->clrTextBk = treePanel->GetTreeViewBkColor();
                     if ((pnmcd->nmcd.uItemState & CDIS_SELECTED) != 0)
                     {
-                        HBRUSH hBrush = HANDLES(CreateSolidBrush(LeftPanel->GetTreeViewSelectionBkColor()));
+                        HBRUSH hBrush = HANDLES(CreateSolidBrush(treePanel->GetTreeViewSelectionBkColor()));
                         if (hBrush != NULL)
                         {
                             FillRect(pnmcd->nmcd.hdc, &pnmcd->nmcd.rc, hBrush);
                             HANDLES(DeleteObject(hBrush));
                         }
-                        pnmcd->clrText = LeftPanel->GetTreeViewSelectionTextColor();
-                        pnmcd->clrTextBk = LeftPanel->GetTreeViewSelectionBkColor();
+                        pnmcd->clrText = treePanel->GetTreeViewSelectionTextColor();
+                        pnmcd->clrTextBk = treePanel->GetTreeViewSelectionBkColor();
                         pnmcd->nmcd.uItemState &= ~(CDIS_SELECTED | CDIS_FOCUS);
                     }
                     return CDRF_NEWFONT;
@@ -7629,7 +7660,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             {
                 LPNMTREEVIEW pnmtv = (LPNMTREEVIEW)lParam;
                 if (pnmtv->action == TVE_EXPAND)
-                    LeftPanel->PopulateTreeViewItem(pnmtv->itemNew.hItem);
+                    treePanel->PopulateTreeViewItem(pnmtv->itemNew.hItem);
                 return 0;
             }
 
@@ -7637,15 +7668,15 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             {
                 LPNMTREEVIEW pnmtv = (LPNMTREEVIEW)lParam;
                 CTreeViewNodeData itemData;
-                CFilesWindow* sourcePanel = LeftPanel->GetTreeViewSourcePanel();
-                if (!LeftPanel->TreeViewActive || sourcePanel == NULL || !sourcePanel->Is(ptDisk))
+                CFilesWindow* sourcePanel = treePanel->GetTreeViewSourcePanel();
+                if (!treePanel->TreeViewActive || sourcePanel == NULL || !sourcePanel->Is(ptDisk))
                     return 0;
 
                 TVITEM item;
                 memset(&item, 0, sizeof(item));
                 item.mask = TVIF_PARAM;
                 item.hItem = pnmtv->itemNew.hItem;
-                if (!TreeView_GetItem(LeftPanel->HTreeView, &item) || item.lParam == 0)
+                if (!TreeView_GetItem(treePanel->HTreeView, &item) || item.lParam == 0)
                     return 0;
                 itemData = *(CTreeViewNodeData*)item.lParam;
 


### PR DESCRIPTION
### Motivation
- The splitter between the treeview and the left panel stayed bright when the user selected the "Windows Dark Mode (experimental)" color scheme; the splitter must be painted in the dark panel color and refreshed when colors change.

### Description
- Handle `WM_ERASEBKGND` and `WM_PAINT` in the treeview-splitter subclass so the splitter is explicitly painted with `DarkModeGetPanelFrameBrush()` when `DarkModeShouldUseDarkColors()` is true, and falls back to `COLOR_BTNFACE` otherwise (`src/fileswn2.cpp`).
- In `CFilesWindow::UpdateTreeViewColors()` invalidate the splitter window (`HTreeSplit`) after updating tree colors so the splitter is repainted immediately (`src/fileswn2.cpp`).
- Call `UpdateTreeViewColors()` from `CFilesWindow::OnColorsChanged()` so tree + splitter colors are refreshed as part of the panel color-change flow (`src/fileswn0.cpp`).

### Testing
- Ran `git diff --check` (no issues reported). 
- Attempted to run a build tool check (`command -v msbuild`) but MSBuild is not available in this environment so a full build/test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2253961c8329ad0ca4c5f917698e)