### PR TITLE
Fix recursive Find list view theme refresh

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -261,6 +261,7 @@ bool gWindowsDarkSchemeSelected = false;
 bool gScrollbarsHooked = false;
 thread_local int gThemeChangeDepth = 0;
 thread_local int gThemeBatchDepth = 0;
+thread_local int gListViewColorUpdateDepth = 0;
 
 static COLORREF gDialogTextColor = GetSysColor(COLOR_BTNTEXT);
 static COLORREF gDialogBackgroundColor = GetSysColor(COLOR_BTNFACE);
@@ -2410,16 +2411,32 @@ COLORREF DarkModeEnsureReadableForeground(COLORREF foreground, COLORREF backgrou
 
 void DarkModeUpdateListViewColors(HWND listView, COLORREF textColor, COLORREF backgroundColor, bool applyHeaderColors)
 {
-#if USE_DARKMODELIB
-    DarkModeBackendDarkModelib::UpdateListViewColors(listView, textColor, backgroundColor, applyHeaderColors);
-#endif
     EnsureInitialized();
 
     if (listView == NULL)
         return;
 
+    // Updating the native or darkmodelib theme for a list view may synchronously
+    // send WM_THEMECHANGED back to the same control.  The find dialog's result
+    // list handles that message by refreshing its list-view colors, so without a
+    // guard the nested WM_THEMECHANGED re-enters this function until the stack is
+    // exhausted.  Let the outer refresh finish; it already applies the requested
+    // colors and invalidates the control.
+    if (gListViewColorUpdateDepth != 0)
+        return;
+
+    struct ListViewColorUpdateScope
+    {
+        ListViewColorUpdateScope() { ++gListViewColorUpdateDepth; }
+        ~ListViewColorUpdateScope() { --gListViewColorUpdateDepth; }
+    } scope;
+
     const COLORREF resolvedText = DarkModeEnsureReadableForeground(textColor, backgroundColor);
     const COLORREF resolvedBackground = backgroundColor;
+
+#if USE_DARKMODELIB
+    DarkModeBackendDarkModelib::UpdateListViewColors(listView, resolvedText, resolvedBackground, applyHeaderColors);
+#endif
 
     DarkModeApplyWindow(listView);
 


### PR DESCRIPTION
### Motivation
- Opening the Find dialog could trigger a `WM_THEMECHANGED` cascade that re-entered the list-view color refresh repeatedly and caused a stack overflow/crash. 
- The native and darkmodelib update paths needed to receive the same already-resolved foreground/background colors to avoid inconsistent behavior during theme changes.

### Description
- Add a thread-local guard `gListViewColorUpdateDepth` and an RAII `ListViewColorUpdateScope` in `DarkModeUpdateListViewColors()` to detect and prevent nested re-entry during synchronous `WM_THEMECHANGED` handling.
- Resolve contrast-corrected colors once with `DarkModeEnsureReadableForeground()` and pass the resolved `resolvedText`/`resolvedBackground` to the backend before applying the native list-view updates.
- Changes are implemented in `src/darkmode.cpp` and preserve the existing application of window/header colors and invalidation logic.

### Testing
- Ran `git diff --check`, which completed with no issues.
- No build or unit-test runs were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a42042418832990c0e2a6f9b2c756)