### PR TITLE
Use configuration storage API for plugin icon lists (fix file-backed config)

### DIFF
--- a/src/plugins2.cpp
+++ b/src/plugins2.cpp
@@ -140,9 +140,9 @@ BOOL SaveIconList(HKEY hKey, const char* valueName, CIconList* iconList)
     DWORD rawPNGSize;
     if (iconList->SaveToPNG(&rawPNG, &rawPNGSize))
     {
-        LONG res = RegSetValueEx(hKey, valueName, 0, REG_BINARY, rawPNG, rawPNGSize);
+        BOOL ret = SetValue(hKey, valueName, REG_BINARY, rawPNG, rawPNGSize);
         free(rawPNG);
-        return TRUE;
+        return ret;
     }
     else
         return FALSE;
@@ -150,17 +150,15 @@ BOOL SaveIconList(HKEY hKey, const char* valueName, CIconList* iconList)
 
 BOOL LoadIconList(HKEY hKey, const char* valueName, CIconList** iconList)
 {
-    DWORD gettedType;
     DWORD bufferSize;
-    LONG res = SalRegQueryValueEx(hKey, valueName, 0, &gettedType, NULL, &bufferSize);
-    if (res != ERROR_SUCCESS || gettedType != REG_BINARY)
+    if (!GetSize(hKey, valueName, REG_BINARY, bufferSize))
         return FALSE;
 
     BYTE* buff = (BYTE*)malloc(bufferSize);
+    if (buff == NULL)
+        return FALSE;
 
-    DWORD bufferSize2 = bufferSize;
-    res = SalRegQueryValueEx(hKey, valueName, 0, &gettedType, buff, &bufferSize2);
-    if (res != ERROR_SUCCESS || bufferSize2 != bufferSize)
+    if (!GetValue(hKey, valueName, REG_BINARY, buff, bufferSize))
     {
         free(buff);
         return FALSE;
@@ -168,7 +166,12 @@ BOOL LoadIconList(HKEY hKey, const char* valueName, CIconList** iconList)
 
     *iconList = new CIconList();
     //(*iconList)->Dump = TRUE;
-    BOOL ret = (*iconList)->CreateFromRawPNG(buff, bufferSize2, 16);
+    BOOL ret = (*iconList)->CreateFromRawPNG(buff, bufferSize, 16);
+    if (!ret)
+    {
+        delete *iconList;
+        *iconList = NULL;
+    }
     free(buff);
     return ret;
 }


### PR DESCRIPTION
### Motivation
- Plugin icons were written/read directly to the Windows Registry which prevented icon lists from being restored when the configuration storage is set to file-backed (`RegFile`).
- The goal is to use the active configuration storage abstraction so icon lists persist and are restored correctly for file-based configurations.

### Description
- Replaced direct registry store in `SaveIconList` with the configuration abstraction call `SetValue` so icon PNG blobs go through the active storage backend (`src/plugins2.cpp`).
- Replaced direct `SalRegQueryValueEx` reads in `LoadIconList` with `GetSize` and `GetValue` so code reads binary icon data via the active storage backend and works for file-backed configs.
- Added allocation null-check for the temporary buffer and cleanup of a partially created `CIconList` when `CreateFromRawPNG` fails to avoid leaking the partially constructed object.
- Changes are contained in `src/plugins2.cpp` (functions `SaveIconList` and `LoadIconList`).

### Testing
- Ran `git diff --check` to verify no whitespace/diff issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3611de45bc8329b4e1c8a7a17bca5c)