### PR TITLE
Fix PowerShell command shell template arguments

### DIFF
--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -3089,7 +3089,7 @@ void CCfgPageMainWindow::ApplyCommandShellTemplate(int templateNameResID)
     case IDS_EXECUTE_TEMPLATE_POWERSHELL:
     {
         SetDlgItemText(HWindow, IDC_CMDLINEAPP_PATH, "powershell");
-        SetDlgItemText(HWindow, IDC_CMDLINEAPP_ARGS, "-NoExit \"& \\\"{command}\\\"\"");
+        SetDlgItemText(HWindow, IDC_CMDLINEAPP_ARGS, "-NoExit \"& {command}\"");
         break;
     }
     }


### PR DESCRIPTION
### Motivation
- Ensure the Command Shell PowerShell template sets the Arguments field to the exact literal `-NoExit "& {command}"` so the dialog shows `-NoExit "& {command}"` (displayed as `-NoExit "& {command}"` -> `-NoExit "& {command}"`).

### Description
- In `CCfgPageMainWindow::ApplyCommandShellTemplate` (src/dialogs5.cpp) the `IDS_EXECUTE_TEMPLATE_POWERSHELL` branch now calls `SetDlgItemText(HWindow, IDC_CMDLINEAPP_ARGS, "-NoExit \"& {command}\"")` so the Arguments edit contains `-NoExit "& {command}"` and displays as `-NoExit "& {command}"`.

### Testing
- Ran automated static checks: a Python script verified the C++ literal decodes to `-NoExit "& {command}"` and a second script confirmed the Templates menu entry, apply branch, path and callback wiring are present; attempting builds via `pwsh -NoProfile -File ./build.ps1 Debug x64` and `cmd.exe /c "build.cmd Debug x64"` failed in this environment because `pwsh`/`cmd.exe` are not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23770fb1708329877e547731135dc8)