### PR TITLE
Add Unicode BOM detection and decoded-text support (UTF-8/UTF-16) to viewer

### DIFF
--- a/src/common/unicode/ViewerBomText.cpp
+++ b/src/common/unicode/ViewerBomText.cpp
@@ -1,0 +1,430 @@
+// SPDX-FileCopyrightText: 2026 Sally Authors
+// SPDX-FileCopyrightText: 2026 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "ViewerBomText.h"
+
+#include <algorithm>
+#include <cwctype>
+#include <limits>
+
+namespace Sally::Unicode
+{
+namespace
+{
+
+constexpr std::uint32_t Replacement = 0xFFFD;
+
+bool IsHighSurrogate(std::uint16_t value)
+{
+    return value >= 0xD800 && value <= 0xDBFF;
+}
+
+bool IsLowSurrogate(std::uint16_t value)
+{
+    return value >= 0xDC00 && value <= 0xDFFF;
+}
+
+std::uint32_t DecodeSurrogatePair(std::uint16_t high, std::uint16_t low)
+{
+    return 0x10000 + (((std::uint32_t)high - 0xD800) << 10) + ((std::uint32_t)low - 0xDC00);
+}
+
+std::uint16_t ReadUtf16(const std::uint8_t* data, BomEncoding encoding)
+{
+    if (encoding == BomEncoding::Utf16Le)
+        return (std::uint16_t)data[0] | ((std::uint16_t)data[1] << 8);
+    return ((std::uint16_t)data[0] << 8) | (std::uint16_t)data[1];
+}
+
+bool IsContinuation(std::uint8_t value)
+{
+    return (value & 0xC0) == 0x80;
+}
+
+std::uint32_t FoldScalar(std::uint32_t scalar, bool caseSensitive)
+{
+    if (caseSensitive)
+        return scalar;
+    if (scalar <= std::numeric_limits<wchar_t>::max())
+        return (std::uint32_t)towlower((wchar_t)scalar);
+    return scalar;
+}
+
+bool IsWordScalar(std::uint32_t scalar)
+{
+    if (scalar == L'_')
+        return true;
+    if (scalar <= std::numeric_limits<wchar_t>::max())
+        return iswalnum((wchar_t)scalar) != 0;
+    return true;
+}
+
+std::vector<std::uint32_t> PatternScalars(const std::wstring& pattern)
+{
+    std::vector<std::uint32_t> scalars;
+    for (std::size_t i = 0; i < pattern.size();)
+    {
+        std::uint32_t scalar = (std::uint32_t)pattern[i++];
+        if (sizeof(wchar_t) == 2 && IsHighSurrogate((std::uint16_t)scalar) && i < pattern.size())
+        {
+            std::uint16_t low = (std::uint16_t)pattern[i];
+            if (IsLowSurrogate(low))
+            {
+                scalar = DecodeSurrogatePair((std::uint16_t)scalar, low);
+                i++;
+            }
+        }
+        scalars.push_back(scalar);
+    }
+    return scalars;
+}
+
+bool MatchAt(const DecodedRun& run, const std::vector<std::uint32_t>& pattern, bool caseSensitive,
+             bool wholeWords, std::size_t cell)
+{
+    if (cell + pattern.size() > run.CellCount())
+        return false;
+    for (std::size_t i = 0; i < pattern.size(); ++i)
+    {
+        if (FoldScalar(run.Scalars[cell + i], caseSensitive) != FoldScalar(pattern[i], caseSensitive))
+            return false;
+    }
+    if (wholeWords)
+    {
+        if (cell > 0 && IsWordScalar(run.Scalars[cell - 1]))
+            return false;
+        if (cell + pattern.size() < run.CellCount() && IsWordScalar(run.Scalars[cell + pattern.size()]))
+            return false;
+    }
+    return true;
+}
+
+} // namespace
+
+void DecodedRun::Clear()
+{
+    Text.clear();
+    CellTextIndex.clear();
+    RawStart.clear();
+    RawEnd.clear();
+    Scalars.clear();
+    RawBytesConsumed = 0;
+}
+
+std::size_t DecodedRun::TextIndexForCellEnd(std::size_t cell) const
+{
+    if (cell >= CellTextIndex.size())
+        return Text.size();
+    return CellTextIndex[cell];
+}
+
+void DecodedRun::AppendCell(std::uint32_t scalar, std::int64_t rawStart, std::int64_t rawEnd)
+{
+    CellTextIndex.push_back(Text.size());
+    RawStart.push_back(rawStart);
+    RawEnd.push_back(rawEnd);
+    Scalars.push_back(scalar);
+
+    if (scalar > 0x10FFFF)
+        scalar = Replacement;
+
+    if (sizeof(wchar_t) == 2 && scalar > 0xFFFF)
+    {
+        scalar -= 0x10000;
+        Text.push_back((wchar_t)(0xD800 + (scalar >> 10)));
+        Text.push_back((wchar_t)(0xDC00 + (scalar & 0x3FF)));
+    }
+    else
+    {
+        Text.push_back((wchar_t)scalar);
+    }
+}
+
+void DecodedRun::AppendRun(const DecodedRun& other)
+{
+    for (std::size_t i = 0; i < other.CellCount(); ++i)
+        AppendCell(other.Scalars[i], other.RawStart[i], other.RawEnd[i]);
+    RawBytesConsumed += other.RawBytesConsumed;
+}
+
+BomInfo DetectBom(const std::uint8_t* data, std::size_t size)
+{
+    if (data == nullptr)
+        return {};
+    if (size >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF)
+        return {BomEncoding::Utf8, 3};
+    if (size >= 2 && data[0] == 0xFF && data[1] == 0xFE)
+        return {BomEncoding::Utf16Le, 2};
+    if (size >= 2 && data[0] == 0xFE && data[1] == 0xFF)
+        return {BomEncoding::Utf16Be, 2};
+    return {};
+}
+
+bool IsLikelyUtf8NoBom(const std::uint8_t* data, std::size_t size)
+{
+    if (data == nullptr || size == 0)
+        return false;
+
+    bool sawMultibyte = false;
+    for (std::size_t i = 0; i < size;)
+    {
+        std::uint8_t lead = data[i];
+        if (lead == 0)
+            return false;
+        if (lead < 0x80)
+        {
+            i++;
+            continue;
+        }
+
+        std::size_t need = 0;
+        std::uint32_t scalar = 0;
+        std::uint32_t minScalar = 0;
+        if (lead >= 0xC2 && lead <= 0xDF)
+        {
+            need = 2;
+            scalar = lead & 0x1F;
+            minScalar = 0x80;
+        }
+        else if (lead >= 0xE0 && lead <= 0xEF)
+        {
+            need = 3;
+            scalar = lead & 0x0F;
+            minScalar = 0x800;
+        }
+        else if (lead >= 0xF0 && lead <= 0xF4)
+        {
+            need = 4;
+            scalar = lead & 0x07;
+            minScalar = 0x10000;
+        }
+        else
+            return false;
+
+        if (i + need > size)
+            break;
+        for (std::size_t j = 1; j < need; ++j)
+        {
+            if (!IsContinuation(data[i + j]))
+                return false;
+            scalar = (scalar << 6) | (data[i + j] & 0x3F);
+        }
+        if (scalar < minScalar || scalar > 0x10FFFF || (scalar >= 0xD800 && scalar <= 0xDFFF))
+            return false;
+        sawMultibyte = true;
+        i += need;
+    }
+    return sawMultibyte;
+}
+
+BomInfo DetectTextEncoding(const std::uint8_t* data, std::size_t size)
+{
+    BomInfo bom = DetectBom(data, size);
+    if (bom.Encoding != BomEncoding::LegacyBytes)
+        return bom;
+    if (IsLikelyUtf8NoBom(data, size))
+        return {BomEncoding::Utf8, 0};
+    return bom;
+}
+
+bool IsDecodedEncoding(BomEncoding encoding)
+{
+    return encoding == BomEncoding::Utf8 || encoding == BomEncoding::Utf16Le ||
+           encoding == BomEncoding::Utf16Be;
+}
+
+std::int64_t AlignToCodeUnit(BomEncoding encoding, std::int64_t offset, std::int64_t textOffset)
+{
+    if (offset < textOffset)
+        return textOffset;
+    if (encoding == BomEncoding::Utf16Le || encoding == BomEncoding::Utf16Be)
+        return textOffset + ((offset - textOffset) & ~1ll);
+    return offset;
+}
+
+DecodedRun DecodeBytes(BomEncoding encoding, const std::uint8_t* data, std::size_t size,
+                       std::int64_t rawOffset, bool flush)
+{
+    DecodedRun run;
+    if (data == nullptr || size == 0 || !IsDecodedEncoding(encoding))
+        return run;
+
+    std::size_t i = 0;
+    if (encoding == BomEncoding::Utf8)
+    {
+        while (i < size)
+        {
+            std::uint8_t lead = data[i];
+            std::uint32_t scalar = 0;
+            std::size_t need = 0;
+            std::uint32_t minScalar = 0;
+
+            if (lead < 0x80)
+            {
+                scalar = lead;
+                need = 1;
+            }
+            else if (lead >= 0xC2 && lead <= 0xDF)
+            {
+                scalar = lead & 0x1F;
+                need = 2;
+                minScalar = 0x80;
+            }
+            else if (lead >= 0xE0 && lead <= 0xEF)
+            {
+                scalar = lead & 0x0F;
+                need = 3;
+                minScalar = 0x800;
+            }
+            else if (lead >= 0xF0 && lead <= 0xF4)
+            {
+                scalar = lead & 0x07;
+                need = 4;
+                minScalar = 0x10000;
+            }
+            else
+            {
+                run.AppendCell(Replacement, rawOffset + (std::int64_t)i, rawOffset + (std::int64_t)i + 1);
+                ++i;
+                continue;
+            }
+
+            if (i + need > size)
+            {
+                if (!flush)
+                    break;
+                run.AppendCell(Replacement, rawOffset + (std::int64_t)i, rawOffset + (std::int64_t)size);
+                i = size;
+                break;
+            }
+
+            bool ok = true;
+            for (std::size_t j = 1; j < need; ++j)
+            {
+                if (!IsContinuation(data[i + j]))
+                {
+                    ok = false;
+                    break;
+                }
+                scalar = (scalar << 6) | (data[i + j] & 0x3F);
+            }
+
+            if (!ok)
+            {
+                run.AppendCell(Replacement, rawOffset + (std::int64_t)i, rawOffset + (std::int64_t)i + 1);
+                ++i;
+                continue;
+            }
+
+            if (scalar < minScalar || scalar > 0x10FFFF ||
+                (scalar >= 0xD800 && scalar <= 0xDFFF))
+            {
+                run.AppendCell(Replacement, rawOffset + (std::int64_t)i, rawOffset + (std::int64_t)i + (std::int64_t)need);
+            }
+            else
+            {
+                run.AppendCell(scalar, rawOffset + (std::int64_t)i, rawOffset + (std::int64_t)i + (std::int64_t)need);
+            }
+            i += need;
+        }
+    }
+    else
+    {
+        while (i + 1 < size)
+        {
+            std::int64_t start = rawOffset + (std::int64_t)i;
+            std::uint16_t first = ReadUtf16(data + i, encoding);
+            if (IsHighSurrogate(first))
+            {
+                if (i + 3 >= size)
+                {
+                    if (!flush)
+                        break;
+                    run.AppendCell(Replacement, start, start + 2);
+                    i += 2;
+                    continue;
+                }
+                std::uint16_t second = ReadUtf16(data + i + 2, encoding);
+                if (IsLowSurrogate(second))
+                {
+                    run.AppendCell(DecodeSurrogatePair(first, second), start, start + 4);
+                    i += 4;
+                }
+                else
+                {
+                    run.AppendCell(Replacement, start, start + 2);
+                    i += 2;
+                }
+            }
+            else if (IsLowSurrogate(first))
+            {
+                run.AppendCell(Replacement, start, start + 2);
+                i += 2;
+            }
+            else
+            {
+                run.AppendCell(first, start, start + 2);
+                i += 2;
+            }
+        }
+        if (i < size && flush)
+        {
+            run.AppendCell(Replacement, rawOffset + (std::int64_t)i, rawOffset + (std::int64_t)size);
+            i = size;
+        }
+    }
+    run.RawBytesConsumed = i;
+    return run;
+}
+
+std::size_t CountPatternCells(const std::wstring& pattern)
+{
+    return PatternScalars(pattern).size();
+}
+
+bool FindLiteralForward(const DecodedRun& run, const std::wstring& pattern, bool caseSensitive,
+                        bool wholeWords, std::size_t startCell, LiteralMatch& match)
+{
+    std::vector<std::uint32_t> scalars = PatternScalars(pattern);
+    if (scalars.empty() || scalars.size() > run.CellCount())
+        return false;
+
+    for (std::size_t cell = std::min(startCell, run.CellCount()); cell + scalars.size() <= run.CellCount(); ++cell)
+    {
+        if (!MatchAt(run, scalars, caseSensitive, wholeWords, cell))
+            continue;
+        match.CellIndex = cell;
+        match.CellCount = scalars.size();
+        match.RawStart = run.RawStart[cell];
+        match.RawEnd = run.RawEnd[cell + scalars.size() - 1];
+        return true;
+    }
+    return false;
+}
+
+bool FindLiteralBackward(const DecodedRun& run, const std::wstring& pattern, bool caseSensitive,
+                         bool wholeWords, std::size_t cellLimit, LiteralMatch& match)
+{
+    std::vector<std::uint32_t> scalars = PatternScalars(pattern);
+    if (scalars.empty() || scalars.size() > run.CellCount())
+        return false;
+
+    cellLimit = std::min(cellLimit, run.CellCount());
+    if (cellLimit < scalars.size())
+        return false;
+
+    for (std::size_t cell = cellLimit - scalars.size() + 1; cell-- > 0;)
+    {
+        if (!MatchAt(run, scalars, caseSensitive, wholeWords, cell))
+            continue;
+        match.CellIndex = cell;
+        match.CellCount = scalars.size();
+        match.RawStart = run.RawStart[cell];
+        match.RawEnd = run.RawEnd[cell + scalars.size() - 1];
+        return true;
+    }
+    return false;
+}
+
+} // namespace Sally::Unicode

--- a/src/common/unicode/ViewerBomText.h
+++ b/src/common/unicode/ViewerBomText.h
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Sally Authors
+// SPDX-FileCopyrightText: 2026 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <cstdint>
+#include <cwchar>
+#include <string>
+#include <vector>
+
+namespace Sally::Unicode
+{
+
+enum class BomEncoding
+{
+    LegacyBytes,
+    Utf8,
+    Utf16Le,
+    Utf16Be,
+};
+
+struct BomInfo
+{
+    BomEncoding Encoding = BomEncoding::LegacyBytes;
+    std::int64_t TextOffset = 0;
+};
+
+struct DecodedRun
+{
+    std::wstring Text;
+    std::vector<std::size_t> CellTextIndex;
+    std::vector<std::int64_t> RawStart;
+    std::vector<std::int64_t> RawEnd;
+    std::vector<std::uint32_t> Scalars;
+    std::size_t RawBytesConsumed = 0;
+
+    void Clear();
+    std::size_t CellCount() const { return RawStart.size(); }
+    std::size_t TextIndexForCellEnd(std::size_t cell) const;
+    void AppendCell(std::uint32_t scalar, std::int64_t rawStart, std::int64_t rawEnd);
+    void AppendRun(const DecodedRun& other);
+};
+
+struct LiteralMatch
+{
+    std::size_t CellIndex = 0;
+    std::size_t CellCount = 0;
+    std::int64_t RawStart = 0;
+    std::int64_t RawEnd = 0;
+};
+
+BomInfo DetectBom(const std::uint8_t* data, std::size_t size);
+BomInfo DetectTextEncoding(const std::uint8_t* data, std::size_t size);
+bool IsLikelyUtf8NoBom(const std::uint8_t* data, std::size_t size);
+bool IsDecodedEncoding(BomEncoding encoding);
+std::int64_t AlignToCodeUnit(BomEncoding encoding, std::int64_t offset, std::int64_t textOffset);
+
+DecodedRun DecodeBytes(BomEncoding encoding, const std::uint8_t* data, std::size_t size,
+                       std::int64_t rawOffset, bool flush);
+
+std::size_t CountPatternCells(const std::wstring& pattern);
+bool FindLiteralForward(const DecodedRun& run, const std::wstring& pattern, bool caseSensitive,
+                        bool wholeWords, std::size_t startCell, LiteralMatch& match);
+bool FindLiteralBackward(const DecodedRun& run, const std::wstring& pattern, bool caseSensitive,
+                         bool wholeWords, std::size_t cellLimit, LiteralMatch& match);
+
+} // namespace Sally::Unicode

--- a/src/consts.h
+++ b/src/consts.h
@@ -713,6 +713,7 @@ DWORD AddUnicodeToClipboard(const char* str, int len);
 BOOL CopyTextToClipboard(const char* text, int textLen = -1, BOOL showEcho = FALSE, HWND hEchoParent = NULL);
 BOOL CopyTextToClipboardW(const wchar_t* text, int textLen = -1, BOOL showEcho = FALSE, HWND hEchoParent = NULL);
 BOOL CopyHTextToClipboard(HGLOBAL hGlobalText, int textLen = -1, BOOL showEcho = FALSE, HWND hEchoParent = NULL);
+BOOL CopyHTextToClipboardW(HGLOBAL hGlobalText, int textLen = -1);
 
 // zjisti z bufferu 'pattern' o delce 'patternLen' jestli jde o text (existuje kodova stranka,
 // ve ktere obsahuje jen povolene znaky - zobrazitelne a ridici) a pokud jde o text, zjisti take

--- a/src/shellib.cpp
+++ b/src/shellib.cpp
@@ -2647,10 +2647,10 @@ STDMETHODIMP CTextDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* medium)
     if ((formatEtc->cfFormat == CF_TEXT || formatEtc->cfFormat == CF_UNICODETEXT) && (formatEtc->tymed & TYMED_HGLOBAL))
     {
         HGLOBAL dataDup = NULL; // create a copy of Data
-        if (Data != NULL)
+        BOOL ok = FALSE;
+        if (formatEtc->cfFormat == CF_TEXT)
         {
-            BOOL ok = FALSE;
-            if (formatEtc->cfFormat == CF_TEXT)
+            if (Data != NULL)
             {
                 SIZE_T size = GlobalSize(Data);
                 dataDup = NOHANDLES(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, size));
@@ -2669,7 +2669,56 @@ STDMETHODIMP CTextDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* medium)
                         HANDLES(GlobalUnlock(dataDup));
                 }
             }
-            else // formatEtc->cfFormat == CF_UNICODETEXT
+            else if (UnicodeData != NULL)
+            {
+                const WCHAR* ptr2 = (const WCHAR*)HANDLES(GlobalLock(UnicodeData));
+                if (ptr2 != NULL)
+                {
+                    int len = WideCharToMultiByte(CP_ACP, 0, ptr2, -1, NULL, 0, NULL, NULL);
+                    if (len > 0)
+                    {
+                        dataDup = NOHANDLES(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, len));
+                        if (dataDup != NULL)
+                        {
+                            char* ptr1 = (char*)HANDLES(GlobalLock(dataDup));
+                            if (ptr1 != NULL)
+                            {
+                                if (WideCharToMultiByte(CP_ACP, 0, ptr2, -1, ptr1, len, NULL, NULL) > 0)
+                                    ok = TRUE;
+                                else
+                                    TRACE_E("WideCharToMultiByte() failed to make ANSI translation for our Unicode text.");
+                                HANDLES(GlobalUnlock(dataDup));
+                            }
+                        }
+                    }
+                    else
+                        TRACE_E("WideCharToMultiByte() failed to return size of ANSI translation for our Unicode text.");
+                    HANDLES(GlobalUnlock(UnicodeData));
+                }
+            }
+        }
+        else // formatEtc->cfFormat == CF_UNICODETEXT
+        {
+            if (UnicodeData != NULL)
+            {
+                SIZE_T size = GlobalSize(UnicodeData);
+                dataDup = NOHANDLES(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, size));
+                if (dataDup != NULL)
+                {
+                    void* ptr1 = HANDLES(GlobalLock(dataDup));
+                    void* ptr2 = HANDLES(GlobalLock(UnicodeData));
+                    if (ptr1 != NULL && ptr2 != NULL)
+                    {
+                        memcpy(ptr1, ptr2, size);
+                        ok = TRUE;
+                    }
+                    if (ptr2 != NULL)
+                        HANDLES(GlobalUnlock(UnicodeData));
+                    if (ptr1 != NULL)
+                        HANDLES(GlobalUnlock(dataDup));
+                }
+            }
+            else if (Data != NULL)
             {
                 const char* ptr2 = (const char*)HANDLES(GlobalLock(Data));
                 if (ptr2 != NULL)
@@ -2696,11 +2745,11 @@ STDMETHODIMP CTextDataObject::GetData(FORMATETC* formatEtc, STGMEDIUM* medium)
                     HANDLES(GlobalUnlock(Data));
                 }
             }
-            if (!ok && dataDup != NULL)
-            {
-                NOHANDLES(GlobalFree(dataDup));
-                dataDup = NULL;
-            }
+        }
+        if (!ok && dataDup != NULL)
+        {
+            NOHANDLES(GlobalFree(dataDup));
+            dataDup = NULL;
         }
         if (dataDup != NULL) // we have the data, store them in the medium and return
         {

--- a/src/shellib.h
+++ b/src/shellib.h
@@ -418,18 +418,29 @@ class CTextDataObject : public IDataObject
 private:
     long RefCount;
     HGLOBAL Data;
+    HGLOBAL UnicodeData;
 
 public:
     CTextDataObject(HGLOBAL data)
     {
         RefCount = 1;
         Data = data;
+        UnicodeData = NULL;
+    }
+    CTextDataObject(HGLOBAL data, BOOL unicodeText)
+    {
+        RefCount = 1;
+        Data = unicodeText ? NULL : data;
+        UnicodeData = unicodeText ? data : NULL;
     }
     virtual ~CTextDataObject()
     {
         if (RefCount != 0)
             TRACE_E("Preliminary destruction of this object.");
-        NOHANDLES(GlobalFree(Data));
+        if (Data != NULL)
+            NOHANDLES(GlobalFree(Data));
+        if (UnicodeData != NULL)
+            NOHANDLES(GlobalFree(UnicodeData));
     }
 
     STDMETHOD(QueryInterface)

--- a/src/vcxproj/salamand.vcxproj
+++ b/src/vcxproj/salamand.vcxproj
@@ -577,6 +577,16 @@
     </ClCompile>
     <ClCompile Include="..\viewer.cpp">
     </ClCompile>
+    <ClCompile Include="..\common\unicode\ViewerBomText.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+      </PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\viewer2.cpp">
     </ClCompile>
     <ClCompile Include="..\viewer3.cpp">
@@ -852,6 +862,8 @@
     <ClInclude Include="..\versinfo.h">
     </ClInclude>
     <ClInclude Include="..\viewer.h">
+    </ClInclude>
+    <ClInclude Include="..\common\unicode\ViewerBomText.h">
     </ClInclude>
     <ClInclude Include="..\worker.h">
     </ClInclude>

--- a/src/vcxproj/salamand.vcxproj.filters
+++ b/src/vcxproj/salamand.vcxproj.filters
@@ -369,6 +369,9 @@
     <ClCompile Include="..\viewer.cpp">
       <Filter>cpp</Filter>
     </ClCompile>
+    <ClCompile Include="..\common\unicode\ViewerBomText.cpp">
+      <Filter>common</Filter>
+    </ClCompile>
     <ClCompile Include="..\viewer2.cpp">
       <Filter>cpp</Filter>
     </ClCompile>
@@ -691,6 +694,9 @@
     </ClInclude>
     <ClInclude Include="..\viewer.h">
       <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\common\unicode\ViewerBomText.h">
+      <Filter>common</Filter>
     </ClInclude>
     <ClInclude Include="..\worker.h">
       <Filter>h</Filter>

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -1136,7 +1136,7 @@ void CViewerWindow::PaintDecodedText(HDC dc, const RECT& fullLine, int lines, in
             __int64 len2 = min((Width - BORDER_WIDTH) / CharWidth + 1, lineLen - OriginX);
             std::size_t left = (std::size_t)OriginX;
             std::size_t right = (std::size_t)(OriginX + len2);
-            std::size_t u1 = len2, u2 = 0, u3 = 0;
+            std::size_t u1 = (std::size_t)len2, u2 = 0, u3 = 0;
             if (selStartCell <= left)
             {
                 if (selEndCell > left)

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -555,6 +555,8 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     CodeType = 0;
     CodeTables.Init(MainWindow->HWindow);
     UseCodeTable = FALSE;
+    TextEncoding = Sally::Unicode::BomEncoding::LegacyBytes;
+    TextContentOffset = 0;
     if (fileName == NULL)
         FileName = NULL; // error
     else
@@ -764,6 +766,457 @@ void MyTextOut(HDC hdc, int nXStart, int nYStart, LPCTSTR lpString, int cbString
     else
         TextOut(hdc, nXStart, nYStart, lpString, cbString);
 }
+
+void MyTextOutW(HDC hdc, int nXStart, int nYStart, const wchar_t* lpString, int cchString)
+{
+#ifdef _DEBUG
+    if (!ViewerFontMeasured)
+        TRACE_E("MyTextOutW(): ViewerFontMeasured is FALSE!");
+#endif // _DEBUG
+    TextOutW(hdc, nXStart, nYStart, lpString, cchString);
+}
+
+namespace
+{
+
+bool IsViewerDecodedEOL(std::uint32_t scalar)
+{
+    return scalar == L'\r' || scalar == L'\n' || scalar == 0;
+}
+
+void AppendVisualCell(Sally::Unicode::DecodedRun& visual, std::uint32_t scalar,
+                      __int64 rawStart, __int64 rawEnd, int tabSize)
+{
+    if (scalar == L'\t')
+    {
+        int tab = (int)(tabSize - (visual.CellCount() % tabSize));
+        if (tab <= 0)
+            tab = 1;
+        while (tab-- > 0)
+            visual.AppendCell(L' ', rawStart, rawEnd);
+    }
+    else
+        visual.AppendCell(scalar, rawStart, rawEnd);
+}
+
+std::size_t DecodedSelectionStartCell(const Sally::Unicode::DecodedRun& visual, __int64 offset)
+{
+    for (std::size_t i = 0; i < visual.CellCount(); ++i)
+    {
+        if (offset <= visual.RawStart[i])
+            return i;
+        if (offset < visual.RawEnd[i])
+            return i;
+    }
+    return visual.CellCount();
+}
+
+std::size_t DecodedSelectionEndCell(const Sally::Unicode::DecodedRun& visual, __int64 offset)
+{
+    for (std::size_t i = 0; i < visual.CellCount(); ++i)
+    {
+        if (offset <= visual.RawStart[i])
+            return i;
+        if (offset <= visual.RawEnd[i])
+            return i + 1;
+    }
+    return visual.CellCount();
+}
+
+void DrawDecodedCells(HDC dc, const Sally::Unicode::DecodedRun& visual, std::size_t cellStart,
+                      std::size_t cellEnd, int xCell)
+{
+    if (cellStart >= cellEnd)
+        return;
+    std::size_t textStart = visual.TextIndexForCellEnd(cellStart);
+    std::size_t textEnd = visual.TextIndexForCellEnd(cellEnd);
+    if (textEnd > textStart)
+        MyTextOutW(dc, xCell * CharWidth, 0, visual.Text.c_str() + textStart, (int)(textEnd - textStart));
+}
+
+} // namespace
+
+BOOL CViewerWindow::DecodeTextRange(HANDLE* hFile, __int64 start, __int64 end,
+                                    Sally::Unicode::DecodedRun& run, BOOL& fatalErr, bool flush)
+{
+    run.Clear();
+    fatalErr = FALSE;
+    if (!HasDecodedTextEncoding())
+        return FALSE;
+
+    start = max(start, TextContentOffset);
+    end = min(end, FileSize);
+    start = Sally::Unicode::AlignToCodeUnit(TextEncoding, start, TextContentOffset);
+    if (end <= start)
+        return TRUE;
+
+    __int64 off = start;
+    while (off < end)
+    {
+        __int64 want = min((__int64)APROX_LINE_LEN + 8, end - off);
+        __int64 len = Prepare(hFile, off, want, fatalErr);
+        if (fatalErr)
+            return FALSE;
+        if (len <= 0)
+            break;
+
+        bool finalChunk = flush && off + len >= end;
+        Sally::Unicode::DecodedRun part = Sally::Unicode::DecodeBytes(TextEncoding, Buffer + (off - Seek), (std::size_t)len, off, finalChunk);
+        if (part.RawBytesConsumed == 0 && part.CellCount() == 0)
+        {
+            if (finalChunk)
+                break;
+            len = min((__int64)APROX_LINE_LEN + 16, FileSize - off);
+            len = Prepare(hFile, off, len, fatalErr);
+            if (fatalErr || len <= 0)
+                return !fatalErr;
+            part = Sally::Unicode::DecodeBytes(TextEncoding, Buffer + (off - Seek), (std::size_t)len, off, off + len >= FileSize);
+            if (part.RawBytesConsumed == 0)
+                break;
+        }
+        run.AppendRun(part);
+        off += (__int64)part.RawBytesConsumed;
+    }
+    return TRUE;
+}
+
+BOOL CViewerWindow::ReadDecodedScalar(HANDLE* hFile, __int64 offset, Sally::Unicode::DecodedRun& scalar, BOOL& fatalErr)
+{
+    scalar.Clear();
+    fatalErr = FALSE;
+    if (!HasDecodedTextEncoding())
+        return FALSE;
+    offset = max(offset, TextContentOffset);
+    offset = Sally::Unicode::AlignToCodeUnit(TextEncoding, offset, TextContentOffset);
+    if (offset >= FileSize)
+        return TRUE;
+
+    __int64 len = Prepare(hFile, offset, min((__int64)8, FileSize - offset), fatalErr);
+    if (fatalErr || len <= 0)
+        return !fatalErr;
+    scalar = Sally::Unicode::DecodeBytes(TextEncoding, Buffer + (offset - Seek), (std::size_t)len, offset, TRUE);
+    return TRUE;
+}
+
+BOOL CViewerWindow::ReadDecodedTextLine(HANDLE* hFile, __int64 lineOffset, __int64 maxCells,
+                                        Sally::Unicode::DecodedRun& visualLine, __int64& lineEnd,
+                                        __int64& nextLineBegin, BOOL& eol, BOOL& wrapped,
+                                        int& eolBytes, BOOL& fatalErr)
+{
+    visualLine.Clear();
+    fatalErr = FALSE;
+    eol = FALSE;
+    wrapped = FALSE;
+    eolBytes = 0;
+
+    if (!HasDecodedTextEncoding())
+        return FALSE;
+
+    __int64 off = max(lineOffset, TextContentOffset);
+    off = Sally::Unicode::AlignToCodeUnit(TextEncoding, off, TextContentOffset);
+    lineEnd = off;
+    nextLineBegin = off;
+    if (off >= FileSize)
+        return TRUE;
+
+    while (off < FileSize)
+    {
+        __int64 readEnd = min(FileSize, off + APROX_LINE_LEN + 8);
+        Sally::Unicode::DecodedRun decoded;
+        if (!DecodeTextRange(hFile, off, readEnd, decoded, fatalErr, readEnd >= FileSize))
+            return FALSE;
+        if (fatalErr)
+            return FALSE;
+        if (decoded.CellCount() == 0)
+        {
+            lineEnd = nextLineBegin = off;
+            return TRUE;
+        }
+
+        for (std::size_t i = 0; i < decoded.CellCount(); ++i)
+        {
+            std::uint32_t scalar = decoded.Scalars[i];
+            if (IsViewerDecodedEOL(scalar))
+            {
+                if (scalar == L'\r')
+                {
+                    if (Configuration.EOL_CRLF)
+                    {
+                        Sally::Unicode::DecodedRun nextScalar;
+                        bool haveNext = false;
+                        if (i + 1 < decoded.CellCount())
+                        {
+                            nextScalar.AppendCell(decoded.Scalars[i + 1], decoded.RawStart[i + 1], decoded.RawEnd[i + 1]);
+                            haveNext = true;
+                        }
+                        else if (ReadDecodedScalar(hFile, decoded.RawEnd[i], nextScalar, fatalErr) && !fatalErr &&
+                                 nextScalar.CellCount() > 0)
+                            haveNext = true;
+                        if (fatalErr)
+                            return FALSE;
+                        if (haveNext && nextScalar.Scalars[0] == L'\n')
+                        {
+                            lineEnd = decoded.RawStart[i];
+                            nextLineBegin = nextScalar.RawEnd[0];
+                            eol = TRUE;
+                            eolBytes = (int)(nextLineBegin - lineEnd);
+                            return TRUE;
+                        }
+                    }
+                    if (Configuration.EOL_CR)
+                    {
+                        lineEnd = decoded.RawStart[i];
+                        nextLineBegin = decoded.RawEnd[i];
+                        eol = TRUE;
+                        eolBytes = (int)(nextLineBegin - lineEnd);
+                        return TRUE;
+                    }
+                }
+                else if (scalar == L'\n')
+                {
+                    if (Configuration.EOL_LF)
+                    {
+                        lineEnd = decoded.RawStart[i];
+                        nextLineBegin = decoded.RawEnd[i];
+                        eol = TRUE;
+                        eolBytes = (int)(nextLineBegin - lineEnd);
+                        return TRUE;
+                    }
+                }
+                else if (Configuration.EOL_NULL)
+                {
+                    lineEnd = decoded.RawStart[i];
+                    nextLineBegin = decoded.RawEnd[i];
+                    eol = TRUE;
+                    eolBytes = (int)(nextLineBegin - lineEnd);
+                    return TRUE;
+                }
+            }
+
+            AppendVisualCell(visualLine, scalar, decoded.RawStart[i], decoded.RawEnd[i], Configuration.TabSize);
+            lineEnd = decoded.RawEnd[i];
+            nextLineBegin = lineEnd;
+            if (WrapText && maxCells > 0 && (__int64)visualLine.CellCount() >= maxCells)
+            {
+                wrapped = TRUE;
+                return TRUE;
+            }
+        }
+        off += (__int64)decoded.RawBytesConsumed;
+        if (decoded.RawBytesConsumed == 0)
+            break;
+    }
+    lineEnd = nextLineBegin = max(lineEnd, off);
+    return TRUE;
+}
+
+void CViewerWindow::PaintDecodedText(HDC dc, const RECT& fullLine, int lines, int columns,
+                                     int clipFirstRow, int clipLastRow, BOOL& fatalErr,
+                                     BOOL& setFindOffset)
+{
+    __int64 xRollLimit = (Width - BORDER_WIDTH) / CharWidth / 6;
+    FirstLineSize = LastLineSize = 0;
+    WrapIsBeforeFirstLine = FALSE;
+
+    RECT r;
+    RECT endRect = fullLine;
+    __int64 lineOffset = max(SeekY, TextContentOffset);
+    BOOL previousEOL = FALSE;
+    for (int i = 0; i < lines; i++)
+    {
+        Sally::Unicode::DecodedRun visual;
+        __int64 lineEnd = lineOffset;
+        __int64 nextLineBegin = lineOffset;
+        BOOL EOL = FALSE;
+        BOOL lineEndIsWrapped = FALSE;
+        int lineEOLSize = 0;
+
+        if (lineOffset >= FileSize)
+        {
+            int redrI = i;
+            if (redrI < clipFirstRow)
+                redrI = clipFirstRow;
+            r.left = BORDER_WIDTH;
+            r.top = CharHeight * redrI;
+            r.bottom = CharHeight * clipLastRow;
+            if (r.bottom > Height)
+                r.bottom = Height;
+            if (r.top <= r.bottom)
+                FillRect(dc, &r, BkgndBrush);
+
+            if (previousEOL)
+            {
+                LineOffset.Add(lineOffset);
+                LineOffset.Add(lineOffset);
+                LineOffset.Add(0);
+            }
+            break;
+        }
+
+        __int64 maxCells = WrapText ? max(1, columns) : TEXT_MAX_LINE_LEN + 1;
+        if (!ReadDecodedTextLine(NULL, lineOffset, maxCells, visual, lineEnd, nextLineBegin,
+                                 EOL, lineEndIsWrapped, lineEOLSize, fatalErr))
+            break;
+        if (fatalErr)
+            break;
+
+        __int64 fullLineLen = max((__int64)0, nextLineBegin - lineOffset);
+        __int64 lineLen = (__int64)visual.CellCount();
+        LineOffset.Add(lineOffset);
+        LineOffset.Add(lineEnd);
+        LineOffset.Add(lineLen);
+
+        __int64 startSel = min(StartSelection, EndSelection);
+        if (startSel == -1)
+            startSel = 0;
+        __int64 endSel = max(StartSelection, EndSelection);
+        if (endSel == -1)
+            endSel = 0;
+        if (startSel == endSel)
+            startSel = endSel = 0;
+
+        std::size_t selStartCell = DecodedSelectionStartCell(visual, startSel);
+        std::size_t selEndCell = DecodedSelectionEndCell(visual, endSel);
+
+        if (ScrollToSelection)
+        {
+            int len2 = (Width - BORDER_WIDTH) / CharWidth;
+            if (len2 - 2 * xRollLimit < (__int64)selEndCell - (__int64)selStartCell)
+            {
+                xRollLimit = (len2 - ((__int64)selEndCell - (__int64)selStartCell)) / 2;
+                if (xRollLimit < 0)
+                    xRollLimit = 0;
+            }
+            __int64 left = OriginX;
+            __int64 right = OriginX + len2;
+            if ((__int64)selStartCell < lineLen)
+            {
+                __int64 originX = OriginX;
+                if ((__int64)selStartCell < left)
+                {
+                    originX = (__int64)selStartCell - xRollLimit;
+                    if (originX < 0)
+                        originX = 0;
+                }
+                else if ((__int64)selStartCell >= right ||
+                         ((__int64)selEndCell < lineLen && (__int64)selEndCell >= right))
+                {
+                    originX = (__int64)selStartCell - xRollLimit;
+                    if (originX < 0)
+                        originX = 0;
+                    __int64 originX2 = (__int64)selEndCell - len2 + 1 + xRollLimit;
+                    if (originX2 < 0)
+                        originX2 = 0;
+                    originX = min(originX, originX2);
+                }
+                if (originX != OriginX)
+                {
+                    setFindOffset = FALSE;
+                    OriginX = originX;
+                    InvalidateRect(HWindow, NULL, FALSE);
+                    break;
+                }
+                else
+                    ScrollToSelection = FALSE;
+            }
+        }
+
+        if (i == 0)
+            FirstLineSize = fullLineLen;
+        if (i + 1 < lines)
+        {
+            ViewSize += fullLineLen;
+            if (i + 2 == lines)
+                LastLineSize = fullLineLen;
+        }
+
+        BOOL blackEnd = (lineEndIsWrapped ? startSel < lineEnd : startSel <= lineEnd) && endSel > lineEnd;
+        if (OriginX < lineLen)
+        {
+            __int64 len2 = min((Width - BORDER_WIDTH) / CharWidth + 1, lineLen - OriginX);
+            std::size_t left = (std::size_t)OriginX;
+            std::size_t right = (std::size_t)(OriginX + len2);
+            std::size_t u1 = len2, u2 = 0, u3 = 0;
+            if (selStartCell <= left)
+            {
+                if (selEndCell > left)
+                {
+                    u1 = 0;
+                    u2 = min(right, selEndCell) - left;
+                    u3 = (std::size_t)len2 - u2;
+                }
+            }
+            else if (selStartCell < right)
+            {
+                if (selEndCell > selStartCell)
+                {
+                    u1 = selStartCell - left;
+                    u2 = min(right, selEndCell) - left - u1;
+                    u3 = (std::size_t)len2 - u2 - u1;
+                }
+            }
+
+            if (i >= clipFirstRow && i <= clipLastRow)
+            {
+                RECT myLine = fullLine;
+                myLine.right = min(myLine.right, (int)(len2 + 1) * CharWidth);
+
+                if (blackEnd)
+                {
+                    endRect.left = 0;
+                    endRect.right = (int)((u1 + u2 + u3) * CharWidth);
+                    FillRect(Bitmap.HMemDC, &endRect, BkgndBrush);
+                    endRect.left = endRect.right;
+                    endRect.right = Width - BORDER_WIDTH;
+                    FillRect(Bitmap.HMemDC, &endRect, BkgndBrushSel);
+                }
+                else
+                    FillRect(Bitmap.HMemDC, &myLine, BkgndBrush);
+
+                if (u3 > 0)
+                    DrawDecodedCells(Bitmap.HMemDC, visual, left + u1 + u2, left + u1 + u2 + u3, (int)(u1 + u2));
+                if (u2 > 0)
+                {
+                    SetBkColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_BK_SELECTED]));
+                    SetTextColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_FG_SELECTED]));
+                    SetBkMode(Bitmap.HMemDC, OPAQUE);
+                    DrawDecodedCells(Bitmap.HMemDC, visual, left + u1, left + u1 + u2, (int)u1);
+                    SetBkMode(Bitmap.HMemDC, TRANSPARENT);
+                    SetTextColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_FG_NORMAL]));
+                    SetBkColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_BK_NORMAL]));
+                }
+                if (u1 > 0)
+                    DrawDecodedCells(Bitmap.HMemDC, visual, left, left + u1, 0);
+
+                BitBlt(dc, BORDER_WIDTH, CharHeight * i, myLine.right,
+                       CharHeight, Bitmap.HMemDC, 0, 0, SRCCOPY);
+
+                if (myLine.right < fullLine.right)
+                {
+                    myLine.top = CharHeight * i;
+                    myLine.bottom = myLine.top + CharHeight;
+                    myLine.left = BORDER_WIDTH + myLine.right;
+                    myLine.right = BORDER_WIDTH + fullLine.right;
+                    FillRect(dc, &myLine, blackEnd ? BkgndBrushSel : BkgndBrush);
+                }
+            }
+        }
+        else if (i >= clipFirstRow && i <= clipLastRow)
+        {
+            r.left = BORDER_WIDTH;
+            r.top = CharHeight * i;
+            r.right = Width;
+            r.bottom = r.top + CharHeight;
+            FillRect(dc, &r, blackEnd ? BkgndBrushSel : BkgndBrush);
+        }
+
+        previousEOL = EOL;
+        if (nextLineBegin <= lineOffset)
+            break;
+        lineOffset = nextLineBegin;
+    }
+}
+
 
 void CViewerWindow::Paint(HDC dc)
 {
@@ -1009,6 +1462,11 @@ void CViewerWindow::Paint(HDC dc)
 
             case vtText:
             {
+                if (HasDecodedTextMode())
+                {
+                    PaintDecodedText(dc, fullLine, lines, columns, clipFirstRow, clipLastRow, fatalErr, setFindOffset);
+                    break;
+                }
                 __int64 xRollLimit = (Width - BORDER_WIDTH) / CharWidth / 6;
                 FirstLineSize = LastLineSize = 0;
 

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -14,6 +14,8 @@
 #define TEXT_MAX_LINE_LEN 10000              // when a line is longer we ask about switching to hex mode; must be <= FIND_LINE_LEN
 #define RECOGNIZE_FILE_TYPE_BUFFER_LEN 10000 // how many characters from the start of the file to use to recognize the file type (RecognizeFileType())
 
+#include "common/unicode/ViewerBomText.h"
+
 #define VIEWER_HISTORY_SIZE 30 // number of remembered strings
 
 // menu positions - redo when the menu changes!
@@ -202,6 +204,10 @@ protected:
                          __int64& previousLineEnd, BOOL allowWrap,
                          BOOL takeLineBegin, BOOL& fatalErr, int* lines, __int64* firstLineEndOff = NULL,
                          __int64* firstLineCharLen = NULL, BOOL addLineIfSeekIsWrap = FALSE);
+    BOOL FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 minSeek, __int64& lineBegin,
+                                __int64& previousLineEnd, BOOL allowWrap,
+                                BOOL takeLineBegin, BOOL& fatalErr, int* lines, __int64* firstLineEndOff = NULL,
+                                __int64* firstLineCharLen = NULL, BOOL addLineIfSeekIsWrap = FALSE);
 
     // if a read error occurs, fatalErr == TRUE; ExitTextMode is TRUE when switching to hex mode
     __int64 FindBegin(__int64 seek, BOOL& fatalErr);
@@ -280,6 +286,21 @@ protected:
 
     // if a read error occurs, fatalErr == TRUE; ExitTextMode does not arise here (it does not become TRUE)
     HGLOBAL GetSelectedText(BOOL& fatalErr); // text for clipboard and drag & drop operations
+    HGLOBAL GetSelectedTextW(BOOL& fatalErr, int* textLen); // decoded Unicode text for clipboard and drag & drop operations
+
+    BOOL HasDecodedTextMode() const { return Type == vtText && Sally::Unicode::IsDecodedEncoding(TextEncoding); }
+    BOOL HasDecodedTextEncoding() const { return Sally::Unicode::IsDecodedEncoding(TextEncoding); }
+    __int64 TextStartOffset() const { return HasDecodedTextEncoding() ? TextContentOffset : 0; }
+    BOOL DecodeTextRange(HANDLE* hFile, __int64 start, __int64 end, Sally::Unicode::DecodedRun& run,
+                         BOOL& fatalErr, bool flush = true);
+    BOOL ReadDecodedScalar(HANDLE* hFile, __int64 offset, Sally::Unicode::DecodedRun& scalar, BOOL& fatalErr);
+    BOOL ReadDecodedTextLine(HANDLE* hFile, __int64 lineOffset, __int64 maxCells,
+                             Sally::Unicode::DecodedRun& visualLine, __int64& lineEnd,
+                             __int64& nextLineBegin, BOOL& eol, BOOL& wrapped,
+                             int& eolBytes, BOOL& fatalErr);
+    void PaintDecodedText(HDC dc, const RECT& fullLine, int lines, int columns, int clipFirstRow,
+                          int clipLastRow, BOOL& fatalErr, BOOL& setFindOffset);
+    BOOL FindDecodedLiteral(HANDLE* hFile, BOOL forward, WORD flags, BOOL& foundMatch, BOOL& fatalErr);
 
     void SetToolTipOffset(__int64 offset);
 
@@ -371,6 +392,8 @@ protected:
     int CodeType;        // numeric encoding identifier; CodeTables memory for this viewer window
     BOOL UseCodeTable;   // should CodeTable be used for recoding?
     char CodeTable[256]; // code table
+    Sally::Unicode::BomEncoding TextEncoding; // decoded text mode selected for BOM/UTF-8 files
+    __int64 TextContentOffset;                // first raw byte of text content (after BOM when present)
 
     char CurrentDir[MAX_PATH]; // path for the open dialog
 

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -698,6 +698,8 @@ void CViewerWindow::OpenFile(const char* file, const char* caption, BOOL wholeCa
     ForceTextMode = FALSE;
     CodeType = 0;
     UseCodeTable = FALSE;
+    TextEncoding = Sally::Unicode::BomEncoding::LegacyBytes;
+    TextContentOffset = 0;
     BOOL fatalErr = FALSE;
     FileChanged(NULL, FALSE, fatalErr, TRUE);
     if (fatalErr)
@@ -817,6 +819,25 @@ void CViewerWindow::FileChanged(HANDLE file, BOOL testOnlyFileSize, BOOL& fatalE
                 ReleaseMouseDrag();
                 FirstLineSize = LastLineSize = ViewSize = 0;
                 LastFindSeekY = -1;
+                TextEncoding = Sally::Unicode::BomEncoding::LegacyBytes;
+                TextContentOffset = 0;
+
+                if (FileSize > 0)
+                {
+                    BYTE sample[RECOGNIZE_FILE_TYPE_BUFFER_LEN] = {0};
+                    DWORD read = 0;
+                    CQuadWord sampleSeek;
+                    sampleSeek.SetUI64(0);
+                    sampleSeek.LoDWord = SetFilePointer(file, sampleSeek.LoDWord, (PLONG)&sampleSeek.HiDWord, FILE_BEGIN);
+                    DWORD seekErr = GetLastError();
+                    if ((sampleSeek.LoDWord != INVALID_SET_FILE_POINTER || seekErr == NO_ERROR) &&
+                        ReadFile(file, sample, (DWORD)min((__int64)sizeof(sample), FileSize), &read, NULL))
+                    {
+                        Sally::Unicode::BomInfo textInfo = Sally::Unicode::DetectTextEncoding(sample, read);
+                        TextEncoding = textInfo.Encoding;
+                        TextContentOffset = textInfo.TextOffset;
+                    }
+                }
 
                 if (detectFileType)
                 {
@@ -838,9 +859,19 @@ void CViewerWindow::FileChanged(HANDLE file, BOOL testOnlyFileSize, BOOL& fatalE
                             CanSwitchQuietlyToHex = FALSE; // if we force Text mode, prompt before switching to Hex
                     }
 
+                    BOOL bomTextMode = HasDecodedTextEncoding() && defViewMode != 2;
+                    if (bomTextMode)
+                    {
+                        Type = vtText;
+                        CodeType = 0;
+                        UseCodeTable = FALSE;
+                        SeekY = TextContentOffset;
+                        FindOffset = TextContentOffset;
+                    }
+
                     int len;
                     BOOL fatalErr2 = FALSE;
-                    if (CodePageAutoSelect || defViewMode == 0)
+                    if (!bomTextMode && (CodePageAutoSelect || defViewMode == 0))
                         len = (int)Prepare(NULL, 0, RECOGNIZE_FILE_TYPE_BUFFER_LEN, fatalErr2);
                     else
                         len = 0;
@@ -885,12 +916,16 @@ void CViewerWindow::FileChanged(HANDLE file, BOOL testOnlyFileSize, BOOL& fatalE
                                 }
                             }
                         }
-                        if (defViewMode == 1)
+                        if (bomTextMode)
+                        {
+                            Type = vtText;
+                        }
+                        else if (defViewMode == 1)
                             Type = vtText;
                         else if (defViewMode == 2)
                             Type = vtHex;
                         // if auto-select is off, fall back to the default conversion
-                        if (!CodePageAutoSelect)
+                        if (!bomTextMode && !CodePageAutoSelect)
                         {
                             int defCodeType;
                             if (!CodeTables.GetCodeType(DefaultConvert, defCodeType))
@@ -904,6 +939,14 @@ void CViewerWindow::FileChanged(HANDLE file, BOOL testOnlyFileSize, BOOL& fatalE
                             }
                         }
                     }
+                }
+
+                if (HasDecodedTextMode())
+                {
+                    CodeType = 0;
+                    UseCodeTable = FALSE;
+                    SeekY = max(SeekY, TextContentOffset);
+                    FindOffset = max(FindOffset, TextContentOffset);
                 }
 
                 if (!fatalErr)
@@ -975,6 +1018,8 @@ void CViewerWindow::FatalFileErrorOccured(DWORD repeatCmd)
     LastFindSeekY = -1;
     LastFindOffset = 0;
     ScrollToSelection = FALSE;
+    TextEncoding = Sally::Unicode::BomEncoding::LegacyBytes;
+    TextContentOffset = 0;
     LineOffset.DestroyMembers();
     EnableSetScroll = TRUE;
     PostMessage(HWindow, WM_USER_VIEWERREFRESH, 0, 0);
@@ -988,6 +1033,76 @@ BOOL CViewerWindow::FindNextEOL(HANDLE* hFile, __int64 seek, __int64 maxSeek, __
     __int64 cr = -2; // offset of the last '\r'
     __int64 len;
     fatalErr = FALSE;
+    if (HasDecodedTextMode())
+    {
+        seek = max(seek, TextContentOffset);
+        maxSeek = min(maxSeek, FileSize);
+        Sally::Unicode::DecodedRun decoded;
+        __int64 decodeEnd = min(FileSize, maxSeek + 8);
+        if (!DecodeTextRange(hFile, seek, decodeEnd, decoded, fatalErr, decodeEnd >= FileSize))
+            return FALSE;
+        if (fatalErr)
+            return FALSE;
+        for (std::size_t i = 0; i < decoded.CellCount(); ++i)
+        {
+            if (decoded.RawStart[i] > maxSeek)
+                break;
+            std::uint32_t scalar = decoded.Scalars[i];
+            if (scalar == L'\r')
+            {
+                if (Configuration.EOL_CRLF)
+                {
+                    Sally::Unicode::DecodedRun nextScalar;
+                    bool haveNext = false;
+                    if (i + 1 < decoded.CellCount())
+                    {
+                        nextScalar.AppendCell(decoded.Scalars[i + 1], decoded.RawStart[i + 1], decoded.RawEnd[i + 1]);
+                        haveNext = true;
+                    }
+                    else if (ReadDecodedScalar(hFile, decoded.RawEnd[i], nextScalar, fatalErr) && !fatalErr &&
+                             nextScalar.CellCount() > 0)
+                        haveNext = true;
+                    if (fatalErr)
+                        return FALSE;
+                    if (haveNext && nextScalar.Scalars[0] == L'\n')
+                    {
+                        lineEnd = decoded.RawStart[i];
+                        nextLineBegin = nextScalar.RawEnd[0];
+                        return TRUE;
+                    }
+                }
+                if (Configuration.EOL_CR)
+                {
+                    lineEnd = decoded.RawStart[i];
+                    nextLineBegin = decoded.RawEnd[i];
+                    return TRUE;
+                }
+            }
+            else if (scalar == L'\n')
+            {
+                if (Configuration.EOL_LF)
+                {
+                    lineEnd = decoded.RawStart[i];
+                    nextLineBegin = decoded.RawEnd[i];
+                    return TRUE;
+                }
+            }
+            else if (scalar == 0 && Configuration.EOL_NULL)
+            {
+                lineEnd = decoded.RawStart[i];
+                nextLineBegin = decoded.RawEnd[i];
+                return TRUE;
+            }
+        }
+        if (maxSeek >= FileSize)
+        {
+            lineEnd = FileSize;
+            nextLineBegin = FileSize;
+            return TRUE;
+        }
+        nextLineBegin = -1;
+        return FALSE;
+    }
     if (seek > 0) // not the start of the file
     {
         len = Prepare(hFile, seek - 1, 1, fatalErr);
@@ -1085,6 +1200,12 @@ BOOL CViewerWindow::FindPreviousEOL(HANDLE* hFile, __int64 seek, __int64 minSeek
         *firstLineEndOff = -1;
     if (firstLineCharLen != NULL)
         *firstLineCharLen = -1;
+    if (HasDecodedTextMode())
+    {
+        return FindPreviousDecodedEOL(hFile, seek, minSeek, lineBegin, previousLineEnd, allowWrap,
+                                      takeLineBegin, fatalErr, lines, firstLineEndOff,
+                                      firstLineCharLen, addLineIfSeekIsWrap);
+    }
     BOOL collectTabs = allowWrap && WrapText || firstLineCharLen != NULL;
     unsigned char *s, *end;
     fatalErr = FALSE;
@@ -1282,6 +1403,87 @@ BOOL CViewerWindow::FindPreviousEOL(HANDLE* hFile, __int64 seek, __int64 minSeek
     return !fatalErr && previousLineEnd != -1;
 }
 
+BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 minSeek, __int64& lineBegin,
+                                           __int64& previousLineEnd, BOOL allowWrap, BOOL takeLineBegin,
+                                           BOOL& fatalErr, int* lines, __int64* firstLineEndOff,
+                                           __int64* firstLineCharLen, BOOL addLineIfSeekIsWrap)
+{
+    UNREFERENCED_PARAMETER(allowWrap);
+    UNREFERENCED_PARAMETER(takeLineBegin);
+    UNREFERENCED_PARAMETER(lines);
+    UNREFERENCED_PARAMETER(addLineIfSeekIsWrap);
+
+    fatalErr = FALSE;
+    lineBegin = max(minSeek, TextContentOffset);
+    previousLineEnd = lineBegin;
+    if (firstLineEndOff != NULL)
+        *firstLineEndOff = -1;
+    if (firstLineCharLen != NULL)
+        *firstLineCharLen = -1;
+
+    minSeek = max(minSeek, TextContentOffset);
+    seek = max(seek, minSeek);
+    if (seek <= minSeek)
+    {
+        previousLineEnd = lineBegin = minSeek;
+        if (firstLineCharLen != NULL)
+            *firstLineCharLen = 0;
+        return TRUE;
+    }
+
+    __int64 pos = minSeek;
+    __int64 lastBegin = minSeek;
+    __int64 lastEnd = minSeek;
+    __int64 lastPreviousEnd = minSeek;
+    __int64 lastLen = 0;
+    while (pos < seek && pos < FileSize)
+    {
+        Sally::Unicode::DecodedRun visual;
+        __int64 lineEnd = pos;
+        __int64 nextLineBegin = pos;
+        BOOL eol = FALSE;
+        BOOL wrapped = FALSE;
+        int eolBytes = 0;
+        __int64 maxCells = WrapText ? max(1, (Width - BORDER_WIDTH) / CharWidth) : TEXT_MAX_LINE_LEN + 1;
+        if (!ReadDecodedTextLine(hFile, pos, maxCells, visual, lineEnd, nextLineBegin,
+                                 eol, wrapped, eolBytes, fatalErr))
+            return FALSE;
+        if (fatalErr)
+            return FALSE;
+        if (nextLineBegin <= pos)
+            break;
+
+        if (nextLineBegin >= seek)
+        {
+            lineBegin = pos;
+            previousLineEnd = lastPreviousEnd;
+            lastEnd = lineEnd;
+            lastLen = (__int64)visual.CellCount();
+            break;
+        }
+
+        lastPreviousEnd = lineEnd;
+        lastBegin = pos;
+        lastEnd = lineEnd;
+        lastLen = (__int64)visual.CellCount();
+        pos = nextLineBegin;
+    }
+
+    if (pos >= seek)
+    {
+        lineBegin = lastBegin;
+        previousLineEnd = lastPreviousEnd;
+    }
+
+    if (lineBegin > TextContentOffset && firstLineEndOff != NULL)
+        *firstLineEndOff = previousLineEnd;
+    if (firstLineCharLen != NULL)
+        *firstLineCharLen = lastLen;
+    if (firstLineEndOff != NULL && *firstLineEndOff == -1)
+        *firstLineEndOff = lastEnd;
+    return TRUE;
+}
+
 __int64
 CViewerWindow::FindSeekBefore(__int64 seek, int lines, BOOL& fatalErr, __int64* firstLineEndOff,
                               __int64* firstLineCharLen, BOOL addLineIfSeekIsWrap) // text display
@@ -1293,11 +1495,14 @@ CViewerWindow::FindSeekBefore(__int64 seek, int lines, BOOL& fatalErr, __int64* 
     if (firstLineCharLen != NULL)
         *firstLineCharLen = -1;
     __int64 beg = seek, prevEnd;
+    __int64 minSeek = TextStartOffset();
+    if (seek < minSeek)
+        seek = minSeek;
     BOOL first = TRUE; // the positions at the start and end of the line coincide; at a wrapped line end
                        // the first seek must take the position at the start, the others at the end
     while (lines--)
     {
-        FindPreviousEOL(NULL, seek, 0, beg, prevEnd, TRUE, first, fatalErr, &lines, first ? firstLineEndOff : NULL,
+        FindPreviousEOL(NULL, seek, minSeek, beg, prevEnd, TRUE, first, fatalErr, &lines, first ? firstLineEndOff : NULL,
                         firstLineCharLen != NULL && *firstLineCharLen == -1 ? firstLineCharLen : NULL,
                         first ? addLineIfSeekIsWrap : FALSE);
         if (fatalErr || ExitTextMode)
@@ -1342,6 +1547,8 @@ CViewerWindow::FindBegin(__int64 seek, BOOL& fatalErr)
     case vtHex:
         return seek - (seek % 16);
     case vtText:
+        if (seek < TextStartOffset())
+            return TextStartOffset();
         return FindSeekBefore(seek, 1, fatalErr);
     }
     return 0;
@@ -1394,6 +1601,90 @@ BOOL CViewerWindow::GetOffsetOrXAbs(__int64 x, __int64* offset, __int64* offsetX
             getXFromOffset && (findOffset < lineBegOff || findOffset > lineEndOff))
         {
             TRACE_C("Unexpected in CViewerWindow::GetOffsetOrXAbs().");
+        }
+        if (HasDecodedTextMode())
+        {
+            Sally::Unicode::DecodedRun visual;
+            if (!DecodeTextRange(NULL, lineBegOff, lineEndOff, visual, fatalErr))
+                return FALSE;
+            if (fatalErr)
+                return FALSE;
+
+            Sally::Unicode::DecodedRun expanded;
+            for (std::size_t i = 0; i < visual.CellCount(); ++i)
+            {
+                if (visual.Scalars[i] == L'\t')
+                {
+                    int tab = (int)(Configuration.TabSize - (expanded.CellCount() % Configuration.TabSize));
+                    if (tab <= 0)
+                        tab = 1;
+                    while (tab-- > 0)
+                        expanded.AppendCell(L' ', visual.RawStart[i], visual.RawEnd[i]);
+                }
+                else
+                    expanded.AppendCell(visual.Scalars[i], visual.RawStart[i], visual.RawEnd[i]);
+            }
+
+            lineCharLen = (__int64)expanded.CellCount();
+            if (getXFromOffset ? findOffset == lineEndOff : x >= lineCharLen)
+            {
+                if (foundX != NULL)
+                    *foundX = lineCharLen;
+                if (offset != NULL)
+                    *offset = lineEndOff;
+                if (offsetX != NULL)
+                    *offsetX = lineCharLen;
+                return TRUE;
+            }
+            if (getXFromOffset ? findOffset == lineBegOff : x <= 0)
+            {
+                if (foundX != NULL)
+                    *foundX = 0;
+                if (offset != NULL)
+                    *offset = lineBegOff;
+                if (offsetX != NULL)
+                    *offsetX = 0;
+                return TRUE;
+            }
+
+            for (std::size_t i = 0; i < expanded.CellCount(); ++i)
+            {
+                if (getXFromOffset)
+                {
+                    if (findOffset <= expanded.RawStart[i])
+                    {
+                        if (foundX != NULL)
+                            *foundX = (__int64)i;
+                        return TRUE;
+                    }
+                    if (findOffset <= expanded.RawEnd[i])
+                    {
+                        if (foundX != NULL)
+                            *foundX = (__int64)i + 1;
+                        return TRUE;
+                    }
+                }
+                else if (x <= (__int64)i + 1)
+                {
+                    if (offset != NULL)
+                    {
+                        if (expanded.RawEnd[i] - expanded.RawStart[i] > 1)
+                            *offset = x > (__int64)i ? expanded.RawEnd[i] : expanded.RawStart[i];
+                        else
+                            *offset = expanded.RawEnd[i];
+                    }
+                    if (offsetX != NULL)
+                        *offsetX = (__int64)i + 1;
+                    return TRUE;
+                }
+            }
+            if (foundX != NULL)
+                *foundX = lineCharLen;
+            if (offset != NULL)
+                *offset = lineEndOff;
+            if (offsetX != NULL)
+                *offsetX = lineCharLen;
+            return TRUE;
         }
         if (getXFromOffset ? findOffset == lineEndOff : x >= lineCharLen)
         {
@@ -1633,6 +1924,26 @@ BOOL CViewerWindow::GetFindText(char* buf, int& len)
     // if (endSel == -1) endSel = 0; // cannot occur (both can be -1 only together, and we never reach this)
     BOOL fatalErr = FALSE;
 
+    if (HasDecodedTextMode())
+    {
+        startSel = max(startSel, TextStartOffset());
+        endSel = max(endSel, startSel);
+        Sally::Unicode::DecodedRun run;
+        if (!DecodeTextRange(NULL, startSel, endSel, run, fatalErr) || fatalErr)
+        {
+            if (fatalErr)
+                FatalFileErrorOccured();
+            return FALSE;
+        }
+        int written = WideCharToMultiByte(CP_ACP, 0, run.Text.c_str(), (int)run.Text.size(),
+                                          buf, FIND_TEXT_LEN - 1, NULL, NULL);
+        if (written <= 0)
+            return FALSE;
+        buf[written] = 0;
+        len = written;
+        return TRUE;
+    }
+
     if (endSel - startSel > FIND_TEXT_LEN - 1)
         endSel = startSel + FIND_TEXT_LEN - 1;
 
@@ -1753,6 +2064,153 @@ CViewerWindow::GetSelectedText(BOOL& fatalErr)
                                         MB_OK | MB_ICONEXCLAMATION);
     }
     return NULL;
+}
+
+HGLOBAL
+CViewerWindow::GetSelectedTextW(BOOL& fatalErr, int* textLen)
+{
+    fatalErr = FALSE;
+    if (textLen != NULL)
+        *textLen = 0;
+    __int64 startSel = min(StartSelection, EndSelection);
+    if (startSel == -1)
+        startSel = TextStartOffset();
+    __int64 endSel = max(StartSelection, EndSelection);
+    if (endSel == -1)
+        endSel = TextStartOffset();
+    startSel = max(startSel, TextStartOffset());
+    endSel = max(endSel, startSel);
+    endSel = min(endSel, FileSize);
+
+    Sally::Unicode::DecodedRun run;
+    if (!DecodeTextRange(NULL, startSel, endSel, run, fatalErr))
+        return NULL;
+    if (fatalErr)
+        return NULL;
+
+    SIZE_T bytes = (run.Text.size() + 1) * sizeof(wchar_t);
+    HGLOBAL h = NOHANDLES(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, bytes));
+    if (h == NULL)
+    {
+        SalMessageBoxViewerPaintBlocked(HWindow, GetErrorText(ERROR_NOT_ENOUGH_MEMORY), LoadStr(IDS_ERRORTITLE),
+                                        MB_OK | MB_ICONEXCLAMATION);
+        return NULL;
+    }
+    wchar_t* s = (wchar_t*)HANDLES(GlobalLock(h));
+    if (s == NULL)
+    {
+        NOHANDLES(GlobalFree(h));
+        return NULL;
+    }
+    if (!run.Text.empty())
+        memcpy(s, run.Text.data(), run.Text.size() * sizeof(wchar_t));
+    s[run.Text.size()] = 0;
+    HANDLES(GlobalUnlock(h));
+    if (textLen != NULL)
+        *textLen = (int)run.Text.size();
+    return h;
+}
+
+BOOL CViewerWindow::FindDecodedLiteral(HANDLE* hFile, BOOL forward, WORD flags, BOOL& foundMatch, BOOL& fatalErr)
+{
+    foundMatch = FALSE;
+    fatalErr = FALSE;
+    if (!HasDecodedTextMode() || FindDialog.Text[0] == 0)
+        return FALSE;
+
+    int wideLen = MultiByteToWideChar(CP_ACP, 0, FindDialog.Text, -1, NULL, 0);
+    if (wideLen <= 1)
+        return FALSE;
+    std::wstring pattern((std::size_t)wideLen, L'\0');
+    MultiByteToWideChar(CP_ACP, 0, FindDialog.Text, -1, pattern.data(), wideLen);
+    pattern.resize((std::size_t)wideLen - 1);
+    std::size_t patternCells = Sally::Unicode::CountPatternCells(pattern);
+    if (patternCells == 0)
+        return TRUE;
+
+    bool caseSensitive = (flags & sfCaseSensitive) != 0;
+    __int64 textStart = TextStartOffset();
+    if (forward)
+    {
+        __int64 off = max(FindOffset, textStart);
+        while (off < FileSize)
+        {
+            __int64 end = min(FileSize, off + FIND_LINE_LEN);
+            Sally::Unicode::DecodedRun run;
+            if (!DecodeTextRange(hFile, off, end, run, fatalErr, end >= FileSize))
+                return FALSE;
+            if (fatalErr)
+                return FALSE;
+            if (run.CellCount() == 0)
+                break;
+
+            std::size_t startCell = 0;
+            while (startCell < run.CellCount() && run.RawEnd[startCell] <= FindOffset)
+                startCell++;
+
+            Sally::Unicode::LiteralMatch match;
+            if (Sally::Unicode::FindLiteralForward(run, pattern, caseSensitive, FindDialog.WholeWords != FALSE,
+                                                   startCell, match))
+            {
+                StartSelection = match.RawStart;
+                EndSelection = match.RawEnd;
+                FindOffset = EndSelection;
+                SelectionIsFindResult = TRUE;
+                foundMatch = TRUE;
+                return TRUE;
+            }
+
+            if (run.CellCount() > patternCells)
+                off = run.RawStart[run.CellCount() - patternCells + 1];
+            else
+                off = run.RawEnd[0];
+            if (off <= FindOffset)
+                off = FindOffset + 1;
+            FindOffset = off;
+        }
+    }
+    else
+    {
+        __int64 off = min(FindOffset, FileSize);
+        while (off > textStart)
+        {
+            __int64 start = max(textStart, off - FIND_LINE_LEN);
+            Sally::Unicode::DecodedRun run;
+            if (!DecodeTextRange(hFile, start, off, run, fatalErr, off >= FileSize))
+                return FALSE;
+            if (fatalErr)
+                return FALSE;
+            if (run.CellCount() == 0)
+                break;
+
+            std::size_t limitCell = run.CellCount();
+            while (limitCell > 0 && run.RawStart[limitCell - 1] >= FindOffset)
+                limitCell--;
+
+            Sally::Unicode::LiteralMatch match;
+            if (Sally::Unicode::FindLiteralBackward(run, pattern, caseSensitive, FindDialog.WholeWords != FALSE,
+                                                    limitCell, match))
+            {
+                StartSelection = match.RawStart;
+                EndSelection = match.RawEnd;
+                FindOffset = StartSelection;
+                SelectionIsFindResult = TRUE;
+                foundMatch = TRUE;
+                return TRUE;
+            }
+
+            if (start == textStart)
+                break;
+            if (run.CellCount() > patternCells)
+                off = run.RawEnd[patternCells - 1];
+            else
+                off = run.RawStart[0];
+            if (off >= FindOffset)
+                off = FindOffset - 1;
+            FindOffset = off;
+        }
+    }
+    return TRUE;
 }
 
 void CViewerWindow::SetToolTipOffset(__int64 offset)

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -1408,79 +1408,179 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
                                            BOOL& fatalErr, int* lines, __int64* firstLineEndOff,
                                            __int64* firstLineCharLen, BOOL addLineIfSeekIsWrap)
 {
+    // Keep decoded backwards navigation close to the legacy byte path: scan backwards from
+    // the current seek instead of replaying the whole file from TextContentOffset.  The
+    // replay implementation was correct but made opening large Unicode files very slow,
+    // because HeightChanged() asks FindSeekBefore(FileSize, visibleLines) during the first
+    // paint and that turned into a full-file decode before any content was drawn.
     UNREFERENCED_PARAMETER(allowWrap);
     UNREFERENCED_PARAMETER(takeLineBegin);
     UNREFERENCED_PARAMETER(lines);
     UNREFERENCED_PARAMETER(addLineIfSeekIsWrap);
 
     fatalErr = FALSE;
-    lineBegin = max(minSeek, TextContentOffset);
-    previousLineEnd = lineBegin;
     if (firstLineEndOff != NULL)
         *firstLineEndOff = -1;
     if (firstLineCharLen != NULL)
         *firstLineCharLen = -1;
 
     minSeek = max(minSeek, TextContentOffset);
-    seek = max(seek, minSeek);
+    seek = max(min(seek, FileSize), minSeek);
+    lineBegin = minSeek;
+    previousLineEnd = minSeek;
     if (seek <= minSeek)
     {
-        previousLineEnd = lineBegin = minSeek;
         if (firstLineCharLen != NULL)
             *firstLineCharLen = 0;
         return TRUE;
     }
 
-    __int64 pos = minSeek;
-    __int64 lastBegin = minSeek;
-    __int64 lastEnd = minSeek;
-    __int64 lastPreviousEnd = minSeek;
-    __int64 lastLen = 0;
-    while (pos < seek && pos < FileSize)
+    auto previousScalarOffset = [&]( __int64 offset) -> __int64
     {
-        Sally::Unicode::DecodedRun visual;
-        __int64 lineEnd = pos;
-        __int64 nextLineBegin = pos;
-        BOOL eol = FALSE;
-        BOOL wrapped = FALSE;
-        int eolBytes = 0;
-        __int64 maxCells = WrapText ? max(1, (Width - BORDER_WIDTH) / CharWidth) : TEXT_MAX_LINE_LEN + 1;
-        if (!ReadDecodedTextLine(hFile, pos, maxCells, visual, lineEnd, nextLineBegin,
-                                 eol, wrapped, eolBytes, fatalErr))
-            return FALSE;
-        if (fatalErr)
-            return FALSE;
-        if (nextLineBegin <= pos)
-            break;
-
-        if (nextLineBegin >= seek)
+        if (offset <= minSeek)
+            return -1;
+        if (TextEncoding == Sally::Unicode::BomEncoding::Utf16Le ||
+            TextEncoding == Sally::Unicode::BomEncoding::Utf16Be)
         {
-            lineBegin = pos;
-            previousLineEnd = lastPreviousEnd;
-            lastEnd = lineEnd;
-            lastLen = (__int64)visual.CellCount();
-            break;
+            __int64 pos = Sally::Unicode::AlignToCodeUnit(TextEncoding, offset - 1, TextContentOffset);
+            if (pos >= offset)
+                pos -= 2;
+            return pos >= minSeek ? pos : -1;
         }
 
-        lastPreviousEnd = lineEnd;
-        lastBegin = pos;
-        lastEnd = lineEnd;
-        lastLen = (__int64)visual.CellCount();
-        pos = nextLineBegin;
-    }
+        __int64 pos = offset - 1;
+        while (pos > minSeek)
+        {
+            __int64 len = Prepare(hFile, pos, 1, fatalErr);
+            if (fatalErr || len != 1)
+                return -1;
+            unsigned char ch = *(Buffer + (pos - Seek));
+            if ((ch & 0xC0) != 0x80)
+                break;
+            pos--;
+        }
+        return pos >= minSeek ? pos : -1;
+    };
 
-    if (pos >= seek)
+    auto readScalar = [&]( __int64 offset, Sally::Unicode::DecodedRun& scalar) -> BOOL
     {
-        lineBegin = lastBegin;
-        previousLineEnd = lastPreviousEnd;
+        scalar.Clear();
+        if (offset < minSeek || offset >= FileSize)
+            return FALSE;
+        return ReadDecodedScalar(hFile, offset, scalar, fatalErr) && !fatalErr && scalar.CellCount() > 0;
+    };
+
+    struct DecodedEol
+    {
+        __int64 LineEnd;
+        __int64 NextLineBegin;
+    };
+
+    auto findPreviousEol = [&]( __int64 limit, DecodedEol& eol) -> BOOL
+    {
+        __int64 pos = previousScalarOffset(limit);
+        while (pos >= minSeek)
+        {
+            Sally::Unicode::DecodedRun scalar;
+            if (!readScalar(pos, scalar))
+                return FALSE;
+            if (scalar.RawStart[0] >= limit)
+            {
+                pos = previousScalarOffset(pos);
+                continue;
+            }
+
+            std::uint32_t ch = scalar.Scalars[0];
+            if (ch == L'\n')
+            {
+                if (Configuration.EOL_CRLF)
+                {
+                    __int64 prevPos = previousScalarOffset(scalar.RawStart[0]);
+                    Sally::Unicode::DecodedRun prevScalar;
+                    if (prevPos >= minSeek && readScalar(prevPos, prevScalar) &&
+                        prevScalar.Scalars[0] == L'\r' && prevScalar.RawEnd[0] == scalar.RawStart[0])
+                    {
+                        eol.LineEnd = prevScalar.RawStart[0];
+                        eol.NextLineBegin = scalar.RawEnd[0];
+                        return TRUE;
+                    }
+                    if (fatalErr)
+                        return FALSE;
+                }
+                if (Configuration.EOL_LF)
+                {
+                    eol.LineEnd = scalar.RawStart[0];
+                    eol.NextLineBegin = scalar.RawEnd[0];
+                    return TRUE;
+                }
+            }
+            else if (ch == L'\r')
+            {
+                if (Configuration.EOL_CRLF)
+                {
+                    Sally::Unicode::DecodedRun nextScalar;
+                    if (scalar.RawEnd[0] < limit && readScalar(scalar.RawEnd[0], nextScalar) &&
+                        nextScalar.Scalars[0] == L'\n' && nextScalar.RawStart[0] == scalar.RawEnd[0] &&
+                        nextScalar.RawEnd[0] <= limit)
+                    {
+                        eol.LineEnd = scalar.RawStart[0];
+                        eol.NextLineBegin = nextScalar.RawEnd[0];
+                        return TRUE;
+                    }
+                    if (fatalErr)
+                        return FALSE;
+                }
+                if (Configuration.EOL_CR)
+                {
+                    eol.LineEnd = scalar.RawStart[0];
+                    eol.NextLineBegin = scalar.RawEnd[0];
+                    return TRUE;
+                }
+            }
+            else if (ch == 0 && Configuration.EOL_NULL)
+            {
+                eol.LineEnd = scalar.RawStart[0];
+                eol.NextLineBegin = scalar.RawEnd[0];
+                return TRUE;
+            }
+
+            pos = previousScalarOffset(pos);
+            if (fatalErr)
+                return FALSE;
+        }
+        return FALSE;
+    };
+
+    DecodedEol currentEol = {minSeek, minSeek};
+    if (findPreviousEol(seek, currentEol))
+    {
+        lineBegin = currentEol.NextLineBegin;
+        previousLineEnd = currentEol.LineEnd;
+    }
+    else if (fatalErr)
+        return FALSE;
+    else
+    {
+        lineBegin = minSeek;
+        previousLineEnd = minSeek;
     }
 
-    if (lineBegin > TextContentOffset && firstLineEndOff != NULL)
-        *firstLineEndOff = previousLineEnd;
+    if (firstLineEndOff != NULL)
+        *firstLineEndOff = lineBegin > minSeek ? previousLineEnd : lineBegin;
+
     if (firstLineCharLen != NULL)
-        *firstLineCharLen = lastLen;
-    if (firstLineEndOff != NULL && *firstLineEndOff == -1)
-        *firstLineEndOff = lastEnd;
+    {
+        __int64 countEnd = max(lineBegin, min(seek, currentEol.LineEnd >= lineBegin ? currentEol.LineEnd : seek));
+        Sally::Unicode::DecodedRun visual;
+        if (countEnd > lineBegin)
+        {
+            if (!DecodeTextRange(hFile, lineBegin, countEnd, visual, fatalErr))
+                return FALSE;
+            if (fatalErr)
+                return FALSE;
+        }
+        *firstLineCharLen = (__int64)visual.CellCount();
+    }
     return TRUE;
 }
 

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1301,7 +1301,13 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
             BOOL fatalErr = FALSE;
             FindingSoDonotSwitchToHex = TRUE; // during searching disable switching to "hex" when a line has more than 10000 characters
-            if (FindDialog.Regular)
+            if (HasDecodedTextMode() && !FindDialog.Regular && !FindDialog.HexMode)
+            {
+                BOOL foundMatch = FALSE;
+                if (FindDecodedLiteral(&hFile, forward, flags, foundMatch, fatalErr) && foundMatch)
+                    found = 0;
+            }
+            else if (FindDialog.Regular)
             {
                 if (RegExp.SetFlags(flags))
                 {
@@ -1777,15 +1783,25 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 CheckSelectionIsNotTooBig(HWindow))
             {
                 BOOL fatalErr = FALSE;
-                HGLOBAL h = GetSelectedText(fatalErr);
-                if (h != NULL)
+                if (HasDecodedTextMode())
                 {
-                    __int64 startSel = min(StartSelection, EndSelection);
-                    // if (startSel == -1) startSel = 0; // cannot happen (-1 can only be both at once and we do not get here)
-                    __int64 endSel = max(StartSelection, EndSelection);
-                    // if (endSel == -1) endSel = 0; // cannot happen (-1 can only be both at once and we do not get here)
-                    if (fatalErr || !CopyHTextToClipboard(h, (int)(endSel - startSel)))
+                    int textLen = 0;
+                    HGLOBAL h = GetSelectedTextW(fatalErr, &textLen);
+                    if (h != NULL && (fatalErr || !CopyHTextToClipboardW(h, textLen)))
                         NOHANDLES(GlobalFree(h));
+                }
+                else
+                {
+                    HGLOBAL h = GetSelectedText(fatalErr);
+                    if (h != NULL)
+                    {
+                        __int64 startSel = min(StartSelection, EndSelection);
+                        // if (startSel == -1) startSel = 0; // cannot happen (-1 can only be both at once and we do not get here)
+                        __int64 endSel = max(StartSelection, EndSelection);
+                        // if (endSel == -1) endSel = 0; // cannot happen (-1 can only be both at once and we do not get here)
+                        if (fatalErr || !CopyHTextToClipboard(h, (int)(endSel - startSel)))
+                            NOHANDLES(GlobalFree(h));
+                    }
                 }
                 if (fatalErr)
                     FatalFileErrorOccured();
@@ -1974,7 +1990,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             if (MouseDrag)
                 return 0;
-            StartSelection = 0;
+            StartSelection = HasDecodedTextMode() ? TextStartOffset() : 0;
             EndSelection = FileSize;
             SelectionIsFindResult = FALSE;
             InvalidateRect(HWindow, NULL, FALSE);
@@ -3002,11 +3018,11 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     POINT p1;
                     GetCursorPos(&p1);
 
-                    HGLOBAL h = GetSelectedText(fatalErr);
+                    HGLOBAL h = HasDecodedTextMode() ? GetSelectedTextW(fatalErr, NULL) : GetSelectedText(fatalErr);
                     if (!fatalErr && h != NULL)
                     {
                         CImpIDropSource* dropSource = new CImpIDropSource(FALSE);
-                        IDataObject* dataObject = new CTextDataObject(h);
+                        IDataObject* dataObject = HasDecodedTextMode() ? new CTextDataObject(h, TRUE) : new CTextDataObject(h);
                         if (dataObject != NULL && dropSource != NULL)
                         {
                             DWORD dwEffect;


### PR DESCRIPTION
### Motivation
- Provide robust detection and decoding of text files with BOM or UTF-8/UTF-16 encodings so the viewer can render, select, copy and search Unicode text correctly.
- Support decoded text layout (expanded tabs, visual cells), EOL handling and literal searching across decoded scalars so features like find, selection and clipboard work with multi-byte encodings.

### Description
- Add a new Unicode helper module `common/unicode/ViewerBomText.{h,cpp}` implementing `DetectBom`, `DetectTextEncoding`, `DecodeBytes`, `DecodedRun` and search helpers (`FindLiteralForward/Backward`, `CountPatternCells`) for UTF-8/UTF-16 decoding and pattern matching.
- Integrate decoded-text mode into the viewer by adding `TextEncoding` and `TextContentOffset` to `CViewerWindow`, detecting encoding on file open, and branching existing text-paths to handle decoded mode (rendering, EOL detection, line reading, seeking, selection, offset computations, searching, copy/drag-and-drop).
- Add `GetSelectedTextW`, `FindDecodedLiteral`, wide text drawing `MyTextOutW`, and decoding-aware implementations of `FindNextEOL`, `FindPreviousEOL`, `FindSeekBefore`, `GetOffsetOrXAbs`, and selection/clipboard/drag-drop flows; update `CTextDataObject` to carry either ANSI or Unicode HGLOBAL payloads.
- Update project files (`salamand.vcxproj`, `.filters`) to include the new source and header files and wire precompiled header settings for the added compile unit.

### Testing
- Performed automated project build with MSBuild/MSVC for the modified `salamand.vcxproj` configurations (Debug/Release, Win32/x64), and the solution compiles successfully with the new sources included.
- No new unit tests were added to the repository as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2332e8d4808329b49c71092d85a851)