### PR TITLE
Include writable configstorage.ini in x64 Inno setup

### DIFF
--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -1157,6 +1157,7 @@ Source: "{#PayloadDir}\plugins\zip\zip2sfx\sam_cz.set"; DestDir: "{app}\plugins\
 Source: "{#PayloadDir}\plugins\zip\zip2sfx\sample.set"; DestDir: "{app}\plugins\zip\zip2sfx"; Flags: ignoreversion
 Source: "{#PayloadDir}\plugins\zip\zip2sfx\zip2sfx.exe"; DestDir: "{app}\plugins\zip\zip2sfx"; Flags: ignoreversion
 Source: "{#PayloadDir}\salamand.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#PayloadDir}\configstorage.ini"; DestDir: "{app}"; Flags: ignoreversion; Permissions: users-modify
 Source: "{#PayloadDir}\toolbars\Back.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\CalculateDirectorySizes.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\CalculateOccupiedSpace.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion


### PR DESCRIPTION
### Motivation
- Ensure `configstorage.ini` shipped next to `salamand.exe` is writable by a regular (non-admin) user when the app is installed into `Program Files`, so the running Salamander can update its storage setting without elevated privileges.

### Description
- Add `configstorage.ini` to the `[Files]` section of `doc/runbook-setup/inno_setup_salamander_x64.iss` with `Permissions: users-modify` so the file is installed next to `salamand.exe` and grants Users modify rights.

### Testing
- Ran `git diff --check` which reported no whitespace/errors and succeeded. 
- Verified the change with `rg -n "configstorage\.ini.*Permissions: users-modify|salamand\.exe" doc/runbook-setup/inno_setup_salamander_x64.iss` which found the new entry. 
- The Inno Setup compiler `iscc` was not available in this environment, so an actual installer build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a391a6124548329bf0ab87d663216db)