### PR TITLE
Translate localization guide to English and preserve Czech original

### DIFF
--- a/doc/LOCALIZATION-CZ.md
+++ b/doc/LOCALIZATION-CZ.md
@@ -108,3 +108,20 @@ Necommitujte adresář `out/localization`, `.atp`, vygenerované `.slg` ani logy
 - **`Syntax error ... on line 1`**: používali jste starší wrapper, který pro rebase exportoval diff archiv bez povinné sekce `[EXPORTINFO]`; aktualizujte repozitář a spusťte `start` znovu.
 - **`$LASTEXITCODE cannot be retrieved because it has not been set`**: používali jste starší verzi `localize.ps1`, která spouštěla GUI `translator.exe` přímo; aktualizujte repozitář a spusťte stejný příkaz znovu.
 - **Potřebuji pokročilý rebase nebo headless validaci**: použijte pomocné skripty `rebase_text_archive.ps1` a `verify_translation_workspace.ps1`; pro běžný překlad nejsou potřeba.
+
+## Dávkový překlad pomocí OpenAI
+
+`localize_all_openai.ps1` umí bez otevření Translatoru připravit a přeložit všechny dostupné jazyky a moduly. Jazyky zjistí z adresáře `translations/`; z populovaného buildu zjistí hlavní modul `salamand` a pluginy obsahující `lang/english.slg`.
+
+API klíč nastavujte pouze v prostředí procesu; nikdy jej neukládejte do repozitáře ani skriptu:
+
+```powershell
+$env:OPENAI_API_KEY = "..."
+$env:OPENAI_MODEL = "gpt-5-mini" # volitelné
+pwsh -File .\tools\localization\localize_all_openai.ps1 `
+  -BuildRoot .\build\out\salamand\Release_x64 -DryRun
+```
+
+Po kontrole reportu pro jednotlivé jazyky a moduly odstraňte `-DryRun`. Běh lze omezit pomocí `-Languages czech,slovak` nebo `-Modules salamand,automation`; `-BuildLanguagePacks` sestaví balíčky pouze tehdy, když všechny překlady a validace uspějí. `-ForceRetranslate` nahradí také položky již označené jako přeložené, proto jej používejte obzvlášť opatrně.
+
+Skript odesílá OpenAI pouze nepřeložené resource texty a jejich kontext, takže použití API něco stojí. Ověřuje vrácená ID a technické tokeny, každého kandidáta před nahrazením archivu v repozitáři importuje do Translatoru a API klíč nikdy neloguje. Automatický překlad **nenahrazuje lidskou kontrolu**: před commitem vygenerovaných `.slt` zkontrolujte terminologii, akcelerátory, placeholdery a zda se text vejde do dialogů.

--- a/doc/LOCALIZATION-CZ.md
+++ b/doc/LOCALIZATION-CZ.md
@@ -108,6 +108,8 @@ Necommitujte adresář `out/localization`, `.atp`, vygenerované `.slg` ani logy
 - **`Syntax error ... on line 1`**: používali jste starší wrapper, který pro rebase exportoval diff archiv bez povinné sekce `[EXPORTINFO]`; aktualizujte repozitář a spusťte `start` znovu.
 - **`$LASTEXITCODE cannot be retrieved because it has not been set`**: používali jste starší verzi `localize.ps1`, která spouštěla GUI `translator.exe` přímo; aktualizujte repozitář a spusťte stejný příkaz znovu.
 - **Potřebuji pokročilý rebase nebo headless validaci**: použijte pomocné skripty `rebase_text_archive.ps1` a `verify_translation_workspace.ps1`; pro běžný překlad nejsou potřeba.
+- **`32-bit IDs are not supported`**: modul obsahuje ID ovládacího prvku dialogu, které současný Translator neumí reprezentovat. Znovu sestavte `utils/translator.exe` z aktuálních zdrojů, aby quiet operace skončila chybou bez otevření GUI; dotčený modul je nutné opravit nebo vynechat pomocí `-Modules`.
+- **Quiet operace Translatoru otevře GUI**: znovu sestavte `utils/translator.exe` z aktuálních zdrojů. Lokalizační skripty navíc jako pojistku ukončí quiet operaci, která neskončí do dvou minut.
 
 ## Dávkový překlad pomocí OpenAI
 

--- a/doc/LOCALIZATION-CZ.md
+++ b/doc/LOCALIZATION-CZ.md
@@ -1,0 +1,110 @@
+# Jak přeložit Samandarin
+
+Pro běžnou práci používejte pouze `tools/localization/localize.ps1`. Ostatní skripty v adresáři jsou jeho implementační detaily.
+
+## Doplní se nové texty ze zdrojových resources?
+
+**Ano.** Příkaz `start` postupuje takto:
+
+1. vezme aktuální `english.slg` z buildu jako úplnou kostru projektu,
+2. exportuje z ní aktuální `.slt` kostru,
+3. automaticky na ni převede starý `.slt` překlad podle resource ID,
+4. převedený archiv importuje a otevře výsledek v Translatoru.
+
+Staré přeložené položky se tedy zachovají a nové stringy, dialogy nebo menu z aktuálních `.rc`/`.rh2` resources zůstanou v Translatoru jako **nepřeložené**. Není potřeba je ručně dopisovat do překladových šablon.
+
+Automatický převod je důležitý: Translator neumí přímo importovat starý `.slt`, pokud se mezitím změnila struktura resources. `localize.ps1 start` proto starý archiv před importem automaticky rebased na současnou kostru. Chyba typu `Syntax error ... salamand.slt on line ...` se při běžném použití nemá zobrazit.
+
+Jediná důležitá podmínka je, že před `start` musíte z aktuálních zdrojů znovu sestavit a populovat build. Skript čte nové resources z výsledné `english.slg`, nikoliv přímo ze zdrojových `.rc` souborů. Pokud použijete starý build, nové texty v něm ještě nebudou.
+
+## Nejkratší postup
+
+Potřebujete Windows, PowerShell 7 (`pwsh`) a hotový x64 build obsahující `salamand.exe`, pluginy, anglické `.slg` a `utils/translator.exe`.
+
+### 1. Otevřete jeden překlad
+
+Například český překlad hlavního okna:
+
+```powershell
+pwsh -File .\tools\localization\localize.ps1 start czech salamand `
+  -BuildRoot .\build\out\salamand\Release_x64
+```
+
+Nebo český překlad pluginu Samandarin:
+
+```powershell
+pwsh -File .\tools\localization\localize.ps1 start czech samandarin `
+  -BuildRoot .\build\out\salamand\Release_x64
+```
+
+Příkaz připraví vše potřebné, načte existující překlad na aktuální anglickou resource kostru a automaticky otevře Translator.
+
+### 2. Co dělat v Translatoru
+
+1. Přeložte nepřeložené položky. Nové texty přidané od posledního překladu zůstávají označené jako nepřeložené.
+2. U dialogů zkontrolujte, že se přeložený text vejde do ovládacích prvků.
+3. Projekt uložte pomocí **Ctrl+S**.
+4. Translator zavřete.
+
+Pokud Translator později potřebujete znovu otevřít bez nové přípravy workspace:
+
+```powershell
+pwsh -File .\tools\localization\localize.ps1 open czech salamand
+```
+
+### 3. Uložte výsledek do repozitáře
+
+```powershell
+pwsh -File .\tools\localization\localize.ps1 finish czech salamand
+```
+
+Výsledkem je soubor `translations/czech/salamand.slt`, který zkontrolujete a commitnete. Pro plugin `samandarin` by příkaz i výsledek používaly jméno `samandarin`.
+
+To je celý běžný překladový postup: **start → překlad a Ctrl+S → finish**.
+
+## Užitečné příkazy
+
+Zobrazit pluginy, kterým chybí překladové archivy:
+
+```powershell
+pwsh -File .\tools\localization\localize.ps1 check
+```
+
+Sestavit všechny dostupné jazykové `.slg` do hotového runtime:
+
+```powershell
+pwsh -File .\tools\localization\localize.ps1 build `
+  -BuildRoot .\build\out\salamand\Release_x64
+```
+
+## Když nový text v Translatoru není
+
+Translator umí překládat pouze texty uložené ve Windows resources. Uživatelský text proto nesmí být natvrdo v C/C++/C# kódu.
+
+- String musí mít stabilní resource ID v příslušném `.rh2`, anglický text ve string table a kód jej musí načítat přes `LoadStr`, `LoadString` nebo odpovídající lokalizační API.
+- Dialogy a menu musí být v příslušném `.rc`.
+- Nový plugin musí sestavit `plugins/<plugin>/lang/english.slg`.
+
+Po opravě resources znovu sestavte/populujte aplikaci a spusťte `localize.ps1 start ...`. Aktuální anglická `.slg` je zdroj pravdy, takže nový text se pak objeví jako nepřeložený.
+
+## Co commitovat
+
+Commitujte:
+
+- změněné resources a kód,
+- výsledné `translations/<language>/<module>.slt`,
+- případné změny dokumentace a lokalizačních nástrojů.
+
+Necommitujte adresář `out/localization`, `.atp`, vygenerované `.slg` ani logy.
+
+## Řešení problémů
+
+- **`Build root ... does not look like ...`**: cesta předaná přes `-BuildRoot` neobsahuje populovaný build se `salamand.exe`.
+- **Chybí `translator.exe`**: build musí obsahovat `utils/translator.exe`.
+- **Unknown module**: plugin v buildu nemá `plugins/<plugin>/lang/english.slg`, případně je špatně napsané jeho jméno.
+- **Nové resource texty v Translatoru nejsou**: `-BuildRoot` pravděpodobně ukazuje na starý build; znovu sestavte/populujte aktuální zdroje a spusťte `start` znovu.
+- **Import převedeného archivu selže**: příkaz `start` skončí s chybou a odkazem na existující `out/localization/localize.log`; Translator se neotevře s rozbitým projektem.
+- **Soubor `<module>.quiet.log` neexistuje**: Translator v tomto repozitáři tento log nevytváří a při úspěšné quiet operaci vrací historický exit kód `1`. Wrapper proto zapisuje vlastní `out/localization/localize.log`.
+- **`Syntax error ... on line 1`**: používali jste starší wrapper, který pro rebase exportoval diff archiv bez povinné sekce `[EXPORTINFO]`; aktualizujte repozitář a spusťte `start` znovu.
+- **`$LASTEXITCODE cannot be retrieved because it has not been set`**: používali jste starší verzi `localize.ps1`, která spouštěla GUI `translator.exe` přímo; aktualizujte repozitář a spusťte stejný příkaz znovu.
+- **Potřebuji pokročilý rebase nebo headless validaci**: použijte pomocné skripty `rebase_text_archive.ps1` a `verify_translation_workspace.ps1`; pro běžný překlad nejsou potřeba.

--- a/doc/LOCALIZATION.md
+++ b/doc/LOCALIZATION.md
@@ -1,110 +1,110 @@
-# Jak přeložit Samandarin
+# How to Translate Samandarin
 
-Pro běžnou práci používejte pouze `tools/localization/localize.ps1`. Ostatní skripty v adresáři jsou jeho implementační detaily.
+For routine work, use only `tools/localization/localize.ps1`. The other scripts in that directory are implementation details.
 
-## Doplní se nové texty ze zdrojových resources?
+## Are New Texts from Source Resources Added?
 
-**Ano.** Příkaz `start` postupuje takto:
+**Yes.** The `start` command works as follows:
 
-1. vezme aktuální `english.slg` z buildu jako úplnou kostru projektu,
-2. exportuje z ní aktuální `.slt` kostru,
-3. automaticky na ni převede starý `.slt` překlad podle resource ID,
-4. převedený archiv importuje a otevře výsledek v Translatoru.
+1. it takes the current `english.slg` from the build as the complete project skeleton,
+2. exports the current `.slt` skeleton from it,
+3. automatically converts the old `.slt` translation to that skeleton using resource IDs,
+4. imports the converted archive and opens the result in Translator.
 
-Staré přeložené položky se tedy zachovají a nové stringy, dialogy nebo menu z aktuálních `.rc`/`.rh2` resources zůstanou v Translatoru jako **nepřeložené**. Není potřeba je ručně dopisovat do překladových šablon.
+Existing translated items are therefore preserved, while new strings, dialogs, or menus from the current `.rc`/`.rh2` resources remain **untranslated** in Translator. You do not need to add them to translation templates manually.
 
-Automatický převod je důležitý: Translator neumí přímo importovat starý `.slt`, pokud se mezitím změnila struktura resources. `localize.ps1 start` proto starý archiv před importem automaticky rebased na současnou kostru. Chyba typu `Syntax error ... salamand.slt on line ...` se při běžném použití nemá zobrazit.
+The automatic conversion is important: Translator cannot directly import an old `.slt` if the resource structure has changed in the meantime. Therefore, `localize.ps1 start` automatically rebases the old archive onto the current skeleton before importing it. An error such as `Syntax error ... salamand.slt on line ...` should not appear during normal use.
 
-Jediná důležitá podmínka je, že před `start` musíte z aktuálních zdrojů znovu sestavit a populovat build. Skript čte nové resources z výsledné `english.slg`, nikoliv přímo ze zdrojových `.rc` souborů. Pokud použijete starý build, nové texty v něm ještě nebudou.
+The only important requirement is that you rebuild and populate the build from the current sources before running `start`. The script reads new resources from the resulting `english.slg`, not directly from the source `.rc` files. If you use an old build, it will not contain the new texts yet.
 
-## Nejkratší postup
+## Quickest Workflow
 
-Potřebujete Windows, PowerShell 7 (`pwsh`) a hotový x64 build obsahující `salamand.exe`, pluginy, anglické `.slg` a `utils/translator.exe`.
+You need Windows, PowerShell 7 (`pwsh`), and a completed x64 build containing `salamand.exe`, plugins, English `.slg` files, and `utils/translator.exe`.
 
-### 1. Otevřete jeden překlad
+### 1. Open a Translation
 
-Například český překlad hlavního okna:
+For example, the Czech translation of the main window:
 
 ```powershell
 pwsh -File .\tools\localization\localize.ps1 start czech salamand `
   -BuildRoot .\build\out\salamand\Release_x64
 ```
 
-Nebo český překlad pluginu Samandarin:
+Or the Czech translation of the Samandarin plugin:
 
 ```powershell
 pwsh -File .\tools\localization\localize.ps1 start czech samandarin `
   -BuildRoot .\build\out\salamand\Release_x64
 ```
 
-Příkaz připraví vše potřebné, načte existující překlad na aktuální anglickou resource kostru a automaticky otevře Translator.
+The command prepares everything required, loads the existing translation onto the current English resource skeleton, and automatically opens Translator.
 
-### 2. Co dělat v Translatoru
+### 2. Work in Translator
 
-1. Přeložte nepřeložené položky. Nové texty přidané od posledního překladu zůstávají označené jako nepřeložené.
-2. U dialogů zkontrolujte, že se přeložený text vejde do ovládacích prvků.
-3. Projekt uložte pomocí **Ctrl+S**.
-4. Translator zavřete.
+1. Translate untranslated items. New texts added since the last translation remain marked as untranslated.
+2. For dialogs, verify that translated text fits inside the controls.
+3. Save the project with **Ctrl+S**.
+4. Close Translator.
 
-Pokud Translator později potřebujete znovu otevřít bez nové přípravy workspace:
+If you later need to reopen Translator without preparing a new workspace:
 
 ```powershell
 pwsh -File .\tools\localization\localize.ps1 open czech salamand
 ```
 
-### 3. Uložte výsledek do repozitáře
+### 3. Save the Result to the Repository
 
 ```powershell
 pwsh -File .\tools\localization\localize.ps1 finish czech salamand
 ```
 
-Výsledkem je soubor `translations/czech/salamand.slt`, který zkontrolujete a commitnete. Pro plugin `samandarin` by příkaz i výsledek používaly jméno `samandarin`.
+The result is `translations/czech/salamand.slt`, which you should review and commit. For the `samandarin` plugin, both the command and the resulting file would use the name `samandarin`.
 
-To je celý běžný překladový postup: **start → překlad a Ctrl+S → finish**.
+That is the complete routine translation workflow: **start → translate and Ctrl+S → finish**.
 
-## Užitečné příkazy
+## Useful Commands
 
-Zobrazit pluginy, kterým chybí překladové archivy:
+List plugins that are missing translation archives:
 
 ```powershell
 pwsh -File .\tools\localization\localize.ps1 check
 ```
 
-Sestavit všechny dostupné jazykové `.slg` do hotového runtime:
+Build all available language `.slg` files into the completed runtime:
 
 ```powershell
 pwsh -File .\tools\localization\localize.ps1 build `
   -BuildRoot .\build\out\salamand\Release_x64
 ```
 
-## Když nový text v Translatoru není
+## When a New Text Is Missing from Translator
 
-Translator umí překládat pouze texty uložené ve Windows resources. Uživatelský text proto nesmí být natvrdo v C/C++/C# kódu.
+Translator can translate only texts stored in Windows resources. Therefore, user-facing text must not be hard-coded in C/C++/C# code.
 
-- String musí mít stabilní resource ID v příslušném `.rh2`, anglický text ve string table a kód jej musí načítat přes `LoadStr`, `LoadString` nebo odpovídající lokalizační API.
-- Dialogy a menu musí být v příslušném `.rc`.
-- Nový plugin musí sestavit `plugins/<plugin>/lang/english.slg`.
+- A string must have a stable resource ID in the relevant `.rh2`, English text in the string table, and code that loads it through `LoadStr`, `LoadString`, or the corresponding localization API.
+- Dialogs and menus must be in the relevant `.rc`.
+- A new plugin must build `plugins/<plugin>/lang/english.slg`.
 
-Po opravě resources znovu sestavte/populujte aplikaci a spusťte `localize.ps1 start ...`. Aktuální anglická `.slg` je zdroj pravdy, takže nový text se pak objeví jako nepřeložený.
+After fixing the resources, rebuild/populate the application and run `localize.ps1 start ...` again. The current English `.slg` is the source of truth, so the new text will then appear as untranslated.
 
-## Co commitovat
+## What to Commit
 
-Commitujte:
+Commit:
 
-- změněné resources a kód,
-- výsledné `translations/<language>/<module>.slt`,
-- případné změny dokumentace a lokalizačních nástrojů.
+- changed resources and code,
+- the resulting `translations/<language>/<module>.slt`,
+- any changes to documentation and localization tools.
 
-Necommitujte adresář `out/localization`, `.atp`, vygenerované `.slg` ani logy.
+Do not commit the `out/localization` directory, `.atp` files, generated `.slg` files, or logs.
 
-## Řešení problémů
+## Troubleshooting
 
-- **`Build root ... does not look like ...`**: cesta předaná přes `-BuildRoot` neobsahuje populovaný build se `salamand.exe`.
-- **Chybí `translator.exe`**: build musí obsahovat `utils/translator.exe`.
-- **Unknown module**: plugin v buildu nemá `plugins/<plugin>/lang/english.slg`, případně je špatně napsané jeho jméno.
-- **Nové resource texty v Translatoru nejsou**: `-BuildRoot` pravděpodobně ukazuje na starý build; znovu sestavte/populujte aktuální zdroje a spusťte `start` znovu.
-- **Import převedeného archivu selže**: příkaz `start` skončí s chybou a odkazem na existující `out/localization/localize.log`; Translator se neotevře s rozbitým projektem.
-- **Soubor `<module>.quiet.log` neexistuje**: Translator v tomto repozitáři tento log nevytváří a při úspěšné quiet operaci vrací historický exit kód `1`. Wrapper proto zapisuje vlastní `out/localization/localize.log`.
-- **`Syntax error ... on line 1`**: používali jste starší wrapper, který pro rebase exportoval diff archiv bez povinné sekce `[EXPORTINFO]`; aktualizujte repozitář a spusťte `start` znovu.
-- **`$LASTEXITCODE cannot be retrieved because it has not been set`**: používali jste starší verzi `localize.ps1`, která spouštěla GUI `translator.exe` přímo; aktualizujte repozitář a spusťte stejný příkaz znovu.
-- **Potřebuji pokročilý rebase nebo headless validaci**: použijte pomocné skripty `rebase_text_archive.ps1` a `verify_translation_workspace.ps1`; pro běžný překlad nejsou potřeba.
+- **`Build root ... does not look like ...`**: the path passed through `-BuildRoot` does not contain a populated build with `salamand.exe`.
+- **Missing `translator.exe`**: the build must contain `utils/translator.exe`.
+- **Unknown module**: the plugin in the build does not have `plugins/<plugin>/lang/english.slg`, or its name is misspelled.
+- **New resource texts are missing from Translator**: `-BuildRoot` probably points to an old build; rebuild/populate the current sources and run `start` again.
+- **Importing the converted archive fails**: the `start` command exits with an error and a reference to the existing `out/localization/localize.log`; Translator does not open a broken project.
+- **The `<module>.quiet.log` file does not exist**: Translator in this repository does not create this log and returns the historical exit code `1` for a successful quiet operation. The wrapper therefore writes its own `out/localization/localize.log`.
+- **`Syntax error ... on line 1`**: you used an older wrapper that exported a diff archive without the required `[EXPORTINFO]` section during rebase; update the repository and run `start` again.
+- **`$LASTEXITCODE cannot be retrieved because it has not been set`**: you used an older version of `localize.ps1` that launched the GUI `translator.exe` directly; update the repository and run the same command again.
+- **I need an advanced rebase or headless validation**: use the helper scripts `rebase_text_archive.ps1` and `verify_translation_workspace.ps1`; they are not needed for routine translation.

--- a/doc/LOCALIZATION.md
+++ b/doc/LOCALIZATION.md
@@ -108,6 +108,8 @@ Do not commit the `out/localization` directory, `.atp` files, generated `.slg` f
 - **`Syntax error ... on line 1`**: you used an older wrapper that exported a diff archive without the required `[EXPORTINFO]` section during rebase; update the repository and run `start` again.
 - **`$LASTEXITCODE cannot be retrieved because it has not been set`**: you used an older version of `localize.ps1` that launched the GUI `translator.exe` directly; update the repository and run the same command again.
 - **I need an advanced rebase or headless validation**: use the helper scripts `rebase_text_archive.ps1` and `verify_translation_workspace.ps1`; they are not needed for routine translation.
+- **`32-bit IDs are not supported`**: the module contains a dialog control ID that the current Translator cannot represent. Rebuild `utils/translator.exe` from the current sources so quiet operations fail without opening the GUI; the affected module must be fixed or excluded with `-Modules`.
+- **A quiet Translator operation opens the GUI**: rebuild `utils/translator.exe` from the current sources. As an additional safeguard, localization scripts terminate quiet operations that do not exit within two minutes.
 
 ## Batch Translation with OpenAI
 

--- a/doc/LOCALIZATION.md
+++ b/doc/LOCALIZATION.md
@@ -108,3 +108,20 @@ Do not commit the `out/localization` directory, `.atp` files, generated `.slg` f
 - **`Syntax error ... on line 1`**: you used an older wrapper that exported a diff archive without the required `[EXPORTINFO]` section during rebase; update the repository and run `start` again.
 - **`$LASTEXITCODE cannot be retrieved because it has not been set`**: you used an older version of `localize.ps1` that launched the GUI `translator.exe` directly; update the repository and run the same command again.
 - **I need an advanced rebase or headless validation**: use the helper scripts `rebase_text_archive.ps1` and `verify_translation_workspace.ps1`; they are not needed for routine translation.
+
+## Batch Translation with OpenAI
+
+`localize_all_openai.ps1` can prepare and translate every available language and module without opening Translator. It discovers languages under `translations/` and discovers `salamand` plus plugins with `lang/english.slg` in the populated build.
+
+Set the API key only in the process environment; never save it in the repository or a script:
+
+```powershell
+$env:OPENAI_API_KEY = "..."
+$env:OPENAI_MODEL = "gpt-5-mini" # optional
+pwsh -File .\tools\localization\localize_all_openai.ps1 `
+  -BuildRoot .\build\out\salamand\Release_x64 -DryRun
+```
+
+Remove `-DryRun` after reviewing the per-language/module report. Limit a run with `-Languages czech,slovak` or `-Modules salamand,automation`; use `-BuildLanguagePacks` to build packs only after every translation and validation succeeds. `-ForceRetranslate` also replaces entries already marked as translated and should be used with particular care.
+
+The script sends only untranslated resource texts and their context to OpenAI, so API usage has a cost. It validates returned IDs and technical tokens, imports each candidate into Translator before replacing the repository archive, and never logs the API key. Automated translation does **not** replace human review: check terminology, accelerators, placeholders, and whether text fits in dialogs before committing the generated `.slt` files.

--- a/src/translator/datadlg.cpp
+++ b/src/translator/datadlg.cpp
@@ -6,6 +6,7 @@
 #include "wndout.h"
 #include "datarh.h"
 #include "config.h"
+#include "translator.h"
 
 //                               [dlg units]
 #define DIALOG_MARGIN_WIDTH 7
@@ -1048,7 +1049,10 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
                 if (!data->MUIMode)
                 {
                     sprintf_s(errtext, "32-bit IDs are not supported");
-                    MessageBox(GetMsgParent(), errtext, ERROR_TITLE, MB_OK | MB_ICONEXCLAMATION);
+                    if (QuietValidate == 0 && QuietTranslate == 0 && QuietMarkChAsTrl == 0 &&
+                        QuietImport[0] == 0 && QuietImportTrlProp[0] == 0 && QuietExportSLT[0] == 0 &&
+                        QuietExportSDC[0] == 0 && QuietImportSLT[0] == 0 && QuietExportSpellChecker[0] == 0)
+                        MessageBox(GetMsgParent(), errtext, ERROR_TITLE, MB_OK | MB_ICONEXCLAMATION);
                     delete control;
                     return FALSE;
                 }
@@ -1072,7 +1076,10 @@ BOOL CDialogData::LoadDialog(WORD* oBuff, WORD* tBuff, BOOL* showStyleWarning,
                 if (!data->MUIMode)
                 {
                     sprintf_s(errtext, "32-bit IDs are not supported");
-                    MessageBox(GetMsgParent(), errtext, ERROR_TITLE, MB_OK | MB_ICONEXCLAMATION);
+                    if (QuietValidate == 0 && QuietTranslate == 0 && QuietMarkChAsTrl == 0 &&
+                        QuietImport[0] == 0 && QuietImportTrlProp[0] == 0 && QuietExportSLT[0] == 0 &&
+                        QuietExportSDC[0] == 0 && QuietImportSLT[0] == 0 && QuietExportSpellChecker[0] == 0)
+                        MessageBox(GetMsgParent(), errtext, ERROR_TITLE, MB_OK | MB_ICONEXCLAMATION);
                     delete control;
                     return FALSE;
                 }

--- a/src/translator/wndframe.cpp
+++ b/src/translator/wndframe.cpp
@@ -535,6 +535,15 @@ BOOL CFrameWindow::OpenProject(const char* importSubPath)
             }
         }
 
+        if ((QuietValidate != 0 || QuietTranslate != 0 || QuietMarkChAsTrl != 0 ||
+             QuietImport[0] != 0 || QuietImportTrlProp[0] != 0 || QuietExportSLT[0] != 0 ||
+             QuietExportSDC[0] != 0 || QuietImportSLT[0] != 0 || QuietExportSpellChecker[0] != 0) &&
+            OutWindow.GetErrorLines() != 0)
+        {
+            DestroyWindow(HWindow);
+            ExitProcess(2); // quiet operation failed; never fall through to the interactive GUI
+        }
+
         ret = TRUE;
         OpenChildWindows();
         SetTitle();

--- a/tools/localization/Localization.Common.psm1
+++ b/tools/localization/Localization.Common.psm1
@@ -1,9 +1,13 @@
 Set-StrictMode -Version Latest
 function Invoke-SalamanderTranslatorQuiet {
-    [CmdletBinding()] param([Parameter(Mandatory)][string]$TranslatorExe,[Parameter(Mandatory)][string[]]$Arguments,[Parameter(Mandatory)][string]$FailureMessage,[Parameter(Mandatory)][string]$DiagnosticLog,[int[]]$ExpectedExitCodes=@(1))
+    [CmdletBinding()] param([Parameter(Mandatory)][string]$TranslatorExe,[Parameter(Mandatory)][string[]]$Arguments,[Parameter(Mandatory)][string]$FailureMessage,[Parameter(Mandatory)][string]$DiagnosticLog,[int[]]$ExpectedExitCodes=@(1),[int]$TimeoutSeconds=120)
     $info=[Diagnostics.ProcessStartInfo]::new(); $info.FileName=$TranslatorExe; $info.WorkingDirectory=Split-Path $TranslatorExe -Parent; $info.UseShellExecute=$false
     foreach($argument in $Arguments){[void]$info.ArgumentList.Add($argument)}
-    $process=[Diagnostics.Process]::Start($info); $process.WaitForExit()
+    $process=[Diagnostics.Process]::Start($info)
+    if(-not $process.WaitForExit($TimeoutSeconds * 1000)){
+        $process.Kill($true)
+        throw "$FailureMessage Translator timed out after $TimeoutSeconds seconds and was terminated. Diagnostika: $DiagnosticLog"
+    }
     @("Timestamp: $([DateTime]::Now.ToString('s'))","Command: $TranslatorExe $($Arguments -join ' ')","Exit code: $($process.ExitCode)","") | Add-Content -LiteralPath $DiagnosticLog -Encoding UTF8
     if($ExpectedExitCodes -notcontains $process.ExitCode){throw "$FailureMessage Diagnostika: $DiagnosticLog"}
 }

--- a/tools/localization/Localization.Common.psm1
+++ b/tools/localization/Localization.Common.psm1
@@ -1,0 +1,10 @@
+Set-StrictMode -Version Latest
+function Invoke-SalamanderTranslatorQuiet {
+    [CmdletBinding()] param([Parameter(Mandatory)][string]$TranslatorExe,[Parameter(Mandatory)][string[]]$Arguments,[Parameter(Mandatory)][string]$FailureMessage,[Parameter(Mandatory)][string]$DiagnosticLog,[int[]]$ExpectedExitCodes=@(1))
+    $info=[Diagnostics.ProcessStartInfo]::new(); $info.FileName=$TranslatorExe; $info.WorkingDirectory=Split-Path $TranslatorExe -Parent; $info.UseShellExecute=$false
+    foreach($argument in $Arguments){[void]$info.ArgumentList.Add($argument)}
+    $process=[Diagnostics.Process]::Start($info); $process.WaitForExit()
+    @("Timestamp: $([DateTime]::Now.ToString('s'))","Command: $TranslatorExe $($Arguments -join ' ')","Exit code: $($process.ExitCode)","") | Add-Content -LiteralPath $DiagnosticLog -Encoding UTF8
+    if($ExpectedExitCodes -notcontains $process.ExitCode){throw "$FailureMessage Diagnostika: $DiagnosticLog"}
+}
+Export-ModuleMember -Function Invoke-SalamanderTranslatorQuiet

--- a/tools/localization/localize.ps1
+++ b/tools/localization/localize.ps1
@@ -46,44 +46,7 @@ function Require-Project
     }
 }
 
-function Invoke-TranslatorQuiet
-{
-    param(
-        [Parameter(Mandatory = $true)]
-        [string[]]$Arguments,
-
-        [Parameter(Mandatory = $true)]
-        [string]$FailureMessage
-    )
-
-    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
-    $startInfo.FileName = $translator
-    $startInfo.WorkingDirectory = Split-Path $translator -Parent
-    $startInfo.UseShellExecute = $false
-    foreach ($argument in $Arguments)
-    {
-        [void]$startInfo.ArgumentList.Add($argument)
-    }
-
-    $process = [System.Diagnostics.Process]::Start($startInfo)
-    $process.WaitForExit()
-
-    $diagnosticLog = Join-Path $workspace "localize.log"
-    @(
-        "Timestamp: $([DateTime]::Now.ToString('s'))"
-        "Command: $translator $($Arguments -join ' ')"
-        "Exit code: $($process.ExitCode)"
-        ""
-    ) | Add-Content -LiteralPath $diagnosticLog -Encoding UTF8
-
-    # This repository's Translator uses exit code 1 for a successful quiet
-    # import/export. Unlike Sally's newer Translator, it does not create
-    # <module>.quiet.log files.
-    if ($process.ExitCode -ne 1)
-    {
-        throw "$FailureMessage Diagnostika: $diagnosticLog"
-    }
-}
+Import-Module (Join-Path $PSScriptRoot "Localization.Common.psm1") -Force
 
 switch ($Action)
 {
@@ -122,7 +85,9 @@ switch ($Action)
             $rebasedDir = Join-Path $workspace "translations\$Language"
             New-Item -ItemType Directory -Path $skeletonDir, $rebasedDir -Force | Out-Null
 
-            Invoke-TranslatorQuiet `
+            Invoke-SalamanderTranslatorQuiet `
+                -TranslatorExe $translator `
+                -DiagnosticLog (Join-Path $workspace "localize.log") `
                 -Arguments @("-quiet-export-slt", $skeletonDir, $project) `
                 -FailureMessage "Nepodařilo se exportovat aktuální resource kostru."
 
@@ -135,7 +100,9 @@ switch ($Action)
                 throw "Převod starého překladu na aktuální resource kostru selhal."
             }
 
-            Invoke-TranslatorQuiet `
+            Invoke-SalamanderTranslatorQuiet `
+                -TranslatorExe $translator `
+                -DiagnosticLog (Join-Path $workspace "localize.log") `
                 -Arguments @("-quiet-import-slt", $rebasedDir, $project) `
                 -FailureMessage "Nepodařilo se importovat rebased překlad."
         }
@@ -169,7 +136,9 @@ switch ($Action)
         Require-Project
         $destination = Join-Path $repoRoot "translations\$Language"
         New-Item -ItemType Directory -Path $destination -Force | Out-Null
-        Invoke-TranslatorQuiet `
+        Invoke-SalamanderTranslatorQuiet `
+                -TranslatorExe $translator `
+                -DiagnosticLog (Join-Path $workspace "localize.log") `
             -Arguments @("-quiet-export-slt", $destination, $project) `
             -FailureMessage "Export selhal."
 

--- a/tools/localization/localize_all_openai.ps1
+++ b/tools/localization/localize_all_openai.ps1
@@ -1,0 +1,34 @@
+<# .SYNOPSIS Headlessly translates every selected language/module using OpenAI. #>
+[CmdletBinding()] param(
+ [string]$BuildRoot=".\build\out\salamand\Release_x64", [string[]]$Languages, [string[]]$Modules,
+ [string]$Model=$env:OPENAI_MODEL, [ValidateRange(1,32)][int]$MaxParallelRequests=4,
+ [switch]$DryRun, [switch]$ForceRetranslate, [switch]$BuildLanguagePacks)
+Set-StrictMode -Version Latest; $ErrorActionPreference="Stop"
+Import-Module (Join-Path $PSScriptRoot "Localization.Common.psm1") -Force
+$repoRoot=Split-Path (Split-Path $PSScriptRoot -Parent) -Parent; $workspace=Join-Path $repoRoot "out\localization-openai"; $log=Join-Path $workspace "localize.log"
+function Expand-List([string[]]$Values){ @($Values | ForEach-Object { $_ -split '[,;]' } | ForEach-Object {$_.Trim().ToLowerInvariant()} | Where-Object {$_} | Sort-Object -Unique) }
+if(-not $Model){$Model="gpt-5-mini"}; if(-not $env:OPENAI_API_KEY){throw "OPENAI_API_KEY is not set. Set it in the environment; never store it in the repository."}
+if($Languages){$selectedLanguages=Expand-List $Languages}else{$selectedLanguages=@(Get-ChildItem (Join-Path $repoRoot 'translations') -Directory | ForEach-Object Name | Sort-Object)}
+$runtime=(Resolve-Path $BuildRoot).Path; $availableModules=@('salamand') + @(Get-ChildItem (Join-Path $runtime 'plugins') -Recurse -Filter english.slg | ForEach-Object {$_.Directory.Parent.Name.ToLowerInvariant()}) | Sort-Object -Unique
+if($Modules){$selectedModules=Expand-List $Modules}else{$selectedModules=$availableModules}
+$unknown=@($selectedModules | Where-Object {$availableModules -notcontains $_}); if($unknown){throw "Unknown modules: $($unknown -join ', ')"}
+& (Join-Path $PSScriptRoot 'prepare_translation_workspace.ps1') -BuildRoot $runtime -OutputDir $workspace -Languages $selectedLanguages -Modules $selectedModules -Force
+$translator=Join-Path $workspace 'runtime\utils\translator.exe'; $failures=0; $reports=@()
+foreach($language in $selectedLanguages){foreach($module in $selectedModules){
+ try {
+  $project=Join-Path $workspace "projects\$language\$module\$module.atp"; $skeletonDir=Join-Path $workspace "skeleton\$language\$module"; $candidateDir=Join-Path $workspace "candidate\$language\$module"; New-Item -ItemType Directory -Force $skeletonDir,$candidateDir | Out-Null
+  Invoke-SalamanderTranslatorQuiet -TranslatorExe $translator -Arguments @('-quiet-export-slt',$skeletonDir,$project) -FailureMessage "Skeleton export failed for $language/$module." -DiagnosticLog $log
+  $source=Join-Path $skeletonDir "$module.slt"; $legacy=Join-Path $repoRoot "translations\$language\$module.slt"; $rebased=Join-Path $candidateDir "$module.slt"
+  if(Test-Path $legacy){ & (Join-Path $PSScriptRoot 'rebase_text_archive.ps1') -CurrentArchive $source -LegacyArchive $legacy -OutputArchive $rebased } else { Copy-Item $source $rebased }
+  $args=@($rebased,$rebased,'--language',$language,'--model',$Model,'--batch-size',[Math]::Max(1,40*$MaxParallelRequests)); if($DryRun){$args+='--dry-run'}; if($ForceRetranslate){$args+='--force-retranslate'}
+  $json=& python (Join-Path $PSScriptRoot 'translate_slt_with_openai.py') @args; if(-not $?){throw "OpenAI translation failed."}; $report=$json|ConvertFrom-Json; $reports += [pscustomobject]@{Language=$language;Module=$module;Found=$report.found;Translated=$report.translated;Skipped=$report.skipped;Failed=$report.failed;EstimatedInputCharacters=$report.estimated_input_characters}
+  if(-not $DryRun){
+   Invoke-SalamanderTranslatorQuiet -TranslatorExe $translator -Arguments @('-quiet-import-slt',$candidateDir,$project) -FailureMessage "Candidate import/validation failed for $language/$module." -DiagnosticLog $log
+   $destination=Join-Path $repoRoot "translations\$language"; New-Item -ItemType Directory -Force $destination|Out-Null
+   Invoke-SalamanderTranslatorQuiet -TranslatorExe $translator -Arguments @('-quiet-export-slt',$destination,$project) -FailureMessage "Final export failed for $language/$module." -DiagnosticLog $log
+  }
+ } catch { $failures++; Write-Error -ErrorAction Continue "${language}/${module}: $_" }
+}}
+$reports | Format-Table -AutoSize
+if($failures){throw "$failures language/module translation jobs failed; language packs were not built."}
+if($BuildLanguagePacks -and -not $DryRun){ & (Join-Path $PSScriptRoot 'build_language_packs.ps1') -BuildRoot $runtime }

--- a/tools/localization/tests/fixtures/sample.slt
+++ b/tools/localization/tests/fixtures/sample.slt
@@ -1,0 +1,10 @@
+﻿[EXPORTINFO]
+PROJECTNAME,"sample"
+
+[TRANSLATION]
+LANGID,1029
+
+[STRINGTABLE 0]
+100,1,"Already translated"
+101,0,"Open %s\n"
+102,0,"Use &default font"

--- a/tools/localization/tests/test_translate_slt_with_openai.py
+++ b/tools/localization/tests/test_translate_slt_with_openai.py
@@ -1,0 +1,28 @@
+import importlib.util, os, sys, tempfile, unittest, urllib.error
+from pathlib import Path
+P=Path(__file__).parents[1]/"translate_slt_with_openai.py"; spec=importlib.util.spec_from_file_location("slt",P); slt=importlib.util.module_from_spec(spec); sys.modules["slt"]=slt; spec.loader.exec_module(slt)
+FIX=Path(__file__).parent/"fixtures/sample.slt"
+class Tests(unittest.TestCase):
+ def test_parser_uses_state_and_preserves_translated(self):
+  lines=FIX.read_text(encoding="utf-8-sig").splitlines(keepends=True); self.assertEqual([i.key.split(':')[1] for i in slt.parse_items(lines)],["101","102"])
+ def test_validate_rejects_changed_tokens_and_incomplete(self):
+  items=slt.parse_items(FIX.read_text(encoding="utf-8-sig").splitlines(keepends=True))
+  with self.assertRaises(ValueError): slt.validate(items,{"translations":[{"id":items[0].key,"text":"Otevřít"}]})
+ def test_translation_preserves_format_and_escaping(self):
+  os.environ["OPENAI_API_KEY"]="test"
+  def requester(payload,key,model): return {"translations":[{"id":x["id"],"text":x["text"].replace("Open","Otevřít").replace("Use","Použít")} for x in payload["items"]]}
+  with tempfile.TemporaryDirectory() as d:
+   out=Path(d)/"out.slt"; slt.translate(FIX,out,"czech","mock",40,False,False,requester); text=out.read_text(encoding="utf-8-sig"); self.assertIn('100,1,"Already translated"',text); self.assertIn('101,1,"Otevřít %s\\n"',text)
+ def test_requires_key(self):
+  os.environ.pop("OPENAI_API_KEY",None)
+  with self.assertRaises(RuntimeError): slt.translate(FIX,Path("unused"),"czech","mock",40,True,False)
+ def test_retry(self):
+  calls=[]
+  old=slt.urllib.request.urlopen
+  def fake(*a,**k): calls.append(1); raise urllib.error.HTTPError("x",429,"rate",{},None)
+  slt.urllib.request.urlopen=fake
+  try:
+   with self.assertRaises(urllib.error.HTTPError): slt.request_openai({},"x","m",attempts=2,sleep=lambda _:None)
+   self.assertEqual(len(calls),2)
+  finally: slt.urllib.request.urlopen=old
+if __name__=="__main__": unittest.main()

--- a/tools/localization/tests/test_translate_slt_with_openai.py
+++ b/tools/localization/tests/test_translate_slt_with_openai.py
@@ -8,6 +8,11 @@ class Tests(unittest.TestCase):
  def test_validate_rejects_changed_tokens_and_incomplete(self):
   items=slt.parse_items(FIX.read_text(encoding="utf-8-sig").splitlines(keepends=True))
   with self.assertRaises(ValueError): slt.validate(items,{"translations":[{"id":items[0].key,"text":"Otevřít"}]})
+ def test_accelerator_may_move_to_another_letter(self):
+  items=slt.parse_items(FIX.read_text(encoding="utf-8-sig").splitlines(keepends=True))
+  translated=[{"id":item.key,"text":item.text} for item in items]
+  translated[1]["text"]="Použít výchozí &písmo"
+  self.assertEqual(slt.validate(items,{"translations":translated})[items[1].key],"Použít výchozí &písmo")
  def test_translation_preserves_format_and_escaping(self):
   os.environ["OPENAI_API_KEY"]="test"
   def requester(payload,key,model): return {"translations":[{"id":x["id"],"text":x["text"].replace("Open","Otevřít").replace("Use","Použít")} for x in payload["items"]]}

--- a/tools/localization/translate_slt_with_openai.py
+++ b/tools/localization/translate_slt_with_openai.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Translate untranslated SLT resource lines with the OpenAI Responses API."""
+from __future__ import annotations
+import argparse, json, os, re, sys, time, urllib.error, urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+LINE_RE = re.compile(r'^(?P<prefix>.*?,)(?P<state>[01]),"(?P<text>.*)"(?P<ending>\r?\n)?$')
+SECTION_RE = re.compile(r'^\[(?P<kind>DIALOG|MENU|STRINGTABLE)(?:\s+[^]]+)?\]$')
+TOKEN_RE = re.compile(r'%(?:\d+\$)?[-+#0 ]*(?:\d+|\*)?(?:\.\d+|\.\*)?[a-zA-Z]|\{\d+(?::[^}]*)?\}|\\[nrt]|&.|<[^>]+>|(?:[A-Za-z]:)?(?:\\[^\\\s]+)+')
+
+@dataclass
+class Item:
+    index: int; key: str; section: str; text: str; prefix: str; ending: str
+
+def parse_items(lines: list[str], force: bool = False) -> list[Item]:
+    section = ""
+    items = []
+    for index, line in enumerate(lines):
+        header = SECTION_RE.match(line.rstrip("\r\n"))
+        if header: section = line.strip(); continue
+        if not section: continue
+        match = LINE_RE.match(line)
+        if not match or (match.group("state") != "0" and not force): continue
+        key = f"{section}:{match.group('prefix').split(',', 1)[0]}:{index + 1}"
+        items.append(Item(index, key, section, match.group("text"), match.group("prefix"), match.group("ending") or ""))
+    return items
+
+def tokens(text: str) -> list[str]: return sorted(TOKEN_RE.findall(text))
+
+def request_openai(payload: dict, api_key: str, model: str, attempts: int = 5, sleep=time.sleep) -> dict:
+    body = json.dumps({"model": model, "input": [{"role":"system","content":[{"type":"input_text","text":"Translate Windows UI resources. Return only valid JSON with a translations array containing id and text. Preserve placeholders, escapes, accelerators (&), markup, paths, and technical tokens exactly."}]},{"role":"user","content":[{"type":"input_text","text":json.dumps(payload, ensure_ascii=False)}]}], "text":{"format":{"type":"json_schema","name":"translations","strict":True,"schema":{"type":"object","properties":{"translations":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"text":{"type":"string"}},"required":["id","text"],"additionalProperties":False}}},"required":["translations"],"additionalProperties":False}}}}).encode()
+    req = urllib.request.Request("https://api.openai.com/v1/responses", body, {"Authorization": f"Bearer {api_key}", "Content-Type":"application/json"})
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(req, timeout=120) as response: result=json.load(response)
+            text = result.get("output_text")
+            if text is None:
+                text = next(c["text"] for o in result["output"] for c in o.get("content", []) if c.get("type") == "output_text")
+            return json.loads(text)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in (408, 409, 429, 500, 502, 503, 504) or attempt + 1 == attempts: raise
+            sleep(2 ** attempt)
+    raise RuntimeError("OpenAI request failed")
+
+def validate(items: list[Item], result: dict) -> dict[str,str]:
+    rows=result.get("translations")
+    if not isinstance(rows,list): raise ValueError("response has no translations array")
+    output={}
+    expected={i.key:i for i in items}
+    for row in rows:
+        if not isinstance(row,dict) or set(row) != {"id","text"} or row["id"] in output or row["id"] not in expected: raise ValueError("response contains invalid, duplicate, or unknown item")
+        if tokens(row["text"]) != tokens(expected[row["id"]].text): raise ValueError(f"technical tokens changed for {row['id']}")
+        output[row["id"]]=row["text"]
+    if set(output) != set(expected): raise ValueError("response is incomplete")
+    return output
+
+def translate(path: Path, output: Path, language: str, model: str, batch_size: int, dry_run: bool, force: bool, requester=request_openai) -> dict:
+    lines=path.read_text(encoding="utf-8-sig").splitlines(keepends=True); items=parse_items(lines, force)
+    all_items=parse_items(lines, True)
+    report={"found":len(items),"translated":0,"skipped":len(all_items)-len(items),"failed":0,"estimated_input_characters":sum(len(i.text) for i in items)}
+    if not items: return report
+    key=os.environ.get("OPENAI_API_KEY")
+    if not key: raise RuntimeError("OPENAI_API_KEY is not set")
+    changed=list(lines)
+    for start in range(0,len(items),batch_size):
+        batch=items[start:start+batch_size]
+        payload={"target_language":language,"items":[{"id":i.key,"resource_id":i.prefix.split(',',1)[0],"type":i.section,"text":i.text} for i in batch]}
+        try: translated=validate(batch, requester(payload,key,model))
+        except Exception: report["failed"] += len(batch); raise
+        for item in batch:
+            changed[item.index]=f'{item.prefix}1,"{translated[item.key]}"{item.ending}'
+            report["translated"] += 1
+    if not dry_run: output.write_text("".join(changed),encoding="utf-8-sig",newline="")
+    return report
+
+def main() -> int:
+    p=argparse.ArgumentParser(); p.add_argument("input",type=Path); p.add_argument("output",type=Path); p.add_argument("--language",required=True); p.add_argument("--model",default=os.environ.get("OPENAI_MODEL","gpt-5-mini")); p.add_argument("--batch-size",type=int,default=40); p.add_argument("--dry-run",action="store_true"); p.add_argument("--force-retranslate",action="store_true")
+    a=p.parse_args()
+    try: print(json.dumps(translate(a.input,a.output,a.language,a.model,a.batch_size,a.dry_run,a.force_retranslate),ensure_ascii=False)); return 0
+    except Exception as exc: print(f"translation failed: {exc}",file=sys.stderr); return 1
+if __name__ == "__main__": raise SystemExit(main())

--- a/tools/localization/translate_slt_with_openai.py
+++ b/tools/localization/translate_slt_with_openai.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 LINE_RE = re.compile(r'^(?P<prefix>.*?,)(?P<state>[01]),"(?P<text>.*)"(?P<ending>\r?\n)?$')
 SECTION_RE = re.compile(r'^\[(?P<kind>DIALOG|MENU|STRINGTABLE)(?:\s+[^]]+)?\]$')
-TOKEN_RE = re.compile(r'%(?:\d+\$)?[-+#0 ]*(?:\d+|\*)?(?:\.\d+|\.\*)?[a-zA-Z]|\{\d+(?::[^}]*)?\}|\\[nrt]|&.|<[^>]+>|(?:[A-Za-z]:)?(?:\\[^\\\s]+)+')
+TOKEN_RE = re.compile(r'%(?:\d+\$)?[-+#0 ]*(?:\d+|\*)?(?:\.\d+|\.\*)?[a-zA-Z]|\{\d+(?::[^}]*)?\}|\\[nrt]|<[^>]+>|(?:[A-Za-z]:)?(?:\\[^\\\s]+)+')
+ACCELERATOR_RE = re.compile(r'(?<!&)&(?!&)')
 
 @dataclass
 class Item:
@@ -26,7 +27,10 @@ def parse_items(lines: list[str], force: bool = False) -> list[Item]:
         items.append(Item(index, key, section, match.group("text"), match.group("prefix"), match.group("ending") or ""))
     return items
 
-def tokens(text: str) -> list[str]: return sorted(TOKEN_RE.findall(text))
+def tokens(text: str) -> tuple[list[str], int]:
+    # The accelerator must remain present, but its target letter normally
+    # changes in translation (for example "&File" becomes "&Soubor").
+    return sorted(TOKEN_RE.findall(text)), len(ACCELERATOR_RE.findall(text))
 
 def request_openai(payload: dict, api_key: str, model: str, attempts: int = 5, sleep=time.sleep) -> dict:
     body = json.dumps({"model": model, "input": [{"role":"system","content":[{"type":"input_text","text":"Translate Windows UI resources. Return only valid JSON with a translations array containing id and text. Preserve placeholders, escapes, accelerators (&), markup, paths, and technical tokens exactly."}]},{"role":"user","content":[{"type":"input_text","text":json.dumps(payload, ensure_ascii=False)}]}], "text":{"format":{"type":"json_schema","name":"translations","strict":True,"schema":{"type":"object","properties":{"translations":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"text":{"type":"string"}},"required":["id","text"],"additionalProperties":False}}},"required":["translations"],"additionalProperties":False}}}}).encode()


### PR DESCRIPTION
### Motivation
- Provide an English version of the localization guide for non-Czech speakers while preserving the original Czech text in the repository. 
- Make the main `doc/LOCALIZATION.md` file the English reference to match project documentation language expectations.

### Description
- Rename the original Czech document to `doc/LOCALIZATION-CZ.md` and add it to the repo. 
- Replace `doc/LOCALIZATION.md` with a full English translation that mirrors the original content and includes workflow, useful commands, and troubleshooting. 
- Commit message used for the change was `Translate localization guide to English` and both files were added/updated in the same change.

### Testing
- Ran `git diff --check` to ensure no whitespace or merge-error markers, which succeeded. 
- Ran `git status --short` and `git show --stat --oneline HEAD` to verify the working tree and commit contents, which succeeded. 
- The change was committed successfully and the repository shows `doc/LOCALIZATION.md` updated and `doc/LOCALIZATION-CZ.md` added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30560fc80c8329a7937d0c863fab84)