### PR TITLE
Allow plugin-FS → plugin-FS Copy/Move via temporary disk bridge

### DIFF
--- a/src/fileswn7.cpp
+++ b/src/fileswn7.cpp
@@ -1503,6 +1503,10 @@ static BOOL UnpackArchiveToArchiveViaTemp(CFilesWindow* source, CPanelTmpEnumDat
     }
     *secondPart = 0;
 
+    // From this point the path is a syntactically valid archive target.
+    // Any later failure is reported by the unpack/pack code; do not fall back to the old "disk only" message.
+    invalidPathOrCancel = TRUE;
+
     int format = PackerFormatConfig.PackIsArchive(archivePath);
     if (format == 0 || !PackerFormatConfig.GetUsePacker(format - 1))
         return FALSE;
@@ -1530,6 +1534,9 @@ static BOOL UnpackArchiveToArchiveViaTemp(CFilesWindow* source, CPanelTmpEnumDat
         done = PackCompress(source->HWindow, source, archivePath, archiveRoot,
                             FALSE, tempRoot, PanelEnumDiskSelection, data);
         SetCurrentDirectoryToSystem();
+
+        if (!done)
+            invalidPathOrCancel = TRUE; // PackCompress already reported/cancelled; do not show the old unsupported fallback.
 
         if (done)
         {

--- a/src/fileswn7.cpp
+++ b/src/fileswn7.cpp
@@ -385,6 +385,10 @@ const char* WINAPI PanelSalEnumSelection(HWND parent, int enumFiles, BOOL* isDir
     return _PanelSalEnumSelection(enumFiles, NULL, isDir, size, fileData, param, parent, errorOccured);
 }
 
+static BOOL UnpackArchiveToPluginFSViaTemp(CFilesWindow* source, CFilesWindow* target,
+                                           CPanelTmpEnumData* data, int sourceFiles, int sourceDirs,
+                                           char* targetPath, BOOL& invalidPathOrCancel);
+
 void CFilesWindow::UnpackZIPArchive(CFilesWindow* target, BOOL deleteOp, const char* tgtPath)
 {
     CALL_STACK_MESSAGE3("CFilesWindow::UnpackZIPArchive(, %d, %s)", deleteOp, tgtPath);
@@ -483,6 +487,15 @@ void CFilesWindow::UnpackZIPArchive(CFilesWindow* target, BOOL deleteOp, const c
 
     if (!deleteOp) // copy
     {
+        int sourceFiles = 0;
+        int i;
+        for (i = 0; i < data.IndexesCount; i++)
+        {
+            if (data.Indexes[i] >= Dirs->Count)
+                sourceFiles++;
+        }
+        int sourceDirs = data.IndexesCount - sourceFiles;
+
         //---  obtain the target directory
         if (target != NULL && target->Is(ptDisk))
         {
@@ -491,7 +504,27 @@ void CFilesWindow::UnpackZIPArchive(CFilesWindow* target, BOOL deleteOp, const c
             target->UserWorkedOnThisPath = TRUE; // default action = operate with the path in the target panel
         }
         else
+        {
             path[0] = 0;
+            if (target != NULL && target->Is(ptPluginFS) && target->GetPluginFS()->NotEmpty() &&
+                target->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMDISKTOFS))
+            {
+                target->GetGeneralPath(path, MAX_PATH);
+                if (!target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 1,
+                                                                   target->GetPluginFS()->GetPluginFSName(),
+                                                                   HWindow, NULL, NULL, NULL,
+                                                                   sourceFiles, sourceDirs, path, NULL))
+                {
+                    path[0] = 0;
+                }
+                else
+                {
+                    // convert the path to external format (before showing it in the dialog)
+                    PluginFSConvertPathToExternal(path);
+                    target->UserWorkedOnThisPath = TRUE; // default action = operate with the path in the target panel
+                }
+            }
+        }
 
         CCopyMoveDialog dlg(HWindow, path, MAX_PATH, LoadStr(IDS_UNPACKCOPY), &str, IDD_COPYDIALOG,
                             Configuration.CopyHistory, COPY_HISTORY_SIZE, TRUE);
@@ -686,20 +719,37 @@ void CFilesWindow::UnpackZIPArchive(CFilesWindow* target, BOOL deleteOp, const c
                 }
                 else
                 {
-                    SalMessageBox(HWindow, LoadStr(IDS_UNPACK_ONLYDISK), LoadStr(IDS_ERRORCOPY),
-                                  MB_OK | MB_ICONEXCLAMATION);
-                    if (pathType == PATH_TYPE_ARCHIVE && (backslashAtEnd || mustBePath))
+                    BOOL invalidPathOrCancel = FALSE;
+                    if (pathType == PATH_TYPE_FS && target != NULL && target->Is(ptPluginFS) &&
+                        UnpackArchiveToPluginFSViaTemp(this, target, &data, sourceFiles, sourceDirs,
+                                                       path, invalidPathOrCancel))
                     {
-                        SalPathAddBackslash(path, MAX_PATH + 200);
+                        if (tgtPath == NULL) // if it is not drag&drop (selection is not cleared there)
+                        {
+                            SetSel(FALSE, -1, TRUE);                        // explicit redraw
+                            PostMessage(HWindow, WM_USER_SELCHANGED, 0, 0); // sel-change notify
+                        }
                     }
-                    if (tgtPath != NULL)
+                    else
                     {
-                        UpdateWindow(MainWindow->HWindow);
-                        delete[] (data.Indexes);
-                        EndStopRefresh();
-                        return;
+                        if (!invalidPathOrCancel)
+                        {
+                            SalMessageBox(HWindow, LoadStr(IDS_UNPACK_ONLYDISK), LoadStr(IDS_ERRORCOPY),
+                                          MB_OK | MB_ICONEXCLAMATION);
+                            if (pathType == PATH_TYPE_ARCHIVE && (backslashAtEnd || mustBePath))
+                            {
+                                SalPathAddBackslash(path, MAX_PATH + 200);
+                            }
+                        }
+                        if (tgtPath != NULL)
+                        {
+                            UpdateWindow(MainWindow->HWindow);
+                            delete[] (data.Indexes);
+                            EndStopRefresh();
+                            return;
+                        }
+                        goto _DLG_AGAIN;
                     }
-                    goto _DLG_AGAIN;
                 }
             }
             else
@@ -717,7 +767,8 @@ void CFilesWindow::UnpackZIPArchive(CFilesWindow* target, BOOL deleteOp, const c
             //---  refresh directories that are not automatically refreshed
             // changes on the target path and its subdirectories (creating new directories and unpacking
             // files/directories)
-            MainWindow->PostChangeOnPathNotification(changesRoot, TRUE);
+            if (changesRoot[0] != 0)
+                MainWindow->PostChangeOnPathNotification(changesRoot, TRUE);
             // change in the directory containing the archive (should not occur during unpack, but refresh just in case it does)
             MainWindow->PostChangeOnPathNotification(GetPath(), FALSE);
         }
@@ -1277,6 +1328,94 @@ const char* WINAPI PanelEnumDiskSelection(HWND parent, int enumFiles, const char
             *lastWrite = f->LastWrite;
         return f->Name;
     }
+}
+
+
+static BOOL UnpackArchiveToPluginFSViaTemp(CFilesWindow* source, CFilesWindow* target,
+                                           CPanelTmpEnumData* data, int sourceFiles, int sourceDirs,
+                                           char* targetPath, BOOL& invalidPathOrCancel)
+{
+    CALL_STACK_MESSAGE2("UnpackArchiveToPluginFSViaTemp(, , , , , %s,)", targetPath);
+
+    invalidPathOrCancel = FALSE;
+
+    if (target == NULL || !target->Is(ptPluginFS) || !target->GetPluginFS()->NotEmpty() ||
+        !target->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMDISKTOFS))
+    {
+        return FALSE;
+    }
+
+    int pathType;
+    BOOL pathIsDir;
+    char* secondPart;
+    if (!source->ParsePath(targetPath, pathType, pathIsDir, secondPart, LoadStr(IDS_ERRORCOPY), NULL, NULL, MAX_PATH) ||
+        pathType != PATH_TYPE_FS)
+    {
+        return FALSE;
+    }
+
+    char fsName[MAX_PATH];
+    int fsNameLen = (int)((secondPart - targetPath) - 1);
+    if (fsNameLen <= 0 || fsNameLen >= MAX_PATH)
+        return FALSE;
+    memcpy(fsName, targetPath, fsNameLen);
+    fsName[fsNameLen] = 0;
+
+    int fsNameIndex;
+    if (!target->GetPluginFS()->IsFSNameFromSamePluginAsThisFS(fsName, fsNameIndex))
+        return FALSE;
+
+    // From this point the path is a valid path for the active target plug-in FS.
+    // Any later failure is reported by extraction/upload code, not by the old "disk only" fallback.
+    invalidPathOrCancel = TRUE;
+
+    char tempRoot[MAX_PATH];
+    if (!SalGetTempFileName(NULL, "ARC", tempRoot, FALSE))
+    {
+        SalMessageBox(source->HWindow, LoadStr(IDS_TMPDIRERROR), LoadStr(IDS_ERRORTITLE), MB_OK | MB_ICONEXCLAMATION);
+        invalidPathOrCancel = TRUE;
+        return FALSE;
+    }
+
+    BOOL done = FALSE;
+    data->Reset();
+    data->WorkPath[0] = 0;
+
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
+    if (PackUncompress(MainWindow->HWindow, source, source->GetZIPArchive(), source->PluginData.GetInterface(),
+                       tempRoot, source->GetZIPPath(), PanelSalEnumSelection, data))
+    {
+        data->Reset();
+        lstrcpyn(data->WorkPath, tempRoot, MAX_PATH);
+
+        char internalTargetPath[2 * MAX_PATH];
+        lstrcpyn(internalTargetPath, targetPath, 2 * MAX_PATH);
+        target->GetPluginFS()->GetPluginInterfaceForFS()->ConvertPathToInternal(fsName, fsNameIndex,
+                                                                                 internalTargetPath + strlen(fsName) + 1);
+
+        BOOL pluginInvalidPathOrCancel = FALSE;
+        if (target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 3, target->GetPluginFS()->GetPluginFSName(),
+                                                          source->HWindow, tempRoot, PanelEnumDiskSelection, data,
+                                                          sourceFiles, sourceDirs, internalTargetPath,
+                                                          &pluginInvalidPathOrCancel))
+        {
+            done = !pluginInvalidPathOrCancel;
+        }
+        else if (pluginInvalidPathOrCancel)
+        {
+            target->GetPluginFS()->GetPluginInterfaceForFS()->ConvertPathToExternal(fsName, fsNameIndex,
+                                                                                     internalTargetPath + strlen(fsName) + 1);
+            lstrcpyn(targetPath, internalTargetPath, MAX_PATH);
+            invalidPathOrCancel = TRUE;
+        }
+    }
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
+
+    RemoveTemporaryDir(tempRoot);
+    data->Reset();
+    data->WorkPath[0] = 0;
+
+    return done;
 }
 
 void CFilesWindow::Pack(CFilesWindow* target, int pluginIndex, const char* pluginName, int delFilesAfterPacking)

--- a/src/fileswn7.cpp
+++ b/src/fileswn7.cpp
@@ -388,6 +388,8 @@ const char* WINAPI PanelSalEnumSelection(HWND parent, int enumFiles, BOOL* isDir
 static BOOL UnpackArchiveToPluginFSViaTemp(CFilesWindow* source, CFilesWindow* target,
                                            CPanelTmpEnumData* data, int sourceFiles, int sourceDirs,
                                            char* targetPath, BOOL& invalidPathOrCancel);
+static BOOL UnpackArchiveToArchiveViaTemp(CFilesWindow* source, CPanelTmpEnumData* data,
+                                         char* targetPath, BOOL& invalidPathOrCancel);
 
 void CFilesWindow::UnpackZIPArchive(CFilesWindow* target, BOOL deleteOp, const char* tgtPath)
 {
@@ -506,22 +508,40 @@ void CFilesWindow::UnpackZIPArchive(CFilesWindow* target, BOOL deleteOp, const c
         else
         {
             path[0] = 0;
-            if (target != NULL && target->Is(ptPluginFS) && target->GetPluginFS()->NotEmpty() &&
-                target->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMDISKTOFS))
+            if (target != NULL && target->Is(ptZIPArchive))
             {
                 target->GetGeneralPath(path, MAX_PATH);
-                if (!target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 1,
-                                                                   target->GetPluginFS()->GetPluginFSName(),
-                                                                   HWindow, NULL, NULL, NULL,
-                                                                   sourceFiles, sourceDirs, path, NULL))
+                SalPathAddBackslash(path, MAX_PATH);
+
+                int format = PackerFormatConfig.PackIsArchive(target->GetZIPArchive());
+                if (format != 0 && PackerFormatConfig.GetUsePacker(format - 1))
                 {
-                    path[0] = 0;
+                    target->UserWorkedOnThisPath = TRUE; // default action = operate with the path in the target panel
                 }
                 else
                 {
-                    // convert the path to external format (before showing it in the dialog)
-                    PluginFSConvertPathToExternal(path);
-                    target->UserWorkedOnThisPath = TRUE; // default action = operate with the path in the target panel
+                    path[0] = 0;
+                }
+            }
+            else
+            {
+                if (target != NULL && target->Is(ptPluginFS) && target->GetPluginFS()->NotEmpty() &&
+                    target->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMDISKTOFS))
+                {
+                    target->GetGeneralPath(path, MAX_PATH);
+                    if (!target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 1,
+                                                                       target->GetPluginFS()->GetPluginFSName(),
+                                                                       HWindow, NULL, NULL, NULL,
+                                                                       sourceFiles, sourceDirs, path, NULL))
+                    {
+                        path[0] = 0;
+                    }
+                    else
+                    {
+                        // convert the path to external format (before showing it in the dialog)
+                        PluginFSConvertPathToExternal(path);
+                        target->UserWorkedOnThisPath = TRUE; // default action = operate with the path in the target panel
+                    }
                 }
             }
         }
@@ -720,9 +740,11 @@ void CFilesWindow::UnpackZIPArchive(CFilesWindow* target, BOOL deleteOp, const c
                 else
                 {
                     BOOL invalidPathOrCancel = FALSE;
-                    if (pathType == PATH_TYPE_FS && target != NULL && target->Is(ptPluginFS) &&
-                        UnpackArchiveToPluginFSViaTemp(this, target, &data, sourceFiles, sourceDirs,
-                                                       path, invalidPathOrCancel))
+                    if ((pathType == PATH_TYPE_FS && target != NULL && target->Is(ptPluginFS) &&
+                         UnpackArchiveToPluginFSViaTemp(this, target, &data, sourceFiles, sourceDirs,
+                                                        path, invalidPathOrCancel)) ||
+                        (pathType == PATH_TYPE_ARCHIVE &&
+                         UnpackArchiveToArchiveViaTemp(this, &data, path, invalidPathOrCancel)))
                     {
                         if (tgtPath == NULL) // if it is not drag&drop (selection is not cleared there)
                         {
@@ -1393,8 +1415,9 @@ static BOOL UnpackArchiveToPluginFSViaTemp(CFilesWindow* source, CFilesWindow* t
         target->GetPluginFS()->GetPluginInterfaceForFS()->ConvertPathToInternal(fsName, fsNameIndex,
                                                                                  internalTargetPath + strlen(fsName) + 1);
 
+        BOOL moveTempToTarget = target->GetPluginFS()->IsServiceSupported(FS_SERVICE_MOVEFROMDISKTOFS);
         BOOL pluginInvalidPathOrCancel = FALSE;
-        if (target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 3, target->GetPluginFS()->GetPluginFSName(),
+        if (target->GetPluginFS()->CopyOrMoveFromDiskToFS(!moveTempToTarget, 3, target->GetPluginFS()->GetPluginFSName(),
                                                           source->HWindow, tempRoot, PanelEnumDiskSelection, data,
                                                           sourceFiles, sourceDirs, internalTargetPath,
                                                           &pluginInvalidPathOrCancel))
@@ -1411,10 +1434,103 @@ static BOOL UnpackArchiveToPluginFSViaTemp(CFilesWindow* source, CFilesWindow* t
     }
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
 
+    if (!done)
+        RemoveTemporaryDir(tempRoot);
+    data->Reset();
+    data->WorkPath[0] = 0;
+
+    return done;
+}
+
+
+static BOOL UnpackArchiveToArchiveViaTemp(CFilesWindow* source, CPanelTmpEnumData* data,
+                                         char* targetPath, BOOL& invalidPathOrCancel)
+{
+    CALL_STACK_MESSAGE2("UnpackArchiveToArchiveViaTemp(, , %s,)", targetPath);
+
+    invalidPathOrCancel = FALSE;
+
+    char archivePath[2 * MAX_PATH];
+    lstrcpyn(archivePath, targetPath, 2 * MAX_PATH);
+
+    int pathType;
+    BOOL pathIsDir;
+    char* secondPart;
+    if (!source->ParsePath(archivePath, pathType, pathIsDir, secondPart, LoadStr(IDS_ERRORCOPY), NULL, NULL, MAX_PATH) ||
+        pathType != PATH_TYPE_ARCHIVE)
+    {
+        return FALSE;
+    }
+
+    if (strlen(secondPart) >= MAX_PATH)
+    {
+        SalMessageBox(source->HWindow, LoadStr(IDS_TOOLONGPATH), LoadStr(IDS_ERRORCOPY), MB_OK | MB_ICONEXCLAMATION);
+        invalidPathOrCancel = TRUE;
+        return FALSE;
+    }
+
+    BOOL hasPath = *secondPart != 0;
+    const char* archiveRoot = hasPath ? secondPart + 1 : "";
+    if (hasPath && (strcmp(archiveRoot, "*.*") == 0 || strcmp(archiveRoot, "*") == 0))
+    {
+        hasPath = FALSE;
+        archiveRoot = "";
+    }
+    else
+    {
+        if (strchr(archiveRoot, '*') != NULL || strchr(archiveRoot, '?') != NULL)
+        {
+            SalMessageBox(source->HWindow, LoadStr(IDS_MOVECOPY_OPMASKSNOTSUP),
+                          LoadStr(IDS_ERRORCOPY), MB_OK | MB_ICONEXCLAMATION);
+            invalidPathOrCancel = TRUE;
+            return FALSE;
+        }
+    }
+    *secondPart = 0;
+
+    int format = PackerFormatConfig.PackIsArchive(archivePath);
+    if (format == 0 || !PackerFormatConfig.GetUsePacker(format - 1))
+        return FALSE;
+
+    char tempRoot[MAX_PATH];
+    if (!SalGetTempFileName(NULL, "ARC", tempRoot, FALSE))
+    {
+        SalMessageBox(source->HWindow, LoadStr(IDS_TMPDIRERROR), LoadStr(IDS_ERRORTITLE), MB_OK | MB_ICONEXCLAMATION);
+        invalidPathOrCancel = TRUE;
+        return FALSE;
+    }
+
+    BOOL done = FALSE;
+    data->Reset();
+    data->WorkPath[0] = 0;
+
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
+    if (PackUncompress(MainWindow->HWindow, source, source->GetZIPArchive(), source->PluginData.GetInterface(),
+                       tempRoot, source->GetZIPPath(), PanelSalEnumSelection, data))
+    {
+        data->Reset();
+        lstrcpyn(data->WorkPath, tempRoot, MAX_PATH);
+
+        SetCurrentDirectory(tempRoot);
+        done = PackCompress(source->HWindow, source, archivePath, archiveRoot,
+                            FALSE, tempRoot, PanelEnumDiskSelection, data);
+        SetCurrentDirectoryToSystem();
+
+        if (done)
+        {
+            char changedPath[MAX_PATH];
+            lstrcpyn(changedPath, archivePath, MAX_PATH);
+            CutDirectory(changedPath);
+            MainWindow->PostChangeOnPathNotification(changedPath, FALSE);
+        }
+    }
+    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
+
     RemoveTemporaryDir(tempRoot);
     data->Reset();
     data->WorkPath[0] = 0;
 
+    invalidPathOrCancel = TRUE;
     return done;
 }
 

--- a/src/fileswn7.cpp
+++ b/src/fileswn7.cpp
@@ -1469,21 +1469,36 @@ static BOOL UnpackArchiveToArchiveViaTemp(CFilesWindow* source, CPanelTmpEnumDat
         return FALSE;
     }
 
-    BOOL hasPath = *secondPart != 0;
-    const char* archiveRoot = hasPath ? secondPart + 1 : "";
-    if (hasPath && (strcmp(archiveRoot, "*.*") == 0 || strcmp(archiveRoot, "*") == 0))
+    char archiveRoot[MAX_PATH];
+    archiveRoot[0] = 0;
+    if (*secondPart != 0)
     {
-        hasPath = FALSE;
-        archiveRoot = "";
-    }
-    else
-    {
-        if (strchr(archiveRoot, '*') != NULL || strchr(archiveRoot, '?') != NULL)
+        lstrcpyn(archiveRoot, secondPart + 1, MAX_PATH);
+        char* opMask = strrchr(archiveRoot, '\\');
+        char* opMask2 = strrchr(archiveRoot, '/');
+        if (opMask == NULL || opMask2 > opMask)
+            opMask = opMask2;
+        if (opMask == NULL)
+            opMask = archiveRoot;
+        else
+            opMask++;
+
+        if (strcmp(opMask, "*.*") == 0 || strcmp(opMask, "*") == 0)
         {
-            SalMessageBox(source->HWindow, LoadStr(IDS_MOVECOPY_OPMASKSNOTSUP),
-                          LoadStr(IDS_ERRORCOPY), MB_OK | MB_ICONEXCLAMATION);
-            invalidPathOrCancel = TRUE;
-            return FALSE;
+            if (opMask == archiveRoot)
+                archiveRoot[0] = 0;
+            else
+                *opMask = 0; // keep the archive subdirectory path including the trailing backslash
+        }
+        else
+        {
+            if (strchr(archiveRoot, '*') != NULL || strchr(archiveRoot, '?') != NULL)
+            {
+                SalMessageBox(source->HWindow, LoadStr(IDS_MOVECOPY_OPMASKSNOTSUP),
+                              LoadStr(IDS_ERRORCOPY), MB_OK | MB_ICONEXCLAMATION);
+                invalidPathOrCancel = TRUE;
+                return FALSE;
+            }
         }
     }
     *secondPart = 0;

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -42,7 +42,7 @@ static BOOL CopyOrMovePluginFSToPluginFSViaTemp(CFilesWindow* source, CFilesWind
     lstrcpyn(targetPath, externalTargetPath, 2 * MAX_PATH);
     char errTitle[200];
     lstrcpyn(errTitle, LoadStr(copy ? IDS_ERRORCOPY : IDS_ERRORMOVE), 200);
-    if (!ParsePath(targetPath, pathType, pathIsDir, secondPart, errTitle, NULL, &error, MAX_PATH) ||
+    if (!source->ParsePath(targetPath, pathType, pathIsDir, secondPart, errTitle, NULL, &error, MAX_PATH) ||
         pathType != PATH_TYPE_FS)
     {
         cancelOrHandlePath = TRUE;

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -117,6 +117,8 @@ static BOOL CopyOrMovePluginFSToPluginFSViaTemp(CFilesWindow* source, CFilesWind
     SalPathAddBackslash(tempTarget, 2 * MAX_PATH);
     char* tempTargetMask = tempTarget + strlen(tempTarget) + 1;
     lstrcpyn(tempTargetMask, "*.*", 2 * MAX_PATH - (int)(tempTargetMask - tempTarget));
+    char* tempTargetWaitMarker = tempTargetMask + strlen(tempTargetMask) + 1;
+    lstrcpyn(tempTargetWaitMarker, "SAL_WAIT_TEMP_BRIDGE", 2 * MAX_PATH - (int)(tempTargetWaitMarker - tempTarget));
 
     BOOL operationMask = FALSE;
     BOOL sourceCancelOrHandlePath = FALSE;
@@ -293,6 +295,8 @@ static BOOL CopyOrMovePluginFSToArchiveViaTemp(CFilesWindow* source, BOOL copy, 
     SalPathAddBackslash(tempTarget, 2 * MAX_PATH);
     char* tempTargetMask = tempTarget + strlen(tempTarget) + 1;
     lstrcpyn(tempTargetMask, "*.*", 2 * MAX_PATH - (int)(tempTargetMask - tempTarget));
+    char* tempTargetWaitMarker = tempTargetMask + strlen(tempTargetMask) + 1;
+    lstrcpyn(tempTargetWaitMarker, "SAL_WAIT_TEMP_BRIDGE", 2 * MAX_PATH - (int)(tempTargetWaitMarker - tempTarget));
 
     BOOL operationMask = FALSE;
     BOOL sourceCancelOrHandlePath = FALSE;

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -322,6 +322,9 @@ static BOOL CopyOrMovePluginFSToArchiveViaTemp(CFilesWindow* source, BOOL copy, 
         SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
         SetCurrentDirectoryToSystem();
 
+        if (!done)
+            cancelOrHandlePath = TRUE; // PackCompress already reported/cancelled; do not show the old unsupported fallback.
+
         if (done)
         {
             char changedPath[MAX_PATH];

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -15,6 +15,169 @@
 #include "shellib.h"
 #include "pack.h"
 
+
+static BOOL CopyOrMovePluginFSToPluginFSViaTemp(CFilesWindow* source, CFilesWindow* target,
+                                                BOOL copy, int panel, int count,
+                                                int selectedFiles, int selectedDirs,
+                                                const char* externalTargetPath,
+                                                BOOL& cancelOrHandlePath)
+{
+    CALL_STACK_MESSAGE3("CopyOrMovePluginFSToPluginFSViaTemp(, , %d, %s)", copy, externalTargetPath);
+
+    cancelOrHandlePath = FALSE;
+
+    if (target == NULL || !target->Is(ptPluginFS) || !target->GetPluginFS()->NotEmpty() ||
+        !target->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMDISKTOFS) ||
+        (!copy && !source->GetPluginFS()->IsServiceSupported(FS_SERVICE_DELETE)))
+    {
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+
+    int pathType;
+    BOOL pathIsDir;
+    char* secondPart;
+    int error;
+    char targetPath[2 * MAX_PATH];
+    lstrcpyn(targetPath, externalTargetPath, 2 * MAX_PATH);
+    char errTitle[200];
+    lstrcpyn(errTitle, LoadStr(copy ? IDS_ERRORCOPY : IDS_ERRORMOVE), 200);
+    if (!ParsePath(targetPath, pathType, pathIsDir, secondPart, errTitle, NULL, &error, MAX_PATH) ||
+        pathType != PATH_TYPE_FS)
+    {
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+
+    char fsName[MAX_PATH];
+    int fsNameLen = (int)((secondPart - targetPath) - 1);
+    if (fsNameLen <= 0 || fsNameLen >= MAX_PATH)
+    {
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+    memcpy(fsName, targetPath, fsNameLen);
+    fsName[fsNameLen] = 0;
+
+    int fsNameIndex;
+    if (!target->GetPluginFS()->IsFSNameFromSamePluginAsThisFS(fsName, fsNameIndex))
+    {
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+
+    char tempRoot[MAX_PATH];
+    if (!SalGetTempFileName(NULL, "FSX", tempRoot, FALSE))
+    {
+        SalMessageBox(source->HWindow, LoadStr(IDS_TMPDIRERROR), LoadStr(IDS_ERRORTITLE), MB_OK | MB_ICONEXCLAMATION);
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+
+    BOOL done = FALSE;
+    BOOL sourceCopied = FALSE;
+    int diskSelectedFiles = selectedFiles;
+    int diskSelectedDirs = selectedDirs;
+    int* indexes = NULL;
+    int oneIndex = -1;
+
+    if (count > 0)
+    {
+        indexes = new int[count];
+        if (indexes == NULL)
+        {
+            TRACE_E(LOW_MEMORY);
+            RemoveTemporaryDir(tempRoot);
+            cancelOrHandlePath = TRUE;
+            return FALSE;
+        }
+        source->GetSelItems(count, indexes);
+    }
+    else
+    {
+        oneIndex = source->GetCaretIndex();
+        count = 1;
+        if (oneIndex >= 0 && oneIndex < source->Dirs->Count + source->Files->Count)
+        {
+            if (oneIndex < source->Dirs->Count)
+            {
+                diskSelectedDirs = 1;
+                diskSelectedFiles = 0;
+            }
+            else
+            {
+                diskSelectedFiles = 1;
+                diskSelectedDirs = 0;
+            }
+        }
+    }
+
+    char tempTarget[2 * MAX_PATH];
+    lstrcpyn(tempTarget, tempRoot, 2 * MAX_PATH);
+    SalPathAddBackslash(tempTarget, 2 * MAX_PATH);
+
+    BOOL operationMask = FALSE;
+    BOOL sourceCancelOrHandlePath = FALSE;
+    if (source->GetPluginFS()->CopyOrMoveFromFS(TRUE, 3, source->GetPluginFS()->GetPluginFSName(),
+                                                source->HWindow, panel, selectedFiles, selectedDirs,
+                                                tempTarget, operationMask, sourceCancelOrHandlePath, NULL) &&
+        !sourceCancelOrHandlePath)
+    {
+        sourceCopied = TRUE;
+
+        CPanelTmpEnumData data;
+        data.IndexesCount = count;
+        data.Indexes = indexes != NULL ? indexes : &oneIndex; // not deallocated by CPanelTmpEnumData
+        data.CurrentIndex = 0;
+        data.ZIPPath = NULL;
+        data.Dirs = source->Dirs;
+        data.Files = source->Files;
+        data.ArchiveDir = NULL;
+        lstrcpyn(data.WorkPath, tempRoot, MAX_PATH);
+        data.EnumLastDir = NULL;
+        data.EnumLastIndex = -1;
+
+        char internalTargetPath[2 * MAX_PATH];
+        lstrcpyn(internalTargetPath, externalTargetPath, 2 * MAX_PATH);
+        target->GetPluginFS()->GetPluginInterfaceForFS()->ConvertPathToInternal(fsName, fsNameIndex,
+                                                                                 internalTargetPath + strlen(fsName) + 1);
+
+        BOOL invalidPathOrCancel = FALSE;
+        if (target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 3, target->GetPluginFS()->GetPluginFSName(),
+                                                          source->HWindow, tempRoot, PanelEnumDiskSelection, &data,
+                                                          diskSelectedFiles, diskSelectedDirs, internalTargetPath,
+                                                          &invalidPathOrCancel))
+        {
+            done = !invalidPathOrCancel;
+        }
+        else if (invalidPathOrCancel)
+        {
+            cancelOrHandlePath = TRUE;
+        }
+    }
+    else
+    {
+        cancelOrHandlePath = sourceCancelOrHandlePath;
+    }
+
+    if (done && !copy)
+    {
+        BOOL cancelOrError = FALSE;
+        done = source->GetPluginFS()->Delete(source->GetPluginFS()->GetPluginFSName(), 2, source->HWindow,
+                                             panel, selectedFiles, selectedDirs, cancelOrError) &&
+               !cancelOrError;
+    }
+
+    if (indexes != NULL)
+        delete[] indexes;
+
+    RemoveTemporaryDir(tempRoot);
+
+    if (!sourceCopied)
+        return FALSE;
+    return done;
+}
+
 void CFilesWindow::PluginFSFilesAction(CPluginFSActionType type)
 {
     CALL_STACK_MESSAGE2("CFilesWindow::PluginFSFilesAction(%d)", type);
@@ -110,11 +273,42 @@ void CFilesWindow::PluginFSFilesAction(CPluginFSActionType type)
             BOOL operationMask = FALSE;
             BOOL cancelOrHandlePath = FALSE;
 
+            int targetSelectedFiles = count - selectedDirs;
+            int targetSelectedDirs = selectedDirs;
+            if (count == 0)
+            {
+                int index = GetCaretIndex();
+                if (index >= Dirs->Count)
+                    targetSelectedFiles = 1;
+                else
+                    targetSelectedDirs = 1;
+            }
+
             char targetPath[2 * MAX_PATH];
             if (target->Is(ptDisk))
                 target->GetGeneralPath(targetPath, 2 * MAX_PATH);
             else
+            {
                 targetPath[0] = 0;
+                if (target->Is(ptPluginFS) && target->GetPluginFS()->NotEmpty() &&
+                    target->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMDISKTOFS))
+                {
+                    target->GetGeneralPath(targetPath, 2 * MAX_PATH);
+                    if (!target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 1,
+                                                                       target->GetPluginFS()->GetPluginFSName(),
+                                                                       HWindow, NULL, NULL, NULL,
+                                                                       targetSelectedFiles, targetSelectedDirs,
+                                                                       targetPath, NULL))
+                    {
+                        targetPath[0] = 0;
+                    }
+                    else
+                    {
+                        // Convert the path to external format before showing it in the dialog.
+                        PluginFSConvertPathToExternal(targetPath);
+                    }
+                }
+            }
 
             BOOL ret = GetPluginFS()->CopyOrMoveFromFS(copy, 1, GetPluginFS()->GetPluginFSName(),
                                                        HWindow, panel, count - selectedDirs,
@@ -206,6 +400,16 @@ void CFilesWindow::PluginFSFilesAction(CPluginFSActionType type)
                         }
                         else
                         {
+                            if (pathType == PATH_TYPE_FS && target->Is(ptPluginFS) &&
+                                CopyOrMovePluginFSToPluginFSViaTemp(this, target, copy, panel, count,
+                                                                    count - selectedDirs, selectedDirs,
+                                                                    targetPath, cancelOrHandlePath))
+                            {
+                                ret = TRUE;
+                                pathError = FALSE;
+                                continue;
+                            }
+
                             SalMessageBox(HWindow,
                                           LoadStr(pathType == PATH_TYPE_ARCHIVE ? IDS_FSCOPYMOVE_ONLYDISK_A : IDS_FSCOPYMOVE_ONLYDISK_FS),
                                           errTitle, MB_OK | MB_ICONEXCLAMATION);

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -115,6 +115,8 @@ static BOOL CopyOrMovePluginFSToPluginFSViaTemp(CFilesWindow* source, CFilesWind
     char tempTarget[2 * MAX_PATH];
     lstrcpyn(tempTarget, tempRoot, 2 * MAX_PATH);
     SalPathAddBackslash(tempTarget, 2 * MAX_PATH);
+    char* tempTargetMask = tempTarget + strlen(tempTarget) + 1;
+    lstrcpyn(tempTargetMask, "*.*", 2 * MAX_PATH - (int)(tempTargetMask - tempTarget));
 
     BOOL operationMask = FALSE;
     BOOL sourceCancelOrHandlePath = FALSE;
@@ -213,21 +215,36 @@ static BOOL CopyOrMovePluginFSToArchiveViaTemp(CFilesWindow* source, BOOL copy, 
         return FALSE;
     }
 
-    BOOL hasPath = *secondPart != 0;
-    const char* archiveRoot = hasPath ? secondPart + 1 : "";
-    if (hasPath && (strcmp(archiveRoot, "*.*") == 0 || strcmp(archiveRoot, "*") == 0))
+    char archiveRoot[MAX_PATH];
+    archiveRoot[0] = 0;
+    if (*secondPart != 0)
     {
-        hasPath = FALSE;
-        archiveRoot = "";
-    }
-    else
-    {
-        if (strchr(archiveRoot, '*') != NULL || strchr(archiveRoot, '?') != NULL)
+        lstrcpyn(archiveRoot, secondPart + 1, MAX_PATH);
+        char* opMask = strrchr(archiveRoot, '\\');
+        char* opMask2 = strrchr(archiveRoot, '/');
+        if (opMask == NULL || opMask2 > opMask)
+            opMask = opMask2;
+        if (opMask == NULL)
+            opMask = archiveRoot;
+        else
+            opMask++;
+
+        if (strcmp(opMask, "*.*") == 0 || strcmp(opMask, "*") == 0)
         {
-            SalMessageBox(source->HWindow, LoadStr(IDS_MOVECOPY_OPMASKSNOTSUP),
-                          errTitle, MB_OK | MB_ICONEXCLAMATION);
-            cancelOrHandlePath = TRUE;
-            return FALSE;
+            if (opMask == archiveRoot)
+                archiveRoot[0] = 0;
+            else
+                *opMask = 0; // keep the archive subdirectory path including the trailing backslash
+        }
+        else
+        {
+            if (strchr(archiveRoot, '*') != NULL || strchr(archiveRoot, '?') != NULL)
+            {
+                SalMessageBox(source->HWindow, LoadStr(IDS_MOVECOPY_OPMASKSNOTSUP),
+                              errTitle, MB_OK | MB_ICONEXCLAMATION);
+                cancelOrHandlePath = TRUE;
+                return FALSE;
+            }
         }
     }
     *secondPart = 0;
@@ -274,6 +291,8 @@ static BOOL CopyOrMovePluginFSToArchiveViaTemp(CFilesWindow* source, BOOL copy, 
     char tempTarget[2 * MAX_PATH];
     lstrcpyn(tempTarget, tempRoot, 2 * MAX_PATH);
     SalPathAddBackslash(tempTarget, 2 * MAX_PATH);
+    char* tempTargetMask = tempTarget + strlen(tempTarget) + 1;
+    lstrcpyn(tempTargetMask, "*.*", 2 * MAX_PATH - (int)(tempTargetMask - tempTarget));
 
     BOOL operationMask = FALSE;
     BOOL sourceCancelOrHandlePath = FALSE;

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -142,8 +142,9 @@ static BOOL CopyOrMovePluginFSToPluginFSViaTemp(CFilesWindow* source, CFilesWind
         target->GetPluginFS()->GetPluginInterfaceForFS()->ConvertPathToInternal(fsName, fsNameIndex,
                                                                                  internalTargetPath + strlen(fsName) + 1);
 
+        BOOL moveTempToTarget = target->GetPluginFS()->IsServiceSupported(FS_SERVICE_MOVEFROMDISKTOFS);
         BOOL invalidPathOrCancel = FALSE;
-        if (target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 3, target->GetPluginFS()->GetPluginFSName(),
+        if (target->GetPluginFS()->CopyOrMoveFromDiskToFS(!moveTempToTarget, 3, target->GetPluginFS()->GetPluginFSName(),
                                                           source->HWindow, tempRoot, PanelEnumDiskSelection, &data,
                                                           diskSelectedFiles, diskSelectedDirs, internalTargetPath,
                                                           &invalidPathOrCancel))
@@ -153,6 +154,161 @@ static BOOL CopyOrMovePluginFSToPluginFSViaTemp(CFilesWindow* source, CFilesWind
         else if (invalidPathOrCancel)
         {
             cancelOrHandlePath = TRUE;
+        }
+    }
+    else
+    {
+        cancelOrHandlePath = sourceCancelOrHandlePath;
+    }
+
+    if (done && !copy)
+    {
+        BOOL cancelOrError = FALSE;
+        done = source->GetPluginFS()->Delete(source->GetPluginFS()->GetPluginFSName(), 2, source->HWindow,
+                                             panel, selectedFiles, selectedDirs, cancelOrError) &&
+               !cancelOrError;
+    }
+
+    if (indexes != NULL)
+        delete[] indexes;
+
+    if (!done)
+        RemoveTemporaryDir(tempRoot);
+
+    if (!sourceCopied)
+        return FALSE;
+    return done;
+}
+
+
+static BOOL CopyOrMovePluginFSToArchiveViaTemp(CFilesWindow* source, BOOL copy, int panel, int count,
+                                               int selectedFiles, int selectedDirs,
+                                               const char* externalTargetPath,
+                                               BOOL& cancelOrHandlePath)
+{
+    CALL_STACK_MESSAGE3("CopyOrMovePluginFSToArchiveViaTemp(, %d, %s,)", copy, externalTargetPath);
+
+    cancelOrHandlePath = FALSE;
+
+    char archivePath[2 * MAX_PATH];
+    lstrcpyn(archivePath, externalTargetPath, 2 * MAX_PATH);
+
+    int pathType;
+    BOOL pathIsDir;
+    char* secondPart;
+    int error;
+    char errTitle[200];
+    lstrcpyn(errTitle, LoadStr(copy ? IDS_ERRORCOPY : IDS_ERRORMOVE), 200);
+    if (!source->ParsePath(archivePath, pathType, pathIsDir, secondPart, errTitle, NULL, &error, MAX_PATH) ||
+        pathType != PATH_TYPE_ARCHIVE)
+    {
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+
+    if (strlen(secondPart) >= MAX_PATH)
+    {
+        SalMessageBox(source->HWindow, LoadStr(IDS_TOOLONGPATH), errTitle, MB_OK | MB_ICONEXCLAMATION);
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+
+    BOOL hasPath = *secondPart != 0;
+    const char* archiveRoot = hasPath ? secondPart + 1 : "";
+    if (hasPath && (strcmp(archiveRoot, "*.*") == 0 || strcmp(archiveRoot, "*") == 0))
+    {
+        hasPath = FALSE;
+        archiveRoot = "";
+    }
+    else
+    {
+        if (strchr(archiveRoot, '*') != NULL || strchr(archiveRoot, '?') != NULL)
+        {
+            SalMessageBox(source->HWindow, LoadStr(IDS_MOVECOPY_OPMASKSNOTSUP),
+                          errTitle, MB_OK | MB_ICONEXCLAMATION);
+            cancelOrHandlePath = TRUE;
+            return FALSE;
+        }
+    }
+    *secondPart = 0;
+
+    int format = PackerFormatConfig.PackIsArchive(archivePath);
+    if (format == 0 || !PackerFormatConfig.GetUsePacker(format - 1) ||
+        (!copy && !source->GetPluginFS()->IsServiceSupported(FS_SERVICE_DELETE)))
+    {
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+
+    char tempRoot[MAX_PATH];
+    if (!SalGetTempFileName(NULL, "FSA", tempRoot, FALSE))
+    {
+        SalMessageBox(source->HWindow, LoadStr(IDS_TMPDIRERROR), LoadStr(IDS_ERRORTITLE), MB_OK | MB_ICONEXCLAMATION);
+        cancelOrHandlePath = TRUE;
+        return FALSE;
+    }
+
+    BOOL done = FALSE;
+    BOOL sourceCopied = FALSE;
+    int* indexes = NULL;
+    int oneIndex = -1;
+
+    if (count > 0)
+    {
+        indexes = new int[count];
+        if (indexes == NULL)
+        {
+            TRACE_E(LOW_MEMORY);
+            RemoveTemporaryDir(tempRoot);
+            cancelOrHandlePath = TRUE;
+            return FALSE;
+        }
+        source->GetSelItems(count, indexes);
+    }
+    else
+    {
+        oneIndex = source->GetCaretIndex();
+        count = 1;
+    }
+
+    char tempTarget[2 * MAX_PATH];
+    lstrcpyn(tempTarget, tempRoot, 2 * MAX_PATH);
+    SalPathAddBackslash(tempTarget, 2 * MAX_PATH);
+
+    BOOL operationMask = FALSE;
+    BOOL sourceCancelOrHandlePath = FALSE;
+    if (source->GetPluginFS()->CopyOrMoveFromFS(TRUE, 3, source->GetPluginFS()->GetPluginFSName(),
+                                                source->HWindow, panel, selectedFiles, selectedDirs,
+                                                tempTarget, operationMask, sourceCancelOrHandlePath, NULL) &&
+        !sourceCancelOrHandlePath)
+    {
+        sourceCopied = TRUE;
+
+        CPanelTmpEnumData data;
+        data.IndexesCount = count;
+        data.Indexes = indexes != NULL ? indexes : &oneIndex; // not deallocated by CPanelTmpEnumData
+        data.CurrentIndex = 0;
+        data.ZIPPath = NULL;
+        data.Dirs = source->Dirs;
+        data.Files = source->Files;
+        data.ArchiveDir = NULL;
+        lstrcpyn(data.WorkPath, tempRoot, MAX_PATH);
+        data.EnumLastDir = NULL;
+        data.EnumLastIndex = -1;
+
+        SetCurrentDirectory(tempRoot);
+        SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
+        done = PackCompress(source->HWindow, source, archivePath, archiveRoot,
+                            FALSE, tempRoot, PanelEnumDiskSelection, &data);
+        SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
+        SetCurrentDirectoryToSystem();
+
+        if (done)
+        {
+            char changedPath[MAX_PATH];
+            lstrcpyn(changedPath, archivePath, MAX_PATH);
+            CutDirectory(changedPath);
+            MainWindow->PostChangeOnPathNotification(changedPath, FALSE);
         }
     }
     else
@@ -290,22 +446,34 @@ void CFilesWindow::PluginFSFilesAction(CPluginFSActionType type)
             else
             {
                 targetPath[0] = 0;
-                if (target->Is(ptPluginFS) && target->GetPluginFS()->NotEmpty() &&
-                    target->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMDISKTOFS))
+                if (target->Is(ptZIPArchive))
                 {
                     target->GetGeneralPath(targetPath, 2 * MAX_PATH);
-                    if (!target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 1,
-                                                                       target->GetPluginFS()->GetPluginFSName(),
-                                                                       HWindow, NULL, NULL, NULL,
-                                                                       targetSelectedFiles, targetSelectedDirs,
-                                                                       targetPath, NULL))
-                    {
+                    SalPathAddBackslash(targetPath, 2 * MAX_PATH);
+
+                    int format = PackerFormatConfig.PackIsArchive(target->GetZIPArchive());
+                    if (format == 0 || !PackerFormatConfig.GetUsePacker(format - 1))
                         targetPath[0] = 0;
-                    }
-                    else
+                }
+                else
+                {
+                    if (target->Is(ptPluginFS) && target->GetPluginFS()->NotEmpty() &&
+                        target->GetPluginFS()->IsServiceSupported(FS_SERVICE_COPYFROMDISKTOFS))
                     {
-                        // Convert the path to external format before showing it in the dialog.
-                        PluginFSConvertPathToExternal(targetPath);
+                        target->GetGeneralPath(targetPath, 2 * MAX_PATH);
+                        if (!target->GetPluginFS()->CopyOrMoveFromDiskToFS(TRUE, 1,
+                                                                           target->GetPluginFS()->GetPluginFSName(),
+                                                                           HWindow, NULL, NULL, NULL,
+                                                                           targetSelectedFiles, targetSelectedDirs,
+                                                                           targetPath, NULL))
+                        {
+                            targetPath[0] = 0;
+                        }
+                        else
+                        {
+                            // Convert the path to external format before showing it in the dialog.
+                            PluginFSConvertPathToExternal(targetPath);
+                        }
                     }
                 }
             }
@@ -400,19 +568,41 @@ void CFilesWindow::PluginFSFilesAction(CPluginFSActionType type)
                         }
                         else
                         {
-                            if (pathType == PATH_TYPE_FS && target->Is(ptPluginFS) &&
-                                CopyOrMovePluginFSToPluginFSViaTemp(this, target, copy, panel, count,
-                                                                    count - selectedDirs, selectedDirs,
-                                                                    targetPath, cancelOrHandlePath))
+                            BOOL handledByTempBridge = FALSE;
+                            BOOL triedTempBridge = FALSE;
+                            if (pathType == PATH_TYPE_FS && target->Is(ptPluginFS))
+                            {
+                                triedTempBridge = TRUE;
+                                handledByTempBridge = CopyOrMovePluginFSToPluginFSViaTemp(this, target, copy, panel, count,
+                                                                                          count - selectedDirs, selectedDirs,
+                                                                                          targetPath, cancelOrHandlePath);
+                            }
+                            else
+                            {
+                                if (pathType == PATH_TYPE_ARCHIVE && target->Is(ptZIPArchive))
+                                {
+                                    triedTempBridge = TRUE;
+                                    handledByTempBridge = CopyOrMovePluginFSToArchiveViaTemp(this, copy, panel, count,
+                                                                                             count - selectedDirs, selectedDirs,
+                                                                                             targetPath, cancelOrHandlePath);
+                                }
+                            }
+                            if (handledByTempBridge)
                             {
                                 ret = TRUE;
                                 pathError = FALSE;
                                 continue;
                             }
-
-                            SalMessageBox(HWindow,
-                                          LoadStr(pathType == PATH_TYPE_ARCHIVE ? IDS_FSCOPYMOVE_ONLYDISK_A : IDS_FSCOPYMOVE_ONLYDISK_FS),
-                                          errTitle, MB_OK | MB_ICONEXCLAMATION);
+                            if (triedTempBridge && cancelOrHandlePath)
+                            {
+                                pathError = TRUE; // the bridge already reported/cancelled the operation; just reopen the dialog
+                            }
+                            else
+                            {
+                                SalMessageBox(HWindow,
+                                              LoadStr(pathType == PATH_TYPE_ARCHIVE ? IDS_FSCOPYMOVE_ONLYDISK_A : IDS_FSCOPYMOVE_ONLYDISK_FS),
+                                              errTitle, MB_OK | MB_ICONEXCLAMATION);
+                            }
                             if (pathType == PATH_TYPE_ARCHIVE && (backslashAtEnd || mustBePath))
                             {
                                 SalPathAddBackslash(targetPath, 2 * MAX_PATH);

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -621,7 +621,9 @@ void CFilesWindow::PluginFSFilesAction(CPluginFSActionType type)
                             }
                             if (triedTempBridge && cancelOrHandlePath)
                             {
-                                pathError = TRUE; // the bridge already reported/cancelled the operation; just reopen the dialog
+                                ret = TRUE; // the bridge already reported/cancelled the operation; do not reopen Copy/Move.
+                                pathError = FALSE;
+                                continue;
                             }
                             else
                             {

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -900,6 +900,19 @@ protected:
 
     int ChngDrvDuplicateItemIndex; // index number of the duplicate item in the Change Drive menu (not used if the menu contains no duplicate item for this FS) (0 = uninitialized value)
 
+    static BOOL IsTempBridgeWaitTarget(int mode, const char* targetPath)
+    {
+        if (mode != 3 || targetPath == NULL)
+            return FALSE;
+
+        // Temporary bridge callers append a second string with the operation mask and
+        // then this marker.  The wrapper must not keep Salamander's plugin lock while
+        // such an asynchronous plugin operation waits for its UI/worker cleanup.
+        const char* opMask = targetPath + strlen(targetPath) + 1;
+        const char* bridgeWaitMarker = opMask + strlen(opMask) + 1;
+        return strcmp(bridgeWaitMarker, "SAL_WAIT_TEMP_BRIDGE") == 0;
+    }
+
 public:
     CPluginFSInterfaceEncapsulation() : IfaceForFS(NULL, 0)
     {
@@ -1322,11 +1335,15 @@ public:
         if (copy && IsServiceSupported(FS_SERVICE_COPYFROMFS) ||
             !copy && IsServiceSupported(FS_SERVICE_MOVEFROMFS))
         {
-            EnterPlugin();
+            BOOL waitForTempBridge = IsTempBridgeWaitTarget(mode, targetPath);
+
+            if (!waitForTempBridge)
+                EnterPlugin();
             BOOL r = Interface->CopyOrMoveFromFS(copy, mode, fsName, parent, panel, selectedFiles,
                                                  selectedDirs, targetPath, operationMask,
                                                  cancelOrHandlePath, dropTarget);
-            LeavePlugin();
+            if (!waitForTempBridge)
+                LeavePlugin();
             return r;
         }
         else

--- a/src/plugins/ftp/dialogs6.cpp
+++ b/src/plugins/ftp/dialogs6.cpp
@@ -1316,7 +1316,7 @@ void COperationDlg::SetupCloseButton(BOOL flashTitle)
         }
         else // the window stays open
         {
-            if (state == opstSuccessfullyFinished && Queue->AllItemsDone()) // everything is "done" -> stop all operation workers; they will no longer be needed
+            if (state == opstSuccessfullyFinished && Queue->AllItemsDone() && !Oper->IsTempBridgeWait()) // everything is "done" -> stop all operation workers; they will no longer be needed
             {
                 int operUID = Oper->GetUID();
                 FTPOperationsList.StopWorkers(HWindow, operUID, -1 /* all workers */);

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -52,6 +52,7 @@ static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* op
             {
                 HANDLE dlgThread = NULL;
                 oper->HideAndCloseOperationDlg(&dlgThread);
+                FTPOperationsList.StopWorkers(SalamanderGeneral->GetMsgBoxParent(), operUID, -1);
                 if (dlgThread == NULL || WaitForAuxThreadExitPumpingMessages(dlgThread))
                     FTPOperationsList.DeleteOperation(operUID, TRUE);
             }

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -9,6 +9,36 @@
 // CPluginFSInterface
 //
 
+// Marker appended after the operation mask by Salamander's temporary bridges.
+// FTP operations are normally modeless, but bridge callers must not continue
+// (for example with Add to archive) until the temporary download is finished.
+static const char* FTP_TEMP_BRIDGE_WAIT_MARKER = "SAL_WAIT_TEMP_BRIDGE";
+
+static COperationState WaitForTempBridgeOperation(CFTPOperation* oper)
+{
+    while (1)
+    {
+        COperationState state = oper->GetOperationState(FALSE);
+        if (state != opstInProgress)
+            return state;
+
+        if (MsgWaitForMultipleObjects(0, NULL, FALSE, 100, QS_ALLINPUT) == WAIT_OBJECT_0)
+        {
+            MSG msg;
+            while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+            {
+                if (msg.message == WM_QUIT)
+                {
+                    PostQuitMessage((int)msg.wParam);
+                    return opstFinishedWithErrors;
+                }
+                TranslateMessage(&msg);
+                DispatchMessage(&msg);
+            }
+        }
+    }
+}
+
 void WINAPI GetTextFromGeneralTextColumn()
 {
     char* s = *(char**)(((char*)((*TransferFileData)->PluginData)) + (*TransferActCustomData));
@@ -1022,6 +1052,12 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                 opMask++;
             opMask++;
         }
+        BOOL waitForTempBridge = FALSE;
+        if (mode == 3)
+        {
+            const char* bridgeWaitMarker = opMask + strlen(opMask) + 1;
+            waitForTempBridge = strcmp(bridgeWaitMarker, FTP_TEMP_BRIDGE_WAIT_MARKER) == 0;
+        }
 
         BOOL success = FALSE; // pre-set the cancel/error state of the operation
         // create the operation object
@@ -1159,13 +1195,21 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                         {
                             oper->SetQueue(queue); // assign the queue of its items to the operation
                             queue = NULL;
-                            if (Config.DownloadAddToQueue)
+                            if (Config.DownloadAddToQueue && !waitForTempBridge)
                                 success = TRUE; // run the operation later -> for now the operation succeeds
                             else                // run the operation within the active "control connection"
                             {
                                 // open the operation progress window and start the operation
                                 if (RunOperation(SalamanderGeneral->GetMsgBoxParent(), operUID, oper, dropTarget))
-                                    success = TRUE; // operation succeeded
+                                {
+                                    if (waitForTempBridge)
+                                    {
+                                        COperationState state = WaitForTempBridgeOperation(oper);
+                                        success = state == opstSuccessfullyFinished;
+                                    }
+                                    else
+                                        success = TRUE; // operation started successfully
+                                }
                                 else
                                     ok = FALSE;
                             }

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -38,6 +38,13 @@ static BOOL PumpMessagesUntilBridgeOperationIsDeleted(int operUID)
 
 static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* oper)
 {
+    // CPluginFSInterfaceEncapsulation holds the global plugin lock while calling
+    // CopyOrMoveFromFS().  FTP workers and dialogs may need to enter the plugin too,
+    // so release the lock while waiting for the asynchronous bridge operation and
+    // reacquire it before returning to the encapsulation wrapper.
+    LeavePlugin();
+
+    COperationState finalState = opstFinishedWithErrors;
     while (1)
     {
         COperationState state = oper->GetOperationState(FALSE);
@@ -57,7 +64,8 @@ static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* op
                     FTPOperationsList.DeleteOperation(operUID, TRUE);
                 }
             }
-            return state;
+            finalState = state;
+            break;
         }
 
         if (MsgWaitForMultipleObjects(0, NULL, FALSE, 100, QS_ALLINPUT) == WAIT_OBJECT_0)
@@ -68,13 +76,18 @@ static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* op
                 if (msg.message == WM_QUIT)
                 {
                     PostQuitMessage((int)msg.wParam);
-                    return opstFinishedWithErrors;
+                    finalState = opstFinishedWithErrors;
+                    EnterPlugin();
+                    return finalState;
                 }
                 TranslateMessage(&msg);
                 DispatchMessage(&msg);
             }
         }
     }
+
+    EnterPlugin();
+    return finalState;
 }
 
 void WINAPI GetTextFromGeneralTextColumn()

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -1239,6 +1239,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                                     // operation object cannot be deleted while this method is still waiting for it.
                                     Config.CloseOperationDlgIfSuccessfullyFinished = FALSE;
                                     Config.CloseOperationDlgWhenOperFinishes = FALSE;
+                                    oper->SetTempBridgeWait(TRUE);
                                 }
                                 if (RunOperation(SalamanderGeneral->GetMsgBoxParent(), operUID, oper, dropTarget))
                                 {

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -52,7 +52,10 @@ static COperationState WaitForTempBridgeOperation(HWND parent, int operUID, CFTP
 
     if (finalState == opstSuccessfullyFinished && FTPOperationsList.IsOperationValid(operUID))
     {
-        FTPOperationsList.StopWorkers(parent, operUID, -1);
+        HWND waitParent = oper->GetOperationDlgHWindow();
+        if (waitParent == NULL || !IsWindow(waitParent))
+            waitParent = parent;
+        FTPOperationsList.StopWorkers(waitParent, operUID, -1);
 
         HANDLE dlgThread = NULL;
         if (FTPOperationsList.CloseOperationDlg(operUID, &dlgThread))

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -14,6 +14,33 @@
 // (for example with Add to archive) until the temporary download is finished.
 static const char* FTP_TEMP_BRIDGE_WAIT_MARKER = "SAL_WAIT_TEMP_BRIDGE";
 
+static BOOL WaitForAuxThreadExitPumpingMessages(HANDLE thread)
+{
+    while (1)
+    {
+        DWORD waitRes = MsgWaitForMultipleObjects(1, &thread, FALSE, 100, QS_ALLINPUT);
+        if (waitRes == WAIT_OBJECT_0)
+        {
+            CALL_STACK_MESSAGE1("AuxThreadQueue.WaitForExit()");
+            return AuxThreadQueue.WaitForExit(thread, 0);
+        }
+        if (waitRes == WAIT_OBJECT_0 + 1)
+        {
+            MSG msg;
+            while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+            {
+                if (msg.message == WM_QUIT)
+                {
+                    PostQuitMessage((int)msg.wParam);
+                    return FALSE;
+                }
+                TranslateMessage(&msg);
+                DispatchMessage(&msg);
+            }
+        }
+    }
+}
+
 static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* oper)
 {
     while (1)
@@ -25,12 +52,8 @@ static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* op
             {
                 HANDLE dlgThread = NULL;
                 oper->HideAndCloseOperationDlg(&dlgThread);
-                if (dlgThread != NULL)
-                {
-                    CALL_STACK_MESSAGE1("AuxThreadQueue.WaitForExit()");
-                    AuxThreadQueue.WaitForExit(dlgThread, INFINITE);
-                }
-                FTPOperationsList.DeleteOperation(operUID, TRUE);
+                if (dlgThread == NULL || WaitForAuxThreadExitPumpingMessages(dlgThread))
+                    FTPOperationsList.DeleteOperation(operUID, TRUE);
             }
             return state;
         }

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -14,17 +14,11 @@
 // (for example with Add to archive) until the temporary download is finished.
 static const char* FTP_TEMP_BRIDGE_WAIT_MARKER = "SAL_WAIT_TEMP_BRIDGE";
 
-static BOOL WaitForAuxThreadExitPumpingMessages(HANDLE thread)
+static BOOL PumpMessagesUntilBridgeOperationIsDeleted(int operUID)
 {
-    while (1)
+    while (FTPOperationsList.IsOperationValid(operUID))
     {
-        DWORD waitRes = MsgWaitForMultipleObjects(1, &thread, FALSE, 100, QS_ALLINPUT);
-        if (waitRes == WAIT_OBJECT_0)
-        {
-            CALL_STACK_MESSAGE1("AuxThreadQueue.WaitForExit()");
-            return AuxThreadQueue.WaitForExit(thread, 0);
-        }
-        if (waitRes == WAIT_OBJECT_0 + 1)
+        if (MsgWaitForMultipleObjects(0, NULL, FALSE, 100, QS_ALLINPUT) == WAIT_OBJECT_0)
         {
             MSG msg;
             while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
@@ -39,6 +33,7 @@ static BOOL WaitForAuxThreadExitPumpingMessages(HANDLE thread)
             }
         }
     }
+    return TRUE;
 }
 
 static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* oper)
@@ -52,9 +47,15 @@ static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* op
             {
                 HANDLE dlgThread = NULL;
                 oper->HideAndCloseOperationDlg(&dlgThread);
-                FTPOperationsList.StopWorkers(SalamanderGeneral->GetMsgBoxParent(), operUID, -1);
-                if (dlgThread == NULL || WaitForAuxThreadExitPumpingMessages(dlgThread))
+                if (dlgThread != NULL)
+                {
+                    PumpMessagesUntilBridgeOperationIsDeleted(operUID);
+                }
+                else
+                {
+                    FTPOperationsList.StopWorkers(SalamanderGeneral->GetMsgBoxParent(), operUID, -1);
                     FTPOperationsList.DeleteOperation(operUID, TRUE);
+                }
             }
             return state;
         }

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -24,7 +24,7 @@ static COperationState WaitForTempBridgeOperation(CFTPOperation* oper)
             if (state == opstSuccessfullyFinished)
             {
                 HANDLE dlgThread = NULL;
-                oper->CloseOperationDlg(&dlgThread);
+                oper->HideAndCloseOperationDlg(&dlgThread);
                 if (dlgThread != NULL)
                 {
                     CALL_STACK_MESSAGE1("AuxThreadQueue.WaitForExit()");

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -14,7 +14,7 @@
 // (for example with Add to archive) until the temporary download is finished.
 static const char* FTP_TEMP_BRIDGE_WAIT_MARKER = "SAL_WAIT_TEMP_BRIDGE";
 
-static COperationState WaitForTempBridgeOperation(CFTPOperation* oper)
+static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* oper)
 {
     while (1)
     {
@@ -30,6 +30,7 @@ static COperationState WaitForTempBridgeOperation(CFTPOperation* oper)
                     CALL_STACK_MESSAGE1("AuxThreadQueue.WaitForExit()");
                     AuxThreadQueue.WaitForExit(dlgThread, INFINITE);
                 }
+                FTPOperationsList.DeleteOperation(operUID, TRUE);
             }
             return state;
         }
@@ -1216,7 +1217,7 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                                 {
                                     if (waitForTempBridge)
                                     {
-                                        COperationState state = WaitForTempBridgeOperation(oper);
+                                        COperationState state = WaitForTempBridgeOperation(operUID, oper);
                                         success = state == opstSuccessfullyFinished;
                                     }
                                     else

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -14,53 +14,22 @@
 // (for example with Add to archive) until the temporary download is finished.
 static const char* FTP_TEMP_BRIDGE_WAIT_MARKER = "SAL_WAIT_TEMP_BRIDGE";
 
-static BOOL PumpMessagesUntilBridgeOperationIsDeleted(int operUID)
-{
-    while (FTPOperationsList.IsOperationValid(operUID))
-    {
-        if (MsgWaitForMultipleObjects(0, NULL, FALSE, 100, QS_ALLINPUT) == WAIT_OBJECT_0)
-        {
-            MSG msg;
-            while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-            {
-                if (msg.message == WM_QUIT)
-                {
-                    PostQuitMessage((int)msg.wParam);
-                    return FALSE;
-                }
-                TranslateMessage(&msg);
-                DispatchMessage(&msg);
-            }
-        }
-    }
-    return TRUE;
-}
-
-static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* oper)
+static COperationState WaitForTempBridgeOperation(HWND parent, int operUID, CFTPOperation* oper)
 {
     // The Salamander wrapper has already avoided holding the plugin lock for
     // SAL_WAIT_TEMP_BRIDGE calls, so this plugin-side wait must not call
-    // EnterPlugin()/LeavePlugin() directly.
+    // EnterPlugin()/LeavePlugin() directly.  Keep the FTP progress dialog alive
+    // while the transfer finishes and close it through the same operation-list
+    // path that is used when the user closes a completed copy-to-disk operation.
     COperationState finalState = opstFinishedWithErrors;
     while (1)
     {
+        if (!FTPOperationsList.IsOperationValid(operUID))
+            return opstFinishedWithErrors;
+
         COperationState state = oper->GetOperationState(FALSE);
         if (state != opstInProgress)
         {
-            if (state == opstSuccessfullyFinished)
-            {
-                HANDLE dlgThread = NULL;
-                oper->HideAndCloseOperationDlg(&dlgThread);
-                if (dlgThread != NULL)
-                {
-                    PumpMessagesUntilBridgeOperationIsDeleted(operUID);
-                }
-                else
-                {
-                    FTPOperationsList.StopWorkers(SalamanderGeneral->GetMsgBoxParent(), operUID, -1);
-                    FTPOperationsList.DeleteOperation(operUID, TRUE);
-                }
-            }
             finalState = state;
             break;
         }
@@ -73,12 +42,27 @@ static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* op
                 if (msg.message == WM_QUIT)
                 {
                     PostQuitMessage((int)msg.wParam);
-                    finalState = opstFinishedWithErrors;
-                    return finalState;
+                    return opstFinishedWithErrors;
                 }
                 TranslateMessage(&msg);
                 DispatchMessage(&msg);
             }
+        }
+    }
+
+    if (finalState == opstSuccessfullyFinished && FTPOperationsList.IsOperationValid(operUID))
+    {
+        FTPOperationsList.StopWorkers(parent, operUID, -1);
+
+        HANDLE dlgThread = NULL;
+        if (FTPOperationsList.CloseOperationDlg(operUID, &dlgThread))
+        {
+            if (dlgThread != NULL)
+            {
+                CALL_STACK_MESSAGE1("AuxThreadQueue.WaitForExit()");
+                AuxThreadQueue.WaitForExit(dlgThread, INFINITE);
+            }
+            FTPOperationsList.DeleteOperation(operUID, TRUE);
         }
     }
 
@@ -1246,11 +1230,21 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                             else                // run the operation within the active "control connection"
                             {
                                 // open the operation progress window and start the operation
+                                int closeOperationDlgIfSuccessfullyFinished = Config.CloseOperationDlgIfSuccessfullyFinished;
+                                int closeOperationDlgWhenOperFinishes = Config.CloseOperationDlgWhenOperFinishes;
+                                if (waitForTempBridge)
+                                {
+                                    // Bridge callers must continue only after the FTP progress dialog is really
+                                    // closed.  Disable the dialog's automatic close path temporarily so the
+                                    // operation object cannot be deleted while this method is still waiting for it.
+                                    Config.CloseOperationDlgIfSuccessfullyFinished = FALSE;
+                                    Config.CloseOperationDlgWhenOperFinishes = FALSE;
+                                }
                                 if (RunOperation(SalamanderGeneral->GetMsgBoxParent(), operUID, oper, dropTarget))
                                 {
                                     if (waitForTempBridge)
                                     {
-                                        COperationState state = WaitForTempBridgeOperation(operUID, oper);
+                                        COperationState state = WaitForTempBridgeOperation(SalamanderGeneral->GetMsgBoxParent(), operUID, oper);
                                         success = state == opstSuccessfullyFinished;
                                     }
                                     else
@@ -1258,6 +1252,11 @@ BOOL CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsNam
                                 }
                                 else
                                     ok = FALSE;
+                                if (waitForTempBridge)
+                                {
+                                    Config.CloseOperationDlgIfSuccessfullyFinished = closeOperationDlgIfSuccessfullyFinished;
+                                    Config.CloseOperationDlgWhenOperFinishes = closeOperationDlgWhenOperFinishes;
+                                }
                             }
                         }
                         if (!ok)

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -20,7 +20,19 @@ static COperationState WaitForTempBridgeOperation(CFTPOperation* oper)
     {
         COperationState state = oper->GetOperationState(FALSE);
         if (state != opstInProgress)
+        {
+            if (state == opstSuccessfullyFinished)
+            {
+                HANDLE dlgThread = NULL;
+                oper->CloseOperationDlg(&dlgThread);
+                if (dlgThread != NULL)
+                {
+                    CALL_STACK_MESSAGE1("AuxThreadQueue.WaitForExit()");
+                    AuxThreadQueue.WaitForExit(dlgThread, INFINITE);
+                }
+            }
             return state;
+        }
 
         if (MsgWaitForMultipleObjects(0, NULL, FALSE, 100, QS_ALLINPUT) == WAIT_OBJECT_0)
         {

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -38,12 +38,9 @@ static BOOL PumpMessagesUntilBridgeOperationIsDeleted(int operUID)
 
 static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* oper)
 {
-    // CPluginFSInterfaceEncapsulation holds the global plugin lock while calling
-    // CopyOrMoveFromFS().  FTP workers and dialogs may need to enter the plugin too,
-    // so release the lock while waiting for the asynchronous bridge operation and
-    // reacquire it before returning to the encapsulation wrapper.
-    LeavePlugin();
-
+    // The Salamander wrapper has already avoided holding the plugin lock for
+    // SAL_WAIT_TEMP_BRIDGE calls, so this plugin-side wait must not call
+    // EnterPlugin()/LeavePlugin() directly.
     COperationState finalState = opstFinishedWithErrors;
     while (1)
     {
@@ -77,7 +74,6 @@ static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* op
                 {
                     PostQuitMessage((int)msg.wParam);
                     finalState = opstFinishedWithErrors;
-                    EnterPlugin();
                     return finalState;
                 }
                 TranslateMessage(&msg);
@@ -86,7 +82,6 @@ static COperationState WaitForTempBridgeOperation(int operUID, CFTPOperation* op
         }
     }
 
-    EnterPlugin();
     return finalState;
 }
 

--- a/src/plugins/ftp/operats.h
+++ b/src/plugins/ftp/operats.h
@@ -2087,6 +2087,7 @@ protected:
 
     COperationDlg* OperationDlg; // operation dialog object (runs in its own thread)
     HANDLE OperationDlgThread;   // handle of the thread in which the last opened operation dialog ran/is running
+    BOOL TempBridgeWait;         // TRUE = caller waits for worker cleanup; operation dialog must not close workers itself
 
     CFTPProxyServer* ProxyServer;          // NULL = "not used (direct connection)"
     const char* ProxyScriptText;           // proxy script text (exists even when the proxy server is not used); WARNING: may point to ProxyServer->ProxyScript (i.e. the text is valid only until ProxyServer is deallocated)
@@ -2347,6 +2348,11 @@ public:
     // closes the operation dialog (if open) and returns the handle of the thread in which the
     // last dialog was open (NULL if the dialog was never open)
     void CloseOperationDlg(HANDLE* dlgThread);
+
+    // marks operation cleanup as owned by a temporary bridge caller; when TRUE,
+    // the operation dialog must not call StopWorkers() on successful completion
+    void SetTempBridgeWait(BOOL tempBridgeWait);
+    BOOL IsTempBridgeWait();
 
     // called by the operation dialog from WM_INITDIALOG; 'dlg' is the dialog (the value in OperationDlg may not
     // be valid if CloseOperationDlg() has already been called); returns success (FALSE =

--- a/src/plugins/ftp/operats.h
+++ b/src/plugins/ftp/operats.h
@@ -2353,6 +2353,7 @@ public:
     // the operation dialog must not call StopWorkers() on successful completion
     void SetTempBridgeWait(BOOL tempBridgeWait);
     BOOL IsTempBridgeWait();
+    HWND GetOperationDlgHWindow();
 
     // called by the operation dialog from WM_INITDIALOG; 'dlg' is the dialog (the value in OperationDlg may not
     // be valid if CloseOperationDlg() has already been called); returns success (FALSE =

--- a/src/plugins/ftp/operats.h
+++ b/src/plugins/ftp/operats.h
@@ -2348,6 +2348,11 @@ public:
     // last dialog was open (NULL if the dialog was never open)
     void CloseOperationDlg(HANDLE* dlgThread);
 
+    // hides and closes the operation dialog (if open) and returns the handle of the thread in which the
+    // last dialog was open (NULL if the dialog was never open); used when a caller must wait for
+    // operation cleanup but should not keep the completed progress window visible
+    void HideAndCloseOperationDlg(HANDLE* dlgThread);
+
     // called by the operation dialog from WM_INITDIALOG; 'dlg' is the dialog (the value in OperationDlg may not
     // be valid if CloseOperationDlg() has already been called); returns success (FALSE =
     // fatal error -> close the dialog)

--- a/src/plugins/ftp/operats.h
+++ b/src/plugins/ftp/operats.h
@@ -2348,11 +2348,6 @@ public:
     // last dialog was open (NULL if the dialog was never open)
     void CloseOperationDlg(HANDLE* dlgThread);
 
-    // hides and closes the operation dialog (if open) and returns the handle of the thread in which the
-    // last dialog was open (NULL if the dialog was never open); used when a caller must wait for
-    // operation cleanup but should not keep the completed progress window visible
-    void HideAndCloseOperationDlg(HANDLE* dlgThread);
-
     // called by the operation dialog from WM_INITDIALOG; 'dlg' is the dialog (the value in OperationDlg may not
     // be valid if CloseOperationDlg() has already been called); returns success (FALSE =
     // fatal error -> close the dialog)

--- a/src/plugins/ftp/operats.h
+++ b/src/plugins/ftp/operats.h
@@ -2805,6 +2805,9 @@ public:
     // returns TRUE if there is no operation in the list
     BOOL IsEmpty();
 
+    // returns TRUE if an operation with this UID still exists in the list
+    BOOL IsOperationValid(int uid);
+
     // adds a new operation to the array (works with FirstFreeIndexInOperations); in 'newuid' (if not NULL)
     // returns the UID of the added operation; returns TRUE on success
     BOOL AddOperation(CFTPOperation* newOper, int* newuid);

--- a/src/plugins/ftp/operats1.cpp
+++ b/src/plugins/ftp/operats1.cpp
@@ -3561,6 +3561,7 @@ CFTPOperation::CFTPOperation()
     Queue = NULL;
     OperationDlg = NULL;
     OperationDlgThread = NULL;
+    TempBridgeWait = FALSE;
 
     ProxyServer = NULL;
     ProxyScriptText = NULL;

--- a/src/plugins/ftp/operats1.cpp
+++ b/src/plugins/ftp/operats1.cpp
@@ -53,6 +53,16 @@ BOOL CFTPOperationsList::IsEmpty()
     return ret;
 }
 
+BOOL CFTPOperationsList::IsOperationValid(int uid)
+{
+    CALL_STACK_MESSAGE2("CFTPOperationsList::IsOperationValid(%d)", uid);
+
+    HANDLES(EnterCriticalSection(&OpListCritSect));
+    BOOL ret = uid >= 0 && uid < Operations.Count && Operations[uid] != NULL;
+    HANDLES(LeaveCriticalSection(&OpListCritSect));
+    return ret;
+}
+
 BOOL CFTPOperationsList::AddOperation(CFTPOperation* newOper, int* newuid)
 {
     CALL_STACK_MESSAGE1("CFTPOperationsList::AddOperation(,)");

--- a/src/plugins/ftp/operats2.cpp
+++ b/src/plugins/ftp/operats2.cpp
@@ -554,6 +554,25 @@ void CFTPOperation::CloseOperationDlg(HANDLE* dlgThread)
     HANDLES(LeaveCriticalSection(&OperCritSect));
 }
 
+void CFTPOperation::SetTempBridgeWait(BOOL tempBridgeWait)
+{
+    CALL_STACK_MESSAGE2("CFTPOperation::SetTempBridgeWait(%d)", tempBridgeWait);
+
+    HANDLES(EnterCriticalSection(&OperCritSect));
+    TempBridgeWait = tempBridgeWait;
+    HANDLES(LeaveCriticalSection(&OperCritSect));
+}
+
+BOOL CFTPOperation::IsTempBridgeWait()
+{
+    CALL_STACK_MESSAGE1("CFTPOperation::IsTempBridgeWait()");
+
+    HANDLES(EnterCriticalSection(&OperCritSect));
+    BOOL ret = TempBridgeWait;
+    HANDLES(LeaveCriticalSection(&OperCritSect));
+    return ret;
+}
+
 BOOL CFTPOperation::AddWorker(CFTPWorker* newWorker)
 {
     CALL_STACK_MESSAGE1("CFTPOperation::AddWorker()");

--- a/src/plugins/ftp/operats2.cpp
+++ b/src/plugins/ftp/operats2.cpp
@@ -561,16 +561,11 @@ void CFTPOperation::HideAndCloseOperationDlg(HANDLE* dlgThread)
     HANDLES(EnterCriticalSection(&OperCritSect));
     if (OperationDlg != NULL)
     {
-        OperationDlg->CloseDlg = TRUE; // there is no synchronized access to CloseDlg, hopefully unnecessarily
         if (OperationDlg->HWindow != NULL)
         {
             ShowWindow(OperationDlg->HWindow, SW_HIDE);
-            PostMessage(OperationDlg->HWindow, WM_CLOSE, 0, 0);
+            PostMessage(OperationDlg->HWindow, WM_APP_CLOSEDLG, 0, 0);
         }
-        OperationDlg = NULL;          // the dialog thread takes care of deallocation
-        ReportChangeInWorkerID = -2;  // dialog changed, reset reporting of changes
-        ReportProgressChange = FALSE; // dialog changed, reset reporting of changes
-        ReportChangeInItemUID = -3;   // dialog changed, reset reporting of changes
     }
     if (dlgThread != NULL)
         *dlgThread = OperationDlgThread;

--- a/src/plugins/ftp/operats2.cpp
+++ b/src/plugins/ftp/operats2.cpp
@@ -554,6 +554,29 @@ void CFTPOperation::CloseOperationDlg(HANDLE* dlgThread)
     HANDLES(LeaveCriticalSection(&OperCritSect));
 }
 
+void CFTPOperation::HideAndCloseOperationDlg(HANDLE* dlgThread)
+{
+    CALL_STACK_MESSAGE1("CFTPOperation::HideAndCloseOperationDlg()");
+
+    HANDLES(EnterCriticalSection(&OperCritSect));
+    if (OperationDlg != NULL)
+    {
+        OperationDlg->CloseDlg = TRUE; // there is no synchronized access to CloseDlg, hopefully unnecessarily
+        if (OperationDlg->HWindow != NULL)
+        {
+            ShowWindow(OperationDlg->HWindow, SW_HIDE);
+            PostMessage(OperationDlg->HWindow, WM_CLOSE, 0, 0);
+        }
+        OperationDlg = NULL;          // the dialog thread takes care of deallocation
+        ReportChangeInWorkerID = -2;  // dialog changed, reset reporting of changes
+        ReportProgressChange = FALSE; // dialog changed, reset reporting of changes
+        ReportChangeInItemUID = -3;   // dialog changed, reset reporting of changes
+    }
+    if (dlgThread != NULL)
+        *dlgThread = OperationDlgThread;
+    HANDLES(LeaveCriticalSection(&OperCritSect));
+}
+
 BOOL CFTPOperation::AddWorker(CFTPWorker* newWorker)
 {
     CALL_STACK_MESSAGE1("CFTPOperation::AddWorker()");

--- a/src/plugins/ftp/operats2.cpp
+++ b/src/plugins/ftp/operats2.cpp
@@ -573,6 +573,16 @@ BOOL CFTPOperation::IsTempBridgeWait()
     return ret;
 }
 
+HWND CFTPOperation::GetOperationDlgHWindow()
+{
+    CALL_STACK_MESSAGE1("CFTPOperation::GetOperationDlgHWindow()");
+
+    HANDLES(EnterCriticalSection(&OperCritSect));
+    HWND ret = OperationDlg != NULL ? OperationDlg->HWindow : NULL;
+    HANDLES(LeaveCriticalSection(&OperCritSect));
+    return ret;
+}
+
 BOOL CFTPOperation::AddWorker(CFTPWorker* newWorker)
 {
     CALL_STACK_MESSAGE1("CFTPOperation::AddWorker()");

--- a/src/plugins/ftp/operats2.cpp
+++ b/src/plugins/ftp/operats2.cpp
@@ -554,24 +554,6 @@ void CFTPOperation::CloseOperationDlg(HANDLE* dlgThread)
     HANDLES(LeaveCriticalSection(&OperCritSect));
 }
 
-void CFTPOperation::HideAndCloseOperationDlg(HANDLE* dlgThread)
-{
-    CALL_STACK_MESSAGE1("CFTPOperation::HideAndCloseOperationDlg()");
-
-    HANDLES(EnterCriticalSection(&OperCritSect));
-    if (OperationDlg != NULL)
-    {
-        if (OperationDlg->HWindow != NULL)
-        {
-            ShowWindow(OperationDlg->HWindow, SW_HIDE);
-            PostMessage(OperationDlg->HWindow, WM_APP_CLOSEDLG, 0, 0);
-        }
-    }
-    if (dlgThread != NULL)
-        *dlgThread = OperationDlgThread;
-    HANDLES(LeaveCriticalSection(&OperCritSect));
-}
-
 BOOL CFTPOperation::AddWorker(CFTPWorker* newWorker)
 {
     CALL_STACK_MESSAGE1("CFTPOperation::AddWorker()");


### PR DESCRIPTION
### Motivation
- Users could not perform `Copy`/`Move`/`Extract` directly between plugin-backed panels (plugin-FS → plugin-FS), so transfers must be bridged via temporary storage. 
- The change enables cross-plugin transfers by reusing existing disk-based import/export plugin services and a temporary directory as the intermediary.

### Description
- Added `CopyOrMovePluginFSToPluginFSViaTemp()` in `src/fileswna.cpp` that creates a temporary directory, asks the source plugin FS to copy selected items into it, and then calls the target plugin FS `CopyOrMoveFromDiskToFS()` to import from that temp location. 
- The helper converts the external FS path to the plugin-internal representation with `ConvertPathToInternal()`, populates a `CPanelTmpEnumData` enumerator for the temp files, and removes the temp directory after the operation. 
- Move semantics are preserved by deleting the original selection from the source plugin FS only after a successful upload/import to the target FS. 
- `CFilesWindow::PluginFSFilesAction()` was updated to seed the Copy/Move dialog with a plugin-target path when the opposite panel is a plugin FS that supports disk-to-FS import, and to route `PATH_TYPE_FS` targets to the new temp-bridge helper instead of rejecting them.

### Testing
- `git diff --check` was run and found no whitespace/merge errors (success). 
- Attempted to run the Windows build command `msbuild src/vcxproj/salamand.sln /t:build /p:Configuration=Debug /p:Platform=x64`, but `msbuild` is not available in this Linux environment so a full build could not be performed (environment limitation). 
- Verified source edits and that the new function integrates with existing `CopyOrMoveFromFS` / `CopyOrMoveFromDiskToFS` call sites by static code inspection (no compile performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221a8ea2548329bebc0cdb5417d5f3)