### PR TITLE
Remove registry configuration after migration to file storage

### DIFF
--- a/src/configstorage.cpp
+++ b/src/configstorage.cpp
@@ -37,14 +37,14 @@ BOOL CConfigurationStorage::BuildRootKeyName(char* keyName, int keyNameSize)
 }
 
 
-void CConfigurationStorage::DeleteStoredRegistryConfiguration(const char* keyName)
+void CConfigurationStorage::DeleteStoredRegistryConfiguration(CSalamanderRegistryExAbstract* registry, const char* keyName)
 {
     HKEY key;
-    if (keyName != NULL && OpenKey(HKEY_CURRENT_USER, keyName, key))
+    if (registry != NULL && keyName != NULL && registry->OpenKey(HKEY_CURRENT_USER, keyName, key))
     {
-        ClearKey(key);
-        CloseKey(key);
-        DeleteKey(HKEY_CURRENT_USER, keyName);
+        registry->ClearKey(key);
+        registry->CloseKey(key);
+        registry->DeleteKey(HKEY_CURRENT_USER, keyName);
     }
 }
 
@@ -358,7 +358,7 @@ BOOL CConfigurationStorage::SwitchStorageType(CConfigurationStorageType newType,
     }
 
     if (oldType == cstRegistry && StorageType == cstRegFile && migrateCurrentData)
-        DeleteStoredRegistryConfiguration(SALAMANDER_ROOT_REG);
+        DeleteStoredRegistryConfiguration(oldRegistry, SALAMANDER_ROOT_REG);
 
     if (oldRegistry != NULL)
         oldRegistry->Release();

--- a/src/configstorage.cpp
+++ b/src/configstorage.cpp
@@ -37,6 +37,17 @@ BOOL CConfigurationStorage::BuildRootKeyName(char* keyName, int keyNameSize)
 }
 
 
+void CConfigurationStorage::DeleteStoredRegistryConfiguration(const char* keyName)
+{
+    HKEY key;
+    if (keyName != NULL && OpenKey(HKEY_CURRENT_USER, keyName, key))
+    {
+        ClearKey(key);
+        CloseKey(key);
+        DeleteKey(HKEY_CURRENT_USER, keyName);
+    }
+}
+
 
 BOOL CConfigurationStorage::GetStorageTypeBootstrapFilePath(char* filePath, int filePathSize)
 {
@@ -345,6 +356,9 @@ BOOL CConfigurationStorage::SwitchStorageType(CConfigurationStorageType newType,
         newRegistry->Release();
         return FALSE;
     }
+
+    if (oldType == cstRegistry && StorageType == cstRegFile && migrateCurrentData)
+        DeleteStoredRegistryConfiguration(SALAMANDER_ROOT_REG);
 
     if (oldRegistry != NULL)
         oldRegistry->Release();

--- a/src/configstorage.h
+++ b/src/configstorage.h
@@ -26,7 +26,7 @@ protected:
     BOOL SaveRegFile();
     void ShowRegFileLoadError(const char* fileName, eRPE_ERROR err);
     void ShowRegFileSaveError(const char* fileName, DWORD err);
-    void DeleteStoredRegistryConfiguration(const char* keyName);
+    void DeleteStoredRegistryConfiguration(CSalamanderRegistryExAbstract* registry, const char* keyName);
 
 public:
     CConfigurationStorage();

--- a/src/configstorage.h
+++ b/src/configstorage.h
@@ -26,6 +26,7 @@ protected:
     BOOL SaveRegFile();
     void ShowRegFileLoadError(const char* fileName, eRPE_ERROR err);
     void ShowRegFileSaveError(const char* fileName, DWORD err);
+    void DeleteStoredRegistryConfiguration(const char* keyName);
 
 public:
     CConfigurationStorage();

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -4879,7 +4879,7 @@ FIND_NEW_SLG_FILE:
                         if (migrateRegistryToFile)
                         {
                             ConfigurationStorage.Flush();
-                            if (!ConfigurationStorage.SwitchStorageType(cstRegFile, FALSE))
+                            if (!ConfigurationStorage.SwitchStorageType(cstRegFile, TRUE))
                                 TRACE_E("Unable to switch configuration storage to file after loading imported configuration.");
                             Configuration.StorageType = (int)ConfigurationStorage.GetStorageType();
                         }


### PR DESCRIPTION
### Motivation
- When the user chooses to migrate configuration from Registry to file-based storage we must also remove the old Registry-stored configuration to avoid duplicate/leftover data.

### Description
- Added `DeleteStoredRegistryConfiguration` to `CConfigurationStorage` (declared in `src/configstorage.h` and implemented in `src/configstorage.cpp`).
- `CConfigurationStorage::SwitchStorageType` now calls `DeleteStoredRegistryConfiguration(SALAMANDER_ROOT_REG)` after a successful registry->file migration so the old HKCU tree is removed.
- Updated the startup conversion path in `src/salamdr1.cpp` to call `SwitchStorageType(..., TRUE)` so the migration (save to file) is performed and the cleanup runs only after the file-backed configuration is written.
- Ensured deletion only occurs after a successful `SaveRegFile` to avoid data loss if migration fails.

### Testing
- Ran `git diff --check` which finished without issues.
- Checked for local build tools with `command -v msbuild || command -v dotnet` and none were available in this environment, so a full build/test was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a352fed5254832985bf7a12a08d17f4)