### PR TITLE
Improve dark mode toolbar/status icon contrast

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1938,21 +1938,25 @@ BOOL DarkModeAdjustDarkMonochromeBitmap(HBITMAP hBitmap, COLORREF transparent, C
         return FALSE;
 
     BITMAPINFO bi;
+    BITMAPINFO dib;
+    BOOL ret = FALSE;
+    BYTE* bits = NULL;
+    int width = 0;
+    int height = 0;
+    int stride = 0;
+
     memset(&bi, 0, sizeof(bi));
     bi.bmiHeader.biSize = sizeof(bi.bmiHeader);
     bi.bmiHeader.biBitCount = 0;
 
-    BOOL ret = FALSE;
-    BYTE* bits = NULL;
     if (!GetDIBits(hDC, hBitmap, 0, 0, NULL, &bi, DIB_RGB_COLORS))
         goto exitus;
 
-    int width = bi.bmiHeader.biWidth;
-    int height = abs(bi.bmiHeader.biHeight);
+    width = bi.bmiHeader.biWidth;
+    height = abs(bi.bmiHeader.biHeight);
     if (width <= 0 || height <= 0)
         goto exitus;
 
-    BITMAPINFO dib;
     memset(&dib, 0, sizeof(dib));
     dib.bmiHeader.biSize = sizeof(dib.bmiHeader);
     dib.bmiHeader.biWidth = width;
@@ -1961,7 +1965,7 @@ BOOL DarkModeAdjustDarkMonochromeBitmap(HBITMAP hBitmap, COLORREF transparent, C
     dib.bmiHeader.biBitCount = 32;
     dib.bmiHeader.biCompression = BI_RGB;
 
-    int stride = width * 4;
+    stride = width * 4;
     bits = (BYTE*)malloc(stride * height);
     if (bits == NULL)
         goto exitus;
@@ -2011,8 +2015,9 @@ HICON DarkModeCreateLightIconIfDarkMonochrome(HICON hIcon, int width, int height
     COLORREF oldBrushColor = CLR_INVALID;
     RECT rc = {0, 0, width, height};
     ICONINFO ii;
-
     BITMAPINFO dib;
+    BYTE* bits = NULL;
+
     memset(&dib, 0, sizeof(dib));
     dib.bmiHeader.biSize = sizeof(dib.bmiHeader);
     dib.bmiHeader.biWidth = width;
@@ -2021,7 +2026,6 @@ HICON DarkModeCreateLightIconIfDarkMonochrome(HICON hIcon, int width, int height
     dib.bmiHeader.biBitCount = 32;
     dib.bmiHeader.biCompression = BI_RGB;
 
-    BYTE* bits = NULL;
     hColorBitmap = HANDLES(CreateDIBSection(hScreenDC, &dib, DIB_RGB_COLORS, (void**)&bits, NULL, 0));
     if (hColorBitmap == NULL || bits == NULL)
         goto exitus;

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1854,3 +1854,235 @@ HBRUSH DarkModeGetPanelFrameBrush()
         brush = HANDLES(CreateSolidBrush(RGB(0x38, 0x38, 0x38)));
     return brush;
 }
+
+static int DarkModeIntMin(int a, int b)
+{
+    return a < b ? a : b;
+}
+
+static int DarkModeIntMax(int a, int b)
+{
+    return a > b ? a : b;
+}
+
+static bool DarkModeIsIgnoredIconPixel(COLORREF color, COLORREF transparent, COLORREF ignoredColor)
+{
+    return color == transparent || (ignoredColor != CLR_INVALID && color == ignoredColor);
+}
+
+static bool DarkModeAnalyzeMonochromePixels(const BYTE* bits, int width, int height, int stride,
+                                            int left, int top, int iconWidth, int iconHeight,
+                                            COLORREF transparent, COLORREF ignoredColor)
+{
+    int visiblePixels = 0;
+    int maxChroma = 0;
+    int brightnessSum = 0;
+    for (int y = 0; y < iconHeight && top + y < height; y++)
+    {
+        const BYTE* row = bits + (top + y) * stride + left * 4;
+        for (int x = 0; x < iconWidth && left + x < width; x++)
+        {
+            BYTE b = row[x * 4 + 0];
+            BYTE g = row[x * 4 + 1];
+            BYTE r = row[x * 4 + 2];
+            COLORREF color = RGB(r, g, b);
+            if (DarkModeIsIgnoredIconPixel(color, transparent, ignoredColor))
+                continue;
+            int hi = DarkModeIntMax((int)r, DarkModeIntMax((int)g, (int)b));
+            int lo = DarkModeIntMin((int)r, DarkModeIntMin((int)g, (int)b));
+            maxChroma = DarkModeIntMax(maxChroma, hi - lo);
+            brightnessSum += (r * 30 + g * 59 + b * 11) / 100;
+            visiblePixels++;
+        }
+    }
+
+    if (visiblePixels == 0)
+        return false;
+
+    int avgBrightness = brightnessSum / visiblePixels;
+    return maxChroma <= 36 && avgBrightness < 170;
+}
+
+static void DarkModeLightenMonochromePixels(BYTE* bits, int width, int height, int stride,
+                                            int left, int top, int iconWidth, int iconHeight,
+                                            COLORREF transparent, COLORREF ignoredColor)
+{
+    for (int y = 0; y < iconHeight && top + y < height; y++)
+    {
+        BYTE* row = bits + (top + y) * stride + left * 4;
+        for (int x = 0; x < iconWidth && left + x < width; x++)
+        {
+            BYTE* pixel = row + x * 4;
+            BYTE b = pixel[0];
+            BYTE g = pixel[1];
+            BYTE r = pixel[2];
+            COLORREF color = RGB(r, g, b);
+            if (DarkModeIsIgnoredIconPixel(color, transparent, ignoredColor))
+                continue;
+
+            int brightness = (r * 30 + g * 59 + b * 11) / 100;
+            int light = DarkModeIntMax(185, DarkModeIntMin(245, 255 - brightness + 25));
+            pixel[0] = pixel[1] = pixel[2] = (BYTE)light;
+        }
+    }
+}
+
+BOOL DarkModeAdjustDarkMonochromeBitmap(HBITMAP hBitmap, COLORREF transparent, COLORREF ignoredColor,
+                                        int iconWidth, int iconHeight)
+{
+    if (hBitmap == NULL || iconWidth <= 0 || iconHeight <= 0)
+        return FALSE;
+
+    HDC hDC = HANDLES(GetDC(NULL));
+    if (hDC == NULL)
+        return FALSE;
+
+    BITMAPINFO bi;
+    memset(&bi, 0, sizeof(bi));
+    bi.bmiHeader.biSize = sizeof(bi.bmiHeader);
+    bi.bmiHeader.biBitCount = 0;
+
+    BOOL ret = FALSE;
+    BYTE* bits = NULL;
+    if (!GetDIBits(hDC, hBitmap, 0, 0, NULL, &bi, DIB_RGB_COLORS))
+        goto exitus;
+
+    int width = bi.bmiHeader.biWidth;
+    int height = abs(bi.bmiHeader.biHeight);
+    if (width <= 0 || height <= 0)
+        goto exitus;
+
+    BITMAPINFO dib;
+    memset(&dib, 0, sizeof(dib));
+    dib.bmiHeader.biSize = sizeof(dib.bmiHeader);
+    dib.bmiHeader.biWidth = width;
+    dib.bmiHeader.biHeight = -height; // top-down for simpler icon-cell addressing
+    dib.bmiHeader.biPlanes = 1;
+    dib.bmiHeader.biBitCount = 32;
+    dib.bmiHeader.biCompression = BI_RGB;
+
+    int stride = width * 4;
+    bits = (BYTE*)malloc(stride * height);
+    if (bits == NULL)
+        goto exitus;
+
+    if (!GetDIBits(hDC, hBitmap, 0, height, bits, &dib, DIB_RGB_COLORS))
+        goto exitus;
+
+    for (int top = 0; top + iconHeight <= height; top += iconHeight)
+    {
+        for (int left = 0; left + iconWidth <= width; left += iconWidth)
+        {
+            if (DarkModeAnalyzeMonochromePixels(bits, width, height, stride, left, top, iconWidth, iconHeight,
+                                                transparent, ignoredColor))
+            {
+                DarkModeLightenMonochromePixels(bits, width, height, stride, left, top, iconWidth, iconHeight,
+                                                transparent, ignoredColor);
+            }
+        }
+    }
+
+    if (!SetDIBits(hDC, hBitmap, 0, height, bits, &dib, DIB_RGB_COLORS))
+        goto exitus;
+
+    ret = TRUE;
+
+exitus:
+    if (bits != NULL)
+        free(bits);
+    HANDLES(ReleaseDC(NULL, hDC));
+    return ret;
+}
+
+HICON DarkModeCreateLightIconIfDarkMonochrome(HICON hIcon, int width, int height, COLORREF transparent)
+{
+    if (hIcon == NULL || width <= 0 || height <= 0)
+        return NULL;
+
+    HDC hScreenDC = HANDLES(GetDC(NULL));
+    HDC hColorDC = NULL;
+    HDC hMaskDC = NULL;
+    HBITMAP hColorBitmap = NULL;
+    HBITMAP hMaskBitmap = NULL;
+    HBITMAP hOldColorBitmap = NULL;
+    HBITMAP hOldMaskBitmap = NULL;
+    HICON hLightIcon = NULL;
+    HGDIOBJ oldBrush = NULL;
+    COLORREF oldBrushColor = CLR_INVALID;
+    RECT rc = {0, 0, width, height};
+    ICONINFO ii;
+
+    BITMAPINFO dib;
+    memset(&dib, 0, sizeof(dib));
+    dib.bmiHeader.biSize = sizeof(dib.bmiHeader);
+    dib.bmiHeader.biWidth = width;
+    dib.bmiHeader.biHeight = -height;
+    dib.bmiHeader.biPlanes = 1;
+    dib.bmiHeader.biBitCount = 32;
+    dib.bmiHeader.biCompression = BI_RGB;
+
+    BYTE* bits = NULL;
+    hColorBitmap = HANDLES(CreateDIBSection(hScreenDC, &dib, DIB_RGB_COLORS, (void**)&bits, NULL, 0));
+    if (hColorBitmap == NULL || bits == NULL)
+        goto exitus;
+
+    hColorDC = HANDLES(CreateCompatibleDC(hScreenDC));
+    if (hColorDC == NULL)
+        goto exitus;
+    hOldColorBitmap = (HBITMAP)SelectObject(hColorDC, hColorBitmap);
+    oldBrush = SelectObject(hColorDC, GetStockObject(DC_BRUSH));
+    oldBrushColor = SetDCBrushColor(hColorDC, transparent);
+    FillRect(hColorDC, &rc, (HBRUSH)GetStockObject(DC_BRUSH));
+    SetDCBrushColor(hColorDC, oldBrushColor);
+    SelectObject(hColorDC, oldBrush);
+
+    if (!DrawIconEx(hColorDC, 0, 0, hIcon, width, height, 0, NULL, DI_NORMAL))
+        goto exitus;
+
+    if (!DarkModeAnalyzeMonochromePixels(bits, width, height, width * 4, 0, 0, width, height, transparent, CLR_INVALID))
+        goto exitus;
+    DarkModeLightenMonochromePixels(bits, width, height, width * 4, 0, 0, width, height, transparent, CLR_INVALID);
+
+    hMaskBitmap = HANDLES(CreateBitmap(width, height, 1, 1, NULL));
+    if (hMaskBitmap == NULL)
+        goto exitus;
+    hMaskDC = HANDLES(CreateCompatibleDC(hScreenDC));
+    if (hMaskDC == NULL)
+        goto exitus;
+    hOldMaskBitmap = (HBITMAP)SelectObject(hMaskDC, hMaskBitmap);
+    PatBlt(hMaskDC, 0, 0, width, height, WHITENESS);
+    for (int y = 0; y < height; y++)
+    {
+        BYTE* row = bits + y * width * 4;
+        for (int x = 0; x < width; x++)
+        {
+            BYTE* pixel = row + x * 4;
+            COLORREF color = RGB(pixel[2], pixel[1], pixel[0]);
+            if (color != transparent)
+                SetPixel(hMaskDC, x, y, RGB(0, 0, 0));
+        }
+    }
+
+    memset(&ii, 0, sizeof(ii));
+    ii.fIcon = TRUE;
+    ii.hbmColor = hColorBitmap;
+    ii.hbmMask = hMaskBitmap;
+    hLightIcon = CreateIconIndirect(&ii);
+
+exitus:
+    if (hOldMaskBitmap != NULL)
+        SelectObject(hMaskDC, hOldMaskBitmap);
+    if (hOldColorBitmap != NULL)
+        SelectObject(hColorDC, hOldColorBitmap);
+    if (hMaskDC != NULL)
+        HANDLES(DeleteDC(hMaskDC));
+    if (hColorDC != NULL)
+        HANDLES(DeleteDC(hColorDC));
+    if (hMaskBitmap != NULL)
+        HANDLES(DeleteObject(hMaskBitmap));
+    if (hColorBitmap != NULL)
+        HANDLES(DeleteObject(hColorBitmap));
+    if (hScreenDC != NULL)
+        HANDLES(ReleaseDC(NULL, hScreenDC));
+    return hLightIcon;
+}

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -81,3 +81,9 @@ void DarkModeUpdateListViewColors(HWND listView);
 void DarkModeUpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors);
 void DarkModeApplyStaticTextColors(HWND hwndParent, HWND specificCtrl);
 void DarkModeUpdateTabControlOverflowButtons(HWND tabControl);
+
+// Recolors only dark monochrome glyphs in a bitmap/icon strip for dark toolbar/status backgrounds.
+// Colorful icons are detected and left unchanged.
+BOOL DarkModeAdjustDarkMonochromeBitmap(HBITMAP hBitmap, COLORREF transparent, COLORREF ignoredColor,
+                                        int iconWidth, int iconHeight);
+HICON DarkModeCreateLightIconIfDarkMonochrome(HICON hIcon, int width, int height, COLORREF transparent);

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -2785,6 +2785,9 @@ BOOL CViewerWindow::InitializeGraphics()
     HBITMAP hTmpColorBitmap;
 
     hTmpColorBitmap = LoadBitmap(DLLInstance, MAKEINTRESOURCE(SalamanderGeneral->CanUse256ColorsBitmap() ? IDB_TOOLBAR256 : IDB_TOOLBAR16));
+    ConfigurePictViewDarkModeFromHost();
+    if (DarkModeShouldUseDarkColors())
+        DarkModeAdjustDarkMonochromeBitmap(hTmpColorBitmap, RGB(255, 0, 255), CLR_INVALID, 16, 16);
     SalamanderGUI->CreateGrayscaleAndMaskBitmaps(hTmpColorBitmap, RGB(255, 0, 255),
                                                  hTmpGrayBitmap, hTmpMaskBitmap);
     HHotToolBarImageList = ImageList_Create(16, 16, ILC_MASK | ILC_COLORDDB, IDX_TB_COUNT, 1);

--- a/src/plugins/pictview/statsbar.cpp
+++ b/src/plugins/pictview/statsbar.cpp
@@ -17,13 +17,32 @@
 // CStatusBar
 //
 
+static HICON LoadPictViewStatusIconForCurrentMode(int resID)
+{
+    HICON hIcon = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(resID), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
+    if (hIcon == NULL)
+        return NULL;
+
+    ConfigurePictViewDarkModeFromHost();
+    if (DarkModeShouldUseDarkColors())
+    {
+        HICON hLightIcon = DarkModeCreateLightIconIfDarkMonochrome(hIcon, 16, 16, RGB(255, 0, 255));
+        if (hLightIcon != NULL)
+        {
+            DestroyIcon(hIcon);
+            hIcon = hLightIcon;
+        }
+    }
+    return hIcon;
+}
+
 CStatusBar::CStatusBar()
     : CWindow(ooAllocated)
 {
-    HCursor = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_CURSOR), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
-    HAnchor = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_ANCHOR), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
-    HSize = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_SIZE), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
-    HPipette = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_PIPETTE), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
+    HCursor = LoadPictViewStatusIconForCurrentMode(IDI_SB_CURSOR);
+    HAnchor = LoadPictViewStatusIconForCurrentMode(IDI_SB_ANCHOR);
+    HSize = LoadPictViewStatusIconForCurrentMode(IDI_SB_SIZE);
+    HPipette = LoadPictViewStatusIconForCurrentMode(IDI_SB_PIPETTE);
     hProgBar = NULL;
 }
 

--- a/src/toolbar4.cpp
+++ b/src/toolbar4.cpp
@@ -14,6 +14,7 @@
 #include "nanosvg\nanosvg.h"
 #include "nanosvg\nanosvgrast.h"
 #include "svg.h"
+#include "darkmode.h"
 
 struct CButtonData
 {
@@ -936,6 +937,9 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
             }
         }
     }
+
+    if (DarkModeShouldUseDarkColors())
+        DarkModeAdjustDarkMonochromeBitmap(hColorBitmap, transparent, bkColorForAlpha, iconSize, iconSize);
 
     ret = TRUE;
 exitus:


### PR DESCRIPTION
### Motivation
- When the host color scheme is set to the experimental "Windows Dark Mode" some toolbar and plugin icons (PictView toolbar/statusbar and main toolbar) are too dark to be visible, so the goal is to make those icons readable in dark mode by selectively lightening only dark monochrome glyphs while leaving colorful icons unchanged.

### Description
- Added dark-mode image helpers in `darkmode.h`/`darkmode.cpp`: `DarkModeAdjustDarkMonochromeBitmap` to scan and recolor dark monochrome glyphs in a bitmap strip and `DarkModeCreateLightIconIfDarkMonochrome` to produce a light `HICON` for dark monochrome icons, plus small internal helpers used by them.
- Integrated the bitmap helper into toolbar generation so `CreateToolbarBitmaps` now calls `DarkModeAdjustDarkMonochromeBitmap` when `DarkModeShouldUseDarkColors()` is true, ensuring only dark single‑color glyphs get lightened for dark toolbars (`src/toolbar4.cpp`).
- Applied the same adjustment inside the PictView plugin before creating its image lists (`CViewerWindow::InitializeGraphics` in `src/plugins/pictview/pictview.cpp`) so PictView toolbar buttons get adjusted in dark mode.
- Updated PictView statusbar icon loading (`src/plugins/pictview/statsbar.cpp`) to use `DarkModeCreateLightIconIfDarkMonochrome` so monochrome status icons are replaced by light copies in dark mode while colorful icons remain unchanged, and adjusted icon mask generation accordingly.

### Testing
- Ran `git diff --check` with no whitespace or diff errors reported, so the patch is syntactically consistent with repository formatting rules. 
- Performed repository-level searches and inspected modified functions to verify new helpers are referenced from toolbar creation and PictView initialization; no runtime build was executed in this environment because Windows build tooling (`msbuild`/`dotnet`/`pwsh`) is not available here. 
- No automated unit tests exist for this platform-specific UI change, so a Windows build + manual smoke test in dark scheme is recommended to validate visual results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ba8a0ac48329a4749916d182a1e7)