### PR TITLE
Add “Open Hyper-V Manager” to Hyper-V Machines context menus and bump version to 1.05

### DIFF
--- a/src/plugins/hypervm/fs.cpp
+++ b/src/plugins/hypervm/fs.cpp
@@ -133,6 +133,26 @@ static bool LaunchVmConnect(const char* vmName, HWND parent)
     return RunDetachedProcessAndWaitForInputIdle(cmdLine, parent, 10000);
 }
 
+static bool LaunchHyperVManager(HWND parent)
+{
+    char mmcPath[MAX_PATH] = {0};
+    char consolePath[MAX_PATH] = {0};
+    DWORD mmcLength = ExpandEnvironmentStringsA("%windir%\\System32\\mmc.exe", mmcPath, _countof(mmcPath));
+    DWORD consoleLength = ExpandEnvironmentStringsA("%windir%\\System32\\virtmgmt.msc", consolePath, _countof(consolePath));
+    if (mmcLength == 0 || mmcLength > _countof(mmcPath) ||
+        consoleLength == 0 || consoleLength > _countof(consolePath))
+    {
+        return false;
+    }
+
+    std::string cmdLine = "\"";
+    cmdLine += mmcPath;
+    cmdLine += "\" \"";
+    cmdLine += consolePath;
+    cmdLine += "\"";
+    return RunDetachedProcessAndWaitForInputIdle(cmdLine, parent, 10000);
+}
+
 
 struct CHyperVItemData
 {
@@ -477,15 +497,25 @@ public:
 
         if (type == fscmPanel || type == fscmPathInPanel)
         {
-            AppendMenuA(menu, MF_STRING, 2005, "Create New Machine");
-            SetMenuItemIcon(menu, 2005, IDI_MENU_NEW_VM);
+            const UINT ID_CREATE_ONLY = 2005;
+            const UINT ID_MANAGER_ONLY = 2006;
+
+            AppendMenuA(menu, MF_STRING, ID_CREATE_ONLY, "Create New Machine");
+            SetMenuItemIcon(menu, ID_CREATE_ONLY, IDI_MENU_NEW_VM);
+            AppendMenuA(menu, MF_STRING, ID_MANAGER_ONLY, "Open Hyper-V Manager");
+            SetMenuItemIcon(menu, ID_MANAGER_ONLY, IDI_PLUGIN_MAIN);
             UINT cmdIdOnly = TrackPopupMenu(menu, TPM_RETURNCMD | TPM_RIGHTBUTTON, menuX, menuY, 0, parent, NULL);
             DestroyMenu(menu);
-            if (cmdIdOnly == 2005)
+            if (cmdIdOnly == ID_CREATE_ONLY)
             {
                 if (!LaunchVmCreate(parent))
                     SalamanderGeneral->SalMessageBox(parent, "Unable to start VMCreate.exe.", "Hyper-V Machines", MB_OK | MB_ICONERROR);
                 SalamanderGeneral->PostRefreshPanelFS(this);
+            }
+            else if (cmdIdOnly == ID_MANAGER_ONLY)
+            {
+                if (!LaunchHyperVManager(parent))
+                    SalamanderGeneral->SalMessageBox(parent, "Unable to open Hyper-V Manager.", "Hyper-V Machines", MB_OK | MB_ICONERROR);
             }
             return;
         }
@@ -518,6 +548,7 @@ public:
         const UINT ID_TURNOFF = 2003;
         const UINT ID_SHUTDOWN = 2004;
         const UINT ID_CREATE = 2005;
+        const UINT ID_MANAGER = 2006;
 
         AppendMenuA(menu, MF_STRING, ID_CONNECT, "Connect");
         SetMenuItemIcon(menu, ID_CONNECT, IDI_MENU_CONNECT);
@@ -535,6 +566,8 @@ public:
         AppendMenuA(menu, MF_SEPARATOR, 0, NULL);
         AppendMenuA(menu, MF_STRING, ID_CREATE, "Create New Machine");
         SetMenuItemIcon(menu, ID_CREATE, IDI_MENU_NEW_VM);
+        AppendMenuA(menu, MF_STRING, ID_MANAGER, "Open Hyper-V Manager");
+        SetMenuItemIcon(menu, ID_MANAGER, IDI_PLUGIN_MAIN);
 
         UINT cmdId = TrackPopupMenu(menu, TPM_RETURNCMD | TPM_RIGHTBUTTON, menuX, menuY, 0, parent, NULL);
         DestroyMenu(menu);
@@ -562,13 +595,18 @@ public:
         {
             success = LaunchVmCreate(parent);
         }
+        else if (cmdId == ID_MANAGER)
+        {
+            success = LaunchHyperVManager(parent);
+        }
 
         if (!success)
         {
             SalamanderGeneral->SalMessageBox(parent, "Hyper-V command failed.", "Hyper-V Machines", MB_OK | MB_ICONERROR);
         }
 
-        SalamanderGeneral->PostRefreshPanelFS(this);
+        if (cmdId != ID_MANAGER)
+            SalamanderGeneral->PostRefreshPanelFS(this);
     }
     virtual BOOL WINAPI HandleMenuMsg(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT* plResult) { (void)uMsg; (void)wParam; (void)lParam; (void)plResult; return FALSE; }
     virtual BOOL WINAPI OpenFindDialog(const char* fsName, int panel) { (void)fsName; (void)panel; return FALSE; }

--- a/src/plugins/hypervm/versinfo.rh2
+++ b/src/plugins/hypervm/versinfo.rh2
@@ -19,7 +19,7 @@
 
 #define VERSINFO_MAJOR       1
 #define VERSINFO_MINORA      0
-#define VERSINFO_MINORB      4
+#define VERSINFO_MINORB      5
 
 #include "spl_vers.h" // vytahneme cisla verzi + buildu
 

--- a/translations/chinesesimplified/hypervm.slt
+++ b/translations/chinesesimplified/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\chinesesimplified\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,2052

--- a/translations/czech/hypervm.slt
+++ b/translations/czech/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\czech\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,1029

--- a/translations/dutch/hypervm.slt
+++ b/translations/dutch/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\dutch\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,1043

--- a/translations/french/hypervm.slt
+++ b/translations/french/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\french\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,1036

--- a/translations/german/hypervm.slt
+++ b/translations/german/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\german\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,1031

--- a/translations/hungarian/hypervm.slt
+++ b/translations/hungarian/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\hungarian\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,1038

--- a/translations/romanian/hypervm.slt
+++ b/translations/romanian/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\romanian\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,1048

--- a/translations/russian/hypervm.slt
+++ b/translations/russian/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\russian\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,1049

--- a/translations/slovak/hypervm.slt
+++ b/translations/slovak/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\slovak\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,1051

--- a/translations/spanish/hypervm.slt
+++ b/translations/spanish/hypervm.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\spanish\hypervm\hypervm.atp"
-TEXTVERSION,"1.04 (x64)"
-VERSION,"1,0,4,183"
+TEXTVERSION,"1.05 (x64)"
+VERSION,"1,0,5,183"
 
 [TRANSLATION]
 LANGID,3082


### PR DESCRIPTION
### Motivation
- Provide quick access to the full Hyper-V Manager from the plugin context menus so users can open the management console directly. 
- Bump plugin metadata so the new change is reflected in the plugin version information.

### Description
- Added a new helper `LaunchHyperVManager` in `src/plugins/hypervm/fs.cpp` which expands `%windir%` and runs `mmc.exe` with `virtmgmt.msc` (effectively: `%windir%\System32\mmc.exe "%windir%\System32\virtmgmt.msc"`).
- Inserted a new menu item `Open Hyper-V Manager` (uses plugin icon `IDI_PLUGIN_MAIN`) immediately under `Create New Machine` in both the empty-panel/context menu branch and the per-item context menu branch in `ContextMenu` in `fs.cpp`, and wired it to call `LaunchHyperVManager`.
- Added new menu command IDs (`2006`) and updated handling so opening the manager does not trigger an unnecessary panel refresh.
- Bumped plugin packed version by incrementing `VERSINFO_MINORB` to `5` in `src/plugins/hypervm/versinfo.rh2` (effective plugin version `1.05`).
- Updated translation export headers `translations/*/hypervm.slt` to `TEXTVERSION "1.05 (x64)"` and `VERSION "1,0,5,183"` to match the new plugin version.

### Testing
- Ran `git diff --check` to ensure no whitespace or index issues and it reported no problems (success).
- Searched the tree with `rg` for `Open Hyper-V Manager`, `LaunchHyperVManager`, `VERSINFO_MINORB`, and `TEXTVERSION,"1.05` to validate changes were applied across `fs.cpp`, `versinfo.rh2` and `translations/*/hypervm.slt` (found expected occurrences; success).
- Verified `git status` / `git diff --stat` to confirm the intended files were modified and staged before commit (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40812518948329b38e1c712e102320)