### PR TITLE
Add vcpkg manifest and PowerShell helper to reproducibly build third-party DLLs

### DIFF
--- a/tools/vcpkg/README.md
+++ b/tools/vcpkg/README.md
@@ -1,0 +1,63 @@
+# Third-party DLL build with vcpkg
+
+This directory contains a small vcpkg manifest and helper script for building the
+runtime DLLs that are not stored in the repository but are needed by the current
+x64 distribution:
+
+- `unrar.dll` for the UnRAR plugin
+- `libeay32.dll` and `ssleay32.dll` for the FTP plugin's legacy OpenSSL loader
+
+The script pins the vcpkg registry baseline and package versions so the produced
+inputs are reproducible:
+
+- `unrar` `7.2.6`
+- `openssl` `1.0.2o-3`
+
+OpenSSL 1.0.2 is intentionally used because the existing FTP plugin loads the
+legacy OpenSSL 1.0.x DLL names and symbols from `src/plugins/ftp/ssl.cpp`.
+Moving to the current OpenSSL 3.x vcpkg package would require porting that code.
+OpenSSL 1.0.2 is end-of-life, so this is a compatibility build for the
+existing FTP plugin rather than a long-term TLS upgrade.
+
+## Build
+
+Run from a Visual Studio Developer PowerShell on Windows:
+
+```powershell
+.\tools\vcpkg\build-third-party-libs.ps1
+```
+
+By default the script:
+
+1. clones `https://github.com/microsoft/vcpkg.git` into `build\vcpkg` unless
+   `VCPKG_ROOT` or `-VcpkgRoot` points at an existing checkout,
+2. checks out the pinned vcpkg baseline,
+3. bootstraps vcpkg,
+4. installs the manifest in `tools\vcpkg\third-party-libs` for the
+   `x64-windows` triplet,
+5. copies the required runtime DLLs into `build\libs`.
+
+Useful options:
+
+```powershell
+.\tools\vcpkg\build-third-party-libs.ps1 -Triplet x64-windows
+.\tools\vcpkg\build-third-party-libs.ps1 -VcpkgRoot C:\src\vcpkg
+.\tools\vcpkg\build-third-party-libs.ps1 -OutputDir C:\tmp\salamander-libs
+```
+
+The final output is:
+
+```text
+build\libs\unrar.dll
+build\libs\libeay32.dll
+build\libs\ssleay32.dll
+```
+
+These DLLs still need to be copied into the runtime layout expected by
+Salamander:
+
+```text
+plugins\unrar\unrar.dll
+utils\libeay32.dll
+utils\ssleay32.dll
+```

--- a/tools/vcpkg/build-third-party-libs.ps1
+++ b/tools/vcpkg/build-third-party-libs.ps1
@@ -1,0 +1,155 @@
+[CmdletBinding()]
+param(
+    [string]$Triplet = 'x64-windows',
+    [string]$VcpkgRoot = $env:VCPKG_ROOT,
+    [string]$OutputDir,
+    [switch]$NoBootstrap,
+    [switch]$SkipInstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+$VcpkgRepository = 'https://github.com/microsoft/vcpkg.git'
+$VcpkgBaseline = 'a0b1c8d3a477c1cb4813d8e127a56961707ca42b'
+$RequiredDlls = @('unrar.dll', 'libeay32.dll', 'ssleay32.dll')
+
+function Resolve-FullPath
+{
+    param([string]$PathValue)
+
+    return [System.IO.Path]::GetFullPath($PathValue)
+}
+
+function Invoke-LoggedCommand
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$Arguments = @(),
+
+        [string]$WorkingDirectory
+    )
+
+    $previousLocation = $null
+    if (![string]::IsNullOrWhiteSpace($WorkingDirectory))
+    {
+        $previousLocation = Get-Location
+        Set-Location -LiteralPath $WorkingDirectory
+    }
+
+    try
+    {
+        Write-Host "> $FilePath $($Arguments -join ' ')"
+        & $FilePath @Arguments
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($Arguments -join ' ')"
+        }
+    }
+    finally
+    {
+        if ($null -ne $previousLocation)
+        {
+            Set-Location -LiteralPath $previousLocation
+        }
+    }
+}
+
+$repoRoot = Resolve-FullPath (Join-Path $PSScriptRoot '..\..')
+$manifestRoot = Join-Path $PSScriptRoot 'third-party-libs'
+
+if ([string]::IsNullOrWhiteSpace($VcpkgRoot))
+{
+    $VcpkgRoot = Join-Path $repoRoot 'build\vcpkg'
+}
+$VcpkgRoot = Resolve-FullPath $VcpkgRoot
+
+if ([string]::IsNullOrWhiteSpace($OutputDir))
+{
+    $OutputDir = Join-Path $repoRoot 'build\libs'
+}
+$OutputDir = Resolve-FullPath $OutputDir
+
+$installRoot = Join-Path $repoRoot 'build\vcpkg_installed_third_party'
+$tripletBinDir = Join-Path (Join-Path $installRoot $Triplet) 'bin'
+$vcpkgExe = Join-Path $VcpkgRoot 'vcpkg.exe'
+
+Write-Host "Repository root: $repoRoot"
+Write-Host "vcpkg root:     $VcpkgRoot"
+Write-Host "Manifest root:  $manifestRoot"
+Write-Host "Triplet:        $Triplet"
+Write-Host "Output dir:     $OutputDir"
+
+if (!(Test-Path -LiteralPath $VcpkgRoot))
+{
+    Write-Host "Cloning vcpkg into $VcpkgRoot"
+    Invoke-LoggedCommand -FilePath 'git' -Arguments @('clone', $VcpkgRepository, $VcpkgRoot)
+}
+
+if (!(Test-Path -LiteralPath (Join-Path $VcpkgRoot '.git')))
+{
+    throw "VcpkgRoot does not look like a git checkout: $VcpkgRoot"
+}
+
+Invoke-LoggedCommand -FilePath 'git' -Arguments @('fetch', '--tags', '--prune', 'origin') -WorkingDirectory $VcpkgRoot
+Invoke-LoggedCommand -FilePath 'git' -Arguments @('checkout', $VcpkgBaseline) -WorkingDirectory $VcpkgRoot
+
+if (!$NoBootstrap -or !(Test-Path -LiteralPath $vcpkgExe))
+{
+    $bootstrap = Join-Path $VcpkgRoot 'bootstrap-vcpkg.bat'
+    if (!(Test-Path -LiteralPath $bootstrap))
+    {
+        throw "Unable to find vcpkg bootstrap script: $bootstrap"
+    }
+
+    Invoke-LoggedCommand -FilePath $bootstrap -Arguments @('-disableMetrics') -WorkingDirectory $VcpkgRoot
+}
+
+if (!(Test-Path -LiteralPath $vcpkgExe))
+{
+    throw "Unable to find vcpkg executable: $vcpkgExe"
+}
+
+if (!$SkipInstall)
+{
+    Invoke-LoggedCommand -FilePath $vcpkgExe -Arguments @(
+        'install',
+        '--triplet', $Triplet,
+        '--x-install-root', $installRoot
+    ) -WorkingDirectory $manifestRoot
+}
+
+if (!(Test-Path -LiteralPath $tripletBinDir))
+{
+    throw "vcpkg bin directory does not exist: $tripletBinDir"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+foreach ($dllName in $RequiredDlls)
+{
+    $source = Join-Path $tripletBinDir $dllName
+    if (!(Test-Path -LiteralPath $source))
+    {
+        $matches = @(Get-ChildItem -LiteralPath (Join-Path $installRoot $Triplet) -Recurse -File -Filter $dllName -ErrorAction SilentlyContinue)
+        if ($matches.Count -eq 1)
+        {
+            $source = $matches[0].FullName
+        }
+        elseif ($matches.Count -gt 1)
+        {
+            throw "Found multiple candidates for ${dllName}: $($matches.FullName -join ', ')"
+        }
+        else
+        {
+            throw "Required DLL was not produced by vcpkg: $dllName"
+        }
+    }
+
+    $destination = Join-Path $OutputDir $dllName
+    Copy-Item -LiteralPath $source -Destination $destination -Force
+    Write-Host "Copied $source -> $destination"
+}
+
+Write-Host "Done. Third-party DLLs are available in $OutputDir"

--- a/tools/vcpkg/third-party-libs/vcpkg.json
+++ b/tools/vcpkg/third-party-libs/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "opensalamander-third-party-libs",
+  "version-string": "0",
+  "dependencies": [
+    "openssl",
+    "unrar"
+  ],
+  "builtin-baseline": "a0b1c8d3a477c1cb4813d8e127a56961707ca42b",
+  "overrides": [
+    {
+      "name": "openssl",
+      "version-string": "1.0.2o-3"
+    },
+    {
+      "name": "unrar",
+      "version": "7.2.6"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a reproducible way to build runtime DLLs that are not checked into the repository (`unrar.dll`, `libeay32.dll`, `ssleay32.dll`) and to support the FTP plugin's legacy OpenSSL loader which requires OpenSSL 1.0.2.
- Pin vcpkg registry baseline and package versions so generated inputs are stable across builds and machines.

### Description
- Add `tools/vcpkg/third-party-libs/vcpkg.json` manifest that pins the `builtin-baseline` and overrides `openssl` to `1.0.2o-3` and `unrar` to `7.2.6`.
- Add `tools/vcpkg/build-third-party-libs.ps1` which clones vcpkg (if needed), checks out the pinned baseline, bootstraps vcpkg, installs the manifest for a specified triplet, and copies the required DLLs into `build\libs` with options for `-Triplet`, `-VcpkgRoot`, `-OutputDir`, `-NoBootstrap`, and `-SkipInstall`.
- Add `tools/vcpkg/README.md` documenting usage, expected output (`build\libs\unrar.dll`, `build\libs\libeay32.dll`, `build\libs\ssleay32.dll`) and how to place DLLs into the runtime layout.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3618c9fb14832992c704c7a8726fb3)