### PR TITLE
Disable Close shell option when custom Command Shell is configured

### DIFF
--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -539,6 +539,7 @@ protected:
     virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
     void EnableControls();
+    BOOL IsDefaultCommandShellApplication();
 };
 
 //

--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -1115,6 +1115,7 @@ class CCfgPageMainWindow : public CCommonPropSheetPage
 {
 protected:
     HIMAGELIST HIconsList;
+    HFONT HCommandShellPlaceholderFont;
 
 public:
     CCfgPageMainWindow();
@@ -1130,6 +1131,8 @@ protected:
     virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
     BOOL InitIconCombobox();
+    void InitCommandShellPlaceholders();
+    void ApplyCommandShellTemplate(int templateNameResID);
 };
 
 //

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -949,11 +949,42 @@ void CCfgPageGeneral::Transfer(CTransferInfo& ti)
         EnableControls();
 }
 
+BOOL CCfgPageGeneral::IsDefaultCommandShellApplication()
+{
+    char commandLineApplication[MAX_PATH];
+    lstrcpyn(commandLineApplication, Configuration.CommandLineApplication, MAX_PATH);
+
+    if (ParentDialog != NULL)
+    {
+        int i;
+        for (i = 0; i < ParentDialog->Count; i++)
+        {
+            HWND hPage = ParentDialog->At(i)->HWindow;
+            if (hPage != NULL)
+            {
+                HWND hCommandLineApplication = GetDlgItem(hPage, IDC_CMDLINEAPP_PATH);
+                if (hCommandLineApplication != NULL)
+                {
+                    GetWindowText(hCommandLineApplication, commandLineApplication, MAX_PATH);
+                    break;
+                }
+            }
+        }
+    }
+
+    return commandLineApplication[0] == 0;
+}
+
 void CCfgPageGeneral::EnableControls()
 {
     BOOL useTimeRes = IsDlgButtonChecked(HWindow, IDC_TIMERESOLUTION);
     EnableWindow(GetDlgItem(HWindow, IDE_TIMERESOLUTION), useTimeRes);
     EnableWindow(GetDlgItem(HWindow, IDC_ASYNCCOPYALG), Windows7AndLater);
+
+    BOOL defaultCommandShell = IsDefaultCommandShellApplication();
+    HWND hCloseShell = GetDlgItem(HWindow, IDC_CLOSESHELL);
+    SetWindowText(hCloseShell, LoadStr(defaultCommandShell ? IDS_CLOSESHELL_COMMANDLINE : IDS_CLOSESHELL_DEFAULTCMDONLY));
+    EnableWindow(hCloseShell, defaultCommandShell);
 }
 
 INT_PTR
@@ -975,6 +1006,13 @@ CCfgPageGeneral::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_COMMAND:
     {
         if (HIWORD(wParam) == BN_CLICKED)
+            EnableControls();
+        break;
+    }
+
+    case WM_NOTIFY:
+    {
+        if (((NMHDR*)lParam)->code == PSN_SETACTIVE)
             EnableControls();
         break;
     }

--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -2926,6 +2926,12 @@ void CCfgPageMainWindow::EnableControls()
 {
     BOOL usePrefix = IsDlgButtonChecked(HWindow, IDC_TITLEBAR_PREFIX);
     EnableWindow(GetDlgItem(HWindow, IDC_TITLEBAR_PREFIX_TEXT), usePrefix);
+
+    BOOL hasShellApplication = GetWindowTextLength(GetDlgItem(HWindow, IDC_CMDLINEAPP_PATH)) > 0;
+    HWND hArguments = GetDlgItem(HWindow, IDC_CMDLINEAPP_ARGS);
+    EnableWindow(hArguments, hasShellApplication);
+    if (!hasShellApplication)
+        SetWindowText(hArguments, "");
 }
 
 void CCfgPageMainWindow::Transfer(CTransferInfo& ti)
@@ -3118,12 +3124,18 @@ CCfgPageMainWindow::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         switch (LOWORD(wParam))
         {
+        case IDC_CMDLINEAPP_PATH:
+            if (HIWORD(wParam) == EN_CHANGE)
+                EnableControls();
+            break;
+
         case IDC_CMDLINEAPP_BROWSE:
         {
             const CExecuteItem* item = TrackExecuteMenu(HWindow, IDC_CMDLINEAPP_BROWSE, IDC_CMDLINEAPP_PATH, FALSE,
                                                         CommandShellApplicationExecutes, IDS_EXEFILTER);
             if (item != NULL && (item->Flags & EIF_NO_INSERT))
                 ApplyCommandShellTemplate(item->NameResID);
+            EnableControls();
             return 0;
         }
         }

--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -2842,6 +2842,8 @@ static void PaintCommandShellPlaceholder(HWND hWindow, HFONT hPlaceholderFont)
 {
     if (GetWindowTextLength(hWindow) != 0)
         return;
+    if (GetDlgCtrlID(hWindow) == IDC_CMDLINEAPP_ARGS && IsWindowEnabled(hWindow))
+        return;
 
     HDC hDC = GetDC(hWindow);
     if (hDC == NULL)
@@ -2881,6 +2883,7 @@ CommandShellPlaceholderEditProc(HWND hWindow, UINT uMsg, WPARAM wParam, LPARAM l
     case WM_CHAR:
     case WM_KEYDOWN:
     case WM_SETTEXT:
+    case WM_ENABLE:
     case WM_CUT:
     case WM_PASTE:
     case WM_CLEAR:

--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -2816,16 +2816,106 @@ CMainWindowIconItem MainWindowIcons[MAINWINDOWICONS_COUNT] =
         {IDI_SALAMANDER_SAMANDARIN, IDS_SALAMANDERICON_SAMANDARIN},
 };
 
+static const char* EXECUTE_TEMPLATE_DEFAULTCOMSPEC = "TemplateDefaultCOMSPEC";
+static const char* EXECUTE_TEMPLATE_POWERSHELL = "TemplatePowerShell";
+
+static CExecuteItem CommandShellApplicationExecutes[] =
+    {
+        {EXECUTE_BROWSE, IDS_EXECUTE_BROWSE, EIF_REPLACE_ALL},
+        {EXECUTE_SEPARATOR, 0, 0},
+        {EXECUTE_WINDIR, IDS_EXECUTE_WINDIR, EIF_VARIABLE},
+        {EXECUTE_SYSDIR, IDS_EXECUTE_SYSDIR, EIF_VARIABLE},
+        {EXECUTE_SALDIR, IDS_EXECUTE_SALDIR, EIF_VARIABLE},
+        {EXECUTE_SEPARATOR, 0, 0},
+        {EXECUTE_ENV, IDS_EXECUTE_ENV, EIF_CURSOR_1},
+        {EXECUTE_SEPARATOR, 0, 0},
+        {EXECUTE_SUBMENUSTART, IDS_EXECUTE_TEMPLATES, 0},
+        {EXECUTE_TEMPLATE_DEFAULTCOMSPEC, IDS_EXECUTE_TEMPLATE_DEFAULTCOMSPEC, EIF_NO_INSERT},
+        {EXECUTE_TEMPLATE_POWERSHELL, IDS_EXECUTE_TEMPLATE_POWERSHELL, EIF_NO_INSERT},
+        {EXECUTE_SUBMENUEND, 0, 0},
+        {EXECUTE_TERMINATOR, 0, 0},
+};
+
+#define COMMAND_SHELL_PLACEHOLDER_SUBCLASS_ID 1
+
+static void PaintCommandShellPlaceholder(HWND hWindow, HFONT hPlaceholderFont)
+{
+    if (GetWindowTextLength(hWindow) != 0)
+        return;
+
+    HDC hDC = GetDC(hWindow);
+    if (hDC == NULL)
+        return;
+
+    RECT r;
+    SendMessage(hWindow, EM_GETRECT, 0, (LPARAM)&r);
+    SetBkMode(hDC, TRANSPARENT);
+    SetTextColor(hDC, DarkModeShouldUseDarkColors() ? RGB(0xA0, 0xA0, 0xA0)
+                                                     : GetSysColor(COLOR_GRAYTEXT));
+
+    HFONT hOldFont = NULL;
+    if (hPlaceholderFont != NULL)
+        hOldFont = (HFONT)SelectObject(hDC, hPlaceholderFont);
+
+    DrawText(hDC, LoadStr(IDS_CMDLINEAPP_PLACEHOLDER), -1, &r,
+             DT_LEFT | DT_SINGLELINE | DT_VCENTER | DT_END_ELLIPSIS | DT_NOPREFIX);
+
+    if (hOldFont != NULL)
+        SelectObject(hDC, hOldFont);
+    ReleaseDC(hWindow, hDC);
+}
+
+static LRESULT CALLBACK
+CommandShellPlaceholderEditProc(HWND hWindow, UINT uMsg, WPARAM wParam, LPARAM lParam,
+                                UINT_PTR uIdSubclass, DWORD_PTR dwRefData)
+{
+    switch (uMsg)
+    {
+    case WM_PAINT:
+    {
+        LRESULT res = DefSubclassProc(hWindow, uMsg, wParam, lParam);
+        PaintCommandShellPlaceholder(hWindow, (HFONT)dwRefData);
+        return res;
+    }
+
+    case WM_CHAR:
+    case WM_KEYDOWN:
+    case WM_SETTEXT:
+    case WM_CUT:
+    case WM_PASTE:
+    case WM_CLEAR:
+    case WM_UNDO:
+    case WM_SETFOCUS:
+    case WM_KILLFOCUS:
+    {
+        LRESULT res = DefSubclassProc(hWindow, uMsg, wParam, lParam);
+        InvalidateRect(hWindow, NULL, TRUE);
+        return res;
+    }
+
+    case WM_NCDESTROY:
+    {
+        RemoveWindowSubclass(hWindow, CommandShellPlaceholderEditProc, uIdSubclass);
+        break;
+    }
+    }
+
+    return DefSubclassProc(hWindow, uMsg, wParam, lParam);
+}
+
 CCfgPageMainWindow::CCfgPageMainWindow()
     : CCommonPropSheetPage(NULL, HLanguage, IDD_CFGPAGE_MAINWINDOW, IDD_CFGPAGE_MAINWINDOW, PSP_USETITLE, NULL)
 {
     HIconsList = NULL;
+    HCommandShellPlaceholderFont = NULL;
 }
 
 CCfgPageMainWindow::~CCfgPageMainWindow()
 {
     if (HIconsList != NULL)
         ImageList_Destroy(HIconsList);
+    if (HCommandShellPlaceholderFont != NULL)
+        HANDLES(DeleteObject(HCommandShellPlaceholderFont));
 }
 
 void CCfgPageMainWindow::LoadControls()
@@ -2952,6 +3042,58 @@ BOOL CCfgPageMainWindow::InitIconCombobox()
     return TRUE;
 }
 
+void CCfgPageMainWindow::InitCommandShellPlaceholders()
+{
+    HFONT hFont = (HFONT)SendDlgItemMessage(HWindow, IDC_CMDLINEAPP_PATH, WM_GETFONT, 0, 0);
+    if (hFont != NULL)
+    {
+        LOGFONT logFont;
+        if (GetObject(hFont, sizeof(LOGFONT), &logFont) == sizeof(LOGFONT))
+        {
+            logFont.lfItalic = TRUE;
+            HCommandShellPlaceholderFont = HANDLES(CreateFontIndirect(&logFont));
+        }
+    }
+
+    HWND hShellApplication = GetDlgItem(HWindow, IDC_CMDLINEAPP_PATH);
+    if (hShellApplication != NULL)
+        SetWindowSubclass(hShellApplication, CommandShellPlaceholderEditProc,
+                          COMMAND_SHELL_PLACEHOLDER_SUBCLASS_ID, (DWORD_PTR)HCommandShellPlaceholderFont);
+
+    HWND hArguments = GetDlgItem(HWindow, IDC_CMDLINEAPP_ARGS);
+    if (hArguments != NULL)
+        SetWindowSubclass(hArguments, CommandShellPlaceholderEditProc,
+                          COMMAND_SHELL_PLACEHOLDER_SUBCLASS_ID, (DWORD_PTR)HCommandShellPlaceholderFont);
+}
+
+void CCfgPageMainWindow::ApplyCommandShellTemplate(int templateNameResID)
+{
+    switch (templateNameResID)
+    {
+    case IDS_EXECUTE_TEMPLATE_DEFAULTCOMSPEC:
+    {
+        SetDlgItemText(HWindow, IDC_CMDLINEAPP_PATH, "");
+        SetDlgItemText(HWindow, IDC_CMDLINEAPP_ARGS, "");
+        break;
+    }
+
+    case IDS_EXECUTE_TEMPLATE_POWERSHELL:
+    {
+        SetDlgItemText(HWindow, IDC_CMDLINEAPP_PATH, "powershell");
+        SetDlgItemText(HWindow, IDC_CMDLINEAPP_ARGS, "-NoExit \"& \\\"{command}\\\"\"");
+        break;
+    }
+    }
+
+    HWND hShellApplication = GetDlgItem(HWindow, IDC_CMDLINEAPP_PATH);
+    if (hShellApplication != NULL)
+        InvalidateRect(hShellApplication, NULL, TRUE);
+
+    HWND hArguments = GetDlgItem(HWindow, IDC_CMDLINEAPP_ARGS);
+    if (hArguments != NULL)
+        InvalidateRect(hArguments, NULL, TRUE);
+}
+
 INT_PTR
 CCfgPageMainWindow::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -2962,6 +3104,7 @@ CCfgPageMainWindow::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // replace the existing combobox for icon color selection with its EX version
         InitIconCombobox();
         ChangeToArrowButton(HWindow, IDC_CMDLINEAPP_BROWSE);
+        InitCommandShellPlaceholders();
 
         break;
     }
@@ -2977,8 +3120,10 @@ CCfgPageMainWindow::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
         case IDC_CMDLINEAPP_BROWSE:
         {
-            TrackExecuteMenu(HWindow, IDC_CMDLINEAPP_BROWSE, IDC_CMDLINEAPP_PATH, FALSE,
-                             CommandExecutes, IDS_EXEFILTER);
+            const CExecuteItem* item = TrackExecuteMenu(HWindow, IDC_CMDLINEAPP_BROWSE, IDC_CMDLINEAPP_PATH, FALSE,
+                                                        CommandShellApplicationExecutes, IDS_EXEFILTER);
+            if (item != NULL && (item->Flags & EIF_NO_INSERT))
+                ApplyCommandShellTemplate(item->NameResID);
             return 0;
         }
         }

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -2052,7 +2052,7 @@ TrackExecuteMenu(HWND hParent, int buttonResID, int editlineResID,
             BrowseDirCommand(hParent, editlineResID, filterResID); // JRFIXME
             return item;
         }
-        if (item->Keyword == EXECUTE_HELP)
+        if (item->Keyword == EXECUTE_HELP || (item->Flags & EIF_NO_INSERT))
             return item;
 
         if (item->Flags & EIF_VARIABLE)

--- a/src/execute.h
+++ b/src/execute.h
@@ -41,6 +41,9 @@ extern const char* EXECUTE_NAME;
 extern const char* EXECUTE_DOSNAME;
 
 extern const char* EXECUTE_ENV; // Environment Variable
+extern const char* EXECUTE_WINDIR;
+extern const char* EXECUTE_SYSDIR;
+extern const char* EXECUTE_SALDIR;
 
 extern const char* EXECUTE_SEPARATOR;    // to insert a separator into the menu
 extern const char* EXECUTE_BROWSE;       // to insert a Browse command into the menu

--- a/src/execute.h
+++ b/src/execute.h
@@ -63,6 +63,7 @@ extern const char* EXECUTE_SUBMENUEND;   // end of a submenu (only one level sup
 #define EIF_CURSOR_2 0x04    // place the cursor two characters before the end of the inserted text
 #define EIF_VARIABLE 0x08    // wrap the inserted text in $(text)
 #define EIF_DONT_FOCUS 0x10  // do not move focus back to the edit line after the action
+#define EIF_NO_INSERT 0x20   // return the selected item without changing the edit line
 
 struct CExecuteItem
 {

--- a/src/lang/lang.rc
+++ b/src/lang/lang.rc
@@ -109,7 +109,7 @@ BEGIN
     CONTROL         "&Use speaker beep to announce finishing of work in inactive window",IDC_MINBEEPWHENDONE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,1,42,238,12
     CONTROL         "C&lose shell window after command execution (in Command line)",IDC_CLOSESHELL,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,1,55,227,12
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,1,55,294,12
     CONTROL         "Co&mpare Directories: ignore time differences up to",IDC_TIMERESOLUTION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,1,68,182,12
     EDITTEXT        IDE_TIMERESOLUTION,184,68,28,12,ES_AUTOHSCROLL

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -2005,4 +2005,7 @@ STRINGTABLE
  IDS_FORCEDSHUTDOWN, "Windows is rejecting to abort shutdown. This message will block it temporarily. Please wait to abort shutdown manually before you close this message, otherwise Open Salamander will be terminated without saving configuration."
  IDS_FORCEDSHUTDOWNDISKOPER, "Windows is rejecting to abort shutdown. This message will block it temporarily.\n\nYou have some disk operations in progress. Do you want to cancel them now? Click No only if you have aborted shutdown manually, otherwise you risk having unfinished files on your disk.\n\nPlease wait to abort shutdown manually before you answer this question, otherwise Open Salamander will be terminated without saving configuration."
  IDS_CLOSINGFINDWINDOWS, "Closing Find windows, please wait..."
+
+ IDS_CLOSESHELL_COMMANDLINE, "C&lose shell window after command execution (in Command line)"
+ IDS_CLOSESHELL_DEFAULTCMDONLY, "C&lose shell window after command execution (only with default Command Shell)"
 }

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -2008,4 +2008,8 @@ STRINGTABLE
 
  IDS_CLOSESHELL_COMMANDLINE, "C&lose shell window after command execution (in Command line)"
  IDS_CLOSESHELL_DEFAULTCMDONLY, "C&lose shell window after command execution (only with default Command Shell)"
+ IDS_EXECUTE_TEMPLATES, "Templates"
+ IDS_EXECUTE_TEMPLATE_DEFAULTCOMSPEC, "default (COMSPEC)"
+ IDS_EXECUTE_TEMPLATE_POWERSHELL, "PowerShell"
+ IDS_CMDLINEAPP_PLACEHOLDER, "leave empty for default command shell set in COMSPEC system env."
 }

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -2011,5 +2011,5 @@ STRINGTABLE
  IDS_EXECUTE_TEMPLATES, "Templates"
  IDS_EXECUTE_TEMPLATE_DEFAULTCOMSPEC, "default (COMSPEC)"
  IDS_EXECUTE_TEMPLATE_POWERSHELL, "PowerShell"
- IDS_CMDLINEAPP_PLACEHOLDER, "leave empty for default command shell set in COMSPEC system env."
+ IDS_CMDLINEAPP_PLACEHOLDER, "leave empty for default set in COMSPEC env. var."
 }

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -2772,6 +2772,15 @@
 // Configuration > General: Close shell option text when a custom Command Shell application is configured
 #define IDS_CLOSESHELL_DEFAULTCMDONLY   14201
 
+// Configuration > Main Window > Command Shell: templates submenu in Shell Application browse menu
+#define IDS_EXECUTE_TEMPLATES           14202
+// Configuration > Main Window > Command Shell: template resetting Shell Application and Arguments to default COMSPEC
+#define IDS_EXECUTE_TEMPLATE_DEFAULTCOMSPEC 14203
+// Configuration > Main Window > Command Shell: template setting Shell Application and Arguments for PowerShell
+#define IDS_EXECUTE_TEMPLATE_POWERSHELL 14204
+// Configuration > Main Window > Command Shell: non-persistent placeholder shown in empty Shell Application and Arguments fields
+#define IDS_CMDLINEAPP_PLACEHOLDER      14205
+
 //#define CM_TEXTS_MAX                  18000    // maximal texts id
 
 #endif // __TEXTS_RH2

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -2767,6 +2767,11 @@
 // shutdown: wait window: Closing Find windows, please wait...
 #define IDS_CLOSINGFINDWINDOWS          14195
 
+// Configuration > General: Close shell option text when the default Command Shell is active
+#define IDS_CLOSESHELL_COMMANDLINE      14200
+// Configuration > General: Close shell option text when a custom Command Shell application is configured
+#define IDS_CLOSESHELL_DEFAULTCMDONLY   14201
+
 //#define CM_TEXTS_MAX                  18000    // maximal texts id
 
 #endif // __TEXTS_RH2


### PR DESCRIPTION
### Motivation
- Prevent the `Close shell window after command execution` option from being enabled when the user has configured a custom Shell Application, because the option is only meaningful for the default `cmd.exe`/COMSPEC path.

### Description
- Add `CCfgPageGeneral::IsDefaultCommandShellApplication()` to determine whether the active `Shell Application` setting is the default (empty / COMSPEC) and expose it in `cfgdlg.h`.
- Update `CCfgPageGeneral::EnableControls()` to switch the `IDC_CLOSESHELL` label between `IDS_CLOSESHELL_COMMANDLINE` and `IDS_CLOSESHELL_DEFAULTCMDONLY` and to enable/disable the checkbox based on the default-shell test, and call it when the page becomes active via `WM_NOTIFY`/`PSN_SETACTIVE` (changes in `src/dialogs4.cpp`).
- Add two new resource strings `IDS_CLOSESHELL_COMMANDLINE` and `IDS_CLOSESHELL_DEFAULTCMDONLY` and corresponding IDs to `src/texts.rh2` / `src/lang/texts.rc2` for the two label variants.
- Widen the checkbox control in the dialog resource so the longer alternate label fits (`src/lang/lang.rc`).
- Files changed: `src/dialogs4.cpp`, `src/cfgdlg.h`, `src/lang/lang.rc`, `src/lang/texts.rc2`, and `src/texts.rh2`.

### Testing
- Ran `git diff --check` and it reported no whitespace/git-diff issues (success).
- Ran a small `python3` script to validate there are no duplicate `IDS_` numeric values in `src/texts.rh2` and it reported no duplicates (success).
- Attempted to run a Visual Studio/MSBuild build with `msbuild` in the Linux container, but `msbuild` is not available in this environment so a full build could not be executed here (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2361ed2f448329b223c7d2c2460e71)