### PR TITLE
Synchronize startup flag with saved settings and advertise save capability

### DIFF
--- a/src/plugins/samandarin/samandarin.cpp
+++ b/src/plugins/samandarin/samandarin.cpp
@@ -69,6 +69,8 @@ void ShowInitializationError(HWND parent)
                                      LoadStr(IDS_PLUGINNAME), MB_OK | MB_ICONERROR);
 }
 
+BOOL SynchronizeLoadOnStartFlagFromSettings();
+
 BOOL WINAPI CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* salamander,
                                                         HWND parent, int id, DWORD eventMask)
 {
@@ -153,10 +155,12 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     SalamanderGUI = salamander->GetSalamanderGUI();
 
     // nastavime zakladni informace o pluginu
-    salamander->SetBasicPluginData(LoadStr(IDS_PLUGINNAME), FUNCTION_CONFIGURATION,
+    salamander->SetBasicPluginData(LoadStr(IDS_PLUGINNAME), FUNCTION_CONFIGURATION | FUNCTION_LOADSAVECONFIGURATION,
                                    VERSINFO_VERSION_NO_PLATFORM, VERSINFO_COPYRIGHT,
                                    LoadStr(IDS_PLUGIN_DESCRIPTION), PluginNameShort,
                                    NULL, NULL);
+
+    SynchronizeLoadOnStartFlagFromSettings();
 
     // nastavime URL home-page pluginu
     salamander->SetPluginHomePageURL(LoadStr(IDS_PLUGIN_HOME));
@@ -387,6 +391,20 @@ namespace
     }
 } // namespace
 
+BOOL SynchronizeLoadOnStartFlagFromSettings()
+{
+    if (SalamanderGeneral == NULL)
+    {
+        return FALSE;
+    }
+
+    NativeUpdateSettings settings;
+    InitializeDefaults(&settings);
+    SalamanderGeneral->CallLoadOrSaveConfiguration(TRUE, LoadOrSaveSettingsCallback, &settings);
+    SalamanderGeneral->SetFlagLoadOnSalamanderStart(settings.CheckOnStartup != 0);
+    return TRUE;
+}
+
 extern "C" __declspec(dllexport) BOOL __stdcall Samandarin_LoadSettings(NativeUpdateSettings* settings)
 {
     if (settings == nullptr || SalamanderGeneral == NULL)
@@ -407,5 +425,6 @@ extern "C" __declspec(dllexport) BOOL __stdcall Samandarin_SaveSettings(const Na
 
     NativeUpdateSettings localCopy = *settings;
     SalamanderGeneral->CallLoadOrSaveConfiguration(FALSE, LoadOrSaveSettingsCallback, &localCopy);
+    SalamanderGeneral->SetFlagLoadOnSalamanderStart(localCopy.CheckOnStartup != 0);
     return TRUE;
 }

--- a/src/plugins/samandarin/versinfo.rh2
+++ b/src/plugins/samandarin/versinfo.rh2
@@ -18,7 +18,7 @@
 // look at shared\versinfo.rc
 
 #define VERSINFO_MAJOR       0
-#define VERSINFO_MINORA      1
+#define VERSINFO_MINORA      2
 #define VERSINFO_MINORB      0
 
 #include "spl_vers.h" // vytahneme cisla verzi + buildu


### PR DESCRIPTION
### Motivation
- Ensure the plugin's runtime "load on Salamander start" flag reflects the persisted `CheckOnStartup` configuration so behavior matches saved settings.
- Mark the plugin as capable of loading/saving configuration by adding the `FUNCTION_LOADSAVECONFIGURATION` flag.
- Apply changes to the runtime flag immediately when settings are saved so the new value takes effect without restart.

### Description
- Add `SynchronizeLoadOnStartFlagFromSettings()` which loads saved settings via `CallLoadOrSaveConfiguration` and calls `SetFlagLoadOnSalamanderStart` based on `CheckOnStartup`.
- Call `SynchronizeLoadOnStartFlagFromSettings()` from `SalamanderPluginEntry` after setting basic plugin data.
- Include `FUNCTION_LOADSAVECONFIGURATION` in the flags passed to `SetBasicPluginData`.
- Update `Samandarin_SaveSettings` to call `SetFlagLoadOnSalamanderStart` after saving settings so the runtime flag is updated.

### Testing
- Automated project build (CI) was run and completed successfully.
- Existing automated unit/integration tests in CI were executed and passed.
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a333dd7ca7883298f8d25758bb333ea)