### PR TITLE
Fix TreeView auto-hide expand behavior and adjust header layout

### DIFF
--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -81,6 +81,7 @@ enum
 {
     TREEVIEW_HEADER_HOT_CLOSE = 0x01,
     TREEVIEW_HEADER_HOT_PIN = 0x02,
+    TREEVIEW_HEADER_AUTOHIDE_EXPAND_TIMER_SET = 0x04,
     TREEVIEW_AUTOHIDE_TIMER = 1,
     TREEVIEW_AUTOHIDE_EXPAND_TIMER = 2,
     TREEVIEW_AUTOHIDE_EXPAND_DELAY = 150
@@ -199,6 +200,8 @@ static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPAR
         else if (wParam == TREEVIEW_AUTOHIDE_EXPAND_TIMER)
         {
             KillTimer(hwnd, TREEVIEW_AUTOHIDE_EXPAND_TIMER);
+            SetWindowLongPtr(hwnd, GWLP_USERDATA,
+                             GetWindowLongPtr(hwnd, GWLP_USERDATA) & ~TREEVIEW_HEADER_AUTOHIDE_EXPAND_TIMER_SET);
             POINT pt;
             GetCursorPos(&pt);
             if (IsPointInWindow(hwnd, pt))
@@ -210,7 +213,15 @@ static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPAR
     {
         if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
         {
-            SetTimer(hwnd, TREEVIEW_AUTOHIDE_EXPAND_TIMER, TREEVIEW_AUTOHIDE_EXPAND_DELAY, NULL);
+            LONG_PTR state = GetWindowLongPtr(hwnd, GWLP_USERDATA);
+            if ((state & TREEVIEW_HEADER_AUTOHIDE_EXPAND_TIMER_SET) == 0)
+            {
+                SetTimer(hwnd, TREEVIEW_AUTOHIDE_EXPAND_TIMER, TREEVIEW_AUTOHIDE_EXPAND_DELAY, NULL);
+                SetWindowLongPtr(hwnd, GWLP_USERDATA,
+                                 state | TREEVIEW_HEADER_AUTOHIDE_EXPAND_TIMER_SET);
+            }
+            TRACKMOUSEEVENT track = {sizeof(track), TME_LEAVE, hwnd, 0};
+            TrackMouseEvent(&track);
             return 0;
         }
         POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
@@ -241,10 +252,22 @@ static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPAR
         }
         break;
 
+    case WM_LBUTTONDOWN:
+        if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
+        {
+            KillTimer(hwnd, TREEVIEW_AUTOHIDE_EXPAND_TIMER);
+            SetWindowLongPtr(hwnd, GWLP_USERDATA, 0);
+            panel->ExpandTreeViewAutoHide();
+            return 0;
+        }
+        break;
+
     case WM_LBUTTONUP:
     {
         if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
         {
+            KillTimer(hwnd, TREEVIEW_AUTOHIDE_EXPAND_TIMER);
+            SetWindowLongPtr(hwnd, GWLP_USERDATA, 0);
             panel->ExpandTreeViewAutoHide();
             return 0;
         }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -8406,15 +8406,16 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             // When right panel is zoomed, tree must also be HWND_TOP to stay visible
             // above the right panel which extends to x=1.
             BOOL treeOnTop = Configuration.TreeViewAutoHide || rightZoomed;
+            int treeX = Configuration.TreeViewAutoHide ? 0 : 1;
+            int treeWindowWidth = treeDisplayWidth + (Configuration.TreeViewAutoHide ? 1 : 0);
             if (LeftPanel != NULL && LeftPanel->HTreeHeader != NULL && LeftPanel->TreeViewActive)
             {
                 BOOL collapsed = Configuration.TreeViewAutoHide && !treeAutoHideExpanded;
-                int headerX = collapsed ? 0 : 1;
-                int headerWidth = collapsed ? treeWidth + 1 : treeDisplayWidth;
+                int headerWidth = collapsed ? treeWidth + 1 : treeWindowWidth;
                 int headerHeight = collapsed ? PanelsHeight : treeHeaderHeight;
                 hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeHeader,
                                               treeOnTop ? HWND_TOP : NULL,
-                                              headerX, TopRebarHeight, headerWidth, headerHeight,
+                                              treeX, TopRebarHeight, headerWidth, headerHeight,
                                               SWP_NOACTIVATE | (treeOnTop ? 0 : SWP_NOZORDER) | SWP_SHOWWINDOW));
             }
             if (LeftPanel != NULL && LeftPanel->HTreeView != NULL && LeftPanel->TreeViewActive)
@@ -8425,7 +8426,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 BOOL show = !Configuration.TreeViewAutoHide || treeAutoHideExpanded;
                 hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeView,
                                               treeOnTop ? HWND_TOP : NULL,
-                                              1, TopRebarHeight + treeHeaderHeight, treeDisplayWidth, treeViewHeight,
+                                              treeX, TopRebarHeight + treeHeaderHeight, treeWindowWidth, treeViewHeight,
                                               SWP_NOACTIVATE | (treeOnTop ? 0 : SWP_NOZORDER) |
                                                   (show ? SWP_SHOWWINDOW : SWP_HIDEWINDOW)));
             }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -8409,11 +8409,12 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             if (LeftPanel != NULL && LeftPanel->HTreeHeader != NULL && LeftPanel->TreeViewActive)
             {
                 BOOL collapsed = Configuration.TreeViewAutoHide && !treeAutoHideExpanded;
-                int headerWidth = collapsed ? treeWidth : treeDisplayWidth;
+                int headerX = collapsed ? 0 : 1;
+                int headerWidth = collapsed ? treeWidth + 1 : treeDisplayWidth;
                 int headerHeight = collapsed ? PanelsHeight : treeHeaderHeight;
                 hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeHeader,
                                               treeOnTop ? HWND_TOP : NULL,
-                                              1, TopRebarHeight, headerWidth, headerHeight,
+                                              headerX, TopRebarHeight, headerWidth, headerHeight,
                                               SWP_NOACTIVATE | (treeOnTop ? 0 : SWP_NOZORDER) | SWP_SHOWWINDOW));
             }
             if (LeftPanel != NULL && LeftPanel->HTreeView != NULL && LeftPanel->TreeViewActive)


### PR DESCRIPTION
### Motivation
- Prevent redundant auto-hide expand timers and ensure clicks immediately expand the auto-hidden TreeView. 
- Keep the TreeView header reachable at the left screen edge when collapsed so mouse events hit the header reliably.

### Description
- Added `TREEVIEW_HEADER_AUTOHIDE_EXPAND_TIMER_SET` flag and store a small state bit in `GWLP_USERDATA` to avoid repeatedly calling `SetTimer` for `TREEVIEW_AUTOHIDE_EXPAND_TIMER` in `TreeViewHeaderSubclassProc`.
- Clear the timer bit on `WM_TIMER` for `TREEVIEW_AUTOHIDE_EXPAND_TIMER` and on relevant mouse events, and stop the timer before expanding to avoid races.
- Added handling for `WM_LBUTTONDOWN` to expand the auto-hidden tree immediately when clicked, and ensure `WM_LBUTTONUP` also clears the timer state before expanding.
- Adjusted header geometry in `mainwnd3.cpp` so a collapsed header is positioned at `x=0` with `treeWidth + 1` width to cover the screen edge and receive mouse events.

### Testing
- Built the project (`make`) to verify compilation after changes, and the build succeeded. 
- Ran the existing automated test suite (`make test` / `ctest`) and reported tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35b0bd47b08329a3627c32909aa07f)