### PR TITLE
Use default active tab border color

### DIFF
--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -2059,11 +2059,7 @@ void CTabWindow::DrawColoredTab(HDC hdc, const RECT& itemRect, const wchar_t* te
     if (selected && Configuration.TabActiveBorder)
     {
         COLORREF borderColor;
-        if (hasCustomColor)
-        {
-            borderColor = baseColor;
-        }
-        else if (useDark)
+        if (useDark)
         {
             if (CurrentColors != NULL)
                 borderColor = GetCOLORREF(CurrentColors[ITEM_FG_FOCUSED]);
@@ -2071,7 +2067,7 @@ void CTabWindow::DrawColoredTab(HDC hdc, const RECT& itemRect, const wchar_t* te
                 borderColor = DarkModeGetDialogTextColor();
         }
         else
-            borderColor = IsColorDark(fillColor) ? RGB(255, 255, 255) : RGB(0, 0, 0);
+            borderColor = GetSysColor(COLOR_BTNTEXT);
 
         int borderHeight = 3;
         RECT borderRect;


### PR DESCRIPTION
### Motivation
- When "Show active tab border" is enabled, the active-tab border should not be painted using a tab's custom color; it should use the same default foreground/button-text colors as tabs without a configured custom color (focused foreground in dark mode, button text in light mode). 

### Description
- Update `DrawColoredTab` in `src/tabwnd.cpp` to stop using `baseColor` when `hasCustomColor` is true and instead select `CurrentColors[ITEM_FG_FOCUSED]` / `DarkModeGetDialogTextColor()` in dark mode and `GetSysColor(COLOR_BTNTEXT)` in light mode for the active border. 

### Testing
- Ran `git diff --check` and no whitespace/patch issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36442a3bec8329b4518a51c71892fc)