### PR TITLE
Apply dark title bars to startup progress dialogs

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -215,6 +215,7 @@ struct WINDOWCOMPOSITIONATTRIBDATA
 
 using fnRtlGetNtVersionNumbers = void(WINAPI*)(LPDWORD major, LPDWORD minor, LPDWORD build);
 using fnSetWindowCompositionAttribute = BOOL(WINAPI*)(HWND hWnd, WINDOWCOMPOSITIONATTRIBDATA*);
+using fnDwmSetWindowAttribute = HRESULT(WINAPI*)(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute);
 using fnShouldAppsUseDarkMode = bool(WINAPI*)();
 using fnAllowDarkModeForWindow = bool(WINAPI*)(HWND hWnd, bool allow);
 using fnAllowDarkModeForApp = bool(WINAPI*)(bool allow);
@@ -230,6 +231,7 @@ using fnIsDarkModeAllowedForApp = bool(WINAPI*)();
 
 HMODULE gUxTheme = nullptr;
 fnSetWindowCompositionAttribute gSetWindowCompositionAttribute = nullptr;
+fnDwmSetWindowAttribute gDwmSetWindowAttribute = nullptr;
 fnShouldAppsUseDarkMode gShouldAppsUseDarkMode = nullptr;
 fnAllowDarkModeForWindow gAllowDarkModeForWindow = nullptr;
 fnAllowDarkModeForApp gAllowDarkModeForApp = nullptr;
@@ -1391,6 +1393,10 @@ void EnsureInitialized()
     if (hUser32)
         gSetWindowCompositionAttribute = reinterpret_cast<fnSetWindowCompositionAttribute>(GetProcAddress(hUser32, "SetWindowCompositionAttribute"));
 
+    auto hDwmApi = LoadLibraryExW(L"dwmapi.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (hDwmApi)
+        gDwmSetWindowAttribute = reinterpret_cast<fnDwmSetWindowAttribute>(GetProcAddress(hDwmApi, "DwmSetWindowAttribute"));
+
     gSupported = gAllowDarkModeForWindow != nullptr &&
                  (gAllowDarkModeForApp != nullptr || gSetPreferredAppMode != nullptr) &&
                  gShouldAppsUseDarkMode != nullptr;
@@ -1513,6 +1519,10 @@ void DarkModeRefreshTitleBar(HWND hwnd)
     if (gBuildNumber < 18362)
     {
         SetPropW(hwnd, L"UseImmersiveDarkModeColors", reinterpret_cast<HANDLE>(static_cast<INT_PTR>(useDark)));
+    }
+    else if (gDwmSetWindowAttribute)
+    {
+        gDwmSetWindowAttribute(hwnd, 20 /* DWMWA_USE_IMMERSIVE_DARK_MODE */, &useDark, sizeof(useDark));
     }
     else if (gSetWindowCompositionAttribute)
     {

--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -562,6 +562,14 @@ CProgressDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            WinLib_DarkMode_PostDeferredRedraw(HWindow);
+        }
+
         SetDlgItemText(HWindow, IDB_PAUSERESUME, LoadStr(IDS_PROGDLGPAUSE));
 
         if (!RunningInOwnThread)

--- a/src/dialogs3.cpp
+++ b/src/dialogs3.cpp
@@ -2899,7 +2899,10 @@ HWND CWaitWindow::Create(HWND hForegroundWnd)
              this);
 
     if (HWindow != NULL)
+    {
         DarkModeApplyWindow(HWindow);
+        DarkModeRefreshTitleBar(HWindow);
+    }
 
     // hack: adjust window size in real time so it works with both old (5 / XP compatible) and new toolsets
     RECT clientR;


### PR DESCRIPTION
### Motivation
- Progress and wait dialogs (startup, plugin-check and save-config progress) showed light title bars even when the user selected the Windows Dark Mode scheme, so titlebar appearance needs to follow the selected dark scheme.
- Use the supported native Windows API (`DwmSetWindowAttribute` / `DWMWA_USE_IMMERSIVE_DARK_MODE`) when available to ensure the non-client/title bar respects dark mode on modern Windows builds.
- Ensure dialogs that are created on non-main threads or that bypass common dialog initialization still get dark-mode styling applied to their window frames.

### Description
- Added `fnDwmSetWindowAttribute` typedef and a `gDwmSetWindowAttribute` resolver and load via `LoadLibraryExW(L"dwmapi.dll", ...)` in `src/darkmode.cpp`.
- Prefer calling `DwmSetWindowAttribute(hwnd, 20 /* DWMWA_USE_IMMERSIVE_DARK_MODE */ , &useDark, sizeof(useDark))` when refreshing the title bar, and fall back to the existing `SetWindowCompositionAttribute` and legacy property paths when `dwmapi` is not available.
- Applied dark-mode tree styling and non-client/title-bar refresh inside the progress dialog initialization (`CProgressDialog::DialogProc` / `WM_INITDIALOG`) by calling `DarkModeApplyTree`, `DarkModeRefreshTitleBar`, `DarkModeApplyStaticTextColors`, and posting a deferred redraw.
- Refreshed the title bar for `CWaitWindow` immediately after it is created by calling `DarkModeApplyWindow` then `DarkModeRefreshTitleBar` so wait/progress windows honor the Windows Dark Mode scheme.

### Testing
- Ran `git diff --check` to validate there are no whitespace/errors reported by `git diff --check`, which passed.
- Verified presence/absence of MSBuild/dotnet via `command -v msbuild || command -v dotnet` in the container and noted no Windows build tooling was available so full Windows build/runtime testing could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38dd956c1c832990b547c22226bf72)