### PR TITLE
Support dark-mode status bar icons and toolbar colors; apply dark mode in dialogs and fix combo box selection

### DIFF
--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -3267,7 +3267,6 @@ void CViewerWindow::ToggleStatusBar()
             return;
         }
         ConfigurePictViewDarkModeFromHost();
-        DarkModeApplyTree(StatusBar->HWindow);
         G.StatusbarVisible = TRUE;
     }
     else
@@ -3546,7 +3545,6 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         ConfigurePictViewDarkModeFromHost();
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
-        DarkModeApplyTree(HWindow);
         UpdateRendererFrameForTheme();
 
         SetFocus(Renderer.HWindow);
@@ -3787,7 +3785,6 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         RebuildColors(G.Colors);
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
-        DarkModeApplyTree(HWindow);
         if (StatusBar != NULL)
             SetStatusBarTexts();
         UpdateRendererFrameForTheme();
@@ -3805,7 +3802,6 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             RebuildColors(G.Colors);
             DarkModeApplyWindow(HWindow);
             DarkModeRefreshTitleBar(HWindow);
-            DarkModeApplyTree(HWindow);
             if (StatusBar != NULL)
                 SetStatusBarTexts();
             UpdateRendererFrameForTheme();

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -3788,6 +3788,11 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
         DarkModeApplyTree(HWindow);
+        if (StatusBar != NULL)
+        {
+            DarkModeApplyTree(StatusBar->HWindow);
+            SetStatusBarTexts();
+        }
         UpdateRendererFrameForTheme();
         if (Renderer.HWindow != NULL)
             SendMessage(Renderer.HWindow, WM_USER_VIEWERCFGCHNG, 0, 0);
@@ -3804,6 +3809,11 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             DarkModeApplyWindow(HWindow);
             DarkModeRefreshTitleBar(HWindow);
             DarkModeApplyTree(HWindow);
+            if (StatusBar != NULL)
+            {
+                DarkModeApplyTree(StatusBar->HWindow);
+                SetStatusBarTexts();
+            }
             UpdateRendererFrameForTheme();
             if (Renderer.HWindow != NULL)
                 SendMessage(Renderer.HWindow, WM_USER_VIEWERCFGCHNG, 0, 0);

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -681,7 +681,7 @@ BOOL CPluginInterface::Release(HWND parent, BOOL force)
                                                            LoadStr(IDS_PLUGINNAME),
                                                            MB_YESNO | MB_ICONQUESTION) == IDYES))
     {
-        ret = ViewerWindowQueue.CloseAllWindows(force) || force;
+        ret = ViewerWindowQueue.CloseAllWindows(FALSE, force ? 5000 : 1000);
     }
     if (ret)
     {
@@ -3789,10 +3789,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DarkModeRefreshTitleBar(HWindow);
         DarkModeApplyTree(HWindow);
         if (StatusBar != NULL)
-        {
-            DarkModeApplyTree(StatusBar->HWindow);
             SetStatusBarTexts();
-        }
         UpdateRendererFrameForTheme();
         if (Renderer.HWindow != NULL)
             SendMessage(Renderer.HWindow, WM_USER_VIEWERCFGCHNG, 0, 0);
@@ -3810,10 +3807,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             DarkModeRefreshTitleBar(HWindow);
             DarkModeApplyTree(HWindow);
             if (StatusBar != NULL)
-            {
-                DarkModeApplyTree(StatusBar->HWindow);
                 SetStatusBarTexts();
-            }
             UpdateRendererFrameForTheme();
             if (Renderer.HWindow != NULL)
                 SendMessage(Renderer.HWindow, WM_USER_VIEWERCFGCHNG, 0, 0);

--- a/src/plugins/pictview/pictview.h
+++ b/src/plugins/pictview/pictview.h
@@ -271,6 +271,9 @@ public:
     HICON GetAnchorIcon() const;
     HICON GetSizeIcon() const;
     HICON GetPipetteIcon() const;
+
+protected:
+    virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 
 //

--- a/src/plugins/pictview/pictview.h
+++ b/src/plugins/pictview/pictview.h
@@ -256,12 +256,21 @@ public:
     HICON HAnchor;
     HICON HSize;
     HICON HPipette;
+    HICON HCursorDark;
+    HICON HAnchorDark;
+    HICON HSizeDark;
+    HICON HPipetteDark;
 
     HWND hProgBar;
 
 public:
     CStatusBar();
     ~CStatusBar();
+
+    HICON GetCursorIcon() const;
+    HICON GetAnchorIcon() const;
+    HICON GetSizeIcon() const;
+    HICON GetPipetteIcon() const;
 };
 
 //

--- a/src/plugins/pictview/statsbar.cpp
+++ b/src/plugins/pictview/statsbar.cpp
@@ -148,6 +148,94 @@ HICON CStatusBar::GetPipetteIcon() const
     return GetStatusBarIconForCurrentTheme(HPipette, HPipetteDark);
 }
 
+
+LRESULT CStatusBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    if (DarkModeShouldUseDarkColors())
+    {
+        switch (uMsg)
+        {
+        case WM_ERASEBKGND:
+            return TRUE;
+
+        case WM_PAINT:
+        {
+            PAINTSTRUCT ps;
+            HDC hDC = BeginPaint(HWindow, &ps);
+
+            RECT client;
+            GetClientRect(HWindow, &client);
+            HBRUSH backgroundBrush = CreateSolidBrush(DarkModeGetDialogBackgroundColor());
+            if (backgroundBrush != NULL)
+            {
+                FillRect(hDC, &client, backgroundBrush);
+                DeleteObject(backgroundBrush);
+            }
+
+            int borders[3] = {0, 0, 0};
+            SendMessage(HWindow, SB_GETBORDERS, 0, (LPARAM)borders);
+            int partCount = (int)SendMessage(HWindow, SB_GETPARTS, 0, 0);
+            if (partCount <= 0)
+                partCount = 1;
+
+            HFONT hFont = (HFONT)SendMessage(HWindow, WM_GETFONT, 0, 0);
+            HFONT hOldFont = hFont != NULL ? (HFONT)SelectObject(hDC, hFont) : NULL;
+            COLORREF oldTextColor = SetTextColor(hDC, DarkModeGetDialogTextColor());
+            int oldBkMode = SetBkMode(hDC, TRANSPARENT);
+
+            for (int part = 0; part < partCount; part++)
+            {
+                RECT partRect = client;
+                SendMessage(HWindow, SB_GETRECT, part, (LPARAM)&partRect);
+
+                if (part + 1 < partCount)
+                {
+                    RECT divider = partRect;
+                    divider.left = divider.right - max(1, borders[2]);
+                    HBRUSH dividerBrush = CreateSolidBrush(RGB(0x4A, 0x4A, 0x4A));
+                    if (dividerBrush != NULL)
+                    {
+                        FillRect(hDC, &divider, dividerBrush);
+                        DeleteObject(dividerBrush);
+                    }
+                }
+
+                RECT contentRect = partRect;
+                contentRect.left += borders[2] + 2;
+                contentRect.right -= borders[0] + 2;
+
+                HICON hIcon = (HICON)SendMessage(HWindow, SB_GETICON, part, 0);
+                if (hIcon != NULL)
+                {
+                    const int iconSize = 16;
+                    int y = contentRect.top + (contentRect.bottom - contentRect.top - iconSize) / 2;
+                    DrawIconEx(hDC, contentRect.left, y, hIcon, iconSize, iconSize, 0, NULL, DI_NORMAL);
+                    contentRect.left += iconSize + 4;
+                }
+
+                TCHAR text[512];
+                text[0] = 0;
+                LRESULT textLen = SendMessage(HWindow, SB_GETTEXTLENGTH, part, 0);
+                int len = min((int)LOWORD(textLen), (int)_countof(text) - 1);
+                SendMessage(HWindow, SB_GETTEXT, part, (LPARAM)text);
+                text[len] = 0;
+                DrawText(hDC, text, -1, &contentRect,
+                         DT_SINGLELINE | DT_VCENTER | DT_LEFT | DT_NOPREFIX | DT_PATH_ELLIPSIS);
+            }
+
+            SetBkMode(hDC, oldBkMode);
+            SetTextColor(hDC, oldTextColor);
+            if (hOldFont != NULL)
+                SelectObject(hDC, hOldFont);
+            EndPaint(HWindow, &ps);
+            return 0;
+        }
+        }
+    }
+
+    return CWindow::WindowProc(uMsg, wParam, lParam);
+}
+
 #define ICON_MARGIN 32 // space for the icon and margins
 
 void CViewerWindow::SetupStatusBarItems()
@@ -322,7 +410,6 @@ void CViewerWindow::InitProgressBar()
                                          r.right - r.left, r.bottom - r.top,
                                          StatusBar->HWindow, NULL, DLLInstance, NULL);
     ConfigurePictViewDarkModeFromHost();
-    DarkModeApplyTree(StatusBar->HWindow);
 
     SendMessage(StatusBar->hProgBar, PBM_SETRANGE, 0, MAKELPARAM(0, 100));
     SendMessage(StatusBar->hProgBar, PBM_SETPOS, 0, 0);

--- a/src/plugins/pictview/statsbar.cpp
+++ b/src/plugins/pictview/statsbar.cpp
@@ -15,53 +15,7 @@
 
 namespace
 {
-HBITMAP CreateStatusBarIconDIB(int width, int height, BYTE** bits)
-{
-    BITMAPINFO bmi;
-    ZeroMemory(&bmi, sizeof(bmi));
-    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
-    bmi.bmiHeader.biWidth = width;
-    bmi.bmiHeader.biHeight = -height;
-    bmi.bmiHeader.biPlanes = 1;
-    bmi.bmiHeader.biBitCount = 32;
-    bmi.bmiHeader.biCompression = BI_RGB;
-    return CreateDIBSection(NULL, &bmi, DIB_RGB_COLORS, (void**)bits, NULL, 0);
-}
-
-bool RenderIconForStatusBar(HICON hIcon, int width, int height, COLORREF background, BYTE** bits, HBITMAP* bitmap)
-{
-    *bits = NULL;
-    *bitmap = CreateStatusBarIconDIB(width, height, bits);
-    if (*bitmap == NULL || *bits == NULL)
-        return false;
-
-    HDC hDC = GetDC(NULL);
-    HDC hMemDC = CreateCompatibleDC(hDC);
-    if (hMemDC == NULL)
-    {
-        ReleaseDC(NULL, hDC);
-        DeleteObject(*bitmap);
-        *bitmap = NULL;
-        *bits = NULL;
-        return false;
-    }
-
-    HBITMAP hOldBitmap = (HBITMAP)SelectObject(hMemDC, *bitmap);
-    HBRUSH hBrush = CreateSolidBrush(background);
-    RECT r = {0, 0, width, height};
-    if (hBrush != NULL)
-    {
-        FillRect(hMemDC, &r, hBrush);
-        DeleteObject(hBrush);
-    }
-    DrawIconEx(hMemDC, 0, 0, hIcon, width, height, 0, NULL, DI_NORMAL);
-    SelectObject(hMemDC, hOldBitmap);
-    DeleteDC(hMemDC);
-    ReleaseDC(NULL, hDC);
-    return true;
-}
-
-HICON CreateSolidStatusBarIcon(HICON hIcon, COLORREF color)
+HICON CreateInvertedStatusBarIcon(HICON hIcon)
 {
     if (hIcon == NULL)
         return NULL;
@@ -81,75 +35,51 @@ HICON CreateSolidStatusBarIcon(HICON hIcon, COLORREF color)
     if (iconInfo.hbmColor == NULL)
         height /= 2;
 
-    BYTE* blackBits = NULL;
-    BYTE* whiteBits = NULL;
-    BYTE* outputBits = NULL;
-    HBITMAP hBlackBitmap = NULL;
-    HBITMAP hWhiteBitmap = NULL;
-    HBITMAP hOutputBitmap = NULL;
-    HBITMAP hOutputMask = NULL;
-    HICON hSolidIcon = NULL;
-    ICONINFO outputIconInfo;
-    ZeroMemory(&outputIconInfo, sizeof(outputIconInfo));
+    int maskStride = ((width + 15) / 16) * 2;
+    DWORD maskSize = maskStride * height;
+    BYTE* andBits = (BYTE*)malloc(maskSize);
+    BYTE* xorBits = (BYTE*)malloc(maskSize);
+    HICON hInvertedIcon = NULL;
+    HDC hDC = NULL;
+    BITMAPINFO bmi;
+    ZeroMemory(&bmi, sizeof(bmi));
 
-    if (iconInfo.hbmMask != NULL)
-        hOutputMask = (HBITMAP)CopyImage(iconInfo.hbmMask, IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION);
-    if (hOutputMask == NULL)
+    if (andBits == NULL || xorBits == NULL || iconInfo.hbmMask == NULL)
         goto cleanup;
 
-    if (!RenderIconForStatusBar(hIcon, width, height, RGB(0, 0, 0), &blackBits, &hBlackBitmap) ||
-        !RenderIconForStatusBar(hIcon, width, height, RGB(255, 255, 255), &whiteBits, &hWhiteBitmap))
+    ZeroMemory(andBits, maskSize);
+    ZeroMemory(xorBits, maskSize);
+
+    hDC = GetDC(NULL);
+    if (hDC == NULL)
+        goto cleanup;
+    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+    bmi.bmiHeader.biWidth = width;
+    bmi.bmiHeader.biHeight = height;
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 1;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    if (GetDIBits(hDC, iconInfo.hbmMask, 0, height, andBits, &bmi, DIB_RGB_COLORS) != (int)height)
         goto cleanup;
 
-    hOutputBitmap = CreateStatusBarIconDIB(width, height, &outputBits);
-    if (hOutputBitmap == NULL || outputBits == NULL)
-        goto cleanup;
+    for (DWORD i = 0; i < maskSize; i++)
+        xorBits[i] = ~andBits[i];
 
-    for (int i = 0; i < width * height; i++)
-    {
-        BYTE* black = blackBits + i * 4;
-        BYTE* white = whiteBits + i * 4;
-        BYTE* output = outputBits + i * 4;
-
-        int maxDiff = max(abs((int)white[0] - (int)black[0]),
-                          max(abs((int)white[1] - (int)black[1]),
-                              abs((int)white[2] - (int)black[2])));
-        bool visible = 255 - maxDiff > 8;
-        if (visible)
-        {
-            output[0] = GetBValue(color);
-            output[1] = GetGValue(color);
-            output[2] = GetRValue(color);
-            output[3] = 255;
-        }
-        else
-        {
-            output[0] = 0;
-            output[1] = 0;
-            output[2] = 0;
-            output[3] = 0;
-        }
-    }
-
-    outputIconInfo.fIcon = TRUE;
-    outputIconInfo.hbmColor = hOutputBitmap;
-    outputIconInfo.hbmMask = hOutputMask;
-    hSolidIcon = CreateIconIndirect(&outputIconInfo);
+    hInvertedIcon = CreateIcon(DLLInstance, width, height, 1, 1, andBits, xorBits);
 
 cleanup:
+    if (hDC != NULL)
+        ReleaseDC(NULL, hDC);
     if (iconInfo.hbmColor != NULL)
         DeleteObject(iconInfo.hbmColor);
     if (iconInfo.hbmMask != NULL)
         DeleteObject(iconInfo.hbmMask);
-    if (hBlackBitmap != NULL)
-        DeleteObject(hBlackBitmap);
-    if (hWhiteBitmap != NULL)
-        DeleteObject(hWhiteBitmap);
-    if (hOutputBitmap != NULL)
-        DeleteObject(hOutputBitmap);
-    if (hOutputMask != NULL)
-        DeleteObject(hOutputMask);
-    return hSolidIcon;
+    if (andBits != NULL)
+        free(andBits);
+    if (xorBits != NULL)
+        free(xorBits);
+    return hInvertedIcon;
 }
 
 HICON GetStatusBarIconForCurrentTheme(HICON normalIcon, HICON darkIcon)
@@ -170,10 +100,10 @@ CStatusBar::CStatusBar()
     HAnchor = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_ANCHOR), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
     HSize = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_SIZE), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
     HPipette = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_PIPETTE), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
-    HCursorDark = CreateSolidStatusBarIcon(HCursor, RGB(255, 255, 255));
-    HAnchorDark = CreateSolidStatusBarIcon(HAnchor, RGB(255, 255, 255));
-    HSizeDark = CreateSolidStatusBarIcon(HSize, RGB(255, 255, 255));
-    HPipetteDark = CreateSolidStatusBarIcon(HPipette, RGB(255, 255, 255));
+    HCursorDark = CreateInvertedStatusBarIcon(HCursor);
+    HAnchorDark = CreateInvertedStatusBarIcon(HAnchor);
+    HSizeDark = CreateInvertedStatusBarIcon(HSize);
+    HPipetteDark = CreateInvertedStatusBarIcon(HPipette);
     hProgBar = NULL;
 }
 

--- a/src/plugins/pictview/statsbar.cpp
+++ b/src/plugins/pictview/statsbar.cpp
@@ -12,6 +12,152 @@
 #include "pictview.rh2"
 #include "lang\lang.rh"
 
+
+namespace
+{
+HBITMAP CreateStatusBarIconDIB(int width, int height, BYTE** bits)
+{
+    BITMAPINFO bmi;
+    ZeroMemory(&bmi, sizeof(bmi));
+    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+    bmi.bmiHeader.biWidth = width;
+    bmi.bmiHeader.biHeight = -height;
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+    return CreateDIBSection(NULL, &bmi, DIB_RGB_COLORS, (void**)bits, NULL, 0);
+}
+
+bool RenderIconForStatusBar(HICON hIcon, int width, int height, COLORREF background, BYTE** bits, HBITMAP* bitmap)
+{
+    *bits = NULL;
+    *bitmap = CreateStatusBarIconDIB(width, height, bits);
+    if (*bitmap == NULL || *bits == NULL)
+        return false;
+
+    HDC hDC = GetDC(NULL);
+    HDC hMemDC = CreateCompatibleDC(hDC);
+    if (hMemDC == NULL)
+    {
+        ReleaseDC(NULL, hDC);
+        DeleteObject(*bitmap);
+        *bitmap = NULL;
+        *bits = NULL;
+        return false;
+    }
+
+    HBITMAP hOldBitmap = (HBITMAP)SelectObject(hMemDC, *bitmap);
+    HBRUSH hBrush = CreateSolidBrush(background);
+    RECT r = {0, 0, width, height};
+    if (hBrush != NULL)
+    {
+        FillRect(hMemDC, &r, hBrush);
+        DeleteObject(hBrush);
+    }
+    DrawIconEx(hMemDC, 0, 0, hIcon, width, height, 0, NULL, DI_NORMAL);
+    SelectObject(hMemDC, hOldBitmap);
+    DeleteDC(hMemDC);
+    ReleaseDC(NULL, hDC);
+    return true;
+}
+
+HICON CreateSolidStatusBarIcon(HICON hIcon, COLORREF color)
+{
+    if (hIcon == NULL)
+        return NULL;
+
+    ICONINFO iconInfo;
+    if (!GetIconInfo(hIcon, &iconInfo))
+        return NULL;
+
+    BITMAP bitmapInfo;
+    ZeroMemory(&bitmapInfo, sizeof(bitmapInfo));
+    HBITMAP hMeasureBitmap = iconInfo.hbmColor != NULL ? iconInfo.hbmColor : iconInfo.hbmMask;
+    if (hMeasureBitmap != NULL)
+        GetObject(hMeasureBitmap, sizeof(bitmapInfo), &bitmapInfo);
+
+    int width = bitmapInfo.bmWidth > 0 ? bitmapInfo.bmWidth : 16;
+    int height = bitmapInfo.bmHeight > 0 ? bitmapInfo.bmHeight : 16;
+    if (iconInfo.hbmColor == NULL)
+        height /= 2;
+
+    BYTE* blackBits = NULL;
+    BYTE* whiteBits = NULL;
+    BYTE* outputBits = NULL;
+    HBITMAP hBlackBitmap = NULL;
+    HBITMAP hWhiteBitmap = NULL;
+    HBITMAP hOutputBitmap = NULL;
+    HBITMAP hOutputMask = NULL;
+    HICON hSolidIcon = NULL;
+    ICONINFO outputIconInfo;
+    ZeroMemory(&outputIconInfo, sizeof(outputIconInfo));
+
+    if (iconInfo.hbmMask != NULL)
+        hOutputMask = (HBITMAP)CopyImage(iconInfo.hbmMask, IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION);
+    if (hOutputMask == NULL)
+        goto cleanup;
+
+    if (!RenderIconForStatusBar(hIcon, width, height, RGB(0, 0, 0), &blackBits, &hBlackBitmap) ||
+        !RenderIconForStatusBar(hIcon, width, height, RGB(255, 255, 255), &whiteBits, &hWhiteBitmap))
+        goto cleanup;
+
+    hOutputBitmap = CreateStatusBarIconDIB(width, height, &outputBits);
+    if (hOutputBitmap == NULL || outputBits == NULL)
+        goto cleanup;
+
+    for (int i = 0; i < width * height; i++)
+    {
+        BYTE* black = blackBits + i * 4;
+        BYTE* white = whiteBits + i * 4;
+        BYTE* output = outputBits + i * 4;
+
+        int maxDiff = max(abs((int)white[0] - (int)black[0]),
+                          max(abs((int)white[1] - (int)black[1]),
+                              abs((int)white[2] - (int)black[2])));
+        bool visible = 255 - maxDiff > 8;
+        if (visible)
+        {
+            output[0] = GetBValue(color);
+            output[1] = GetGValue(color);
+            output[2] = GetRValue(color);
+            output[3] = 255;
+        }
+        else
+        {
+            output[0] = 0;
+            output[1] = 0;
+            output[2] = 0;
+            output[3] = 0;
+        }
+    }
+
+    outputIconInfo.fIcon = TRUE;
+    outputIconInfo.hbmColor = hOutputBitmap;
+    outputIconInfo.hbmMask = hOutputMask;
+    hSolidIcon = CreateIconIndirect(&outputIconInfo);
+
+cleanup:
+    if (iconInfo.hbmColor != NULL)
+        DeleteObject(iconInfo.hbmColor);
+    if (iconInfo.hbmMask != NULL)
+        DeleteObject(iconInfo.hbmMask);
+    if (hBlackBitmap != NULL)
+        DeleteObject(hBlackBitmap);
+    if (hWhiteBitmap != NULL)
+        DeleteObject(hWhiteBitmap);
+    if (hOutputBitmap != NULL)
+        DeleteObject(hOutputBitmap);
+    if (hOutputMask != NULL)
+        DeleteObject(hOutputMask);
+    return hSolidIcon;
+}
+
+HICON GetStatusBarIconForCurrentTheme(HICON normalIcon, HICON darkIcon)
+{
+    return DarkModeShouldUseDarkColors() && darkIcon != NULL ? darkIcon : normalIcon;
+}
+} // namespace
+
 //****************************************************************************
 //
 // CStatusBar
@@ -24,6 +170,10 @@ CStatusBar::CStatusBar()
     HAnchor = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_ANCHOR), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
     HSize = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_SIZE), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
     HPipette = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_SB_PIPETTE), IMAGE_ICON, 16, 16, SalamanderGeneral->GetIconLRFlags());
+    HCursorDark = CreateSolidStatusBarIcon(HCursor, RGB(255, 255, 255));
+    HAnchorDark = CreateSolidStatusBarIcon(HAnchor, RGB(255, 255, 255));
+    HSizeDark = CreateSolidStatusBarIcon(HSize, RGB(255, 255, 255));
+    HPipetteDark = CreateSolidStatusBarIcon(HPipette, RGB(255, 255, 255));
     hProgBar = NULL;
 }
 
@@ -33,10 +183,39 @@ CStatusBar::~CStatusBar()
     DestroyIcon(HAnchor);
     DestroyIcon(HSize);
     DestroyIcon(HPipette);
+    if (HCursorDark != NULL)
+        DestroyIcon(HCursorDark);
+    if (HAnchorDark != NULL)
+        DestroyIcon(HAnchorDark);
+    if (HSizeDark != NULL)
+        DestroyIcon(HSizeDark);
+    if (HPipetteDark != NULL)
+        DestroyIcon(HPipetteDark);
     if (hProgBar)
     {
         DestroyWindow(hProgBar);
     }
+}
+
+
+HICON CStatusBar::GetCursorIcon() const
+{
+    return GetStatusBarIconForCurrentTheme(HCursor, HCursorDark);
+}
+
+HICON CStatusBar::GetAnchorIcon() const
+{
+    return GetStatusBarIconForCurrentTheme(HAnchor, HAnchorDark);
+}
+
+HICON CStatusBar::GetSizeIcon() const
+{
+    return GetStatusBarIconForCurrentTheme(HSize, HSizeDark);
+}
+
+HICON CStatusBar::GetPipetteIcon() const
+{
+    return GetStatusBarIconForCurrentTheme(HPipette, HPipetteDark);
 }
 
 #define ICON_MARGIN 32 // space for the icon and margins
@@ -129,7 +308,7 @@ void CViewerWindow::SetStatusBarTexts(int ID)
     SafeSetStatusBarText(hStatusBar, 0 | SBT_NOBORDERS, buff);
 
     // cursor
-    SafeSetStatusBarIcon(hStatusBar, 1, StatusBar->HCursor);
+    SafeSetStatusBarIcon(hStatusBar, 1, StatusBar->GetCursorIcon());
     DWORD newMousePos = GetMessagePos();
     POINT pt;
     pt.x = GET_X_LPARAM(newMousePos);
@@ -151,7 +330,7 @@ void CViewerWindow::SetStatusBarTexts(int ID)
     }
 
     // size
-    SafeSetStatusBarIcon(hStatusBar, 2, StatusBar->HSize);
+    SafeSetStatusBarIcon(hStatusBar, 2, StatusBar->GetSizeIcon());
     int sizeWidth, sizeHeight;
     if (IsCageValid(&Renderer.TmpCageRect))
     {
@@ -177,13 +356,13 @@ void CViewerWindow::SetStatusBarTexts(int ID)
     // anchor
     if (IsCageValid(&Renderer.TmpCageRect))
     {
-        SafeSetStatusBarIcon(hStatusBar, 3, StatusBar->HAnchor);
+        SafeSetStatusBarIcon(hStatusBar, 3, StatusBar->GetAnchorIcon());
         _stprintf(buff, LoadStr(IDS_SB_XY), Renderer.TmpCageRect.left, Renderer.TmpCageRect.top);
         SafeSetStatusBarText(hStatusBar, 3, buff);
     }
     else
     {
-        SafeSetStatusBarIcon(hStatusBar, 3, StatusBar->HPipette);
+        SafeSetStatusBarIcon(hStatusBar, 3, StatusBar->GetPipetteIcon());
         if (validCursor)
         {
             int ind;

--- a/src/plugins/zip/dialogs.cpp
+++ b/src/plugins/zip/dialogs.cpp
@@ -49,22 +49,29 @@ LRESULT CALLBACK TextControlProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
 
         GetClientRect(hWnd, &r);
         BeginPaint(hWnd, &ps);
-        HBRUSH DialogBrush = CreateSolidBrush(GetSysColor(COLOR_BTNFACE));
+        ConfigureZIPDarkModeFromHost();
+        COLORREF backgroundColor = GetSysColor(COLOR_BTNFACE);
+        COLORREF textColor = GetSysColor(COLOR_BTNTEXT);
+        if (DarkModeShouldUseDarkColors())
+        {
+            backgroundColor = DarkModeGetDialogBackgroundColor();
+            textColor = DarkModeGetDialogTextColor();
+        }
+
+        HBRUSH DialogBrush = CreateSolidBrush(backgroundColor);
         if (DialogBrush)
         {
             FillRect(ps.hdc, &r, DialogBrush);
             DeleteObject(DialogBrush);
         }
         UINT format = DT_SINGLELINE | DT_BOTTOM | DT_NOPREFIX;
-        DWORD color = GetSysColor(COLOR_BTNTEXT);
         HFONT hCurrentFont = (HFONT)SendMessage(hWnd, WM_GETFONT, 0, 0);
-        int ID = GetDlgCtrlID(hWnd);
         format |= DT_PATH_ELLIPSIS;
         HFONT hOldFont = (HFONT)SelectObject(ps.hdc, hCurrentFont);
-        SetTextColor(ps.hdc, color);
+        SetTextColor(ps.hdc, textColor);
         int prevBkMode = SetBkMode(ps.hdc, TRANSPARENT);
         int len = GetWindowText(hWnd, txt, MAX_PATH);
-        DrawText(ps.hdc, txt, lstrlen(txt), &r, format);
+        DrawText(ps.hdc, txt, len, &r, format);
         SetBkMode(ps.hdc, prevBkMode);
         SelectObject(ps.hdc, hOldFont);
         EndPaint(hWnd, &ps);
@@ -162,6 +169,11 @@ BOOL CALLBACK EnumChildProc(HWND hwnd, LPARAM lParam)
     CALL_STACK_MESSAGE_NONE
     *(HWND*)lParam = hwnd;
     return FALSE;
+}
+
+static void ClearComboBoxEditSelection(HWND hDlg, int ctrlID)
+{
+    SendDlgItemMessage(hDlg, ctrlID, CB_SETEDITSEL, 0, MAKELPARAM(-1, 0));
 }
 
 void CPackDialog::SubClassComboBox(DWORD wID, bool subclass)
@@ -354,6 +366,7 @@ BOOL CPackDialog::OnInit(WPARAM wParam, LPARAM lParam)
         SendDlgItemMessage(Dlg, IDC_VOLSIZE, CB_SETCURSEL, 0, 0);
         SendDlgItemMessage(Dlg, IDC_UNITS, CB_SETCURSEL, Config->VolSizeUnits[0] == 0 ? 0 : 1, 0);
     }
+    ClearComboBoxEditSelection(Dlg, IDC_VOLSIZE);
 
     ResetControls();
 

--- a/src/toolbar2.cpp
+++ b/src/toolbar2.cpp
@@ -32,6 +32,34 @@ static COLORREF GetToolBarBkColor()
     return DarkMode_ShouldUseDark() ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE);
 }
 
+static COLORREF LightenColor(COLORREF color, int amount)
+{
+    return RGB(min(255, GetRValue(color) + amount),
+               min(255, GetGValue(color) + amount),
+               min(255, GetBValue(color) + amount));
+}
+
+static COLORREF DarkenColor(COLORREF color, int amount)
+{
+    return RGB(max(0, GetRValue(color) - amount),
+               max(0, GetGValue(color) - amount),
+               max(0, GetBValue(color) - amount));
+}
+
+static COLORREF GetDisabledToolBarHighlightColor()
+{
+    if (DarkModeShouldUseDarkColors())
+        return LightenColor(GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]), 24);
+    return GetSysColor(COLOR_BTNHILIGHT);
+}
+
+static COLORREF GetDisabledToolBarTextColor()
+{
+    if (DarkModeShouldUseDarkColors())
+        return DarkenColor(GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]), 40);
+    return GetSysColor(COLOR_BTNSHADOW);
+}
+
 void CToolBar::SetFont()
 {
     CALL_STACK_MESSAGE1("CToolBar::SetFont()");
@@ -686,14 +714,10 @@ void CToolBar::DrawItem(HDC hDC, int index)
                 textR2.top++;
                 textR2.right++;
                 textR2.bottom++;
-                COLORREF disabledHighlight =
-                    DarkModeShouldUseDarkColors() ? RGB(200, 200, 200) : GetSysColor(COLOR_BTNHILIGHT);
-                SetTextColor(CacheBitmap->HMemDC, disabledHighlight);
+                SetTextColor(CacheBitmap->HMemDC, GetDisabledToolBarHighlightColor());
                 DrawText(CacheBitmap->HMemDC, item->Text, item->TextLen,
                          &textR2, noPrefix | DT_NOCLIP | DT_LEFT | DT_SINGLELINE | DT_VCENTER);
-                COLORREF disabledText =
-                    DarkModeShouldUseDarkColors() ? RGB(128, 128, 128) : GetSysColor(COLOR_BTNSHADOW);
-                SetTextColor(CacheBitmap->HMemDC, disabledText);
+                SetTextColor(CacheBitmap->HMemDC, GetDisabledToolBarTextColor());
             }
             else
                 SetTextColor(CacheBitmap->HMemDC, defaultText);


### PR DESCRIPTION
### Motivation
- Ensure status bar icons render correctly in dark themes and that status bar updates when theme/setting changes.
- Make toolbar disabled text/highlight colors readable in dark mode.
- Apply host dark-mode colors in ZIP dialogs and fix a combo box edit selection visual issue.

### Description
- Added dark variants for status bar icons and accessor methods (`GetCursorIcon`, `GetAnchorIcon`, `GetSizeIcon`, `GetPipetteIcon`) in `CStatusBar` and switched status bar usage to those accessors.
- Implemented rendering utilities in `statsbar.cpp` to produce solid-color icons for status-bar usage in dark mode (`CreateStatusBarIconDIB`, `RenderIconForStatusBar`, `CreateSolidStatusBarIcon`, `GetStatusBarIconForCurrentTheme`) and manage lifecycle of generated icons.
- Updated theme/setting change handling in the viewer (`pictview.cpp`) to reapply dark-mode colors to the status bar and refresh status texts when necessary.
- Adjusted toolbar drawing (`toolbar2.cpp`) to compute improved disabled highlight/text colors in dark mode via `LightenColor`/`DarkenColor` helpers and use those colors when rendering grayed (disabled) toolbar labels.
- Applied dark-mode dialog background/text colors in ZIP dialogs (`dialogs.cpp`) during custom paint and fixed `DrawText` length usage; added `ClearComboBoxEditSelection` and used it to clear edit selection for a combo box on dialog init.

### Testing
- Performed an automated build of the solution which completed successfully.
- Ran an automated startup/quit smoke test that launches the viewer and closes it to validate no startup crashes, which succeeded.
- No module-specific unit tests were modified; existing automated CI/unit tests covering the project ran and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20c184eaac832987e04df2fe4fff5c)