### PR TITLE
Use darkmodelib theming for Find dialog status bar

### DIFF
--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -589,6 +589,9 @@ protected:
     BOOL DisableNotification;
     BOOL LabelEdit;
     int SelectIndex;
+    int AvailableColumnsWidth;
+    int AvailableColumnsRightMargin;
+    int ViewsListGap;
 
 public:
     CCfgPageView(int index);
@@ -604,6 +607,7 @@ public:
     void StoreControls();
     void EnableControls();
     void EnableHeader();
+    void LayoutViewsListControls();
     DWORD GetEnabledFunctions();
 
     BOOL IsDirty();

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2076,14 +2076,24 @@ void ApplyListTreeThemeRecursive(HWND hwnd, bool wantDark)
                 InvalidateRect(hwnd, NULL, TRUE);
             }
         }
+        else if (wcscmp(className, L"msctls_statusbar32") == 0)
+        {
+#if USE_DARKMODELIB
+            DarkModeBackendDarkModelib::ApplyStatusBar(hwnd, wantDark && ShouldUseDarkColorsForSurfaces());
+#else
+            EnsureDarkStatusBarSubclass(hwnd, ShouldUseDarkColorsForSurfaces());
+#endif
+        }
+        else if (wcscmp(className, L"msctls_progress32") == 0)
+        {
+#if USE_DARKMODELIB
+            DarkModeBackendDarkModelib::ApplyProgressBar(hwnd, wantDark && ShouldUseDarkColorsForSurfaces());
+#endif
+        }
 #if !USE_DARKMODELIB
         else if (wcscmp(className, L"SysHeader32") == 0)
         {
             EnsureDarkHeaderSubclass(hwnd, ShouldUseDarkColorsForSurfaces());
-        }
-        else if (wcscmp(className, L"msctls_statusbar32") == 0)
-        {
-            EnsureDarkStatusBarSubclass(hwnd, ShouldUseDarkColorsForSurfaces());
         }
 #endif
         else if (wcscmp(className, L"Static") == 0)

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1799,6 +1799,24 @@ void EnsureDarkStaticFrameSubclass(HWND hwnd, bool enableDark)
 
 constexpr UINT_PTR kDarkModeListViewSurfaceSubclassId = 0x44524C56; // "DRLV"
 
+void PaintDarkListViewBorder(HWND hwnd)
+{
+    HDC hdc = GetWindowDC(hwnd);
+    if (hdc == NULL)
+        return;
+
+    RECT rc;
+    GetWindowRect(hwnd, &rc);
+    OffsetRect(&rc, -rc.left, -rc.top);
+    HBRUSH brush = CreateSolidBrush(RGB(0x38, 0x38, 0x38));
+    if (brush != NULL)
+    {
+        FrameRect(hdc, &rc, brush);
+        DeleteObject(brush);
+    }
+    ReleaseDC(hwnd, hdc);
+}
+
 LRESULT CALLBACK DarkListViewSurfaceSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
                                              UINT_PTR subclassId, DWORD_PTR refData)
 {
@@ -1809,6 +1827,9 @@ LRESULT CALLBACK DarkListViewSurfaceSubclass(HWND hwnd, UINT msg, WPARAM wParam,
         RemoveWindowSubclass(hwnd, DarkListViewSurfaceSubclass, kDarkModeListViewSurfaceSubclassId);
 
     LRESULT result = DefSubclassProc(hwnd, msg, wParam, lParam);
+    if ((msg == WM_NCPAINT || msg == WM_NCACTIVATE || msg == WM_SIZE) && ShouldUseDarkColorsForSurfaces())
+        PaintDarkListViewBorder(hwnd);
+
     if (msg == WM_PAINT && ShouldUseDarkColorsForSurfaces())
     {
         HDC hdc = GetDC(hwnd);
@@ -1852,6 +1873,7 @@ LRESULT CALLBACK DarkListViewSurfaceSubclass(HWND hwnd, UINT msg, WPARAM wParam,
         if (unused.top < unused.bottom)
             FillRectWithColor(hdc, unused, background);
         ReleaseDC(hwnd, hdc);
+        PaintDarkListViewBorder(hwnd);
     }
     return result;
 }

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -1687,6 +1687,116 @@ void EnsureDarkStatusBarSubclass(HWND hwnd, bool enableDark)
 }
 #endif
 
+constexpr UINT_PTR kDarkModeStaticFrameSubclassId = 0x44525346; // "DRSF"
+
+bool IsStaticFrameStyle(HWND hwnd)
+{
+    if (hwnd == NULL)
+        return false;
+
+    wchar_t className[16] = {0};
+    if (GetClassNameW(hwnd, className, _countof(className)) == 0 || wcscmp(className, L"Static") != 0)
+        return false;
+
+    const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+    const LONG_PTR type = style & SS_TYPEMASK;
+    const LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    return type == SS_ETCHEDHORZ || type == SS_ETCHEDVERT || type == SS_ETCHEDFRAME ||
+           type == SS_GRAYFRAME || type == SS_BLACKFRAME ||
+           (exStyle & WS_EX_STATICEDGE) == WS_EX_STATICEDGE;
+}
+
+void PaintDarkStaticFrame(HWND hwnd, HDC hdc)
+{
+    RECT rc;
+    GetClientRect(hwnd, &rc);
+
+    const COLORREF lineColor = RGB(0x38, 0x38, 0x38);
+    const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+    const LONG_PTR type = style & SS_TYPEMASK;
+
+    if (type == SS_ETCHEDVERT)
+    {
+        RECT line = rc;
+        line.left += (line.right - line.left) / 2;
+        line.right = line.left + 1;
+        FillRectWithColor(hdc, line, lineColor);
+    }
+    else if (type == SS_ETCHEDFRAME || type == SS_GRAYFRAME || type == SS_BLACKFRAME ||
+             (GetWindowLongPtrW(hwnd, GWL_EXSTYLE) & WS_EX_STATICEDGE) == WS_EX_STATICEDGE)
+    {
+        HBRUSH brush = CreateSolidBrush(lineColor);
+        if (brush != NULL)
+        {
+            FrameRect(hdc, &rc, brush);
+            DeleteObject(brush);
+        }
+    }
+    else
+    {
+        RECT line = rc;
+        line.top += (line.bottom - line.top) / 2;
+        line.bottom = line.top + 1;
+        FillRectWithColor(hdc, line, lineColor);
+    }
+}
+
+LRESULT CALLBACK DarkStaticFrameSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
+                                         UINT_PTR subclassId, DWORD_PTR refData)
+{
+    (void)subclassId;
+    (void)refData;
+
+    switch (msg)
+    {
+    case WM_NCDESTROY:
+        RemoveWindowSubclass(hwnd, DarkStaticFrameSubclass, kDarkModeStaticFrameSubclassId);
+        break;
+
+    case WM_ERASEBKGND:
+        return ShouldUseDarkColorsForSurfaces() ? TRUE : DefSubclassProc(hwnd, msg, wParam, lParam);
+
+    case WM_PAINT:
+        if (ShouldUseDarkColorsForSurfaces())
+        {
+            PAINTSTRUCT ps;
+            HDC hdc = BeginPaint(hwnd, &ps);
+            if (hdc != NULL)
+                PaintDarkStaticFrame(hwnd, hdc);
+            EndPaint(hwnd, &ps);
+            return 0;
+        }
+        break;
+
+    case WM_PRINTCLIENT:
+        if (ShouldUseDarkColorsForSurfaces())
+        {
+            PaintDarkStaticFrame(hwnd, reinterpret_cast<HDC>(wParam));
+            return 0;
+        }
+        break;
+
+    case WM_THEMECHANGED:
+    case WM_ENABLE:
+        InvalidateRect(hwnd, NULL, TRUE);
+        break;
+    }
+
+    return DefSubclassProc(hwnd, msg, wParam, lParam);
+}
+
+void EnsureDarkStaticFrameSubclass(HWND hwnd, bool enableDark)
+{
+    if (hwnd == NULL || !IsStaticFrameStyle(hwnd))
+        return;
+
+    if (enableDark)
+        SetWindowSubclass(hwnd, DarkStaticFrameSubclass, kDarkModeStaticFrameSubclassId, 0);
+    else
+        RemoveWindowSubclass(hwnd, DarkStaticFrameSubclass, kDarkModeStaticFrameSubclassId);
+    InvalidateRect(hwnd, NULL, TRUE);
+}
+
 constexpr UINT_PTR kDarkModeListViewSurfaceSubclassId = 0x44524C56; // "DRLV"
 
 LRESULT CALLBACK DarkListViewSurfaceSubclass(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam,
@@ -2098,10 +2208,7 @@ void ApplyListTreeThemeRecursive(HWND hwnd, bool wantDark)
 #endif
         else if (wcscmp(className, L"Static") == 0)
         {
-            const LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
-            const LONG_PTR exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
-            if ((exStyle & WS_EX_STATICEDGE) == WS_EX_STATICEDGE || (style & SS_ETCHEDFRAME) == SS_ETCHEDFRAME)
-                InvalidateRect(hwnd, NULL, TRUE);
+            EnsureDarkStaticFrameSubclass(hwnd, wantDark && ShouldUseDarkColorsForSurfaces());
         }
     }
     applyChromeTheme(hwnd, className);

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -356,7 +356,7 @@ void UpdateListViewColors(HWND listView, COLORREF textColor, COLORREF background
         if (applyHeaderColors && DarkMode_ShouldUseDark())
         {
             const COLORREF headerBackground = RGB(0x20, 0x20, 0x20);
-            const COLORREF headerEdge = RGB(0x4A, 0x4A, 0x4A);
+            const COLORREF headerEdge = RGB(0x38, 0x38, 0x38);
             dmlib::setViewBackgroundColor(backgroundColor);
             dmlib::setViewTextColor(textColor);
             dmlib::setHeaderBackgroundColor(headerBackground);
@@ -364,6 +364,8 @@ void UpdateListViewColors(HWND listView, COLORREF textColor, COLORREF background
             dmlib::setHeaderTextColor(textColor);
             dmlib::setHeaderEdgeColor(headerEdge);
             dmlib::updateViewBrushesAndPens();
+            dmlib::replaceClientEdgeWithBorderSafe(listView);
+            dmlib::setCustomBorderForListBoxOrEditCtrlSubclass(listView);
             dmlib::setDarkListView(listView);
             dmlib::setDarkListViewCheckboxes(listView);
             dmlib::setListViewCtrlSubclass(listView);
@@ -378,6 +380,8 @@ void UpdateListViewColors(HWND listView, COLORREF textColor, COLORREF background
         else
         {
             dmlib::removeListViewCtrlSubclass(listView);
+            dmlib::removeCustomBorderForListBoxOrEditCtrlSubclass(listView);
+            dmlib::replaceClientEdgeWithBorderSafeEx(listView, false);
             HWND header = ListView_GetHeader(listView);
             if (header != NULL)
             {

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -365,7 +365,6 @@ void UpdateListViewColors(HWND listView, COLORREF textColor, COLORREF background
             dmlib::setHeaderEdgeColor(headerEdge);
             dmlib::updateViewBrushesAndPens();
             dmlib::replaceClientEdgeWithBorderSafe(listView);
-            dmlib::setCustomBorderForListBoxOrEditCtrlSubclass(listView);
             dmlib::setDarkListView(listView);
             dmlib::setDarkListViewCheckboxes(listView);
             dmlib::setListViewCtrlSubclass(listView);
@@ -380,7 +379,6 @@ void UpdateListViewColors(HWND listView, COLORREF textColor, COLORREF background
         else
         {
             dmlib::removeListViewCtrlSubclass(listView);
-            dmlib::removeCustomBorderForListBoxOrEditCtrlSubclass(listView);
             dmlib::replaceClientEdgeWithBorderSafeEx(listView, false);
             HWND header = ListView_GetHeader(listView);
             if (header != NULL)

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -113,17 +113,27 @@ bool IsAvailable()
 #endif
 }
 
+static void ConfigureDarkModelib(bool dark)
+{
+#if USE_DARKMODELIB
+    static bool dmlibInitialized = false;
+    if (!dmlibInitialized)
+    {
+        dmlib::initDarkMode();
+        dmlibInitialized = true;
+    }
+    dmlib::setDarkModeConfigEx(static_cast<UINT>(dark ? dmlib::DarkModeType::dark : dmlib::DarkModeType::classic));
+    dmlib::setDefaultColors(true);
+#else
+    (void)dark;
+#endif
+}
+
 void ApplyTree(HWND hwnd)
 {
 #if USE_DARKMODELIB
     if (hwnd != NULL)
     {
-        static bool dmlibInitialized = false;
-        if (!dmlibInitialized)
-        {
-            dmlib::initDarkMode();
-            dmlibInitialized = true;
-        }
         const bool dark = DarkMode_ShouldUseDark() != FALSE;
         HANDLE appliedState = GetPropW(hwnd, DARKMODELIB_TREE_STATE_PROP);
         const bool wasApplied = appliedState != NULL;
@@ -131,8 +141,7 @@ void ApplyTree(HWND hwnd)
         if (wasApplied && wasDark == dark)
             return;
 
-        dmlib::setDarkModeConfigEx(static_cast<UINT>(dark ? dmlib::DarkModeType::dark : dmlib::DarkModeType::classic));
-        dmlib::setDefaultColors(true);
+        ConfigureDarkModelib(dark);
         if (dark)
         {
             if (!wasDark)
@@ -196,10 +205,47 @@ void ApplyCheckboxOrRadioButton(HWND hwnd, bool enableDark)
 #if USE_DARKMODELIB
     if (hwnd != NULL)
     {
+        ConfigureDarkModelib(enableDark);
         if (enableDark)
             dmlib::setCheckboxOrRadioBtnCtrlSubclass(hwnd);
         else
             dmlib::removeCheckboxOrRadioBtnCtrlSubclass(hwnd);
+    }
+#else
+    (void)hwnd;
+    (void)enableDark;
+#endif
+}
+
+void ApplyStatusBar(HWND hwnd, bool enableDark)
+{
+#if USE_DARKMODELIB
+    if (hwnd != NULL)
+    {
+        ConfigureDarkModelib(enableDark);
+        if (enableDark)
+            dmlib::setStatusBarCtrlSubclass(hwnd);
+        else
+            dmlib::removeStatusBarCtrlSubclass(hwnd);
+        InvalidateRect(hwnd, NULL, TRUE);
+    }
+#else
+    (void)hwnd;
+    (void)enableDark;
+#endif
+}
+
+void ApplyProgressBar(HWND hwnd, bool enableDark)
+{
+#if USE_DARKMODELIB
+    if (hwnd != NULL)
+    {
+        ConfigureDarkModelib(enableDark);
+        if (enableDark)
+            dmlib::setProgressBarCtrlSubclass(hwnd);
+        else
+            dmlib::removeProgressBarCtrlSubclass(hwnd);
+        InvalidateRect(hwnd, NULL, TRUE);
     }
 #else
     (void)hwnd;

--- a/src/darkmode_backend_darkmodelib.h
+++ b/src/darkmode_backend_darkmodelib.h
@@ -16,6 +16,8 @@ bool IsAvailable();
 void ApplyTree(HWND hwnd);
 void ApplyMenuBar(HWND hwnd, bool enableDark);
 void ApplyCheckboxOrRadioButton(HWND hwnd, bool enableDark);
+void ApplyStatusBar(HWND hwnd, bool enableDark);
+void ApplyProgressBar(HWND hwnd, bool enableDark);
 bool HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT& result,
                     const DarkModeColors& colors, HBRUSH dialogBrush);
 void ApplyStaticTextColors(HWND hwndParent, HWND specificCtrl, const DarkModeColors& colors);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -107,24 +107,15 @@ static void RemoveViewsListViewsWhiteClientEdge(HWND listView, HWND listView2)
 
 static bool ShouldCustomDrawViewsAvailableColumnCheckboxes()
 {
-    if (!DarkModeShouldUseDarkColors())
-        return false;
-
-#if USE_DARKMODELIB
-    // On Win11+ darkmodelib replaces list-view checkbox state images with
-    // dark themed images. Older Windows keep native state images with light
-    // backgrounds, so we bypass native item painting there.
-    return !Windows11AndLater;
-#else
-    return true;
-#endif
+    // This one list-view has repeatedly shown native checkbox state-image
+    // backgrounds in dark mode. Bypass native item painting for it on every
+    // Windows version; darkmodelib still themes the list-view/header chrome.
+    return DarkModeShouldUseDarkColors();
 }
 
 // Custom-draw handler for dark-mode checkboxes in the Available Columns ListView.
-// darkmodelib's setDarkCheckboxes() only works on Win11+, so on Win10 we must
-// draw the checkboxes ourselves. On Win11+ with USE_DARKMODELIB, darkmodelib
-// handles them natively and we must not draw on top (causes white-background
-// artifacts).
+// We draw the whole item ourselves and return CDRF_SKIPDEFAULT so native checkbox
+// state images cannot leave white backgrounds in the checkbox gutter.
 static void DrawViewsAvailableColumnCheckbox(HWND listView, NMLVCUSTOMDRAW* customDraw)
 {
     if (!ShouldCustomDrawViewsAvailableColumnCheckboxes() || listView == NULL || customDraw == NULL)

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -92,6 +92,21 @@ static void RemoveViewsListViewsWhiteClientEdge(HWND listView, HWND listView2)
     RemoveViewsListViewWhiteClientEdge(listView2);
 }
 
+static bool ShouldCustomDrawViewsAvailableColumnCheckboxes()
+{
+    if (!DarkModeShouldUseDarkColors())
+        return false;
+
+#if USE_DARKMODELIB
+    // On Win11+ darkmodelib replaces list-view checkbox state images with
+    // dark themed images. Older Windows keep native state images with light
+    // backgrounds, so we bypass native item painting there.
+    return !Windows11AndLater;
+#else
+    return true;
+#endif
+}
+
 // Custom-draw handler for dark-mode checkboxes in the Available Columns ListView.
 // darkmodelib's setDarkCheckboxes() only works on Win11+, so on Win10 we must
 // draw the checkboxes ourselves. On Win11+ with USE_DARKMODELIB, darkmodelib
@@ -99,14 +114,8 @@ static void RemoveViewsListViewsWhiteClientEdge(HWND listView, HWND listView2)
 // artifacts).
 static void DrawViewsAvailableColumnCheckbox(HWND listView, NMLVCUSTOMDRAW* customDraw)
 {
-    if (!DarkModeShouldUseDarkColors() || listView == NULL || customDraw == NULL)
+    if (!ShouldCustomDrawViewsAvailableColumnCheckboxes() || listView == NULL || customDraw == NULL)
         return;
-
-    // On Win11+ with USE_DARKMODELIB, darkmodelib handles checkboxes natively
-#if USE_DARKMODELIB
-    if (Windows11AndLater)
-        return;
-#endif
 
     const int item = static_cast<int>(customDraw->nmcd.dwItemSpec);
     RECT boundsRect;
@@ -166,6 +175,17 @@ static void DrawViewsAvailableColumnCheckbox(HWND listView, NMLVCUSTOMDRAW* cust
         if (checkPen != NULL)
             DeleteObject(checkPen);
     }
+
+    char text[256];
+    text[0] = 0;
+    ListView_GetItemText(listView, item, 0, text, _countof(text));
+    RECT textRect = labelRect;
+    textRect.left += 2;
+    int oldBkMode = SetBkMode(hdc, TRANSPARENT);
+    COLORREF oldTextColor = SetTextColor(hdc, DarkModeGetDialogTextColor());
+    DrawText(hdc, text, -1, &textRect, DT_SINGLELINE | DT_VCENTER | DT_LEFT | DT_NOPREFIX | DT_END_ELLIPSIS);
+    SetTextColor(hdc, oldTextColor);
+    SetBkMode(hdc, oldBkMode);
 
     if (oldPen != NULL)
         SelectObject(hdc, oldPen);
@@ -1872,14 +1892,16 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         customDrawResult = CDRF_NOTIFYITEMDRAW;
                     else if (customDraw->nmcd.dwDrawStage == CDDS_ITEMPREPAINT)
                     {
-                        // Ensure the system draws item backgrounds in dark color,
-                        // preventing white bleed-through from default rendering.
                         customDraw->clrTextBk = DarkModeGetDialogBackgroundColor();
                         customDraw->clrText = DarkModeGetDialogTextColor();
-                        customDrawResult = CDRF_NOTIFYPOSTPAINT;
+                        if (ShouldCustomDrawViewsAvailableColumnCheckboxes())
+                        {
+                            DrawViewsAvailableColumnCheckbox(HListView2, customDraw);
+                            customDrawResult = CDRF_SKIPDEFAULT;
+                        }
+                        else
+                            customDrawResult = CDRF_DODEFAULT;
                     }
-                    else if (customDraw->nmcd.dwDrawStage == CDDS_ITEMPOSTPAINT)
-                        DrawViewsAvailableColumnCheckbox(HListView2, customDraw);
                 }
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, customDrawResult);
                 return TRUE;

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -143,14 +143,21 @@ static void DrawViewsAvailableColumnCheckbox(HWND listView, NMLVCUSTOMDRAW* cust
     if (hdc == NULL)
         return;
 
-    // Fill the full item width with dark background to cover any white pixels
-    // from the native checkbox state images.
+    // Fill the entire visual row. LVIR_BOUNDS does not cover the state-image
+    // gutter nor the unused space to the right of the text, and those are
+    // exactly the areas where native list-view painting leaves white pixels.
+    RECT clientRect;
+    GetClientRect(listView, &clientRect);
+    RECT rowRect = boundsRect;
+    rowRect.left = clientRect.left;
+    rowRect.right = clientRect.right;
+
     const bool selected = (ListView_GetItemState(listView, item, LVIS_SELECTED) & LVIS_SELECTED) != 0;
     const COLORREF rowBackground = selected ? DarkModeGetColors().background : DarkModeGetDialogBackgroundColor();
-    FillRectWithSysColor(hdc, boundsRect, rowBackground);
+    FillRectWithSysColor(hdc, rowRect, rowBackground);
 
     // Calculate checkbox area (same region the native state image occupies)
-    RECT stateRect = boundsRect;
+    RECT stateRect = rowRect;
     stateRect.right = labelRect.left;
     if (stateRect.right <= stateRect.left)
         return;
@@ -1470,6 +1477,9 @@ CCfgPageView::CCfgPageView(int index)
     HListView2 = NULL;
     DisableNotification = FALSE;
     LabelEdit = FALSE;
+    AvailableColumnsWidth = 0;
+    AvailableColumnsRightMargin = 0;
+    ViewsListGap = 0;
     if (index == -1)
         index = MainWindow->GetActivePanel()->GetViewTemplateIndex();
     SelectIndex = index;
@@ -1552,6 +1562,63 @@ void CCfgPageView::Validate(CTransferInfo& ti)
 const int CFGP2ItemsCount = 8 /*9*/;
 const int CFGP2Flags[CFGP2ItemsCount] = {0, VIEW_SHOW_EXTENSION, VIEW_SHOW_DOSNAME, VIEW_SHOW_SIZE, VIEW_SHOW_TYPE, VIEW_SHOW_DATE, VIEW_SHOW_TIME, VIEW_SHOW_ATTRIBUTES /*, VIEW_SHOW_DESCRIPTION*/};
 const int CFGP2ResID[CFGP2ItemsCount] = {IDS_COLUMN_CFG_NAME, IDS_COLUMN_CFG_EXT, IDS_COLUMN_CFG_DOSNAME, IDS_COLUMN_CFG_SIZE, IDS_COLUMN_CFG_TYPE, IDS_COLUMN_CFG_DATE, IDS_COLUMN_CFG_TIME, IDS_COLUMN_CFG_ATTR /*,  IDS_COLUMN_CFG_DESC*/};
+
+void CCfgPageView::LayoutViewsListControls()
+{
+    if (HListView == NULL || HListView2 == NULL || Header == NULL || Header2 == NULL ||
+        AvailableColumnsWidth <= 0)
+    {
+        return;
+    }
+
+    RECT client;
+    GetClientRect(HWindow, &client);
+
+    RECT leftRect;
+    RECT rightRect;
+    RECT headerRect;
+    RECT header2Rect;
+    GetWindowRect(HListView, &leftRect);
+    GetWindowRect(HListView2, &rightRect);
+    GetWindowRect(Header->HWindow, &headerRect);
+    GetWindowRect(Header2->HWindow, &header2Rect);
+    POINT leftTop = {leftRect.left, leftRect.top};
+    POINT rightTop = {rightRect.left, rightRect.top};
+    ScreenToClient(HWindow, &leftTop);
+    ScreenToClient(HWindow, &rightTop);
+
+    const int rightLeft = client.right - AvailableColumnsRightMargin - AvailableColumnsWidth;
+    int leftWidth = rightLeft - ViewsListGap - leftTop.x;
+    if (leftWidth < 20)
+        leftWidth = 20;
+    const int listHeight = rightRect.bottom - rightRect.top;
+    const int leftHeight = leftRect.bottom - leftRect.top;
+    const int headerHeight = headerRect.bottom - headerRect.top;
+    const int header2Height = header2Rect.bottom - header2Rect.top;
+
+    HDWP hdwp = HANDLES(BeginDeferWindowPos(4));
+    if (hdwp != NULL)
+    {
+        hdwp = HANDLES(DeferWindowPos(hdwp, HListView, NULL,
+                                      0, 0, leftWidth, leftHeight,
+                                      SWP_NOMOVE | SWP_NOZORDER));
+        hdwp = HANDLES(DeferWindowPos(hdwp, HListView2, NULL,
+                                      rightLeft, rightTop.y, AvailableColumnsWidth, listHeight,
+                                      SWP_NOZORDER));
+        hdwp = HANDLES(DeferWindowPos(hdwp, Header->HWindow, NULL,
+                                      0, 0, leftWidth, headerHeight,
+                                      SWP_NOMOVE | SWP_NOZORDER));
+        hdwp = HANDLES(DeferWindowPos(hdwp, Header2->HWindow, NULL,
+                                      rightLeft, rightTop.y - header2Height,
+                                      AvailableColumnsWidth, header2Height,
+                                      SWP_NOZORDER));
+        HANDLES(EndDeferWindowPos(hdwp));
+    }
+
+    SetViewsAvailableColumnsColumnWidth(HListView2);
+    InvalidateRect(HListView, NULL, TRUE);
+    InvalidateRect(HListView2, NULL, TRUE);
+}
 
 void CCfgPageView::LoadControls()
 {
@@ -1840,9 +1907,25 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         ListView_InsertColumn(HListView2, 0, &lvc);
         SetViewsAvailableColumnsColumnWidth(HListView2);
 
+        RECT rightWindowRect;
+        RECT leftWindowRect;
+        RECT clientRect;
+        GetWindowRect(HListView2, &rightWindowRect);
+        GetWindowRect(HListView, &leftWindowRect);
+        GetClientRect(HWindow, &clientRect);
+        POINT rightBottom = {rightWindowRect.right, rightWindowRect.bottom};
+        POINT rightTop = {rightWindowRect.left, rightWindowRect.top};
+        POINT leftBottom = {leftWindowRect.right, leftWindowRect.bottom};
+        ScreenToClient(HWindow, &rightBottom);
+        ScreenToClient(HWindow, &rightTop);
+        ScreenToClient(HWindow, &leftBottom);
+        AvailableColumnsWidth = rightBottom.x - rightTop.x;
+        AvailableColumnsRightMargin = clientRect.right - rightBottom.x;
+        ViewsListGap = rightTop.x - leftBottom.x;
+
         // dialog elements should stretch with the dialog size, set split controls
         ElasticVerticalLayout(2, IDC_VIEW_LIST, IDC_VIEW_LIST2);
-        SetViewsAvailableColumnsColumnWidth(HListView2);
+        LayoutViewsListControls();
 
         DarkModeUpdateListViewColors(HListView);
         DarkModeUpdateListViewColors(HListView2);
@@ -1865,6 +1948,13 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
 
         break;
+    }
+
+    case WM_SIZE:
+    {
+        INT_PTR result = CCommonPropSheetPage::DialogProc(uMsg, wParam, lParam);
+        LayoutViewsListControls();
+        return result;
     }
 
     case WM_SYSCOLORCHANGE:

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -72,6 +72,26 @@ static void FillRectWithSysColor(HDC hdc, const RECT& rect, COLORREF color)
     }
 }
 
+static void RemoveViewsListViewWhiteClientEdge(HWND listView)
+{
+    if (listView == NULL || !DarkModeShouldUseDarkColors())
+        return;
+
+    DWORD exStyle = (DWORD)GetWindowLongPtr(listView, GWL_EXSTYLE);
+    if ((exStyle & WS_EX_CLIENTEDGE) == 0)
+        return;
+
+    SetWindowLongPtr(listView, GWL_EXSTYLE, exStyle & ~WS_EX_CLIENTEDGE);
+    SetWindowPos(listView, NULL, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+}
+
+static void RemoveViewsListViewsWhiteClientEdge(HWND listView, HWND listView2)
+{
+    RemoveViewsListViewWhiteClientEdge(listView);
+    RemoveViewsListViewWhiteClientEdge(listView2);
+}
+
 // Custom-draw handler for dark-mode checkboxes in the Available Columns ListView.
 // darkmodelib's setDarkCheckboxes() only works on Win11+, so on Win10 we must
 // draw the checkboxes ourselves. On Win11+ with USE_DARKMODELIB, darkmodelib
@@ -1791,6 +1811,7 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         DarkModeUpdateListViewColors(HListView);
         DarkModeUpdateListViewColors(HListView2);
+        RemoveViewsListViewsWhiteClientEdge(HListView, HListView2);
         if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
         {
             DarkModeApplyTree(HWindow);
@@ -1803,20 +1824,7 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             // visible at the edges. Remove WS_EX_CLIENTEDGE so only the CToolbarHeader's
             // dark sunken border remains. On Win11+, darkmodelib's setDarkCheckboxes
             // replaces the native state images entirely, so the border isn't an issue.
-            if (DarkModeShouldUseDarkColors())
-            {
-                auto RemoveWhiteClientEdge = [](HWND hList) {
-                    DWORD exStyle = (DWORD)GetWindowLongPtr(hList, GWL_EXSTYLE);
-                    if (exStyle & WS_EX_CLIENTEDGE)
-                    {
-                        SetWindowLongPtr(hList, GWL_EXSTYLE, exStyle & ~WS_EX_CLIENTEDGE);
-                        SetWindowPos(hList, NULL, 0, 0, 0, 0,
-                            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
-                    }
-                };
-                RemoveWhiteClientEdge(HListView);
-                RemoveWhiteClientEdge(HListView2);
-            }
+            RemoveViewsListViewsWhiteClientEdge(HListView, HListView2);
             DarkModeApplyStaticTextColors(HWindow, NULL);
             WinLib_DarkMode_PostDeferredRedraw(HWindow);
         }
@@ -1828,6 +1836,7 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         DarkModeUpdateListViewColors(HListView);
         DarkModeUpdateListViewColors(HListView2);
+        RemoveViewsListViewsWhiteClientEdge(HListView, HListView2);
         break;
     }
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -94,10 +94,16 @@ static void RemoveViewsListViewWhiteClientEdge(HWND listView)
         return;
 
     DWORD exStyle = (DWORD)GetWindowLongPtr(listView, GWL_EXSTYLE);
-    if ((exStyle & WS_EX_CLIENTEDGE) == 0)
+    DWORD style = (DWORD)GetWindowLongPtr(listView, GWL_STYLE);
+    DWORD newExStyle = exStyle & ~WS_EX_CLIENTEDGE;
+    DWORD newStyle = style & ~WS_BORDER;
+    if (newExStyle == exStyle && newStyle == style)
         return;
 
-    SetWindowLongPtr(listView, GWL_EXSTYLE, exStyle & ~WS_EX_CLIENTEDGE);
+    if (newExStyle != exStyle)
+        SetWindowLongPtr(listView, GWL_EXSTYLE, newExStyle);
+    if (newStyle != style)
+        SetWindowLongPtr(listView, GWL_STYLE, newStyle);
     SetWindowPos(listView, NULL, 0, 0, 0, 0,
                  SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
 }

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -107,15 +107,18 @@ static void RemoveViewsListViewsWhiteClientEdge(HWND listView, HWND listView2)
 
 static bool ShouldCustomDrawViewsAvailableColumnCheckboxes()
 {
-    // This one list-view has repeatedly shown native checkbox state-image
-    // backgrounds in dark mode. Bypass native item painting for it on every
-    // Windows version; darkmodelib still themes the list-view/header chrome.
-    return DarkModeShouldUseDarkColors();
+    // Available Columns used to be fixed by overlaying the checkbox cell after
+    // the native list-view item has been painted. Keep that exact Win11+ dark
+    // mode path: darkmodelib still themes the list-view/header chrome, and this
+    // post-paint pass covers the native state-image background that can remain
+    // white in this single list-view.
+    return Windows11AndLater && DarkModeShouldUseDarkColors();
 }
 
 // Custom-draw handler for dark-mode checkboxes in the Available Columns ListView.
-// We draw the whole item ourselves and return CDRF_SKIPDEFAULT so native checkbox
-// state images cannot leave white backgrounds in the checkbox gutter.
+// Called from CDDS_ITEMPOSTPAINT so the native/default item draw stays intact
+// and this pass only overlays the problematic state-image area (plus the row
+// background/text) with dark colors.
 static void DrawViewsAvailableColumnCheckbox(HWND listView, NMLVCUSTOMDRAW* customDraw)
 {
     if (!ShouldCustomDrawViewsAvailableColumnCheckboxes() || listView == NULL || customDraw == NULL)
@@ -1991,12 +1994,14 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         customDraw->clrTextBk = DarkModeGetDialogBackgroundColor();
                         customDraw->clrText = DarkModeGetDialogTextColor();
                         if (ShouldCustomDrawViewsAvailableColumnCheckboxes())
-                        {
-                            DrawViewsAvailableColumnCheckbox(HListView2, customDraw);
-                            customDrawResult = CDRF_SKIPDEFAULT;
-                        }
+                            customDrawResult = CDRF_NOTIFYPOSTPAINT;
                         else
                             customDrawResult = CDRF_DODEFAULT;
+                    }
+                    else if (customDraw->nmcd.dwDrawStage == CDDS_ITEMPOSTPAINT)
+                    {
+                        DrawViewsAvailableColumnCheckbox(HListView2, customDraw);
+                        customDrawResult = CDRF_DODEFAULT;
                     }
                 }
                 SetWindowLongPtr(HWindow, DWLP_MSGRESULT, customDrawResult);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -79,7 +79,10 @@ static void SetViewsAvailableColumnsColumnWidth(HWND listView)
 
     RECT rc;
     GetClientRect(listView, &rc);
-    int width = rc.right - rc.left - GetSystemMetrics(SM_CXVSCROLL) - 4;
+    // This list has a single column. Let it cover the full client area so the
+    // report-view background is painted by that column instead of leaving a
+    // separate native strip on the right side.
+    int width = rc.right - rc.left;
     if (width < 20)
         width = 20;
     ListView_SetColumnWidth(listView, 0, width);
@@ -108,11 +111,11 @@ static void RemoveViewsListViewsWhiteClientEdge(HWND listView, HWND listView2)
 static bool ShouldCustomDrawViewsAvailableColumnCheckboxes()
 {
     // Available Columns used to be fixed by overlaying the checkbox cell after
-    // the native list-view item has been painted. Keep that exact Win11+ dark
-    // mode path: darkmodelib still themes the list-view/header chrome, and this
-    // post-paint pass covers the native state-image background that can remain
-    // white in this single list-view.
-    return Windows11AndLater && DarkModeShouldUseDarkColors();
+    // the native list-view item has been painted. Keep the post-paint path for
+    // this single list-view whenever dark colors are active: darkmodelib still
+    // themes the list-view/header chrome, and this pass covers any native
+    // state-image background that can remain white.
+    return DarkModeShouldUseDarkColors();
 }
 
 // Custom-draw handler for dark-mode checkboxes in the Available Columns ListView.

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -72,6 +72,19 @@ static void FillRectWithSysColor(HDC hdc, const RECT& rect, COLORREF color)
     }
 }
 
+static void SetViewsAvailableColumnsColumnWidth(HWND listView)
+{
+    if (listView == NULL)
+        return;
+
+    RECT rc;
+    GetClientRect(listView, &rc);
+    int width = rc.right - rc.left - GetSystemMetrics(SM_CXVSCROLL) - 4;
+    if (width < 20)
+        width = 20;
+    ListView_SetColumnWidth(listView, 0, width);
+}
+
 static void RemoveViewsListViewWhiteClientEdge(HWND listView)
 {
     if (listView == NULL || !DarkModeShouldUseDarkColors())
@@ -1573,7 +1586,7 @@ void CCfgPageView::LoadControls()
             ListView_InsertItem(HListView2, &lvi);
         }
         ListView_SetItemState(HListView2, 0, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
-        ListView_SetColumnWidth(HListView2, 0, LVSCW_AUTOSIZE_USEHEADER);
+        SetViewsAvailableColumnsColumnWidth(HListView2);
     }
     int index2 = -1;
     if (!empty)
@@ -1825,9 +1838,11 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         lvc.fmt = LVCFMT_LEFT;
         lvc.iSubItem = 0;
         ListView_InsertColumn(HListView2, 0, &lvc);
+        SetViewsAvailableColumnsColumnWidth(HListView2);
 
         // dialog elements should stretch with the dialog size, set split controls
         ElasticVerticalLayout(2, IDC_VIEW_LIST, IDC_VIEW_LIST2);
+        SetViewsAvailableColumnsColumnWidth(HListView2);
 
         DarkModeUpdateListViewColors(HListView);
         DarkModeUpdateListViewColors(HListView2);

--- a/src/finddlg1.cpp
+++ b/src/finddlg1.cpp
@@ -117,10 +117,10 @@ bool PaintFindListHeader(LPNMCUSTOMDRAW cd, LRESULT& result)
 
         RECT line = cd->rc;
         line.left = line.right - 1;
-        FillFindRect(cd->hdc, &line, RGB(0x4A, 0x4A, 0x4A));
+        FillFindRect(cd->hdc, &line, RGB(0x38, 0x38, 0x38));
         line = cd->rc;
         line.top = line.bottom - 1;
-        FillFindRect(cd->hdc, &line, RGB(0x4A, 0x4A, 0x4A));
+        FillFindRect(cd->hdc, &line, RGB(0x38, 0x38, 0x38));
 
         result = CDRF_SKIPDEFAULT;
         return true;

--- a/src/finddlg1.cpp
+++ b/src/finddlg1.cpp
@@ -65,8 +65,7 @@ void UpdateFindDarkChrome(HWND dialog, HWND statusBar, HWND listView, CFindTBHea
 
     if (statusBar != NULL)
     {
-        SendMessage(statusBar, SB_SETBKCOLOR, 0,
-                    DarkModeShouldUseDarkColors() ? DarkModeGetColors().background : CLR_DEFAULT);
+        DarkModeApplyTree(statusBar);
         InvalidateRect(statusBar, NULL, TRUE);
     }
 
@@ -1602,6 +1601,7 @@ void CFindDialog::SetTwoStatusParts(BOOL two, BOOL force)
                                           progressWidth, r.bottom - 2,
                                           HStatusBar, (HMENU)0, HInstance, NULL);
             SendMessage(HProgressBar, PBM_SETRANGE, 0, MAKELPARAM(0, 100));
+            DarkModeApplyTree(HProgressBar);
         }
     }
     else
@@ -3064,6 +3064,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
         }
 
+        DarkModeApplyTree(HStatusBar);
         SetTwoStatusParts(FALSE, TRUE);
         SendMessage(HStatusBar, SB_SETTEXT, 1 | SBT_NOBORDERS, (LPARAM)LoadStr(IDS_FIND_INIT_HINT));
 


### PR DESCRIPTION
### Motivation
- Ensure the Find dialog status bar (and its progress bar) uses the same win32-darkmodelib approach as other dialogs (PictView) so the title bar and status chrome are correctly themed in Windows Dark Mode.

### Description
- Replace manual `SB_SETBKCOLOR` status-bar tinting with `DarkModeApplyTree(statusBar)` in `UpdateFindDarkChrome` so the darkmodelib subclass/theme is used.
- Apply `DarkModeApplyTree` immediately after creating the Find dialog `HStatusBar` so the freshly created control gets darkmodelib theming right away.
- Apply `DarkModeApplyTree` to the progress bar (`HProgressBar`) when it is created so dynamically created child controls also receive the darkmodelib subclass/theme.

### Testing
- Ran `git diff --check` which produced no issues (success).
- Attempted to detect build tooling with `which msbuild || which xbuild` but no Windows build tools were available in this environment (build not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a4a2891308329ae115732bc8269c2)