### PR TITLE
Prevent dark scrollbar hook from outliving unloaded plugins

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1361,9 +1361,11 @@ void DarkModeSetEnabled(bool enabled)
     else if (gSetPreferredAppMode)
         gSetPreferredAppMode(gEnabled ? AllowDark : Default);
 
-    if (gEnabled)
-        HookDarkScrollbars();
-
+    // The scrollbar fix patches a process-wide comctl32 import with a callback
+    // located in the calling module. Do not install it implicitly here because
+    // plugins also compile this helper and can be unloaded while comctl32 is
+    // still using their callback. The non-unloadable host installs the hook
+    // explicitly through DarkModeFixScrollbars().
     RefreshColorPolicy();
 
     if (gFlushMenuThemes)
@@ -1500,6 +1502,17 @@ bool DarkModeHandleSettingChange(UINT message, LPARAM lParam)
 
 void DarkModeFixScrollbars()
 {
+    // HookDarkScrollbars installs a callback into comctl32. A callback owned by
+    // an unloadable plugin would become a dangling function pointer when that
+    // plugin is released, so only allow the process executable to install it.
+    HMODULE callerModule = NULL;
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            reinterpret_cast<LPCWSTR>(&DarkModeFixScrollbars), &callerModule) ||
+        callerModule != GetModuleHandleW(NULL))
+    {
+        return;
+    }
+
     EnsureInitialized();
     if (!gSupported)
         return;

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -45,7 +45,8 @@ void DarkModeRefreshTitleBar(HWND hwnd);
 // message represents a color scheme change (ImmersiveColorSet).
 bool DarkModeHandleSettingChange(UINT message, LPARAM lParam);
 
-// Installs the dark scrollbar hook (no-op on unsupported systems).
+// Installs the process-wide dark scrollbar hook. Only the main executable can
+// install it; calls from unloadable plugins are ignored.
 void DarkModeFixScrollbars();
 
 // Supplies dialog foreground/background colors and brush for WM_CTLCOLOR helpers.

--- a/src/plugins/textviewer/managed_bridge.cpp
+++ b/src/plugins/textviewer/managed_bridge.cpp
@@ -366,10 +366,6 @@ extern "C" __declspec(dllexport) UINT32 __stdcall TextViewer_GetCurrentColor(int
 extern "C" __declspec(dllexport) void __stdcall TextViewer_SetDarkModeState(BOOL enabled)
 {
     DarkModeSetEnabled(enabled != FALSE);
-    if (enabled)
-    {
-        DarkModeFixScrollbars();
-    }
 }
 
 extern "C" __declspec(dllexport) void __stdcall TextViewer_ApplyDarkModeTree(HWND hwnd)

--- a/src/plugins/webview2renderviewer/managed_bridge.cpp
+++ b/src/plugins/webview2renderviewer/managed_bridge.cpp
@@ -366,10 +366,6 @@ extern "C" __declspec(dllexport) UINT32 __stdcall RenderViewer_GetCurrentColor(i
 extern "C" __declspec(dllexport) void __stdcall RenderViewer_SetDarkModeState(BOOL enabled)
 {
     DarkModeSetEnabled(enabled != FALSE);
-    if (enabled)
-    {
-        DarkModeFixScrollbars();
-    }
 }
 
 extern "C" __declspec(dllexport) void __stdcall RenderViewer_ApplyDarkModeTree(HWND hwnd)

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -3402,6 +3402,8 @@ void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons)
 
     const bool windowsDarkEnabled = Configuration.UseWindowsDarkMode != FALSE;
     DarkModeSetEnabled(windowsDarkEnabled);
+    if (windowsDarkEnabled)
+        DarkModeFixScrollbars();
 
     const bool useDarkColors = windowsDarkEnabled;
 


### PR DESCRIPTION
### Motivation
- A crash on shutdown was caused by plugins (notably the ZIP plugin) installing a process-wide comctl32 scrollbar hook whose callback lived in the plugin DLL and became a dangling pointer after the plugin was unloaded.
- The process-wide scrollbar fix must not be installed implicitly by unloadable modules because that can leave `comctl32.dll` pointing into unmapped plugin memory.

### Description
- Stop installing the process-wide scrollbar hook from `DarkModeSetEnabled()` so enabling dark mode no longer implicitly patches `comctl32.dll` from arbitrary modules.
- Make `DarkModeFixScrollbars()` refuse to install the hook unless it is called from the main executable by checking the caller module with `GetModuleHandleExW(...GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT)` and comparing to `GetModuleHandleW(NULL)`.
- Install the hook from the non-unloadable host path by calling `DarkModeFixScrollbars()` from the host color update code (`src/salamdr1.cpp`) when appropriate, and remove the redundant unsafe calls from unloadable plugins (`src/plugins/textviewer/managed_bridge.cpp` and `src/plugins/webview2renderviewer/managed_bridge.cpp`).
- Document the host-only behaviour of the process-wide scrollbar hook in `src/darkmode.h`.

### Testing
- Ran `git diff --check` to validate no whitespace or trivial issues and it passed.
- Executed a static validation script that confirmed `DarkModeFixScrollbars()` is only called from `src/salamdr1.cpp` and that the function contains the main-module guard, and this check passed.
- Verified repository status is clean after the change in the working tree, and no local build errors were detected in static checks.
- A full Windows/MSBuild build was not executed in this environment because `msbuild` is not available, so runtime verification on Windows is still recommended on CI or a developer machine.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2445f7db9483298e0731361b99e66a)