### PR TITLE
Fix Colors configuration mask layout after resizing

### DIFF
--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -809,6 +809,7 @@ protected:
     void LoadMasks();
     void StoreMasks();
     void EnableControls();
+    void LayoutMaskControls();
 };
 
 //

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3963,6 +3963,13 @@ void CCfgPageColors::StoreMasks()
 }
 
 
+static int CfgPageColorsDluY(HWND hWindow, int dluY)
+{
+    RECT r = {0, 0, 0, dluY};
+    MapDialogRect(hWindow, &r);
+    return r.bottom;
+}
+
 static void MoveDlgCtrlVertically(HWND hWindow, HDWP& hdwp, int resID, int y)
 {
     HWND hCtrl = GetDlgItem(hWindow, resID);
@@ -3994,13 +4001,15 @@ void CCfgPageColors::LayoutMaskControls()
     // can collapse the gaps between the list, the attribute label/checkboxes and
     // the mask color buttons after the page is resized horizontally.  Reapply the
     // original vertical spacing from the dialog resource after the generic layout
-    // has finished.
-    const int attrLabelY = listBottom.y + 4;
-    const int checkColY = attrLabelY + 9;
-    const int maskLabelY = attrLabelY + 3;
-    const int maskButtonY = attrLabelY + 1;
-    const int noteY = attrLabelY + 59;
-    const int rowStep = 14;
+    // has finished.  Convert the resource DLU offsets to pixels first; using raw
+    // DLU values as pixels makes the controls look vertically glued together.
+    const int attrLabelY = listBottom.y + CfgPageColorsDluY(HWindow, 4);
+    const int checkColY = attrLabelY + CfgPageColorsDluY(HWindow, 9);
+    const int maskLabelY = attrLabelY + CfgPageColorsDluY(HWindow, 3);
+    const int maskButtonY = attrLabelY + CfgPageColorsDluY(HWindow, 1);
+    const int noteY = attrLabelY + CfgPageColorsDluY(HWindow, 59);
+    const int rowStep = CfgPageColorsDluY(HWindow, 14);
+    const int checkStep = CfgPageColorsDluY(HWindow, 12);
 
     HDWP hdwp = HANDLES(BeginDeferWindowPos(1 + PAGE7_CTRLCOUNT + 1 + 2 * CFG_COLORS_BUTTONS));
     if (hdwp == NULL)
@@ -4008,12 +4017,12 @@ void CCfgPageColors::LayoutMaskControls()
 
     MoveDlgCtrlVertically(HWindow, hdwp, IDC_STATIC_3, attrLabelY);
     MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_ARCHIVE, checkColY);
-    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_READONLY, checkColY + 12);
-    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_HIDDEN, checkColY + 24);
-    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_SYSTEM, checkColY + 36);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_READONLY, checkColY + checkStep);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_HIDDEN, checkColY + 2 * checkStep);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_SYSTEM, checkColY + 3 * checkStep);
     MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_COMPRESSED, checkColY);
-    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_ENCRYPTED, checkColY + 12);
-    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_DIRECTORY, checkColY + 24);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_ENCRYPTED, checkColY + checkStep);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_DIRECTORY, checkColY + 2 * checkStep);
     MoveDlgCtrlVertically(HWindow, hdwp, IDC_STATIC_6, noteY);
 
     for (int i = 0; i < CFG_COLORS_BUTTONS; i++)

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3962,6 +3962,69 @@ void CCfgPageColors::StoreMasks()
     }
 }
 
+
+static void MoveDlgCtrlVertically(HWND hWindow, HDWP& hdwp, int resID, int y)
+{
+    HWND hCtrl = GetDlgItem(hWindow, resID);
+    if (hCtrl == NULL || hdwp == NULL)
+        return;
+
+    RECT r;
+    GetWindowRect(hCtrl, &r);
+    POINT p = {r.left, r.top};
+    ScreenToClient(hWindow, &p);
+    hdwp = HANDLES(DeferWindowPos(hdwp, hCtrl, NULL,
+                                  p.x, y, 0, 0,
+                                  SWP_NOSIZE | SWP_NOZORDER));
+}
+
+void CCfgPageColors::LayoutMaskControls()
+{
+    HWND hList = GetDlgItem(HWindow, IDC_C_LIST);
+    if (hList == NULL)
+        return;
+
+    RECT listRect;
+    GetWindowRect(hList, &listRect);
+    POINT listBottom = {listRect.left, listRect.bottom};
+    ScreenToClient(HWindow, &listBottom);
+
+    // Keep the attribute block anchored below the resized mask list.  The generic
+    // elastic layout moves these controls as one bottom-aligned envelope, which
+    // can collapse the gaps between the list, the attribute label/checkboxes and
+    // the mask color buttons after the page is resized horizontally.  Reapply the
+    // original vertical spacing from the dialog resource after the generic layout
+    // has finished.
+    const int attrLabelY = listBottom.y + 4;
+    const int checkColY = attrLabelY + 9;
+    const int maskLabelY = attrLabelY + 3;
+    const int maskButtonY = attrLabelY + 1;
+    const int noteY = attrLabelY + 59;
+    const int rowStep = 14;
+
+    HDWP hdwp = HANDLES(BeginDeferWindowPos(1 + PAGE7_CTRLCOUNT + 1 + 2 * CFG_COLORS_BUTTONS));
+    if (hdwp == NULL)
+        return;
+
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_STATIC_3, attrLabelY);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_ARCHIVE, checkColY);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_READONLY, checkColY + 12);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_HIDDEN, checkColY + 24);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_SYSTEM, checkColY + 36);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_COMPRESSED, checkColY);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_ENCRYPTED, checkColY + 12);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_C_DIRECTORY, checkColY + 24);
+    MoveDlgCtrlVertically(HWindow, hdwp, IDC_STATIC_6, noteY);
+
+    for (int i = 0; i < CFG_COLORS_BUTTONS; i++)
+    {
+        MoveDlgCtrlVertically(HWindow, hdwp, CConfigurationPage7Masks[i], maskLabelY + i * rowStep);
+        MoveDlgCtrlVertically(HWindow, hdwp, CConfigurationPage7MasksBut[i], maskButtonY + i * rowStep);
+    }
+
+    HANDLES(EndDeferWindowPos(hdwp));
+}
+
 void CCfgPageColors::EnableControls()
 {
     CALL_STACK_MESSAGE1("CCfgPageColors::EnableControls()");
@@ -4525,7 +4588,11 @@ MENU_TEMPLATE_ITEM CfgPageColorsMenu3[] =
         break;
     }
     }
-    return CCommonPropSheetPage::DialogProc(uMsg, wParam, lParam);
+
+    INT_PTR result = CCommonPropSheetPage::DialogProc(uMsg, wParam, lParam);
+    if (uMsg == WM_INITDIALOG || uMsg == WM_SIZE)
+        LayoutMaskControls();
+    return result;
 }
 
 //


### PR DESCRIPTION
### Motivation
- The Colors page in Configuration could misplace the attribute label, checkboxes and mask color buttons after the dialog is resized because the generic elastic layout collapses the vertical gaps between the mask list and the controls below it.

### Description
- Add `LayoutMaskControls()` to `CCfgPageColors` and declare it in `src/cfgdlg.h` to perform a corrective vertical layout for the attribute label, checkboxes and mask color buttons.
- Implement `MoveDlgCtrlVertically()` helper and `CCfgPageColors::LayoutMaskControls()` in `src/dialogs4.cpp` to compute the mask-list bottom and re-anchor the related controls preserving original vertical spacing.
- Call `LayoutMaskControls()` after the shared property-page layout by invoking it from `DialogProc` when handling `WM_INITDIALOG` and `WM_SIZE` so the corrective layout runs once initialization/resize finished.

### Testing
- Ran `git diff --check` to verify there are no whitespace or simple diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36059da6c08329a3e4845edfcfeac4)