### PR TITLE
Přidána podpora Windows dark mode pro dialogy ZIP a 7‑Zip

### DIFF
--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -1,13 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#ifdef DARKMODE_BACKEND_NO_PRECOMP
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <commctrl.h>
-#else
 #include "precomp.h"
-#endif
 
 #include "darkmode_backend_darkmodelib.h"
 #include "darkmode.h"

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#ifdef DARKMODE_BACKEND_NO_PRECOMP
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <commctrl.h>
+#else
 #include "precomp.h"
+#endif
 
 #include "darkmode_backend_darkmodelib.h"
 #include "darkmode.h"

--- a/src/plugins/7zip/7zip.cpp
+++ b/src/plugins/7zip/7zip.cpp
@@ -72,6 +72,135 @@ DWORD* TransferRowData = NULL;
 CPluginDataInterfaceAbstract** TransferPluginDataIface = NULL;
 DWORD* TransferActCustomData = NULL;
 
+
+namespace
+{
+BOOL SevenZipHostPolicyKnown = FALSE;
+BOOL SevenZipHostUseWindowsDarkMode = FALSE;
+COLORREF SevenZipHostSchemeText = CLR_INVALID;
+COLORREF SevenZipHostSchemeBackground = CLR_INVALID;
+DWORD SevenZipMainThreadId = 0;
+HBRUSH SevenZipDarkModeDialogBrush = NULL;
+COLORREF SevenZipDarkModeDialogBrushColor = CLR_INVALID;
+
+HBRUSH SevenZipGetDarkModeDialogBrush(COLORREF background)
+{
+    if (SevenZipDarkModeDialogBrush == NULL || SevenZipDarkModeDialogBrushColor != background)
+    {
+        if (SevenZipDarkModeDialogBrush != NULL)
+            DeleteObject(SevenZipDarkModeDialogBrush);
+        SevenZipDarkModeDialogBrush = CreateSolidBrush(background);
+        SevenZipDarkModeDialogBrushColor = background;
+    }
+    return SevenZipDarkModeDialogBrush;
+}
+}
+
+void Release7ZipDarkModeResources()
+{
+    if (SevenZipDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(SevenZipDarkModeDialogBrush);
+        SevenZipDarkModeDialogBrush = NULL;
+        SevenZipDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+
+BOOL SevenZipCanQueryHostDarkMode()
+{
+    return SalamanderGeneral != NULL &&
+           SevenZipMainThreadId != 0 &&
+           GetCurrentThreadId() == SevenZipMainThreadId;
+}
+
+void Refresh7ZipDarkModeFromHost()
+{
+    // Archiver dialogs can be shown from operation UI loops. Salamander host
+    // configuration/color APIs are main-thread-only, so non-main UI consumes
+    // this cached snapshot.
+    if (!SevenZipCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                              &useWindowsDarkMode,
+                                              sizeof(useWindowsDarkMode),
+                                              NULL))
+    {
+        SevenZipHostPolicyKnown = TRUE;
+        SevenZipHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (SevenZipHostPolicyKnown && SevenZipHostUseWindowsDarkMode)
+    {
+        SevenZipHostSchemeText = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        SevenZipHostSchemeBackground = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+BOOL SevenZipShouldUseWindowsDarkMode()
+{
+    return SevenZipHostPolicyKnown && SevenZipHostUseWindowsDarkMode;
+}
+
+void Configure7ZipDarkModeFromHost()
+{
+    Refresh7ZipDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = SevenZipShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && SevenZipHostSchemeText != CLR_INVALID && SevenZipHostSchemeBackground != CLR_INVALID)
+    {
+        text = SevenZipHostSchemeText;
+        background = SevenZipHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = SevenZipGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void Apply7ZipDarkMode(HWND hwnd)
+{
+    Configure7ZipDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL Apply7ZipDarkModeIfSelected(HWND hwnd)
+{
+    if (!SevenZipShouldUseWindowsDarkMode())
+        return FALSE;
+
+    Apply7ZipDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL Handle7ZipDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!SevenZipShouldUseWindowsDarkMode())
+        return FALSE;
+
+    Configure7ZipDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 // names of the entries in the registry
 const char* CONFIG_SHOW_EXTENDED_OPTIONS = "Show Extended Options";
 const char* CONFIG_EXTENDED_LIST_INFO = "Extended List Info";
@@ -104,6 +233,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 
     case DLL_PROCESS_DETACH:
     {
+        Release7ZipDarkModeResources();
         break;
     }
     }
@@ -143,6 +273,8 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
         return NULL;
     }
 
+    SevenZipMainThreadId = GetCurrentThreadId();
+
     // load the language module (.slg)
     HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "7-Zip" /* neprekladat! */);
     if (HLanguage == NULL)
@@ -153,6 +285,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     SalamanderSafeFile = salamander->GetSalamanderSafeFile();
     // obtain the interface that provides customized Windows controls used in Salamander
     SalamanderGUI = salamander->GetSalamanderGUI();
+    Refresh7ZipDarkModeFromHost();
 
     // set the help file name
     SalamanderGeneral->SetHelpFileName("7zip.chm");

--- a/src/plugins/7zip/7zip.h
+++ b/src/plugins/7zip/7zip.h
@@ -236,3 +236,10 @@ extern CPluginInterface PluginInterface;
 #define CRT_MEM_DUMP_ALL_OBJECTS_SINCE ;
 
 #endif //DUMP_MEM_OBJECTS
+
+void Release7ZipDarkModeResources();
+BOOL SevenZipShouldUseWindowsDarkMode();
+void Configure7ZipDarkModeFromHost();
+void Apply7ZipDarkMode(HWND hwnd);
+BOOL Apply7ZipDarkModeIfSelected(HWND hwnd);
+BOOL Handle7ZipDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);

--- a/src/plugins/7zip/dialogs.cpp
+++ b/src/plugins/7zip/dialogs.cpp
@@ -434,7 +434,37 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // horizontally and vertically center the dialog relative to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
+        Apply7ZipDarkMode(HWindow);
         break; // request focus from DefDlgProc
+
+    case WM_THEMECHANGED:
+        Apply7ZipDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+
+    case WM_SETTINGCHANGE:
+        Configure7ZipDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            Apply7ZipDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (Handle7ZipDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
 
     case WM_COMMAND:
         break;
@@ -446,6 +476,7 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 void CCommonDialog::NotifDlgJustCreated()
 {
     SalamanderGUI->ArrangeHorizontalLines(HWindow);
+    Apply7ZipDarkMode(HWindow);
 }
 
 //****************************************************************************

--- a/src/plugins/7zip/precomp.h
+++ b/src/plugins/7zip/precomp.h
@@ -52,3 +52,4 @@
 #include "arraylt.h"
 #include "winliblt.h"
 #include "auxtools.h"
+#include "../../darkmode.h"

--- a/src/plugins/7zip/vcxproj/7zip.props
+++ b/src/plugins/7zip/vcxproj/7zip.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\7za\cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\7za\cpp;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/7zip/vcxproj/7zip.vcxproj
+++ b/src/plugins/7zip/vcxproj/7zip.vcxproj
@@ -130,6 +130,7 @@
     <ClCompile Include="..\..\..\darkmode.cpp" />
     <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
       <LanguageStandard>stdcpplatest</LanguageStandard>

--- a/src/plugins/7zip/vcxproj/7zip.vcxproj
+++ b/src/plugins/7zip/vcxproj/7zip.vcxproj
@@ -128,40 +128,51 @@
     <ClCompile Include="..\..\shared\mhandles.cpp">
     </ClCompile>
     <ClCompile Include="..\..\..\darkmode.cpp" />
-    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/src/plugins/7zip/vcxproj/7zip.vcxproj
+++ b/src/plugins/7zip/vcxproj/7zip.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>DARKMODE_BACKEND_NO_PRECOMP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
       <LanguageStandard>stdcpplatest</LanguageStandard>

--- a/src/plugins/7zip/vcxproj/7zip.vcxproj
+++ b/src/plugins/7zip/vcxproj/7zip.vcxproj
@@ -127,6 +127,44 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\mhandles.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\winliblt.cpp">
     </ClCompile>
     <ClCompile Include="..\7za\cpp\7zip\Common\FileStreams.cpp">

--- a/src/plugins/7zip/vcxproj/7zip.vcxproj
+++ b/src/plugins/7zip/vcxproj/7zip.vcxproj
@@ -131,7 +131,7 @@
     <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PreprocessorDefinitions>DARKMODE_BACKEND_NO_PRECOMP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\common;..\..\..\common\dep;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
       <LanguageStandard>stdcpplatest</LanguageStandard>

--- a/src/plugins/7zip/vcxproj/7zip.vcxproj.filters
+++ b/src/plugins/7zip/vcxproj/7zip.vcxproj.filters
@@ -30,6 +30,39 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
     <ClCompile Include="..\7zclient.cpp">
       <Filter>cpp</Filter>
     </ClCompile>

--- a/src/plugins/zip/common.cpp
+++ b/src/plugins/zip/common.cpp
@@ -25,6 +25,7 @@
 #include "add_del.h"
 #include "sfxmake/sfxmake.h"
 #include "inflate.h"
+#include "main.h"
 
 #ifndef SSZIP
 #include "zip.rh"
@@ -75,6 +76,10 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     if (fdwReason == DLL_PROCESS_ATTACH)
     {
         DLLInstance = hinstDLL;
+    }
+    else if (fdwReason == DLL_PROCESS_DETACH)
+    {
+        ReleaseZipDarkModeResources();
     }
     return TRUE; // DLL can be loaded
 }

--- a/src/plugins/zip/dialogs.cpp
+++ b/src/plugins/zip/dialogs.cpp
@@ -27,6 +27,7 @@
 #include "common.h"
 #include "add_del.h"
 #include "dialogs.h"
+#include "main.h"
 
 WNDPROC OrigTextControlProc;
 WNDPROC OrigCBEditCtrlProc;
@@ -49,14 +50,16 @@ LRESULT CALLBACK TextControlProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 
         GetClientRect(hWnd, &r);
         BeginPaint(hWnd, &ps);
-        HBRUSH DialogBrush = CreateSolidBrush(GetSysColor(COLOR_BTNFACE));
+        HBRUSH DialogBrush = CreateSolidBrush(DarkModeShouldUseDarkColors() ? DarkModeGetDialogBackgroundColor() :
+                                                                   GetSysColor(COLOR_BTNFACE));
         if (DialogBrush)
         {
             FillRect(ps.hdc, &r, DialogBrush);
             DeleteObject(DialogBrush);
         }
         UINT format = DT_SINGLELINE | DT_BOTTOM | DT_NOPREFIX;
-        DWORD color = GetSysColor(COLOR_BTNTEXT);
+        DWORD color = DarkModeShouldUseDarkColors() ? DarkModeGetDialogTextColor() :
+                                                        GetSysColor(COLOR_BTNTEXT);
         HFONT hCurrentFont = (HFONT)SendMessage(hWnd, WM_GETFONT, 0, 0);
         int ID = GetDlgCtrlID(hWnd);
         format |= DT_PATH_ELLIPSIS;
@@ -92,7 +95,8 @@ LRESULT CALLBACK SmallIconProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPara
         RECT r;
         GetClientRect(hWnd, &r);
 
-        HBRUSH DialogBrush = CreateSolidBrush(GetSysColor(COLOR_BTNFACE));
+        HBRUSH DialogBrush = CreateSolidBrush(DarkModeShouldUseDarkColors() ? DarkModeGetDialogBackgroundColor() :
+                                                                   GetSysColor(COLOR_BTNFACE));
         if (DialogBrush)
         {
             FillRect(ps.hdc, &r, DialogBrush);
@@ -223,6 +227,36 @@ INT_PTR CPackDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
         return OnInit(wParam, lParam);
+
+    case WM_THEMECHANGED:
+        ApplyZipDarkMode(Dlg);
+        RedrawWindow(Dlg, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+
+    case WM_SETTINGCHANGE:
+        ConfigureZipDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyZipDarkMode(Dlg);
+            InvalidateRect(Dlg, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleZipDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
+
     case WM_COMMAND:
         switch (LOWORD(wParam))
         {
@@ -333,6 +367,7 @@ BOOL CPackDialog::OnInit(WPARAM wParam, LPARAM lParam)
     ResetControls();
 
     CenterDlgToParent();
+    ApplyZipDarkMode(Dlg);
     return TRUE;
 }
 
@@ -783,6 +818,36 @@ INT_PTR CConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
         return OnInit(wParam, lParam);
+
+    case WM_THEMECHANGED:
+        ApplyZipDarkMode(Dlg);
+        RedrawWindow(Dlg, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+
+    case WM_SETTINGCHANGE:
+        ConfigureZipDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyZipDarkMode(Dlg);
+            InvalidateRect(Dlg, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleZipDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
+
     case WM_COMMAND:
         switch (LOWORD(wParam))
         {
@@ -858,6 +923,7 @@ BOOL CConfigDialog::OnInit(WPARAM wParam, LPARAM lParam)
     SendDlgItemMessage(Dlg, IDC_CFG_LISTINFOPACKEDSIZE, BM_SETCHECK, Config->ListInfoPackedSize ? BST_CHECKED : BST_UNCHECKED, 0);
 
     CenterDlgToParent();
+    ApplyZipDarkMode(Dlg);
     return TRUE;
 }
 

--- a/src/plugins/zip/main.cpp
+++ b/src/plugins/zip/main.cpp
@@ -59,6 +59,135 @@ CSalamanderDebugAbstract* SalamanderDebug = NULL;
 // interface providing customized Windows controls used in Salamander
 CSalamanderGUIAbstract* SalamanderGUI = NULL;
 
+
+namespace
+{
+BOOL ZipHostPolicyKnown = FALSE;
+BOOL ZipHostUseWindowsDarkMode = FALSE;
+COLORREF ZipHostSchemeText = CLR_INVALID;
+COLORREF ZipHostSchemeBackground = CLR_INVALID;
+DWORD ZipMainThreadId = 0;
+HBRUSH ZipDarkModeDialogBrush = NULL;
+COLORREF ZipDarkModeDialogBrushColor = CLR_INVALID;
+
+HBRUSH ZipGetDarkModeDialogBrush(COLORREF background)
+{
+    if (ZipDarkModeDialogBrush == NULL || ZipDarkModeDialogBrushColor != background)
+    {
+        if (ZipDarkModeDialogBrush != NULL)
+            DeleteObject(ZipDarkModeDialogBrush);
+        ZipDarkModeDialogBrush = CreateSolidBrush(background);
+        ZipDarkModeDialogBrushColor = background;
+    }
+    return ZipDarkModeDialogBrush;
+}
+}
+
+void ReleaseZipDarkModeResources()
+{
+    if (ZipDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(ZipDarkModeDialogBrush);
+        ZipDarkModeDialogBrush = NULL;
+        ZipDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+
+BOOL ZipCanQueryHostDarkMode()
+{
+    return SalamanderGeneral != NULL &&
+           ZipMainThreadId != 0 &&
+           GetCurrentThreadId() == ZipMainThreadId;
+}
+
+void RefreshZipDarkModeFromHost()
+{
+    // Archiver dialogs can be shown from operation UI loops. Salamander host
+    // configuration/color APIs are main-thread-only, so non-main UI consumes
+    // this cached snapshot.
+    if (!ZipCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                              &useWindowsDarkMode,
+                                              sizeof(useWindowsDarkMode),
+                                              NULL))
+    {
+        ZipHostPolicyKnown = TRUE;
+        ZipHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (ZipHostPolicyKnown && ZipHostUseWindowsDarkMode)
+    {
+        ZipHostSchemeText = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        ZipHostSchemeBackground = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+BOOL ZipShouldUseWindowsDarkMode()
+{
+    return ZipHostPolicyKnown && ZipHostUseWindowsDarkMode;
+}
+
+void ConfigureZipDarkModeFromHost()
+{
+    RefreshZipDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = ZipShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && ZipHostSchemeText != CLR_INVALID && ZipHostSchemeBackground != CLR_INVALID)
+    {
+        text = ZipHostSchemeText;
+        background = ZipHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = ZipGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyZipDarkMode(HWND hwnd)
+{
+    ConfigureZipDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL ApplyZipDarkModeIfSelected(HWND hwnd)
+{
+    if (!ZipShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ApplyZipDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL HandleZipDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!ZipShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureZipDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 // configuration key definitions
 const char* CONFIG_LEVEL = "Level";
 const char* CONFIG_ENCRYPTMETHOD = "Encryption Method";
@@ -137,6 +266,8 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
         return NULL;
     }
 
+    ZipMainThreadId = GetCurrentThreadId();
+
     // load the language module (.slg)
     HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "ZIP" /* neprekladat! */);
     if (HLanguage == NULL)
@@ -147,6 +278,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     SalamanderSafeFile = salamander->GetSalamanderSafeFile();
     SalamanderCrypt = SalamanderGeneral->GetSalamanderCrypt();
     SalamanderBZIP2 = SalamanderGeneral->GetSalamanderBZIP2();
+    RefreshZipDarkModeFromHost();
 
     // obtain the interface providing customized Windows controls used in Salamander
     SalamanderGUI = salamander->GetSalamanderGUI();

--- a/src/plugins/zip/main.h
+++ b/src/plugins/zip/main.h
@@ -16,3 +16,10 @@
 #define CRT_MEM_DUMP_ALL_OBJECTS_SINCE ;
 
 #endif //DUMP_MEM_OBJECTS
+
+void ReleaseZipDarkModeResources();
+BOOL ZipShouldUseWindowsDarkMode();
+void ConfigureZipDarkModeFromHost();
+void ApplyZipDarkMode(HWND hwnd);
+BOOL ApplyZipDarkModeIfSelected(HWND hwnd);
+BOOL HandleZipDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);

--- a/src/plugins/zip/precomp.h
+++ b/src/plugins/zip/precomp.h
@@ -25,5 +25,6 @@
 #include "dbg.h"
 
 #include "array2.h"
+#include "../../darkmode.h"
 
 #include "config.h"

--- a/src/plugins/zip/precomp.h
+++ b/src/plugins/zip/precomp.h
@@ -25,6 +25,7 @@
 #include "dbg.h"
 
 #include "array2.h"
+#include "mhandles.h"
 #include "../../darkmode.h"
 
 #include "config.h"

--- a/src/plugins/zip/vcxproj/zip.props
+++ b/src/plugins/zip/vcxproj/zip.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\shared\lukas;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ZIP_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\shared\lukas;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ZIP_DLL;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/zip/vcxproj/zip.vcxproj
+++ b/src/plugins/zip/vcxproj/zip.vcxproj
@@ -123,6 +123,44 @@
   <ItemGroup>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\lukas\resedit.cpp">
     </ClCompile>
     <ClCompile Include="..\add.cpp">

--- a/src/plugins/zip/vcxproj/zip.vcxproj.filters
+++ b/src/plugins/zip/vcxproj/zip.vcxproj.filters
@@ -15,6 +15,39 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <Filter>cpp</Filter>
+    </ClCompile>
     <ClCompile Include="..\add.cpp">
       <Filter>cpp</Filter>
     </ClCompile>


### PR DESCRIPTION
### Motivation
- Dialogy „Create New Archive“ a „Configuration“ v ZIP a 7‑Zip stále používaly světlé systémové barvy místo zvoleného `Windows Dark Mode` hostitelského schématu, což narušovalo konzistenci UI při aktivovaném dark mode.
- Řešení má koherentně znovu použít existující win32‑darkmodelib/`darkmode` infrastrukturu, jak je použito v ostatních pluginech (PictView, Renamer, Undelete, FTP), a sdílet hostitelské schéma barev a štětce mezi dialogy a pluginem.

### Description
- Přidány helpery pro načítání/cachování hostitelského schématu a konfiguraci dark mode v ZIP pluginu (`src/plugins/zip/main.cpp`, `src/plugins/zip/main.h`) a v 7‑Zip pluginu (`src/plugins/7zip/7zip.cpp`, `src/plugins/7zip/7zip.h`), včetně tvorby/odstranění HBRUSHu, `Refresh*FromHost`, `Configure*FromHost`, `Apply*DarkMode` a `Handle*DarkCtlColor` funkcí.
- Upraveny dialogové soubory, aby používaly dark mode barvy při kreslení vlastních prvků a reagovaly na `WM_THEMECHANGED`/`WM_SETTINGCHANGE` a `WM_CTLCOLOR*` zprávy; konkrétně `src/plugins/zip/dialogs.cpp` (Create New Archive / Configuration) a `src/plugins/7zip/dialogs.cpp` (common dialog base + konfigurace).
- Zajištěno, že pluginy pořídí hlavní UI thread id a refreshnou snapshot schématu po inicializaci (`ZipMainThreadId` / `SevenZipMainThreadId`), a při `DLL_PROCESS_DETACH` se uvolní vytvořené darkmode resources (`Release*DarkModeResources`).
- Aktualizovány projektové soubory a precomp hlavičky tak, aby byly do buildu zahrnuty zdroje `win32-darkmodelib` a přidány makra/`AdditionalIncludeDirectories` (`src/plugins/*/precomp.h`, `*.vcxproj`, `*.vcxproj.filters`, `*.props`).

### Testing
- Spuštěno `git diff --check` a opravy nevrátily chyby, kontrola proběhla úspěšně.
- Ověřeno parsování upravených MSBuild XML souborů pomocí Pythonu a `xml.etree.ElementTree.parse()` (všechny upravené `.props` / `.vcxproj` / `.filters` soubory jsou validní XML), test úspěšný.
- Pokus o lokální build pomocí `msbuild src/plugins/zip/vcxproj/zip.vcxproj /p:Configuration=Release /p:Platform=x64` selhal v tomto kontejneru, protože `msbuild` není dostupný (`msbuild: command not found`), takže funkční build a běhové ověření na Windows je potřeba na CI/Windows stroji.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3278dd6c8329b1173418373477a0)