### PR TITLE
Add confirmation option for history path-not-found errors

### DIFF
--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -270,6 +270,7 @@ struct CConfiguration
         CnfrmDSTShiftsIgnored,   // Compare Directories: file pairs were found with timestamps differing by exactly one or two hours; show warning that these differences were ignored?
         CnfrmDSTShiftsOccured,   // Compare Directories: file pairs were found with timestamps differing by exactly one or two hours; show hint that these differences can be ignored?
         CnfrmCopyMoveOptionsNS,  // Copy/Move: some Options are set but the target is FS/archive (options are NotSupported)
+        CnfrmChangeDirHistoryErr, // Show error when browsing history and the target path no longer exists
 
         // Drive specific
         DrvSpecFloppyMon,    // Use automatic refresh

--- a/src/consts.h
+++ b/src/consts.h
@@ -1599,6 +1599,7 @@ extern const char* SALCF_FAKE_SRCFSPATH;
 // promenne pro CanChangeDirectory() a AllowChangeDirectory()
 extern int ChangeDirectoryAllowed; // 0 znamena, ze je mozne menit adresar
 extern BOOL ChangeDirectoryRequest;
+extern BOOL SuppressChangeDirHistoryErr; // TRUE = suppress path-not-found error while browsing directory history
 // funkce obsluhujici automatickou zmenu aktualniho adresare na systemovy
 // - kvuli odmapovavani z jinych softu a mazani adresaru zobrazenych Salamandrem
 BOOL CanChangeDirectory();

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -447,6 +447,7 @@ CConfiguration::CConfiguration()
     CnfrmDSTShiftsIgnored = TRUE;
     CnfrmDSTShiftsOccured = TRUE;
     CnfrmCopyMoveOptionsNS = TRUE;
+    CnfrmChangeDirHistoryErr = TRUE;
     //  PanelTooltip = TRUE;
     KeepPluginsSorted = TRUE;
     ShowSLGIncomplete = TRUE;

--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -1764,6 +1764,7 @@ void CCfgPageConfirmations::InitTree()
     AddItem(HShowMessage, -1, IDS_CNFRM_ONADDTOARCHIVE, &Configuration.CnfrmAddToArchive);
     AddItem(HShowMessage, -1, IDS_CNFRM_ONCREATEDIR, &Configuration.CnfrmCreateDir);
     AddItem(HShowMessage, -1, IDS_CNFRM_COPYMOVEOPTNS, &Configuration.CnfrmCopyMoveOptionsNS);
+    AddItem(HShowMessage, -1, IDS_CNFRM_CHANGEDIRHISTORYERR, &Configuration.CnfrmChangeDirHistoryErr);
 
     // select the first usable item
     TreeView_Select(HTreeView, hFirst, TVGN_CARET);

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -2746,7 +2746,9 @@ BOOL CFilesWindow::ChangePathToDisk(HWND parent, const char* path, int suggested
                 // we just received a new listing; if there are any reported panel changes, we cancel them
                 InvalidateChangesInPanelWeHaveNewListing();
 
-                if (lastErr != ERROR_SUCCESS && (!isRefresh || openIfPathIsInaccessibleGoToCfg) && shorterPathWarning)
+                if (lastErr != ERROR_SUCCESS && (!isRefresh || openIfPathIsInaccessibleGoToCfg) && shorterPathWarning &&
+                    (!SuppressChangeDirHistoryErr ||
+                     lastErr != ERROR_FILE_NOT_FOUND && lastErr != ERROR_PATH_NOT_FOUND))
                 {                        // if it's not a refresh and messages about path-shortening are supposed to be shown ...
                     if (!refreshListBox) // we'll display a message; we must perform refresh-list-box
                     {

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -2815,7 +2815,11 @@ BOOL CFilesWindow::ChangePathToDisk(HWND parent, const char* path, int suggested
                 if (!pathInvalid &&               // the user already knows the UNC path couldn't be revived
                     err != ERROR_USER_TERMINATED) // the user also knows about the abort (ESC)
                 {
-                    CheckPath(TRUE, changedPath, err, TRUE, parent); // other errors - just display the message
+                    if (!SuppressChangeDirHistoryErr ||
+                        err != ERROR_FILE_NOT_FOUND && err != ERROR_PATH_NOT_FOUND)
+                    {
+                        CheckPath(TRUE, changedPath, err, TRUE, parent); // other errors - just display the message
+                    }
                 }
             }
 

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -1730,6 +1730,7 @@ STRINGTABLE
  IDS_CNFRM_ONADDTOARCHIVE, "Do you want to add files into existing archive?"
  IDS_CNFRM_ONCREATEDIR, "The directory doesn't exist. Do you want to create it?"
  IDS_CNFRM_COPYMOVEOPTNS, "Copy/Move to archives and plugin FS: options will be ignored."
+ IDS_CNFRM_CHANGEDIRHISTORYERR, "Error changing directory while browsing history (path not found)."
 
  IDS_CANCLOSESALAMANDER, "Do you want to close Open Salamander?"
 

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -612,6 +612,7 @@ const char* CONFIG_CNFRM_SHOWNAMETOCOMP = "Show Names To Compare";
 const char* CONFIG_CNFRM_DSTSHIFTSIGNORED = "DST Shifts Ignored";
 const char* CONFIG_CNFRM_DSTSHIFTSOCCURED = "DST Shifts Occured";
 const char* CONFIG_CNFRM_COPYMOVEOPTIONSNS = "Copy Move Options Not Supported";
+const char* CONFIG_CNFRM_CHANGEDIRHISTORYERR = "Change Dir History Error";
 
 const char* SALAMANDER_DRVSPEC_REG = "Drive Special Settings";
 const char* CONFIG_DRVSPEC_FLOPPY_MON = "Floppy Automatic Refresh";
@@ -2328,6 +2329,8 @@ void CMainWindow::SaveConfig(HWND parent)
                              &Configuration.CnfrmDSTShiftsOccured, sizeof(DWORD));
                     SetValue(actSubKey, CONFIG_CNFRM_COPYMOVEOPTIONSNS, REG_DWORD,
                              &Configuration.CnfrmCopyMoveOptionsNS, sizeof(DWORD));
+                    SetValue(actSubKey, CONFIG_CNFRM_CHANGEDIRHISTORYERR, REG_DWORD,
+                             &Configuration.CnfrmChangeDirHistoryErr, sizeof(DWORD));
 
                     CloseKey(actSubKey);
                 }
@@ -4179,6 +4182,8 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                          &Configuration.CnfrmDSTShiftsOccured, sizeof(DWORD));
                 GetValue(actSubKey, CONFIG_CNFRM_COPYMOVEOPTIONSNS, REG_DWORD,
                          &Configuration.CnfrmCopyMoveOptionsNS, sizeof(DWORD));
+                GetValue(actSubKey, CONFIG_CNFRM_CHANGEDIRHISTORYERR, REG_DWORD,
+                         &Configuration.CnfrmChangeDirHistoryErr, sizeof(DWORD));
 
                 CloseKey(actSubKey);
             }

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -299,6 +299,7 @@ BOOL PostStatusbarRepaint = FALSE;
 
 int ChangeDirectoryAllowed = 0;
 BOOL ChangeDirectoryRequest = FALSE;
+BOOL SuppressChangeDirHistoryErr = FALSE;
 
 BOOL SkipOneActivateRefresh = FALSE;
 

--- a/src/salamdr3.cpp
+++ b/src/salamdr3.cpp
@@ -1832,7 +1832,10 @@ void CPathHistory::Execute(int index, BOOL forward, CFilesWindow* panel, BOOL al
             {
                 Lock = TRUE;
                 item = Paths[ForwardIndex + index - 1];
+                BOOL oldSuppressChangeDirHistoryErr = SuppressChangeDirHistoryErr;
+                SuppressChangeDirHistoryErr = !Configuration.CnfrmChangeDirHistoryErr;
                 change = item->Execute(panel);
+                SuppressChangeDirHistoryErr = oldSuppressChangeDirHistoryErr;
                 if (!change)
                     item = NULL; // failed to change the path => keep it in the history
                 Lock = FALSE;
@@ -1855,7 +1858,10 @@ void CPathHistory::Execute(int index, BOOL forward, CFilesWindow* panel, BOOL al
                 {
                     Lock = TRUE;
                     item = Paths[count - index];
+                    BOOL oldSuppressChangeDirHistoryErr = SuppressChangeDirHistoryErr;
+                    SuppressChangeDirHistoryErr = !Configuration.CnfrmChangeDirHistoryErr;
                     change = item->Execute(panel);
+                    SuppressChangeDirHistoryErr = oldSuppressChangeDirHistoryErr;
                     if (!change)
                         item = NULL; // failed to change the path => keep it in the history
                     Lock = FALSE;

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -2386,6 +2386,7 @@
 #define IDS_CNFRM_STOPFIND              13476
 #define IDS_CNFRM_CLOSEARCHIVE          13477
 #define IDS_CNFRM_ONCREATEDIR           13478
+#define IDS_CNFRM_CHANGEDIRHISTORYERR    13479
 
 //                        rezervovat do 13550
 #define IDS_CANCLOSESALAMANDER          13551


### PR DESCRIPTION
### Motivation
- When navigating directory history, attempting to go to a path that no longer exists currently shows the "Error Changing Directory" dialog; users need an option to suppress that dialog while browsing history.

### Description
- Added a new configuration flag `CnfrmChangeDirHistoryErr` in `CConfiguration` and set its default to `TRUE` so existing behavior is preserved (`src/cfgdlg.h`, `src/dialogs4.cpp`).
- Exposed the option in the UI under `Configuration -> Confirmations -> Show message` by adding a new tree item linked to `IDS_CNFRM_CHANGEDIRHISTORYERR` (`src/dialogs5.cpp`, `src/lang/texts.rc2`, `src/texts.rh2`).
- Persisted the setting to registry with new key `CONFIG_CNFRM_CHANGEDIRHISTORYERR` and load/save logic (`src/mainwnd2.cpp`) and added the corresponding `CONFIG_*` string (`src/mainwnd2.cpp`).
- Implemented runtime suppression: introduced `SuppressChangeDirHistoryErr` global and temporarily set it while executing history navigation (`src/consts.h`, `src/salamdr1.cpp`, `src/salamdr3.cpp`), and conditionally skipped showing `CheckPath` error dialogs for `ERROR_FILE_NOT_FOUND` / `ERROR_PATH_NOT_FOUND` when suppression is active (`src/fileswn2.cpp`).

### Testing
- Ran `git diff --check` to ensure no whitespace/merge errors; result: passed.
- Ran `git status --short` to verify working tree; result: clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39d9482aec832996036fd7115fb115)