### PR TITLE
Add Tree View to toolbar context menu

### DIFF
--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2238,6 +2238,7 @@ MENU_TEMPLATE_ITEM ToolbarsCtxMenu[] =
   {MNTT_IT, IDS_DRIVEBAR2
   {MNTT_IT, IDS_MIDDLETOOLBAR
   {MNTT_IT, IDS_COMMANDLINE
+  {MNTT_IT, IDS_MENU_OPT_VSB_TREE
   {MNTT_IT, IDS_BOTTOMTOOLBAR
   {MNTT_IT, IDS_GRIPSINTOOLBAR
   {MNTT_IT, IDS_SHOWLABELS
@@ -2284,6 +2285,11 @@ MENU_TEMPLATE_ITEM ToolbarsCtxMenu[] =
         mii.String = LoadStr(IDS_COMMANDLINE);
         mii.ID = 5;
         mii.State = EditPermanentVisible ? MENU_STATE_CHECKED : 0;
+        menu.InsertItem(0xffffffff, TRUE, &mii);
+
+        mii.String = LoadStr(IDS_MENU_OPT_VSB_TREE);
+        mii.ID = 13;
+        mii.State = Configuration.TreeViewVisible ? MENU_STATE_CHECKED : 0;
         menu.InsertItem(0xffffffff, TRUE, &mii);
 
         mii.String = LoadStr(IDS_BOTTOMTOOLBAR);
@@ -2558,6 +2564,9 @@ MENU_TEMPLATE_ITEM InfoLineMenu[] =
             break;
         case 12:
             cm = CM_TOGGLEPLUGINSBAR;
+            break;
+        case 13:
+            cm = CM_TOGGLETREEVIEW;
             break;
         }
         if (cm != 0)


### PR DESCRIPTION
### Motivation
- Expose the existing panel `Tree View` toggle in the toolbar right-click context menu so it appears in the same position as `Options > Show > Tree View` for quicker access.

### Description
- Inserted `IDS_MENU_OPT_VSB_TREE` into the `ToolbarsCtxMenu` template and added a menu item that loads `LoadStr(IDS_MENU_OPT_VSB_TREE)` and reflects `Configuration.TreeViewVisible` in `src/mainwnd1.cpp`.
- Wired the new context menu index (`case 13`) to the existing `CM_TOGGLETREEVIEW` command so the item reuses the same toggle behavior as the main menu.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or simple syntax issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20c9406834832983fc929374059c82)