### PR TITLE
Link UxTheme for dark mode targets

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1235,65 +1235,6 @@ void PaintAutoSuggestItemsWindow(HWND hwnd, HDC hdc)
         PaintAutoSuggestListView(hwnd, hdc);
 }
 
-void PaintAutoSuggestSizeGrip(HWND hwnd, HDC hdc)
-{
-    if (hwnd == NULL || hdc == NULL || !DarkModeShouldUseDarkColors())
-        return;
-
-    RECT rcClient;
-    GetClientRect(hwnd, &rcClient);
-    const DarkModeColors& colors = DarkModeGetColors();
-
-    HTHEME hTheme = OpenThemeData(hwnd, L"DarkMode_Explorer::Status");
-
-    const int statusGripPart = 6;
-    SIZE szGrip{};
-    if (hTheme != NULL)
-        GetThemePartSize(hTheme, hdc, statusGripPart, 0, &rcClient, TS_DRAW, &szGrip);
-    if (szGrip.cx <= 0 || szGrip.cy <= 0)
-    {
-        szGrip.cx = GetSystemMetrics(SM_CXVSCROLL);
-        szGrip.cy = GetSystemMetrics(SM_CYHSCROLL);
-    }
-
-    RECT rcGrip{rcClient};
-    rcGrip.left = rcGrip.right - szGrip.cx;
-    rcGrip.top = rcGrip.bottom - szGrip.cy;
-    FillRectWithColor(hdc, rcGrip, colors.background);
-
-    if (hTheme != NULL)
-    {
-        DrawThemeBackground(hTheme, hdc, statusGripPart, 0, &rcGrip, NULL);
-        CloseThemeData(hTheme);
-    }
-    else
-    {
-        HPEN lightPen = CreatePen(PS_SOLID, 1, RGB(105, 105, 105));
-        HPEN darkPen = CreatePen(PS_SOLID, 1, RGB(50, 50, 50));
-        if (lightPen != NULL && darkPen != NULL)
-        {
-            HGDIOBJ oldPen = SelectObject(hdc, lightPen);
-            for (int offset = 4; offset <= 12; offset += 4)
-            {
-                MoveToEx(hdc, rcGrip.right - offset, rcGrip.bottom - 2, NULL);
-                LineTo(hdc, rcGrip.right - 2, rcGrip.bottom - offset);
-            }
-            SelectObject(hdc, darkPen);
-            for (int offset = 5; offset <= 13; offset += 4)
-            {
-                MoveToEx(hdc, rcGrip.right - offset, rcGrip.bottom - 2, NULL);
-                LineTo(hdc, rcGrip.right - 2, rcGrip.bottom - offset);
-            }
-            if (oldPen != NULL)
-                SelectObject(hdc, oldPen);
-        }
-        if (lightPen != NULL)
-            DeleteObject(lightPen);
-        if (darkPen != NULL)
-            DeleteObject(darkPen);
-    }
-}
-
 LRESULT CALLBACK DarkAutoSuggestSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
                                          UINT_PTR subclassId, DWORD_PTR refData)
 {
@@ -1325,17 +1266,6 @@ LRESULT CALLBACK DarkAutoSuggestSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPA
             PaintAutoSuggestItemsWindow(hwnd, hdc);
             EndPaint(hwnd, &ps);
             return 0;
-        }
-        if (IsAutoSuggestDropdownClass(hwnd) && DarkModeShouldUseDarkColors())
-        {
-            LRESULT ret = DefSubclassProc(hwnd, msg, wParam, lParam);
-            HDC hdc = GetDC(hwnd);
-            if (hdc != NULL)
-            {
-                PaintAutoSuggestSizeGrip(hwnd, hdc);
-                ReleaseDC(hwnd, hdc);
-            }
-            return ret;
         }
         break;
 

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1235,6 +1235,64 @@ void PaintAutoSuggestItemsWindow(HWND hwnd, HDC hdc)
         PaintAutoSuggestListView(hwnd, hdc);
 }
 
+void PaintAutoSuggestSizeGrip(HWND hwnd, HDC hdc)
+{
+    if (hwnd == NULL || hdc == NULL || !DarkModeShouldUseDarkColors())
+        return;
+
+    RECT rcClient;
+    GetClientRect(hwnd, &rcClient);
+    const DarkModeColors& colors = DarkModeGetColors();
+
+    HTHEME hTheme = OpenThemeData(hwnd, L"DarkMode_Explorer::Status");
+
+    SIZE szGrip{};
+    if (hTheme != NULL)
+        GetThemePartSize(hTheme, hdc, SP_GRIPPER, 0, &rcClient, TS_DRAW, &szGrip);
+    if (szGrip.cx <= 0 || szGrip.cy <= 0)
+    {
+        szGrip.cx = GetSystemMetrics(SM_CXVSCROLL);
+        szGrip.cy = GetSystemMetrics(SM_CYHSCROLL);
+    }
+
+    RECT rcGrip{rcClient};
+    rcGrip.left = rcGrip.right - szGrip.cx;
+    rcGrip.top = rcGrip.bottom - szGrip.cy;
+    FillRectWithColor(hdc, rcGrip, colors.background);
+
+    if (hTheme != NULL)
+    {
+        DrawThemeBackground(hTheme, hdc, SP_GRIPPER, 0, &rcGrip, NULL);
+        CloseThemeData(hTheme);
+    }
+    else
+    {
+        HPEN lightPen = CreatePen(PS_SOLID, 1, RGB(105, 105, 105));
+        HPEN darkPen = CreatePen(PS_SOLID, 1, RGB(50, 50, 50));
+        if (lightPen != NULL && darkPen != NULL)
+        {
+            HGDIOBJ oldPen = SelectObject(hdc, lightPen);
+            for (int offset = 4; offset <= 12; offset += 4)
+            {
+                MoveToEx(hdc, rcGrip.right - offset, rcGrip.bottom - 2, NULL);
+                LineTo(hdc, rcGrip.right - 2, rcGrip.bottom - offset);
+            }
+            SelectObject(hdc, darkPen);
+            for (int offset = 5; offset <= 13; offset += 4)
+            {
+                MoveToEx(hdc, rcGrip.right - offset, rcGrip.bottom - 2, NULL);
+                LineTo(hdc, rcGrip.right - 2, rcGrip.bottom - offset);
+            }
+            if (oldPen != NULL)
+                SelectObject(hdc, oldPen);
+        }
+        if (lightPen != NULL)
+            DeleteObject(lightPen);
+        if (darkPen != NULL)
+            DeleteObject(darkPen);
+    }
+}
+
 LRESULT CALLBACK DarkAutoSuggestSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
                                          UINT_PTR subclassId, DWORD_PTR refData)
 {
@@ -1273,20 +1331,7 @@ LRESULT CALLBACK DarkAutoSuggestSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPA
             HDC hdc = GetDC(hwnd);
             if (hdc != NULL)
             {
-                RECT rcClient;
-                GetClientRect(hwnd, &rcClient);
-                HTHEME hTheme = OpenThemeData(hwnd, L"Status");
-                if (hTheme != NULL)
-                {
-                    SIZE szGrip{};
-                    const int SP_GRIPPER = 6;
-                    GetThemePartSize(hTheme, hdc, SP_GRIPPER, 0, &rcClient, TS_DRAW, &szGrip);
-                    RECT rcGrip{ rcClient };
-                    rcGrip.left = rcGrip.right - szGrip.cx;
-                    rcGrip.top = rcGrip.bottom - szGrip.cy;
-                    DrawThemeBackground(hTheme, hdc, SP_GRIPPER, 0, &rcGrip, NULL);
-                    CloseThemeData(hTheme);
-                }
+                PaintAutoSuggestSizeGrip(hwnd, hdc);
                 ReleaseDC(hwnd, hdc);
             }
             return ret;

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1246,9 +1246,10 @@ void PaintAutoSuggestSizeGrip(HWND hwnd, HDC hdc)
 
     HTHEME hTheme = OpenThemeData(hwnd, L"DarkMode_Explorer::Status");
 
+    const int statusGripPart = 6;
     SIZE szGrip{};
     if (hTheme != NULL)
-        GetThemePartSize(hTheme, hdc, SP_GRIPPER, 0, &rcClient, TS_DRAW, &szGrip);
+        GetThemePartSize(hTheme, hdc, statusGripPart, 0, &rcClient, TS_DRAW, &szGrip);
     if (szGrip.cx <= 0 || szGrip.cy <= 0)
     {
         szGrip.cx = GetSystemMetrics(SM_CXVSCROLL);
@@ -1262,7 +1263,7 @@ void PaintAutoSuggestSizeGrip(HWND hwnd, HDC hdc)
 
     if (hTheme != NULL)
     {
-        DrawThemeBackground(hTheme, hdc, SP_GRIPPER, 0, &rcGrip, NULL);
+        DrawThemeBackground(hTheme, hdc, statusGripPart, 0, &rcGrip, NULL);
         CloseThemeData(hTheme);
     }
     else

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -4227,7 +4227,7 @@ void CCfgPageColors::LayoutMaskControls()
     ScreenToClient(HWindow, &listTop);
     const int maskButtonHeight = firstMaskButtonRect.bottom - firstMaskButtonRect.top;
     const int requiredBelowList = CfgPageColorsDluY(HWindow, 4 + 1 + 4 * 14) + maskButtonHeight;
-    const int bottomPadding = CfgPageColorsDluY(HWindow, 8);
+    const int bottomPadding = CfgPageColorsDluY(HWindow, 2);
     const int maxListBottom = clientRect.bottom - bottomPadding - requiredBelowList;
     const int minListHeight = CfgPageColorsDluY(HWindow, 24);
     if (listRect.bottom - listRect.top > minListHeight)

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -4218,6 +4218,30 @@ void CCfgPageColors::LayoutMaskControls()
 
     RECT listRect;
     GetWindowRect(hList, &listRect);
+    RECT firstMaskButtonRect = {};
+    GetWindowRect(GetDlgItem(HWindow, IDC_C_MASK1_C), &firstMaskButtonRect);
+    RECT clientRect;
+    GetClientRect(HWindow, &clientRect);
+
+    POINT listTop = {listRect.left, listRect.top};
+    ScreenToClient(HWindow, &listTop);
+    const int maskButtonHeight = firstMaskButtonRect.bottom - firstMaskButtonRect.top;
+    const int requiredBelowList = CfgPageColorsDluY(HWindow, 4 + 1 + 4 * 14) + maskButtonHeight;
+    const int bottomPadding = CfgPageColorsDluY(HWindow, 8);
+    const int maxListBottom = clientRect.bottom - bottomPadding - requiredBelowList;
+    const int minListHeight = CfgPageColorsDluY(HWindow, 24);
+    if (listRect.bottom - listRect.top > minListHeight)
+    {
+        const int currentListBottom = listTop.y + (listRect.bottom - listRect.top);
+        if (currentListBottom > maxListBottom)
+        {
+            const int newListHeight = maxListBottom - listTop.y > minListHeight ? maxListBottom - listTop.y : minListHeight;
+            SetWindowPos(hList, NULL, 0, 0, listRect.right - listRect.left, newListHeight,
+                         SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+            GetWindowRect(hList, &listRect);
+        }
+    }
+
     POINT listBottom = {listRect.left, listRect.bottom};
     ScreenToClient(HWindow, &listBottom);
 

--- a/src/lang/lang.rc
+++ b/src/lang/lang.rc
@@ -798,16 +798,16 @@ BEGIN
     COMBOBOX        IDC_C_SCHEME,3,13,129,88,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "&Item",IDC_STATIC_2,3,29,46,8
     COMBOBOX        IDC_C_ITEM,3,39,129,99,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    RTEXT           "dummy",IDC_C_ITEM1_L,178,7,82,8
-    PUSHBUTTON      "",IDC_C_ITEM1_C,265,5,30,12
-    RTEXT           "dummy",IDC_C_ITEM2_L,178,21,82,8
-    PUSHBUTTON      "",IDC_C_ITEM2_C,265,19,30,12
-    RTEXT           "dummy",IDC_C_ITEM3_L,178,35,82,8
-    PUSHBUTTON      "",IDC_C_ITEM3_C,265,33,30,12
-    RTEXT           "dummy",IDC_C_ITEM4_L,172,49,88,8
-    PUSHBUTTON      "",IDC_C_ITEM4_C,265,47,30,12
-    RTEXT           "dummy",IDC_C_ITEM5_L,172,63,88,8
-    PUSHBUTTON      "",IDC_C_ITEM5_C,265,61,30,12
+    RTEXT           "dummy",IDC_C_ITEM1_L,178,3,82,8
+    PUSHBUTTON      "",IDC_C_ITEM1_C,265,1,30,12
+    RTEXT           "dummy",IDC_C_ITEM2_L,178,17,82,8
+    PUSHBUTTON      "",IDC_C_ITEM2_C,265,15,30,12
+    RTEXT           "dummy",IDC_C_ITEM3_L,178,31,82,8
+    PUSHBUTTON      "",IDC_C_ITEM3_C,265,29,30,12
+    RTEXT           "dummy",IDC_C_ITEM4_L,172,45,88,8
+    PUSHBUTTON      "",IDC_C_ITEM4_C,265,43,30,12
+    RTEXT           "dummy",IDC_C_ITEM5_L,172,59,88,8
+    PUSHBUTTON      "",IDC_C_ITEM5_C,265,57,30,12
     CONTROL         "",IDC_STATIC_4,"Static",SS_ETCHEDHORZ | WS_GROUP,225,80,71,1
     LTEXT           "Additional Rules for Highlighting of Files and Directories in Panels",IDC_STATIC_5,3,76,220,8
     LTEXT           "Masks Priority &List:",IDC_C_LIST_HEADER,3,94,66,8

--- a/src/plugins/shared/vcxproj/plugin_base.props
+++ b/src/plugins/shared/vcxproj/plugin_base.props
@@ -24,7 +24,7 @@
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
     <Link>
-      <AdditionalDependencies>comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;UxTheme.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
       <OutputFile>$(OutDir)$(ProjectName).spl</OutputFile>
       <AdditionalLibraryDirectories>..\..\shared\libs\$(ShortPlatform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/src/vcxproj/salmon/salmon_base.props
+++ b/src/vcxproj/salmon/salmon_base.props
@@ -22,7 +22,7 @@
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
     <Link>
-      <AdditionalDependencies>comctl32.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;Ws2_32.lib;UxTheme.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\..\plugins\shared\libs\$(ShortPlatform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
### Motivation
- Resolve unresolved linker errors for dark-mode themed APIs (e.g. `OpenThemeData`, `CloseThemeData`, `DrawThemeBackground`, `GetThemePartSize`) by ensuring `UxTheme.lib` is linked for targets that compile `darkmode.cpp`.

### Description
- Add `UxTheme.lib` to the `<AdditionalDependencies>` in `src/plugins/shared/vcxproj/plugin_base.props` and `src/vcxproj/salmon/salmon_base.props` so plugin and utility link steps include the uxtheme import library.

### Testing
- Parsed both modified `.props` files with `python3` using `xml.etree.ElementTree` to ensure valid XML, and the parse succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a34d7a970832993495a6701d3263f)