### PR TITLE
Respect custom colors in Windows dark mode

### DIFF
--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -315,12 +315,6 @@ HBRUSH HMenuGrayTextBrush = NULL;
 
 static bool gDarkModeBrushesOwned = false;
 
-static bool gWindowsDarkPaletteActive = false;
-static SALCOLOR* gWindowsDarkPaletteTarget = NULL;
-static SALCOLOR gWindowsDarkPaletteBackup[NUMBER_OF_COLORS];
-static SALCOLOR gWindowsDarkViewerBackup[NUMBER_OF_VIEWERCOLORS];
-static bool gWindowsDarkViewerSaved = false;
-static CHighlightMasks* gWindowsDarkHighlightBackup = NULL;
 
 static COLORREF LightenColor(COLORREF color, int amount)
 {
@@ -562,64 +556,13 @@ void WindowsDarkModeBuildPalette(SALCOLOR* colors, SALCOLOR* viewerColors)
 
 static void WindowsDarkModeUpdatePalette(bool useDarkColors)
 {
-    SALCOLOR* target = CurrentColors;
-    if (!useDarkColors)
+    if (useDarkColors)
     {
-        if (gWindowsDarkPaletteActive && gWindowsDarkPaletteTarget != NULL)
-        {
-            memcpy(gWindowsDarkPaletteTarget, gWindowsDarkPaletteBackup, sizeof(gWindowsDarkPaletteBackup));
-            if (gWindowsDarkViewerSaved)
-                WindowsLightModeBuildViewerPalette(ViewerColors);
-            if (gWindowsDarkHighlightBackup != NULL && MainWindow != NULL && MainWindow->HighlightMasks != NULL)
-                MainWindow->HighlightMasks->Load(*gWindowsDarkHighlightBackup);
-        }
-        if (gWindowsDarkHighlightBackup != NULL)
-        {
-            delete gWindowsDarkHighlightBackup;
-            gWindowsDarkHighlightBackup = NULL;
-        }
-        gWindowsDarkPaletteActive = false;
-        gWindowsDarkPaletteTarget = NULL;
-        gWindowsDarkViewerSaved = false;
-        return;
+        // The Windows Dark Mode scheme is only an initial preset for UserColors.
+        // Do not rebuild the preset on every color refresh: doing so overwrites
+        // colors customized on Configuration / Colors (for example Hot Items,
+        // captions and panel colors) and prevents them from being saved and used.
     }
-
-    if (gWindowsDarkPaletteActive && gWindowsDarkPaletteTarget != target)
-    {
-        if (gWindowsDarkPaletteTarget != NULL)
-            memcpy(gWindowsDarkPaletteTarget, gWindowsDarkPaletteBackup, sizeof(gWindowsDarkPaletteBackup));
-        if (gWindowsDarkViewerSaved)
-            memcpy(ViewerColors, gWindowsDarkViewerBackup, sizeof(gWindowsDarkViewerBackup));
-        if (gWindowsDarkHighlightBackup != NULL && MainWindow != NULL && MainWindow->HighlightMasks != NULL)
-            MainWindow->HighlightMasks->Load(*gWindowsDarkHighlightBackup);
-        if (gWindowsDarkHighlightBackup != NULL)
-        {
-            delete gWindowsDarkHighlightBackup;
-            gWindowsDarkHighlightBackup = NULL;
-        }
-        gWindowsDarkPaletteActive = false;
-        gWindowsDarkPaletteTarget = NULL;
-        gWindowsDarkViewerSaved = false;
-    }
-
-    if (!gWindowsDarkPaletteActive)
-    {
-        gWindowsDarkPaletteTarget = target;
-        memcpy(gWindowsDarkPaletteBackup, target, sizeof(gWindowsDarkPaletteBackup));
-        memcpy(gWindowsDarkViewerBackup, ViewerColors, sizeof(gWindowsDarkViewerBackup));
-        gWindowsDarkViewerSaved = true;
-        if (MainWindow != NULL && MainWindow->HighlightMasks != NULL)
-        {
-            gWindowsDarkHighlightBackup = new CHighlightMasks(10, 5);
-            if (gWindowsDarkHighlightBackup != NULL)
-                gWindowsDarkHighlightBackup->Load(*MainWindow->HighlightMasks);
-        }
-        gWindowsDarkPaletteActive = true;
-    }
-
-    WindowsDarkModeBuildPalette(target, ViewerColors);
-    if (MainWindow != NULL && MainWindow->HighlightMasks != NULL)
-        WindowsDarkModeBuildHighlightMasks(MainWindow->HighlightMasks);
 }
 
 


### PR DESCRIPTION
### Motivation

- Prevent the Windows Dark Mode (experimental) color preset from overwriting user-customized colors in Configuration → Colors on every color refresh.
- Users expect colors they set for Panel, Hot Item, Active Caption and Inactive Caption to be saved and respected even when the Windows Dark Mode scheme is selected.
- The previous behavior rebuilt/restored the dark preset on every refresh which erased custom UserColors and prevented them from being stored.

### Description

- Change implemented in `src/salamdr1.cpp` by modifying `WindowsDarkModeUpdatePalette` so the Windows Dark Mode scheme acts only as an initial preset and no longer rebuilds the preset on each color refresh.
- Removed the previous backup/restore logic that repeatedly copied palettes and highlight masks during refreshes, avoiding overwriting `UserColors` (several static helper variables referencing the backup state were eliminated as part of the simplification).
- Left `WindowsDarkModeBuildPalette` and highlight mask builders intact so the preset can still be generated when explicitly needed, while user edits in Configuration → Colors are preserved.

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and it succeeded.
- Verified repository status with `git status --short` and created the commit titled `Respect custom colors in Windows dark mode` (no build/test performed in this change set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37308733808329a953c7ff9dbe9cfe)