### PR TITLE
Update Samandarin x64 setup and runbook metadata to 5.0-samandarin-0.4

### DIFF
--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -11,8 +11,8 @@
 ; the fallback path below is relative to this .iss file.
 
 #define MyAppName "Open Salamander Samandarin"
-#define MyAppDisplayName "Open Salamander 5.0 Samandarin 0.3 (x64)"
-#define MyAppVersion "5.0-samandarin-0.3"
+#define MyAppDisplayName "Open Salamander 5.0 Samandarin 0.4 (x64)"
+#define MyAppVersion "5.0-samandarin-0.4"
 #define MyAppPublisher "KRtekTM"
 #define MyAppURL "https://github.com/KRtkovo-eu-AI/salamander"
 #define MyAppExeName "salamand.exe"
@@ -26,7 +26,7 @@
 #endif
 
 [Setup]
-AppId=OpenSalamanderSamandarin-x64-5.0-samandarin-0.3
+AppId=OpenSalamanderSamandarin-x64-5.0-samandarin-0.4
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppVerName={#MyAppDisplayName}
@@ -836,17 +836,17 @@ Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; Flags: no
 ; UninstallString intentionally targets Inno Setup's uninstaller instead of the
 ; legacy remove\remove.exe payload so this installer can uninstall its own files.
 Root: HKCU; Subkey: "Software\Open Salamander Samandarin\Applications\Open Salamander Samandarin (x64)"; ValueType: string; ValueName: "Last Directory"; ValueData: "{app}"; Flags: uninsdeletevalue
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "DisplayName"; ValueData: "{#MyAppDisplayName}"; Flags: uninsdeletekey
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "DisplayIcon"; ValueData: "{app}\{#MyAppExeName}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "DisplayVersion"; ValueData: "{#MyAppVersion}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: dword; ValueName: "VersionMajor"; ValueData: "5"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: dword; ValueName: "VersionMinor"; ValueData: "0"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "InstallLocation"; ValueData: "{app}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "UninstallString"; ValueData: """{uninstallexe}"""
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "QuietUninstallString"; ValueData: """{uninstallexe}"" /SILENT"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "Publisher"; ValueData: "{#MyAppPublisher}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "HelpLink"; ValueData: "{#MyAppURL}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)"; ValueType: string; ValueName: "UrlInfoAbout"; ValueData: "{#MyAppURL}"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "DisplayName"; ValueData: "{#MyAppDisplayName}"; Flags: uninsdeletekey
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "DisplayIcon"; ValueData: "{app}\{#MyAppExeName}"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "DisplayVersion"; ValueData: "{#MyAppVersion}"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: dword; ValueName: "VersionMajor"; ValueData: "5"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: dword; ValueName: "VersionMinor"; ValueData: "0"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "InstallLocation"; ValueData: "{app}"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "UninstallString"; ValueData: """{uninstallexe}"""
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "QuietUninstallString"; ValueData: """{uninstallexe}"" /SILENT"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "Publisher"; ValueData: "{#MyAppPublisher}"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "HelpLink"; ValueData: "{#MyAppURL}"
+Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)"; ValueType: string; ValueName: "UrlInfoAbout"; ValueData: "{#MyAppURL}"
 
 [UninstallRun]
 ; INF [DelShellExts] listed these shell-extension DLLs for cleanup.
@@ -864,13 +864,13 @@ begin
   Result := True;
   DeleteUserConfigurationRegistry := False;
 
-  if RegKeyExists(HKCU, 'Software\Open Salamander Samandarin\5.0-samandarin-0.3') then
+  if RegKeyExists(HKCU, 'Software\Open Salamander Samandarin\5.0-samandarin-0.4') then
   begin
     DeleteUserConfigurationRegistry :=
       MsgBox(
         'Do you want to remove the Open Salamander Samandarin user configuration from the registry?'#13#10#13#10 +
         'Registry key:'#13#10 +
-        'HKCU\Software\Open Salamander Samandarin\5.0-samandarin-0.3'#13#10#13#10 +
+        'HKCU\Software\Open Salamander Samandarin\5.0-samandarin-0.4'#13#10#13#10 +
         'Choose Yes to delete the key including all contents, or No to keep your settings.',
         mbConfirmation,
         MB_YESNO) = IDYES;
@@ -880,7 +880,7 @@ end;
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
   if (CurUninstallStep = usPostUninstall) and DeleteUserConfigurationRegistry then
-    RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Open Salamander Samandarin\5.0-samandarin-0.3');
+    RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Open Salamander Samandarin\5.0-samandarin-0.4');
 end;
 
 procedure CurPageChanged(CurPageID: Integer);
@@ -897,7 +897,7 @@ begin
   begin
     { Mirrors the setup_x64.inf IncrementFileContent metadata by ensuring plugins.ver exists.
       The legacy installer used the registry value
-      HKCU\Software\Open Salamander Samandarin\5.0-samandarin-0.3\Configuration\Plugins.ver Version (x64)
+      HKCU\Software\Open Salamander Samandarin\5.0-samandarin-0.4\Configuration\Plugins.ver Version (x64)
       to decide whether selected plugins should be appended. Inno installs the staged plugins directly. }
     PluginsVer := ExpandConstant('{app}\plugins\plugins.ver');
     if not FileExists(PluginsVer) then

--- a/doc/runbook-setup/self-extract-create.set
+++ b/doc/runbook-setup/self-extract-create.set
@@ -66,7 +66,7 @@ remove_temp=1
 ;In this manner behaves e.g like some versions of Install Shield.
 ;This option is ignored unless 'remove_temp' is set to 1.
 
-wait_for="5.0-samandarin-0.3\setup.exe"
+wait_for="5.0-samandarin-0.4\setup.exe"
 
 ;specify whether to start extraction automatically when a user runs
 ;self-extracting archive
@@ -106,7 +106,7 @@ create_target_dir=1
 ;extraction target directory, if you specify a program you can also
 ;type in its arguments
 
-command="5.0-samandarin-0.3\setup.exe"
+command="5.0-samandarin-0.4\setup.exe"
 
 ;sfx package to be used when creating self-extracting archive
 ;relative path is relative to the directory with zip2sfx.exe
@@ -147,7 +147,7 @@ button_text="&Extract"
 
 ;vendor name in bottom-left corner of main sfx dialog
 
-vendor="© 1997-2026 Open Salamander Authors"
+vendor="Â© 1997-2026 Open Salamander Authors"
 
 ;www link in bottom-right corner of main sfx dialog
 

--- a/doc/runbook-setup/setup_x64.inf
+++ b/doc/runbook-setup/setup_x64.inf
@@ -770,21 +770,21 @@
 %1\salamand.exe,%8\Open Salamander Samandarin (x64).lnk,%@%1\utils\muires.dll,-101
 
 [AddRegistryKeys]
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)
-HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.3
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)
+HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.4
 
 [AddRegistryValues]
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),DisplayName,1,Open Salamander 5.0-samandarin-0.3 (x64)
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),DisplayIcon,1,%1\salamand.exe
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),DisplayVersion,1,5.0-samandarin-0.3
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),VersionMajor,1,5
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),VersionMinor,1,0
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),InstallLocation,1,%1
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),UninstallString,1,%1\remove\remove.exe
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),QuietUninstallString,1,%1\remove\remove.exe /q
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),Publisher,1,Open Salamander Project
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),HelpLink,1,https://github.com/KRtkovo-eu-AI/salamander
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),UrlInfoAbout,1,https://github.com/KRtkovo-eu-AI/salamander
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),DisplayName,1,Open Salamander 5.0-samandarin-0.4 (x64)
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),DisplayIcon,1,%1\salamand.exe
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),DisplayVersion,1,5.0-samandarin-0.4
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),VersionMajor,1,5
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),VersionMinor,1,0
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),InstallLocation,1,%1
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),UninstallString,1,%1\remove\remove.exe
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),QuietUninstallString,1,%1\remove\remove.exe /q
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),Publisher,1,Open Salamander Project
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),HelpLink,1,https://github.com/KRtkovo-eu-AI/salamander
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),UrlInfoAbout,1,https://github.com/KRtkovo-eu-AI/salamander
 
 [DelShellExts]
 %1\utils\salextx64.dll
@@ -794,17 +794,17 @@ HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-sam
 
 [Private]
 ApplicationName="Open Salamander: Samandarin"
-ApplicationNameVer="Open Salamander 5.0-samandarin-0.3 (x64)"
+ApplicationNameVer="Open Salamander 5.0-samandarin-0.4 (x64)"
 DefaultDirectory=%4\Open Salamander Samandarin
 LastDirectories=HKCU,Software\Open Salamander Samandarin\Applications\Open Salamander Samandarin (x64)
 LicenseFile=%0\doc\license.txt
 LicenseFileCZ=%0\doc\license_cz.txt
 ViewReadme=%1\doc\readme.txt
 RunProgram=%1\salamand.exe
-IncrementFileContentSrc=HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.3\Configuration,Plugins.ver Version (x64)
+IncrementFileContentSrc=HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.4\Configuration,Plugins.ver Version (x64)
 IncrementFileContentDst=%1\plugins\plugins.ver,winscp\winscp.spl,jsonviewer\jsonviewer.spl,textviewer\textviewer.spl,webview2renderviewer\webview2renderviewer.spl,samandarin\samandarin.spl
 SaveRemoveLog=%1\remove\remove.rlg
-AutoImportConfig=HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.3,AutoImportConfig
+AutoImportConfig=HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.4,AutoImportConfig
 DisplayWelcomeWarning=0
 SLGLanguages=english.slg
 WERLocalDumps=salamand.exe,salmon.exe,salopen.exe,salspawn.exe,fcremote.exe,salpvenv.exe

--- a/tools/setup_x64.inf
+++ b/tools/setup_x64.inf
@@ -770,21 +770,21 @@
 %1\salamand.exe,%8\Open Salamander Samandarin (x64).lnk,%@%1\utils\muires.dll,-101
 
 [AddRegistryKeys]
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64)
-HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.3
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64)
+HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.4
 
 [AddRegistryValues]
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),DisplayName,1,Open Salamander 5.0-samandarin-0.3 (x64)
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),DisplayIcon,1,%1\salamand.exe
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),DisplayVersion,1,5.0-samandarin-0.3
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),VersionMajor,1,5
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),VersionMinor,1,0
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),InstallLocation,1,%1
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),UninstallString,1,%1\remove\remove.exe
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),QuietUninstallString,1,%1\remove\remove.exe /q
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),Publisher,1,Open Salamander Project
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),HelpLink,1,https://github.com/KRtkovo-eu-AI/salamander
-HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.3 (x64),UrlInfoAbout,1,https://github.com/KRtkovo-eu-AI/salamander
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),DisplayName,1,Open Salamander 5.0-samandarin-0.4 (x64)
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),DisplayIcon,1,%1\salamand.exe
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),DisplayVersion,1,5.0-samandarin-0.4
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),VersionMajor,1,5
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),VersionMinor,1,0
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),InstallLocation,1,%1
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),UninstallString,1,%1\remove\remove.exe
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),QuietUninstallString,1,%1\remove\remove.exe /q
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),Publisher,1,Open Salamander Project
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),HelpLink,1,https://github.com/KRtkovo-eu-AI/salamander
+HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.4 (x64),UrlInfoAbout,1,https://github.com/KRtkovo-eu-AI/salamander
 
 [DelShellExts]
 %1\utils\salextx64.dll
@@ -794,17 +794,17 @@ HKLM,SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-sam
 
 [Private]
 ApplicationName="Open Salamander: Samandarin"
-ApplicationNameVer="Open Salamander 5.0-samandarin-0.3 (x64)"
+ApplicationNameVer="Open Salamander 5.0-samandarin-0.4 (x64)"
 DefaultDirectory=%4\Open Salamander Samandarin
 LastDirectories=HKCU,Software\Open Salamander Samandarin\Applications\Open Salamander Samandarin (x64)
 LicenseFile=%0\doc\license.txt
 LicenseFileCZ=%0\doc\license_cz.txt
 ViewReadme=%1\doc\readme.txt
 RunProgram=%1\salamand.exe
-IncrementFileContentSrc=HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.3\Configuration,Plugins.ver Version (x64)
+IncrementFileContentSrc=HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.4\Configuration,Plugins.ver Version (x64)
 IncrementFileContentDst=%1\plugins\plugins.ver,winscp\winscp.spl,jsonviewer\jsonviewer.spl,textviewer\textviewer.spl,webview2renderviewer\webview2renderviewer.spl,samandarin\samandarin.spl
 SaveRemoveLog=%1\remove\remove.rlg
-AutoImportConfig=HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.3,AutoImportConfig
+AutoImportConfig=HKCU,Software\Open Salamander Samandarin\5.0-samandarin-0.4,AutoImportConfig
 DisplayWelcomeWarning=0
 SLGLanguages=english.slg
 WERLocalDumps=salamand.exe,salmon.exe,salopen.exe,salspawn.exe,fcremote.exe,salpvenv.exe


### PR DESCRIPTION
### Motivation
- The Samandarin Update Notifier and installer metadata were out of sync: some installer/runbook files referenced `5.0-samandarin-0.3` while the product/plugin version is `5.0-samandarin-0.4`, which can cause the notifier or installers to report the older version or use wrong registry keys.

### Description
- Replaced `5.0-samandarin-0.3` with `5.0-samandarin-0.4` in x64 installer/runbook artifacts to keep registry keys, DisplayVersion and installer identifiers consistent.
- Files updated: `tools/setup_x64.inf`, `doc/runbook-setup/setup_x64.inf`, `doc/runbook-setup/inno_setup_salamander_x64.iss`, and `doc/runbook-setup/self-extract-create.set`.
- Changes include `MyAppVersion` / `MyAppDisplayName` / `AppId` in the Inno script, `ApplicationNameVer`, `IncrementFileContentSrc`, `AutoImportConfig`, Add/Remove registry keys/values and the self-extract `wait_for`/`command` paths.

### Testing
- Ran `git diff --check` to ensure no whitespace/overlap issues and it reported OK.
- Searched for leftover old references with `rg -n "5\.0-samandarin-0\.3|Samandarin 0\.3"` and confirmed no matches in the modified files (no occurrences remaining).
- Verified the new references with `rg -n "5\.0-samandarin-0\.4|Samandarin 0\.4"` and confirmed the expected updates in the four modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e83746b08329a2103642f6027edd)