### PR TITLE
Fix portable config default directory loading

### DIFF
--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -3311,10 +3311,17 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
 
         if (OpenKey(salamander, SALAMANDER_DEFDIRS_REG, actKey))
         {
-            DWORD values;
-            DWORD res = RegQueryInfoKey(actKey, NULL, 0, 0, NULL, NULL, NULL, &values, NULL,
-                                        NULL, NULL, NULL);
-            if (res == ERROR_SUCCESS)
+            BOOL useActiveRegistry = FALSE;
+            CSalamanderRegistryExAbstract* registry = ConfigurationStorage.GetRegistry();
+            if (registry != NULL && ConfigurationStorage.UseActiveRegistryForKey(actKey))
+                useActiveRegistry = TRUE;
+
+            DWORD values = 0;
+            DWORD res = ERROR_SUCCESS;
+            if (!useActiveRegistry)
+                res = RegQueryInfoKey(actKey, NULL, 0, 0, NULL, NULL, NULL, &values, NULL,
+                                      NULL, NULL, NULL);
+            if (useActiveRegistry || res == ERROR_SUCCESS)
             {
                 char dir[4] = " :\\"; // reset DefaultDir
                 char d;
@@ -3329,11 +3336,19 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                 DWORD nameLen, dataLen, type;
 
                 int i;
-                for (i = 0; i < (int)values; i++)
+                for (i = 0; useActiveRegistry || i < (int)values; i++)
                 {
                     nameLen = 2;
                     dataLen = MAX_PATH;
-                    res = RegEnumValue(actKey, i, name, &nameLen, 0, &type, path, &dataLen);
+                    if (useActiveRegistry)
+                    {
+                        name[0] = 0;
+                        if (!registry->EnumValue(actKey, i, name, SizeOf(name), &type, path, &dataLen))
+                            break;
+                        res = ERROR_SUCCESS;
+                    }
+                    else
+                        res = RegEnumValue(actKey, i, name, &nameLen, 0, &type, path, &dataLen);
                     if (res == ERROR_SUCCESS)
                         if (type == REG_SZ)
                         {


### PR DESCRIPTION
### Motivation
- Starting with configuration storage set to file-backed (portable) caused an error dialog "Error Loading Configuration: (6) The handle is invalid." because code used direct WinAPI registry enumeration on handles owned by the in-memory/portable registry implementation.

### Description
- Detect when the active configuration backend is the file-backed in-memory registry via `ConfigurationStorage.GetRegistry()` and `ConfigurationStorage.UseActiveRegistryForKey()` and switch to the registry abstraction in that case.
- Replace `RegQueryInfoKey`/`RegEnumValue` usage with `registry->EnumValue(...)` for the portable backend and iterate until `EnumValue` fails, while keeping the original WinAPI path for real registry keys.
- Added loop and control-flow changes in `src/mainwnd2.cpp` to support both enumeration mechanisms without showing the invalid-handle error.

### Testing
- Ran `git diff --check` which returned no whitespace errors and succeeded.
- Attempted to build with `msbuild` (`msbuild src/vcxproj/salamand.sln /t:Build /p:Configuration=Debug /p:Platform=x64`) but `msbuild` is not available in this environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33cd6a684083298c4bedda0b326e56)