### PR TITLE
Avoid registry writes and add file-config-aware uninstall in Inno script

### DIFF
--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -46,7 +46,7 @@ ArchitecturesInstallIn64BitMode=x64
 PrivilegesRequired=admin
 UninstallDisplayName={#MyAppDisplayName}
 UninstallDisplayIcon=..\..\src\res\samandarin.ico
-; Keep this disabled because [Registry] below writes the legacy Add/Remove Programs key pointing to Inno's uninstaller; enabling it would add a duplicate Inno uninstall entry.
+; Keep this disabled so the installer does not create Add/Remove Programs registry entries.
 CreateUninstallRegKey=no
 SetupIconFile=..\..\src\res\samandarin.ico
 LicenseFile={#SourcePath}\license.txt
@@ -1232,22 +1232,6 @@ Name: "{group}\Open Salamander Samandarin (x64)"; Filename: "{app}\{#MyAppExeNam
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; Flags: nowait postinstall skipifsilent
 
-[Registry]
-; Legacy keys and values mirrored from [AddRegistryKeys] and [AddRegistryValues].
-; UninstallString intentionally targets Inno Setup's uninstaller instead of the
-; legacy remove\remove.exe payload so this installer can uninstall its own files.
-Root: HKCU; Subkey: "Software\Open Salamander Samandarin\Applications\Open Salamander Samandarin (x64)"; ValueType: string; ValueName: "Last Directory"; ValueData: "{app}"; Flags: uninsdeletevalue
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "DisplayName"; ValueData: "{#MyAppDisplayName}"; Flags: uninsdeletekey
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "DisplayIcon"; ValueData: "{app}\{#MyAppExeName}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "DisplayVersion"; ValueData: "{#MyAppVersion}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: dword; ValueName: "VersionMajor"; ValueData: "5"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: dword; ValueName: "VersionMinor"; ValueData: "0"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "InstallLocation"; ValueData: "{app}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "UninstallString"; ValueData: """{uninstallexe}"""
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "QuietUninstallString"; ValueData: """{uninstallexe}"" /SILENT"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "Publisher"; ValueData: "{#MyAppPublisher}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "HelpLink"; ValueData: "{#MyAppURL}"
-Root: HKLM64; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Open Salamander 5.0-samandarin-0.6 (x64)"; ValueType: string; ValueName: "UrlInfoAbout"; ValueData: "{#MyAppURL}"
 
 [UninstallRun]
 ; INF [DelShellExts] listed these shell-extension DLLs for cleanup.
@@ -1258,18 +1242,46 @@ Filename: "{sys}\regsvr32.exe"; Parameters: "/u /s ""{app}\utils\salextx86.dll""
 
 
 var
-  DeleteUserConfigurationRegistry: Boolean;
+  DeleteUserConfiguration: Boolean;
+  DeleteUserConfigurationFromFile: Boolean;
+
+function IsFileConfigurationStorageSelected(): Boolean;
+var
+  StorageType: String;
+begin
+  StorageType := GetIniString(
+    'Configuration',
+    'StorageType',
+    'Registry',
+    ExpandConstant('{app}\configstorage.ini'));
+  Result := CompareText(StorageType, 'RegFile') = 0;
+end;
 
 function InitializeUninstall(): Boolean;
 begin
   Result := True;
-  DeleteUserConfigurationRegistry := False;
+  DeleteUserConfiguration := False;
+  DeleteUserConfigurationFromFile := IsFileConfigurationStorageSelected();
 
-  if RegKeyExists(HKCU, 'Software\Open Salamander Samandarin\5.0-samandarin-0.6') then
+  if DeleteUserConfigurationFromFile then
   begin
-    DeleteUserConfigurationRegistry :=
+    if FileExists(ExpandConstant('{app}\config.reg')) or FileExists(ExpandConstant('{app}\configstorage.ini')) then
+    begin
+      DeleteUserConfiguration :=
+        MsgBox(
+          'Do you want to remove the Open Salamander Samandarin user configuration?'#13#10#13#10 +
+          'File storage:'#13#10 +
+          ExpandConstant('{app}\config.reg') + #13#10#13#10 +
+          'Choose Yes to delete the configuration files, or No to keep your settings.',
+          mbConfirmation,
+          MB_YESNO) = IDYES;
+    end;
+  end
+  else if RegKeyExists(HKCU, 'Software\Open Salamander Samandarin\5.0-samandarin-0.6') then
+  begin
+    DeleteUserConfiguration :=
       MsgBox(
-        'Do you want to remove the Open Salamander Samandarin user configuration from the registry?'#13#10#13#10 +
+        'Do you want to remove the Open Salamander Samandarin user configuration?'#13#10#13#10 +
         'Registry key:'#13#10 +
         'HKCU\Software\Open Salamander Samandarin\5.0-samandarin-0.6'#13#10#13#10 +
         'Choose Yes to delete the key including all contents, or No to keep your settings.',
@@ -1280,8 +1292,16 @@ end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
-  if (CurUninstallStep = usPostUninstall) and DeleteUserConfigurationRegistry then
-    RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Open Salamander Samandarin\5.0-samandarin-0.6');
+  if (CurUninstallStep = usPostUninstall) and DeleteUserConfiguration then
+  begin
+    if DeleteUserConfigurationFromFile then
+    begin
+      DeleteFile(ExpandConstant('{app}\config.reg'));
+      DeleteFile(ExpandConstant('{app}\configstorage.ini'));
+    end
+    else
+      RegDeleteKeyIncludingSubkeys(HKCU, 'Software\Open Salamander Samandarin\5.0-samandarin-0.6');
+  end;
 end;
 
 procedure CurPageChanged(CurPageID: Integer);


### PR DESCRIPTION
### Motivation
- Prevent the installer from writing legacy HKCU/HKLM registry entries and support the new option to store user configuration in files instead of the registry.
- Make the uninstaller prompt and cleanup behave correctly depending on whether configuration is stored in the registry or in files.

### Description
- Removed the Inno `[Registry]` section so the installer no longer writes legacy registry keys during install and clarified `CreateUninstallRegKey=no` to avoid creating Add/Remove registry entries.
- Added `IsFileConfigurationStorageSelected()` and the boolean flags `DeleteUserConfiguration` / `DeleteUserConfigurationFromFile` to detect `StorageType=RegFile` from `configstorage.ini` using `GetIniString( ..., ExpandConstant('{app}\configstorage.ini'))`.
- Replaced the uninstall prompt text with `Do you want to remove the Open Salamander Samandarin user configuration?` and, when file storage is selected, show `File storage:` with `ExpandConstant('{app}\config.reg')` instead of the registry key lines.
- On user confirmation the uninstaller now deletes either the registry key `HKCU\Software\Open Salamander Samandarin\5.0-samandarin-0.6` (registry storage) or the files `config.reg` and `configstorage.ini` (file storage) using `RegDeleteKeyIncludingSubkeys` or `DeleteFile` respectively.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems.
- Searched the modified script for the new behavior with `rg -n "^\[Registry\]|Root: HK|CreateUninstallRegKey=no|Do you want to remove|File storage:|configstorage\.ini|config\.reg|RegDeleteKeyIncludingSubkeys|DeleteFile" doc/runbook-setup/inno_setup_salamander_x64.iss` and verified the expected lines are present.
- Attempted to compile the Inno script with `iscc` but the Inno Setup compiler is not installed in this environment, so the script could not be compiled here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347b2534dc8329b57f8325bdfb1a1a)