### PR TITLE
Route mouse-wheel events from tab-strip gaps to the tab control

### DIFF
--- a/src/salamdr3.cpp
+++ b/src/salamdr3.cpp
@@ -2890,6 +2890,27 @@ UINT GetMouseWheelScrollChars()
     return uCachedScrollChars;
 }
 
+HWND GetTabWindowFromPoint(HWND hWindow, POINT screenPt)
+{
+    HWND root = hWindow != NULL ? GetAncestor(hWindow, GA_ROOT) : NULL;
+    if (root == NULL)
+        return NULL;
+
+    const int tabControlIDs[] = {IDC_LEFTTABCTRL, IDC_RIGHTTABCTRL};
+    for (int i = 0; i < (int)_countof(tabControlIDs); ++i)
+    {
+        HWND tabWindow = GetDlgItem(root, tabControlIDs[i]);
+        if (tabWindow == NULL || !IsWindowVisible(tabWindow))
+            continue;
+
+        RECT tabRect;
+        if (GetWindowRect(tabWindow, &tabRect) && PtInRect(&tabRect, screenPt))
+            return tabWindow;
+    }
+
+    return NULL;
+}
+
 BOOL PostMouseWheelMessage(MSG* pMSG)
 {
     // find the window under the mouse cursor
@@ -2922,6 +2943,13 @@ BOOL PostMouseWheelMessage(MSG* pMSG)
             TRACE_E("GetClassName() failed!");
             hWindow = pMSG->hwnd;
         }
+        // Route wheel messages from anywhere in a visible panel tab strip, including the blank
+        // area after the last tab button, to the tab control so its subclass can scroll
+        // overflowed tabs. WindowFromPoint() can otherwise return the main window for that gap.
+        HWND tabWindow = GetTabWindowFromPoint(hWindow, pMSG->pt);
+        if (tabWindow != NULL)
+            hWindow = tabWindow;
+
         // If this is a scrollbar or an up-down helper with a parent window, post the message to the parent.
         // Scrollbars in the panels are not subclassed, so this is currently the only way
         // for the panel to receive wheel messages when the cursor is over the scrollbar.


### PR DESCRIPTION
### Motivation

- Make mouse-wheel scrolling work when the pointer is over the empty area of a panel tab strip (the gap after the last tab button) so overflowed tabs can be scrolled without having to hover a tab button or the up/down arrows.

### Description

- Added `GetTabWindowFromPoint(HWND, POINT)` in `src/salamdr3.cpp` which finds a visible left/right tab control (`IDC_LEFTTABCTRL` / `IDC_RIGHTTABCTRL`) under a screen point by checking the root window's dialog items and doing `GetWindowRect` + `PtInRect`.
- Modified `PostMouseWheelMessage(MSG*)` in `src/salamdr3.cpp` to call the helper and redirect wheel messages to the tab control when the cursor is anywhere over the tab strip (including the blank area), before the existing scrollbar/up-down parent routing logic.
- Kept existing scrollbar/up-down routing and hook-based wheel routing behavior intact; added a safe cast when iterating `_countof`.

### Testing

- Ran `git diff --check` with no issues reported.
- Attempted a build with `msbuild` (`msbuild src/vcxproj/salamand.sln`), but the tool is not available in the current environment so a compile test was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a209f440a188329ae1e6e5ee944f8bd)