### PR TITLE
Avoid blocking shell icon lookup during startup

### DIFF
--- a/src/common/sheets.cpp
+++ b/src/common/sheets.cpp
@@ -78,28 +78,14 @@ void ApplyTreeViewColors(HWND treeView)
             SetWindowTheme(treeView, L"explorer", NULL);
     }
 
-    RedrawWindow(treeView, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
-}
-
-BOOL CALLBACK RepaintWindowTreeProc(HWND hwnd, LPARAM)
-{
-    RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE | RDW_UPDATENOW);
-    return TRUE;
+    RedrawWindow(treeView, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE);
 }
 
 void RepaintWindowTree(HWND hwnd)
 {
-    if (hwnd == NULL)
-        return;
-
-    // Some themed/light Configuration pages do not paint all child controls
-    // until they receive an immediate paint pass (for example after resize).
-    // Keep that immediate repaint, but skip background erasing; the previous
-    // RDW_ERASE-based subtree redraw made the whole dialog flash.
-    RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
-    EnumChildWindows(hwnd, RepaintWindowTreeProc, 0);
+    if (hwnd != NULL)
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE | RDW_ALLCHILDREN);
 }
-
 
 bool IsChoiceButton(HWND hwnd)
 {
@@ -529,7 +515,7 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_COMMONDLG_DARKMODE_REDRAW:
     {
-        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE | RDW_ALLCHILDREN);
         return TRUE;
     }
     }
@@ -709,8 +695,7 @@ void CTPHCaptionWindow::SetText(const TCHAR* text)
         Allocated = l + 2;
     }
     _tcscpy_s(Text, Allocated, text);
-    InvalidateRect(HWindow, NULL, TRUE);
-    UpdateWindow(HWindow);
+    InvalidateRect(HWindow, NULL, FALSE);
 }
 
 LRESULT
@@ -942,20 +927,6 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // after the window is moved.
         PostMessage(HWindow, _TPD_WM_POST_INIT_REDRAW, 0, 0);
 
-        // The first selected page can finish creating before the holder has its
-        // final position/size. Queue one repaint after WM_INITDIALOG returns so
-        // light-scheme controls are painted immediately instead of appearing only
-        // after the window is moved.
-        PostMessage(HWindow, _TPD_WM_POST_INIT_REDRAW, 0, 0);
-
-        break;
-    }
-
-
-    case WM_SHOWWINDOW:
-    {
-        if (wParam)
-            PostMessage(HWindow, _TPD_WM_POST_INIT_REDRAW, 0, 0);
         break;
     }
 

--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -849,7 +849,7 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_COMMONDLG_DARKMODE_REDRAW:
     {
-        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE | RDW_ALLCHILDREN);
         return TRUE;
     }
     }

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -260,6 +260,7 @@ static bool gPropagatingThemeChange = false;
 
 const wchar_t* kDarkModeThemeProp = L"Salamander.DarkMode.Theme";
 const wchar_t* kDarkModeClassicButtonProp = L"Salamander.DarkMode.ClassicButton";
+const wchar_t* kDarkModeChoiceButtonProp = L"Salamander.DarkMode.ChoiceButton";
 
 bool ShouldUseDarkColorsForSurfaces();
 
@@ -482,18 +483,23 @@ void EnsureDarkChoiceButtonSubclass(HWND hwnd, bool enableDark)
     if (hwnd == NULL)
         return;
 
+    const bool isDark = GetPropW(hwnd, kDarkModeChoiceButtonProp) != NULL;
+    if (isDark == enableDark)
+        return;
+
     if (enableDark)
     {
         EnsureClassicButtonTheme(hwnd, true);
         SetWindowSubclass(hwnd, DarkChoiceButtonSubclass, kDarkModeChoiceButtonSubclassId, 0);
-        InvalidateRect(hwnd, NULL, TRUE);
+        SetPropW(hwnd, kDarkModeChoiceButtonProp, reinterpret_cast<HANDLE>(1));
     }
     else
     {
         RemoveWindowSubclass(hwnd, DarkChoiceButtonSubclass, kDarkModeChoiceButtonSubclassId);
+        RemovePropW(hwnd, kDarkModeChoiceButtonProp);
         EnsureClassicButtonTheme(hwnd, false);
-        InvalidateRect(hwnd, NULL, TRUE);
     }
+    InvalidateRect(hwnd, NULL, TRUE);
 }
 
 void PaintDarkTabOverflowButton(HWND hwnd, HDC hdc)

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -14,6 +14,9 @@ namespace DarkModeBackendDarkModelib
 {
 
 #if USE_DARKMODELIB
+static const wchar_t* DARKMODELIB_TREE_STATE_PROP = L"Salamander.DarkModeLib.TreeState";
+static const wchar_t* DARKMODELIB_MENU_DARK_PROP = L"Salamander.DarkModeLib.MenuDark";
+
 static void RemoveControlSubclass(HWND hwnd)
 {
     if (hwnd == NULL)
@@ -54,8 +57,6 @@ static void RemoveControlSubclass(HWND hwnd)
         dmlib::removeHotKeyCtrlSubclass(hwnd);
     else if (lstrcmpiW(className, L"SysDateTimePick32") == 0)
         dmlib::removeDTPCtrlSubclass(hwnd);
-
-    InvalidateRect(hwnd, NULL, TRUE);
 }
 
 static BOOL CALLBACK RemoveControlSubclassProc(HWND hwnd, LPARAM)
@@ -72,7 +73,6 @@ static void RemoveWindowAndChildSubclasses(HWND hwnd)
     dmlib::removeWindowEraseBgSubclass(hwnd);
     dmlib::removeWindowMenuBarSubclass(hwnd);
     EnumChildWindows(hwnd, RemoveControlSubclassProc, 0);
-    InvalidateRect(hwnd, NULL, TRUE);
 }
 #endif
 static COLORREF EnsureReadableForBackground(COLORREF text, COLORREF background)
@@ -107,23 +107,38 @@ void ApplyTree(HWND hwnd)
             dmlibInitialized = true;
         }
         const bool dark = DarkMode_ShouldUseDark() != FALSE;
+        HANDLE appliedState = GetPropW(hwnd, DARKMODELIB_TREE_STATE_PROP);
+        const bool wasApplied = appliedState != NULL;
+        const bool wasDark = appliedState == reinterpret_cast<HANDLE>(2);
+        if (wasApplied && wasDark == dark)
+            return;
+
         dmlib::setDarkModeConfigEx(static_cast<UINT>(dark ? dmlib::DarkModeType::dark : dmlib::DarkModeType::classic));
         dmlib::setDefaultColors(true);
         if (dark)
         {
-            dmlib::setDarkWndNotifySafe(hwnd);
-            dmlib::setChildCtrlsSubclassAndTheme(hwnd);
-            ApplyMenuBar(hwnd, true);
+            if (!wasDark)
+            {
+                dmlib::setDarkWndNotifySafe(hwnd);
+                dmlib::setChildCtrlsSubclassAndTheme(hwnd);
+                SetPropW(hwnd, DARKMODELIB_TREE_STATE_PROP, reinterpret_cast<HANDLE>(2));
+            }
         }
         else
         {
-            // Light Salamander schemes must be real native light UI.  Do not ask
-            // darkmodelib to apply even its light-mode themes/subclasses here; just
-            // tear down any hooks left from a previous Windows Dark Mode session.
-            RemoveWindowAndChildSubclasses(hwnd);
-            ApplyMenuBar(hwnd, false);
+            // Remove dark subclasses only on the dark-to-light transition. Repeatedly removing
+            // subclasses while controls are painting loses checkbox/radio invalidations and flickers.
+            if (wasDark)
+            {
+                RemoveWindowAndChildSubclasses(hwnd);
+                dmlib::setChildCtrlsTheme(hwnd);
+            }
+            SetPropW(hwnd, DARKMODELIB_TREE_STATE_PROP, reinterpret_cast<HANDLE>(1));
         }
+        ApplyMenuBar(hwnd, dark);
         dmlib::setDarkTitleBar(hwnd);
+        if (wasApplied && wasDark != dark)
+            RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
     }
 #else
     (void)hwnd;
@@ -136,10 +151,19 @@ void ApplyMenuBar(HWND hwnd, bool enableDark)
 #if USE_DARKMODELIB
     if (hwnd != NULL)
     {
+        const bool wasDark = GetPropW(hwnd, DARKMODELIB_MENU_DARK_PROP) != NULL;
+        if (wasDark == enableDark)
+            return;
         if (enableDark)
+        {
             dmlib::setWindowMenuBarSubclass(hwnd);
+            SetPropW(hwnd, DARKMODELIB_MENU_DARK_PROP, reinterpret_cast<HANDLE>(1));
+        }
         else
+        {
             dmlib::removeWindowMenuBarSubclass(hwnd);
+            RemovePropW(hwnd, DARKMODELIB_MENU_DARK_PROP);
+        }
         DrawMenuBar(hwnd);
     }
 #else

--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -1643,6 +1643,10 @@ static int GetChangeDriveUserFolderTextResId(CDriveTypeEnum driveType)
     }
 }
 
+// Keep known-folder lookups from checking redirected paths. Without this flag, the shell may
+// synchronously wait for an unavailable network location.
+static const DWORD CHANGE_DRIVE_KF_FLAG_DONT_VERIFY = 0x00004000;
+
 BOOL GetChangeDriveUserFolderPath(CDriveTypeEnum driveType, char* path, int pathLen)
 {
     if (path == NULL || pathLen <= 0)
@@ -1665,7 +1669,8 @@ BOOL GetChangeDriveUserFolderPath(CDriveTypeEnum driveType, char* path, int path
         if (DynSHGetKnownFolderPath != NULL)
         {
             PWSTR knownPath = NULL;
-            if (DynSHGetKnownFolderPath(*folderID, 0, NULL, &knownPath) == S_OK && knownPath != NULL)
+            if (DynSHGetKnownFolderPath(*folderID, CHANGE_DRIVE_KF_FLAG_DONT_VERIFY, NULL, &knownPath) == S_OK &&
+                knownPath != NULL)
             {
                 ret = ConvertU2A(knownPath, -1, path, pathLen) != 0;
                 if (!ret)
@@ -1697,6 +1702,36 @@ BOOL GetChangeDriveUserFolderPath(CDriveTypeEnum driveType, char* path, int path
     }
 
     return ret && path[0] != 0;
+}
+
+HICON GetChangeDriveUserFolderIcon(CDriveTypeEnum driveType, int iconSize)
+{
+    HICON icon = NULL;
+    const GUID* folderID = GetChangeDriveUserFolderKnownFolderID(driveType);
+    if (folderID != NULL && WindowsVistaAndLater)
+    {
+        typedef HRESULT(WINAPI * FSHGetKnownFolderIDList)(REFKNOWNFOLDERID rfid,
+                                                          DWORD /* KNOWN_FOLDER_FLAG */ dwFlags,
+                                                          HANDLE hToken,
+                                                          ITEMIDLIST * *ppidl); // free *ppidl with CoTaskMemFree
+        FSHGetKnownFolderIDList DynSHGetKnownFolderIDList = (FSHGetKnownFolderIDList)GetProcAddress(GetModuleHandle("shell32.dll"),
+                                                                                                    "SHGetKnownFolderIDList");
+        if (DynSHGetKnownFolderIDList != NULL)
+        {
+            ITEMIDLIST* pidl = NULL;
+            if (DynSHGetKnownFolderIDList(*folderID, CHANGE_DRIVE_KF_FLAG_DONT_VERIFY, NULL, &pidl) == S_OK &&
+                pidl != NULL)
+            {
+                SHFILEINFO sfi;
+                if (SHGetFileInfo((const char*)pidl, 0, &sfi, sizeof(sfi), SHGFI_PIDL | SHGFI_ICON | SHGFI_SMALLICON) != 0)
+                    icon = sfi.hIcon;
+                CoTaskMemFree(pidl);
+            }
+        }
+    }
+    if (icon == NULL)
+        icon = SalLoadIcon(ImageResDLL, 112, iconSize);
+    return icon;
 }
 
 void CDrivesList::AddToDrives(CDriveData& drv, int textResId, char hotkey, CDriveTypeEnum driveType,
@@ -2102,13 +2137,13 @@ BOOL CDrivesList::BuildData(BOOL noTimeout, TDirectArray<CDriveData>* copyDrives
     if (Drives->Count > 0 && !IsLastItemSeparator())
         Drives->Add(drvSeparator);
 
-    // User folders can be redirected to unavailable network locations. Do not ask the shell
-    // for their icons by path here because SHGetFileInfo would then block application startup.
+    // User folders can be redirected to unavailable network locations. Add configured folders
+    // without resolving their paths and get their icons from non-verifying known-folder PIDLs.
     // adding user folders
     if (Configuration.ChangeDriveShowMyDoc)
     {
         AddToDrives(drv, IDS_MYDOCUMENTS, ';', drvtMyDocuments, getGrayIcons,
-                    SalLoadIcon(ImageResDLL, 112, iconSize));
+                    GetChangeDriveUserFolderIcon(drvtMyDocuments, iconSize));
     }
 
     struct CChangeDriveUserFolderItem
@@ -2126,12 +2161,11 @@ BOOL CDrivesList::BuildData(BOOL noTimeout, TDirectArray<CDriveData>* copyDrives
     };
     for (int j = 0; j < _countof(userFolders); j++)
     {
-        char path[MAX_PATH];
-        if (*userFolders[j].Show && GetChangeDriveUserFolderPath(userFolders[j].DriveType, path, MAX_PATH))
+        if (*userFolders[j].Show)
         {
             AddToDrives(drv, GetChangeDriveUserFolderTextResId(userFolders[j].DriveType), 0,
                         userFolders[j].DriveType, getGrayIcons,
-                        SalLoadIcon(ImageResDLL, 112, iconSize));
+                        GetChangeDriveUserFolderIcon(userFolders[j].DriveType, iconSize));
         }
     }
 

--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -1643,10 +1643,6 @@ static int GetChangeDriveUserFolderTextResId(CDriveTypeEnum driveType)
     }
 }
 
-// Keep known-folder lookups from checking redirected paths. Without this flag, the shell may
-// synchronously wait for an unavailable network location.
-static const DWORD CHANGE_DRIVE_KF_FLAG_DONT_VERIFY = 0x00004000;
-
 BOOL GetChangeDriveUserFolderPath(CDriveTypeEnum driveType, char* path, int pathLen)
 {
     if (path == NULL || pathLen <= 0)
@@ -1669,8 +1665,7 @@ BOOL GetChangeDriveUserFolderPath(CDriveTypeEnum driveType, char* path, int path
         if (DynSHGetKnownFolderPath != NULL)
         {
             PWSTR knownPath = NULL;
-            if (DynSHGetKnownFolderPath(*folderID, CHANGE_DRIVE_KF_FLAG_DONT_VERIFY, NULL, &knownPath) == S_OK &&
-                knownPath != NULL)
+            if (DynSHGetKnownFolderPath(*folderID, 0, NULL, &knownPath) == S_OK && knownPath != NULL)
             {
                 ret = ConvertU2A(knownPath, -1, path, pathLen) != 0;
                 if (!ret)
@@ -1706,28 +1701,13 @@ BOOL GetChangeDriveUserFolderPath(CDriveTypeEnum driveType, char* path, int path
 
 HICON GetChangeDriveUserFolderIcon(CDriveTypeEnum driveType, int iconSize)
 {
+    char path[MAX_PATH];
     HICON icon = NULL;
-    const GUID* folderID = GetChangeDriveUserFolderKnownFolderID(driveType);
-    if (folderID != NULL && WindowsVistaAndLater)
+    if (GetChangeDriveUserFolderPath(driveType, path, MAX_PATH))
     {
-        typedef HRESULT(WINAPI * FSHGetKnownFolderIDList)(REFKNOWNFOLDERID rfid,
-                                                          DWORD /* KNOWN_FOLDER_FLAG */ dwFlags,
-                                                          HANDLE hToken,
-                                                          ITEMIDLIST * *ppidl); // free *ppidl with CoTaskMemFree
-        FSHGetKnownFolderIDList DynSHGetKnownFolderIDList = (FSHGetKnownFolderIDList)GetProcAddress(GetModuleHandle("shell32.dll"),
-                                                                                                    "SHGetKnownFolderIDList");
-        if (DynSHGetKnownFolderIDList != NULL)
-        {
-            ITEMIDLIST* pidl = NULL;
-            if (DynSHGetKnownFolderIDList(*folderID, CHANGE_DRIVE_KF_FLAG_DONT_VERIFY, NULL, &pidl) == S_OK &&
-                pidl != NULL)
-            {
-                SHFILEINFO sfi;
-                if (SHGetFileInfo((const char*)pidl, 0, &sfi, sizeof(sfi), SHGFI_PIDL | SHGFI_ICON | SHGFI_SMALLICON) != 0)
-                    icon = sfi.hIcon;
-                CoTaskMemFree(pidl);
-            }
-        }
+        SHFILEINFO sfi;
+        if (SHGetFileInfo(path, 0, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_SMALLICON) != 0)
+            icon = sfi.hIcon;
     }
     if (icon == NULL)
         icon = SalLoadIcon(ImageResDLL, 112, iconSize);
@@ -2137,8 +2117,6 @@ BOOL CDrivesList::BuildData(BOOL noTimeout, TDirectArray<CDriveData>* copyDrives
     if (Drives->Count > 0 && !IsLastItemSeparator())
         Drives->Add(drvSeparator);
 
-    // User folders can be redirected to unavailable network locations. Add configured folders
-    // without resolving their paths and get their icons from non-verifying known-folder PIDLs.
     // adding user folders
     if (Configuration.ChangeDriveShowMyDoc)
     {
@@ -2161,7 +2139,8 @@ BOOL CDrivesList::BuildData(BOOL noTimeout, TDirectArray<CDriveData>* copyDrives
     };
     for (int j = 0; j < _countof(userFolders); j++)
     {
-        if (*userFolders[j].Show)
+        char path[MAX_PATH];
+        if (*userFolders[j].Show && GetChangeDriveUserFolderPath(userFolders[j].DriveType, path, MAX_PATH))
         {
             AddToDrives(drv, GetChangeDriveUserFolderTextResId(userFolders[j].DriveType), 0,
                         userFolders[j].DriveType, getGrayIcons,

--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -1699,21 +1699,6 @@ BOOL GetChangeDriveUserFolderPath(CDriveTypeEnum driveType, char* path, int path
     return ret && path[0] != 0;
 }
 
-HICON GetChangeDriveUserFolderIcon(CDriveTypeEnum driveType, int iconSize)
-{
-    char path[MAX_PATH];
-    HICON icon = NULL;
-    if (GetChangeDriveUserFolderPath(driveType, path, MAX_PATH))
-    {
-        SHFILEINFO sfi;
-        if (SHGetFileInfo(path, 0, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_SMALLICON) != 0)
-            icon = sfi.hIcon;
-    }
-    if (icon == NULL)
-        icon = SalLoadIcon(ImageResDLL, 112, iconSize);
-    return icon;
-}
-
 void CDrivesList::AddToDrives(CDriveData& drv, int textResId, char hotkey, CDriveTypeEnum driveType,
                               BOOL getGrayIcons, HICON icon, BOOL destroyIcon, const char* itemText)
 {
@@ -2117,11 +2102,13 @@ BOOL CDrivesList::BuildData(BOOL noTimeout, TDirectArray<CDriveData>* copyDrives
     if (Drives->Count > 0 && !IsLastItemSeparator())
         Drives->Add(drvSeparator);
 
+    // User folders can be redirected to unavailable network locations. Do not ask the shell
+    // for their icons by path here because SHGetFileInfo would then block application startup.
     // adding user folders
     if (Configuration.ChangeDriveShowMyDoc)
     {
         AddToDrives(drv, IDS_MYDOCUMENTS, ';', drvtMyDocuments, getGrayIcons,
-                    GetChangeDriveUserFolderIcon(drvtMyDocuments, iconSize));
+                    SalLoadIcon(ImageResDLL, 112, iconSize));
     }
 
     struct CChangeDriveUserFolderItem
@@ -2144,7 +2131,7 @@ BOOL CDrivesList::BuildData(BOOL noTimeout, TDirectArray<CDriveData>* copyDrives
         {
             AddToDrives(drv, GetChangeDriveUserFolderTextResId(userFolders[j].DriveType), 0,
                         userFolders[j].DriveType, getGrayIcons,
-                        GetChangeDriveUserFolderIcon(userFolders[j].DriveType, iconSize));
+                        SalLoadIcon(ImageResDLL, 112, iconSize));
         }
     }
 

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -630,10 +630,13 @@ void CFilesWindowAncestor::SetPath(const char* path)
         ((CFilesWindow*)this)->SetAutomaticRefresh(TRUE, TRUE);
     }
 
-    if (MainWindow != NULL && MainWindow->LeftPanel != NULL)
-        MainWindow->LeftPanel->RefreshTreeView();
-    else
-        ((CFilesWindow*)this)->RefreshTreeView();
+    if (MainWindow == NULL || !MainWindow->RestoringPanelPaths)
+    {
+        if (MainWindow != NULL && MainWindow->LeftPanel != NULL)
+            MainWindow->LeftPanel->RefreshTreeView();
+        else
+            ((CFilesWindow*)this)->RefreshTreeView();
+    }
 }
 
 void CFilesWindow::RefreshTreeView()

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -430,6 +430,7 @@ public:
     CToolTip* ToolTip; // always exists and is created-all controls use this single tooltip
 
     BOOL Created;
+    BOOL RestoringPanelPaths; // suppress repeated Tree View rebuilds while LoadConfig restores panels
 
     CHotPathItems HotPaths;
     CViewTemplates ViewTemplates;

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -349,6 +349,7 @@ CMainWindow::CMainWindow()
     DisableIdleProcessing = FALSE;
     strcpy(SelectionMask, "*.*");
     Created = FALSE;
+    RestoringPanelPaths = FALSE;
     //  DrivesControlHWnd = NULL;
     HDisabledKeyboard = NULL;
     CmdShow = SW_SHOWNORMAL;

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -2899,7 +2899,20 @@ void CMainWindow::LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalama
         if (Configuration.WorkDirsHistoryScope == wdhsPerTab)
             UpdateDirectoryLineHistoryState(panel);
 
-        BOOL restored = RestorePanelPathFromConfig(this, panel, path);
+        BOOL restored;
+        if (i != activeIndex && IsDiskOrUNCPath(path))
+        {
+            // Hidden tabs do not need a directory listing during startup. Remember their disk path
+            // cheaply and let SwitchPanelTab load the listing when the user first activates them.
+            panel->SetPanelType(ptDisk);
+            panel->SetPath(path);
+            panel->NeedsRefreshOnActivation = TRUE;
+            UpdatePanelTabTitle(panel);
+            restored = TRUE;
+        }
+        else
+            restored = RestorePanelPathFromConfig(this, panel, path);
+
         if (i == activeIndex)
         {
             activeRestored = restored;

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -4404,19 +4404,8 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
         if (cmdLine && !SystemPolicies.GetNoRun())
             PostMessage(HWindow, WM_COMMAND, CM_TOGGLEEDITLINE, TRUE);
 
-        // Process messages that accumulated while reading the registry, but do not wait for the
-        // queue to become empty. Timers and background workers can keep posting messages, which
-        // could starve the rest of startup here indefinitely.
-        MSG msg;
-        DWORD processMessagesStart = GetTickCount();
-        int processedMessages = 0;
-        while (processedMessages < 100 && GetTickCount() - processMessagesStart < 100 &&
-               PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-            processedMessages++;
-        }
+        // Leave queued messages for the main message loop. Dispatching them while the window is
+        // still being initialized can synchronously run expensive refresh handlers and delay startup.
 
         // set the active panel according to command line parameters
         if (ret && cmdLineParams != NULL)

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -4389,8 +4389,13 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
         strcpy(rightPanelPath, leftPanelPath);
         char sysDefDir[MAX_PATH];
         lstrcpyn(sysDefDir, DefaultDir[LowerCase[leftPanelPath[0]] - 'a'], MAX_PATH);
+        // Restoring each saved panel/tab path updates its monitoring state. Defer Tree View rebuilding
+        // until the final active panel is focused below; rebuilding it for every restored path makes
+        // startup perform the same synchronous directory enumeration many times.
+        RestoringPanelPaths = TRUE;
         LoadPanelConfig(leftPanelPath, cpsLeft, salamander, SALAMANDER_LEFTP_REG);
         LoadPanelConfig(rightPanelPath, cpsRight, salamander, SALAMANDER_RIGHTP_REG);
+        RestoringPanelPaths = FALSE;
         if (Configuration.WorkDirsHistoryScope == wdhsPerTab)
             RebuildSharedDirHistoryFromPanels();
 

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -4404,11 +4404,18 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
         if (cmdLine && !SystemPolicies.GetNoRun())
             PostMessage(HWindow, WM_COMMAND, CM_TOGGLEEDITLINE, TRUE);
 
-        MSG msg; // process all pending messages
-        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+        // Process messages that accumulated while reading the registry, but do not wait for the
+        // queue to become empty. Timers and background workers can keep posting messages, which
+        // could starve the rest of startup here indefinitely.
+        MSG msg;
+        DWORD processMessagesStart = GetTickCount();
+        int processedMessages = 0;
+        while (processedMessages < 100 && GetTickCount() - processMessagesStart < 100 &&
+               PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
         {
             TranslateMessage(&msg);
             DispatchMessage(&msg);
+            processedMessages++;
         }
 
         // set the active panel according to command line parameters


### PR DESCRIPTION
### Motivation
- Nedávná změna přidala při sestavování seznamu "Change Drive" dotazy na ikony uživatelských složek pomocí `SHGetFileInfo`, které mohou při přesměrování (např. Documents na síťové úložiště) dlouho blokovat start aplikace a zamrazit splash obrazovku s textem "Reading configuration from registry...".
- Je potřeba obnovit neblokující chování při startu a zabránit synchronním shellovým voláním na potenciálně nedostupné cesty.

### Description
- Odebrána pomocná funkce `GetChangeDriveUserFolderIcon` a odstraněno volání `SHGetFileInfo` z kritické cesty inicializace v `src/drivelst.cpp`.
- Při vytváření položek Change Drive se nyní místo dotazu na souborový systém používá zabudovaná ikona přes `SalLoadIcon(ImageResDLL, 112, iconSize)`.
- Přidán vysvětlující komentář v kódu, proč je nezbytné neprovádět dotazy podle cesty během startu (riziko blokace při nedostupných síťových složkách).
- Všechny změny jsou v `src/drivelst.cpp` a byly commitnuty s popisem `Avoid blocking shell icon lookup during startup`.

### Testing
- Spuštěna kontrola zdroje pomocí `git diff --check` a provedené skriptové ověření, že startovací sekce uživatelských položek již neobsahuje volání `SHGetFileInfo` ani `GetChangeDriveUserFolderIcon`, obě kontroly prošly.
- Ověřen stav repozitáře pomocí `git status --short --branch` a vytvořen commit (`42200da` v pracovním větvi). 
- Pokus o lokální build přes `pwsh -File ./build.ps1 Debug x64` selhal, protože v tomto prostředí není nainstalován `pwsh`, tudíž plná kompilace nebyla zde ověřena.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23d17d5e708329ba736d146e44de54)