### PR TITLE
Enable dark mode for Registry and Services plugin dialogs

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -3114,7 +3114,7 @@ HBRUSH DarkModeGetPanelFrameBrush()
 {
     static HBRUSH brush = NULL;
     if (brush == NULL)
-        brush = HANDLES(CreateSolidBrush(RGB(0x38, 0x38, 0x38)));
+        brush = CreateSolidBrush(RGB(0x38, 0x38, 0x38));
     return brush;
 }
 

--- a/src/dialogs6.cpp
+++ b/src/dialogs6.cpp
@@ -1361,6 +1361,15 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         InitColumns();
         Refresh();
 
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeUpdateListViewColors(HListView);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            WinLib_DarkMode_PostDeferredRedraw(HWindow);
+        }
+
         if (ListView_GetItemCount(HListView) == 0)
         {
             SendMessage(HWindow, WM_COMMAND, IDCANCEL, 0);

--- a/src/dialogs6.cpp
+++ b/src/dialogs6.cpp
@@ -751,32 +751,6 @@ CSharesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CDisconnectDialog
 //
 
-static const UINT WM_DISCONNECT_DARKMODE_REAPPLY = WM_APP + 0x3D1;
-
-static void ApplyDisconnectDialogDarkMode(HWND hWindow, HWND hListView)
-{
-    if (!WinLib_DarkMode_ShouldApplyDialogTree(hWindow))
-        return;
-
-    DarkModeApplyWindow(hWindow);
-    DarkModeApplyTree(hWindow);
-    DarkModeRefreshTitleBar(hWindow);
-    DarkModeApplyStaticTextColors(hWindow, NULL);
-
-    if (hListView != NULL)
-    {
-        DarkModeApplyWindow(hListView);
-        DarkModeUpdateListViewColors(hListView);
-        HWND hHeader = ListView_GetHeader(hListView);
-        if (hHeader != NULL)
-            DarkModeApplyWindow(hHeader);
-    }
-
-    DarkModeApplyWindow(GetDlgItem(hWindow, IDOK));
-    DarkModeApplyWindow(GetDlgItem(hWindow, IDCANCEL));
-    DarkModeApplyWindow(GetDlgItem(hWindow, IDHELP));
-}
-
 CDisconnectDialog::CDisconnectDialog(CFilesWindow* panel)
     : CCommonDialog(HLanguage, IDD_DISCONNECT, IDD_DISCONNECT, panel->HWindow), Connections(10, 5)
 {
@@ -1387,9 +1361,6 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         InitColumns();
         Refresh();
 
-        ApplyDisconnectDialogDarkMode(HWindow, HListView);
-        PostMessage(HWindow, WM_DISCONNECT_DARKMODE_REAPPLY, 0, 0);
-
         if (ListView_GetItemCount(HListView) == 0)
         {
             SendMessage(HWindow, WM_COMMAND, IDCANCEL, 0);
@@ -1397,13 +1368,6 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
         break;
-    }
-
-    case WM_DISCONNECT_DARKMODE_REAPPLY:
-    {
-        ApplyDisconnectDialogDarkMode(HWindow, HListView);
-        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_FRAME);
-        return TRUE;
     }
 
     case WM_NOTIFY:
@@ -1446,35 +1410,6 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
-    case WM_THEMECHANGED:
-    {
-        ApplyDisconnectDialogDarkMode(HWindow, HListView);
-        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_FRAME);
-        return TRUE;
-    }
-
-    case WM_SYSCOLORCHANGE:
-    {
-        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
-            DarkModeUpdateListViewColors(HListView);
-        else
-            ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
-        break;
-    }
-
-    case WM_CTLCOLORDLG:
-    case WM_CTLCOLORSTATIC:
-    case WM_CTLCOLORBTN:
-    case WM_CTLCOLOREDIT:
-    case WM_CTLCOLORLISTBOX:
-    case WM_CTLCOLORMSGBOX:
-    case WM_CTLCOLORSCROLLBAR:
-    {
-        LRESULT brush = 0;
-        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
-            return brush;
-        break;
-    }
     }
     return CCommonDialog::DialogProc(uMsg, wParam, lParam);
 }

--- a/src/dialogs6.cpp
+++ b/src/dialogs6.cpp
@@ -751,6 +751,32 @@ CSharesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CDisconnectDialog
 //
 
+static const UINT WM_DISCONNECT_DARKMODE_REAPPLY = WM_APP + 0x3D1;
+
+static void ApplyDisconnectDialogDarkMode(HWND hWindow, HWND hListView)
+{
+    if (!WinLib_DarkMode_ShouldApplyDialogTree(hWindow))
+        return;
+
+    DarkModeApplyWindow(hWindow);
+    DarkModeApplyTree(hWindow);
+    DarkModeRefreshTitleBar(hWindow);
+    DarkModeApplyStaticTextColors(hWindow, NULL);
+
+    if (hListView != NULL)
+    {
+        DarkModeApplyWindow(hListView);
+        DarkModeUpdateListViewColors(hListView);
+        HWND hHeader = ListView_GetHeader(hListView);
+        if (hHeader != NULL)
+            DarkModeApplyWindow(hHeader);
+    }
+
+    DarkModeApplyWindow(GetDlgItem(hWindow, IDOK));
+    DarkModeApplyWindow(GetDlgItem(hWindow, IDCANCEL));
+    DarkModeApplyWindow(GetDlgItem(hWindow, IDHELP));
+}
+
 CDisconnectDialog::CDisconnectDialog(CFilesWindow* panel)
     : CCommonDialog(HLanguage, IDD_DISCONNECT, IDD_DISCONNECT, panel->HWindow), Connections(10, 5)
 {
@@ -1361,14 +1387,8 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         InitColumns();
         Refresh();
 
-        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
-        {
-            DarkModeApplyTree(HWindow);
-            DarkModeRefreshTitleBar(HWindow);
-            DarkModeUpdateListViewColors(HListView);
-            DarkModeApplyStaticTextColors(HWindow, NULL);
-            WinLib_DarkMode_PostDeferredRedraw(HWindow);
-        }
+        ApplyDisconnectDialogDarkMode(HWindow, HListView);
+        PostMessage(HWindow, WM_DISCONNECT_DARKMODE_REAPPLY, 0, 0);
 
         if (ListView_GetItemCount(HListView) == 0)
         {
@@ -1377,6 +1397,13 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
         break;
+    }
+
+    case WM_DISCONNECT_DARKMODE_REAPPLY:
+    {
+        ApplyDisconnectDialogDarkMode(HWindow, HListView);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_FRAME);
+        return TRUE;
     }
 
     case WM_NOTIFY:
@@ -1421,16 +1448,9 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_THEMECHANGED:
     {
-        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
-        {
-            DarkModeApplyTree(HWindow);
-            DarkModeRefreshTitleBar(HWindow);
-            DarkModeUpdateListViewColors(HListView);
-            DarkModeApplyStaticTextColors(HWindow, NULL);
-            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
-            return TRUE;
-        }
-        break;
+        ApplyDisconnectDialogDarkMode(HWindow, HListView);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_FRAME);
+        return TRUE;
     }
 
     case WM_SYSCOLORCHANGE:
@@ -1439,6 +1459,20 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             DarkModeUpdateListViewColors(HListView);
         else
             ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        LRESULT brush = 0;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
         break;
     }
     }

--- a/src/dialogs6.cpp
+++ b/src/dialogs6.cpp
@@ -611,6 +611,14 @@ CSharesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         InitColumns();
         Refresh();
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeUpdateListViewColors(HListView);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            WinLib_DarkMode_PostDeferredRedraw(HWindow);
+        }
         break;
     }
 
@@ -712,9 +720,26 @@ CSharesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
+    case WM_THEMECHANGED:
+    {
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeUpdateListViewColors(HListView);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return TRUE;
+        }
+        break;
+    }
+
     case WM_SYSCOLORCHANGE:
     {
-        ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+            DarkModeUpdateListViewColors(HListView);
+        else
+            ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
         break;
     }
     }
@@ -1385,9 +1410,26 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
+    case WM_THEMECHANGED:
+    {
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeUpdateListViewColors(HListView);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return TRUE;
+        }
+        break;
+    }
+
     case WM_SYSCOLORCHANGE:
     {
-        ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+            DarkModeUpdateListViewColors(HListView);
+        else
+            ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
         break;
     }
     }
@@ -2605,9 +2647,26 @@ CCfgPageIconOvrls::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
+    case WM_THEMECHANGED:
+    {
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeUpdateListViewColors(HListView);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return TRUE;
+        }
+        break;
+    }
+
     case WM_SYSCOLORCHANGE:
     {
-        ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+            DarkModeUpdateListViewColors(HListView);
+        else
+            ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
         break;
     }
 

--- a/src/editwnd.cpp
+++ b/src/editwnd.cpp
@@ -1888,13 +1888,6 @@ BOOL CEditWindow::Create(HWND hParent, int childID)
     SendMessage(HWindow, CB_LIMITTEXT, GetCmdLineLimit(), 0);
     FillHistory();
     EnableWindow(HWindow, Enabled);
-    if (DarkModeShouldUseDarkColors())
-    {
-        DarkModeApplyWindow(HWindow);
-        DarkModeApplyTree(HWindow);
-        if (EditLine != NULL && EditLine->HWindow != NULL)
-            DarkModeApplyWindow(EditLine->HWindow);
-    }
     return hWnd != NULL;
 }
 
@@ -2019,20 +2012,6 @@ CEditWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_LBUTTONUP:
     {
         Tracking = FALSE;
-        break;
-    }
-
-    case WM_THEMECHANGED:
-    case WM_SETTINGCHANGE:
-    {
-        if (DarkModeShouldUseDarkColors())
-        {
-            DarkModeApplyWindow(HWindow);
-            DarkModeApplyTree(HWindow);
-            if (EditLine != NULL && EditLine->HWindow != NULL)
-                DarkModeApplyWindow(EditLine->HWindow);
-            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
-        }
         break;
     }
 

--- a/src/editwnd.cpp
+++ b/src/editwnd.cpp
@@ -2022,6 +2022,20 @@ CEditWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+    {
+        if (DarkModeShouldUseDarkColors())
+        {
+            DarkModeApplyWindow(HWindow);
+            DarkModeApplyTree(HWindow);
+            if (EditLine != NULL && EditLine->HWindow != NULL)
+                DarkModeApplyWindow(EditLine->HWindow);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        }
+        break;
+    }
+
     case WM_CTLCOLOREDIT:
     case WM_CTLCOLORLISTBOX:
     case WM_CTLCOLORSTATIC:

--- a/src/editwnd.cpp
+++ b/src/editwnd.cpp
@@ -1888,6 +1888,13 @@ BOOL CEditWindow::Create(HWND hParent, int childID)
     SendMessage(HWindow, CB_LIMITTEXT, GetCmdLineLimit(), 0);
     FillHistory();
     EnableWindow(HWindow, Enabled);
+    if (DarkModeShouldUseDarkColors())
+    {
+        DarkModeApplyWindow(HWindow);
+        DarkModeApplyTree(HWindow);
+        if (EditLine != NULL && EditLine->HWindow != NULL)
+            DarkModeApplyWindow(EditLine->HWindow);
+    }
     return hWnd != NULL;
 }
 

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -39,6 +39,7 @@ static const char* TREEVIEW_SPLIT_OWNER = "SAL_TREEVIEW_SPLIT_OWNER";
 static const UINT_PTR TREEVIEW_HEADER_SUBCLASS_ID = 1;
 
 static HHOOK HDisconnectDarkModeHook = NULL;
+static HHOOK HDisconnectDarkModeCallWndHook = NULL;
 
 static void ApplyDarkModeToCreatedDisconnectDialog(HWND hWindow)
 {
@@ -65,6 +66,24 @@ static LRESULT CALLBACK DisconnectDarkModeHookProc(int code, WPARAM wParam, LPAR
         ApplyDarkModeToCreatedDisconnectDialog((HWND)wParam);
 
     return CallNextHookEx(HDisconnectDarkModeHook, code, wParam, lParam);
+}
+
+static LRESULT CALLBACK DisconnectDarkModeCallWndHookProc(int code, WPARAM wParam, LPARAM lParam)
+{
+    if (code >= 0)
+    {
+        CWPSTRUCT* message = (CWPSTRUCT*)lParam;
+        if (message != NULL &&
+            (message->message == WM_INITDIALOG ||
+             message->message == WM_SHOWWINDOW ||
+             message->message == WM_WINDOWPOSCHANGED ||
+             message->message == WM_NCACTIVATE))
+        {
+            ApplyDarkModeToCreatedDisconnectDialog(message->hwnd);
+        }
+    }
+
+    return CallNextHookEx(HDisconnectDarkModeCallWndHook, code, wParam, lParam);
 }
 
 static void DrawTreeViewHeaderIcon(HDC hdc, int left, int top, int size, COLORREF color)
@@ -1532,10 +1551,19 @@ void CFilesWindow::DisconnectNet()
     //  WNetDisconnectDialog(HWindow, RESOURCETYPE_DISK);
 
     if (DarkModeShouldUseDarkColors())
+    {
         HDisconnectDarkModeHook = SetWindowsHookEx(WH_CBT, DisconnectDarkModeHookProc, NULL, GetCurrentThreadId()); // HANDLES can't do this
+        HDisconnectDarkModeCallWndHook = SetWindowsHookEx(WH_CALLWNDPROC, DisconnectDarkModeCallWndHookProc, NULL, GetCurrentThreadId()); // HANDLES can't do this
+    }
 
     CDisconnectDialog dlg(this);
     INT_PTR disconnectResult = dlg.Execute();
+
+    if (HDisconnectDarkModeCallWndHook != NULL)
+    {
+        UnhookWindowsHookEx(HDisconnectDarkModeCallWndHook); // HANDLES can't do this
+        HDisconnectDarkModeCallWndHook = NULL;
+    }
 
     if (HDisconnectDarkModeHook != NULL)
     {

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -38,6 +38,35 @@ static const char* TREEVIEW_SPLIT_SUBCLASSPROC = "SAL_TREEVIEW_SPLIT_SUBCLASSPRO
 static const char* TREEVIEW_SPLIT_OWNER = "SAL_TREEVIEW_SPLIT_OWNER";
 static const UINT_PTR TREEVIEW_HEADER_SUBCLASS_ID = 1;
 
+static HHOOK HDisconnectDarkModeHook = NULL;
+
+static void ApplyDarkModeToCreatedDisconnectDialog(HWND hWindow)
+{
+    if (hWindow == NULL || !DarkModeShouldUseDarkColors())
+        return;
+
+    WCHAR className[32];
+    if (GetClassNameW(hWindow, className, _countof(className)) == 0 ||
+        lstrcmpiW(className, L"#32770") != 0)
+    {
+        return;
+    }
+
+    DarkModeApplyWindow(hWindow);
+    DarkModeApplyTree(hWindow);
+    DarkModeRefreshTitleBar(hWindow);
+    DarkModeApplyStaticTextColors(hWindow, NULL);
+    RedrawWindow(hWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_FRAME);
+}
+
+static LRESULT CALLBACK DisconnectDarkModeHookProc(int code, WPARAM wParam, LPARAM lParam)
+{
+    if (code == HCBT_CREATEWND || code == HCBT_ACTIVATE)
+        ApplyDarkModeToCreatedDisconnectDialog((HWND)wParam);
+
+    return CallNextHookEx(HDisconnectDarkModeHook, code, wParam, lParam);
+}
+
 static void DrawTreeViewHeaderIcon(HDC hdc, int left, int top, int size, COLORREF color)
 {
     if (size < 8)
@@ -1502,8 +1531,19 @@ void CFilesWindow::DisconnectNet()
     //  because MainWindow was NULL;
     //  WNetDisconnectDialog(HWindow, RESOURCETYPE_DISK);
 
+    if (DarkModeShouldUseDarkColors())
+        HDisconnectDarkModeHook = SetWindowsHookEx(WH_CBT, DisconnectDarkModeHookProc, NULL, GetCurrentThreadId()); // HANDLES can't do this
+
     CDisconnectDialog dlg(this);
-    if (dlg.Execute() == IDCANCEL && dlg.NoConnection())
+    INT_PTR disconnectResult = dlg.Execute();
+
+    if (HDisconnectDarkModeHook != NULL)
+    {
+        UnhookWindowsHookEx(HDisconnectDarkModeHook); // HANDLES can't do this
+        HDisconnectDarkModeHook = NULL;
+    }
+
+    if (disconnectResult == IDCANCEL && dlg.NoConnection())
     {
         // dialog didn't appear because it contained zero resources -- show info
         SalMessageBox(HWindow, LoadStr(IDS_DISCONNECT_NODRIVES),

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -38,54 +38,6 @@ static const char* TREEVIEW_SPLIT_SUBCLASSPROC = "SAL_TREEVIEW_SPLIT_SUBCLASSPRO
 static const char* TREEVIEW_SPLIT_OWNER = "SAL_TREEVIEW_SPLIT_OWNER";
 static const UINT_PTR TREEVIEW_HEADER_SUBCLASS_ID = 1;
 
-static HHOOK HDisconnectDarkModeHook = NULL;
-static HHOOK HDisconnectDarkModeCallWndHook = NULL;
-
-static void ApplyDarkModeToCreatedDisconnectDialog(HWND hWindow)
-{
-    if (hWindow == NULL || !DarkModeShouldUseDarkColors())
-        return;
-
-    WCHAR className[32];
-    if (GetClassNameW(hWindow, className, _countof(className)) == 0 ||
-        lstrcmpiW(className, L"#32770") != 0)
-    {
-        return;
-    }
-
-    DarkModeApplyWindow(hWindow);
-    DarkModeApplyTree(hWindow);
-    DarkModeRefreshTitleBar(hWindow);
-    DarkModeApplyStaticTextColors(hWindow, NULL);
-    RedrawWindow(hWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_FRAME);
-}
-
-static LRESULT CALLBACK DisconnectDarkModeHookProc(int code, WPARAM wParam, LPARAM lParam)
-{
-    if (code == HCBT_CREATEWND || code == HCBT_ACTIVATE)
-        ApplyDarkModeToCreatedDisconnectDialog((HWND)wParam);
-
-    return CallNextHookEx(HDisconnectDarkModeHook, code, wParam, lParam);
-}
-
-static LRESULT CALLBACK DisconnectDarkModeCallWndHookProc(int code, WPARAM wParam, LPARAM lParam)
-{
-    if (code >= 0)
-    {
-        CWPSTRUCT* message = (CWPSTRUCT*)lParam;
-        if (message != NULL &&
-            (message->message == WM_INITDIALOG ||
-             message->message == WM_SHOWWINDOW ||
-             message->message == WM_WINDOWPOSCHANGED ||
-             message->message == WM_NCACTIVATE))
-        {
-            ApplyDarkModeToCreatedDisconnectDialog(message->hwnd);
-        }
-    }
-
-    return CallNextHookEx(HDisconnectDarkModeCallWndHook, code, wParam, lParam);
-}
-
 static void DrawTreeViewHeaderIcon(HDC hdc, int left, int top, int size, COLORREF color)
 {
     if (size < 8)
@@ -1550,28 +1502,8 @@ void CFilesWindow::DisconnectNet()
     //  because MainWindow was NULL;
     //  WNetDisconnectDialog(HWindow, RESOURCETYPE_DISK);
 
-    if (DarkModeShouldUseDarkColors())
-    {
-        HDisconnectDarkModeHook = SetWindowsHookEx(WH_CBT, DisconnectDarkModeHookProc, NULL, GetCurrentThreadId()); // HANDLES can't do this
-        HDisconnectDarkModeCallWndHook = SetWindowsHookEx(WH_CALLWNDPROC, DisconnectDarkModeCallWndHookProc, NULL, GetCurrentThreadId()); // HANDLES can't do this
-    }
-
     CDisconnectDialog dlg(this);
-    INT_PTR disconnectResult = dlg.Execute();
-
-    if (HDisconnectDarkModeCallWndHook != NULL)
-    {
-        UnhookWindowsHookEx(HDisconnectDarkModeCallWndHook); // HANDLES can't do this
-        HDisconnectDarkModeCallWndHook = NULL;
-    }
-
-    if (HDisconnectDarkModeHook != NULL)
-    {
-        UnhookWindowsHookEx(HDisconnectDarkModeHook); // HANDLES can't do this
-        HDisconnectDarkModeHook = NULL;
-    }
-
-    if (disconnectResult == IDCANCEL && dlg.NoConnection())
+    if (dlg.Execute() == IDCANCEL && dlg.NoConnection())
     {
         // dialog didn't appear because it contained zero resources -- show info
         SalMessageBox(HWindow, LoadStr(IDS_DISCONNECT_NODRIVES),

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1658,8 +1658,17 @@ CColorGraph::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             CBitmap bitmap;
             bitmap.CreateBmp(hdc, ClientRect.right, ClientRect.bottom);
 
-            HBRUSH hBrush = (HBRUSH)(COLOR_BTNFACE + 1);
-            FillRect(bitmap.HMemDC, &ClientRect, hBrush);
+            if (DarkModeShouldUseDarkColors())
+            {
+                HBRUSH hBrush = HANDLES(CreateSolidBrush(DarkModeGetDialogBackgroundColor()));
+                FillRect(bitmap.HMemDC, &ClientRect, hBrush);
+                HANDLES(DeleteObject(hBrush));
+            }
+            else
+            {
+                HBRUSH hBrush = (HBRUSH)(COLOR_BTNFACE + 1);
+                FillRect(bitmap.HMemDC, &ClientRect, hBrush);
+            }
 
             PaintFace(bitmap.HMemDC);
 

--- a/src/plugins/automation/entry.cpp
+++ b/src/plugins/automation/entry.cpp
@@ -83,6 +83,7 @@ CPluginInterfaceAbstract*
     CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
 
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
     SalamanderGUI = salamander->GetSalamanderGUI();
 
     // requires latest version of Salamander

--- a/src/plugins/automation/precomp.h
+++ b/src/plugins/automation/precomp.h
@@ -109,3 +109,5 @@ ICanHandleException : public IUnknown
 
 extern CSalamanderGeneralAbstract* SalamanderGeneral;
 extern CSalamanderGUIAbstract* SalamanderGUI;
+
+#include "mhandles.h"

--- a/src/plugins/automation/vcxproj/automation.props
+++ b/src/plugins/automation/vcxproj/automation.props
@@ -9,8 +9,8 @@
       <TypeLibraryName>..\generated\$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;..\generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comsuppwd.lib;shlwapi.lib;comctl32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/plugins/automation/vcxproj/automation.vcxproj
+++ b/src/plugins/automation/vcxproj/automation.vcxproj
@@ -122,6 +122,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/dbviewer/dbviewer.cpp
+++ b/src/plugins/dbviewer/dbviewer.cpp
@@ -349,6 +349,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the generic Salamander interface
     SalGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalGeneral);
 
     // set the help file name
     SalGeneral->SetHelpFileName("dbviewer.chm");

--- a/src/plugins/dbviewer/precomp.h
+++ b/src/plugins/dbviewer/precomp.h
@@ -33,7 +33,10 @@
 #include "spl_vers.h"
 #include "spl_gui.h"
 #include "dbg.h"
+#include "mhandles.h"
 #include "arraylt.h"
 #include "winliblt.h"
 
 #include "const.h"
+
+#include "../../darkmode.h"

--- a/src/plugins/dbviewer/vcxproj/dbviewer.props
+++ b/src/plugins/dbviewer/vcxproj/dbviewer.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/dbviewer/vcxproj/dbviewer.vcxproj
+++ b/src/plugins/dbviewer/vcxproj/dbviewer.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/demoplug/demoplug.cpp
+++ b/src/plugins/demoplug/demoplug.cpp
@@ -399,6 +399,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the general Salamander interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
     SalamanderGeneral->GetLowerAndUpperCase(&LowerCase, &UpperCase);
     // obtain the interface providing customized Windows controls used in Salamander
     SalamanderGUI = salamander->GetSalamanderGUI();

--- a/src/plugins/demoplug/vcxproj/demoplug.props
+++ b/src/plugins/demoplug/vcxproj/demoplug.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>MSImg32.Lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/plugins/demoplug/vcxproj/demoplug.vcxproj
+++ b/src/plugins/demoplug/vcxproj/demoplug.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/demoview/demoview.cpp
+++ b/src/plugins/demoview/demoview.cpp
@@ -154,6 +154,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the general Salamander interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
     // obtain the interface providing customized Windows controls used in Salamander
     SalamanderGUI = salamander->GetSalamanderGUI();
 

--- a/src/plugins/demoview/vcxproj/demoview.props
+++ b/src/plugins/demoview/vcxproj/demoview.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/demoview/vcxproj/demoview.vcxproj
+++ b/src/plugins/demoview/vcxproj/demoview.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/folders/folders.cpp
+++ b/src/plugins/folders/folders.cpp
@@ -87,6 +87,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the general Salamander interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
 
     // obtain the interface providing customized Windows controls used in Salamander
     SalamanderGUI = salamander->GetSalamanderGUI();

--- a/src/plugins/folders/vcxproj/folders.props
+++ b/src/plugins/folders/vcxproj/folders.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/plugins/folders/vcxproj/folders.vcxproj
+++ b/src/plugins/folders/vcxproj/folders.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/ftp/dialogs1.cpp
+++ b/src/plugins/ftp/dialogs1.cpp
@@ -706,6 +706,20 @@ protected:
     {
         switch (uMsg)
         {
+        case WM_CREATE:
+        case WM_INITDIALOG:
+        {
+            ApplyFTPDarkMode(HWindow);
+            break;
+        }
+
+        case WM_THEMECHANGED:
+        {
+            ApplyFTPDarkMode(HWindow);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return 0;
+        }
+
         case WM_WINDOWPOSCHANGING:
         {
             WINDOWPOS* pos = (WINDOWPOS*)lParam;
@@ -760,6 +774,7 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
                 delete wnd; // window is not attached, destroy it right here
             else
             {
+                ApplyFTPDarkMode(wnd->HWindow);
                 PostMessage(wnd->HWindow, WM_APP + 1000, 0, 0); // to detach CCenteredPropertyWindow from the dialog
             }
         }

--- a/src/plugins/hypervm/managed/EntryPoint.cs
+++ b/src/plugins/hypervm/managed/EntryPoint.cs
@@ -114,14 +114,18 @@ public static class EntryPoint
     {
         const string description = "Show local Hyper-V virtual machines in panel.";
         const string copyright = "Copyleft 2026 Ondrej Kotas, KRtkovo.eu";
-        MessageBox.Show(new WindowHandleWrapper(parent),
+        ThemeHelper.ShowMessageBox(new WindowHandleWrapper(parent),
             description + Environment.NewLine + copyright,
             "About",
             MessageBoxButtons.OK,
             MessageBoxIcon.Information);
         return 0;
     }
-    private static int ShowConfiguration(IntPtr parent) { MessageBox.Show(new WindowHandleWrapper(parent), "No configuration yet.", "Configuration", MessageBoxButtons.OK, MessageBoxIcon.Information); return 0; }
+    private static int ShowConfiguration(IntPtr parent)
+    {
+        ThemeHelper.ShowMessageBox(new WindowHandleWrapper(parent), "No configuration yet.", "Configuration", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        return 0;
+    }
 
     private static IntPtr ParseHandle(string value) => ulong.TryParse(value, out var parsed) ? new IntPtr(unchecked((long)parsed)) : IntPtr.Zero;
 

--- a/src/plugins/nethood/entry.cpp
+++ b/src/plugins/nethood/entry.cpp
@@ -138,6 +138,7 @@ SalamanderPluginEntry(
 
     // Initialize global variables.
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
     SalamanderGUI = salamander->GetSalamanderGUI();
 
     // setup help file name

--- a/src/plugins/nethood/vcxproj/nethood.props
+++ b/src/plugins/nethood/vcxproj/nethood.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>MPR.LIB;SHLWAPI.LIB;Netapi32.lib;WtsApi32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/plugins/nethood/vcxproj/nethood.vcxproj
+++ b/src/plugins/nethood/vcxproj/nethood.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/peviewer/peviewer.cpp
+++ b/src/plugins/peviewer/peviewer.cpp
@@ -107,6 +107,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // Obtain Salamander's general interface.
     SalGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalGeneral);
 
     // Set the basic plugin information.
     salamander->SetBasicPluginData(LoadStr(IDS_PLUGIN_NAME),

--- a/src/plugins/peviewer/precomp.h
+++ b/src/plugins/peviewer/precomp.h
@@ -32,4 +32,5 @@
 #include "spl_vers.h"
 
 #include "dbg.h"
+#include "mhandles.h"
 #include "winliblt.h"

--- a/src/plugins/peviewer/vcxproj/peviewer.props
+++ b/src/plugins/peviewer/vcxproj/peviewer.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/peviewer/vcxproj/peviewer.vcxproj
+++ b/src/plugins/peviewer/vcxproj/peviewer.vcxproj
@@ -165,9 +165,6 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
-    <ClCompile Include="..\..\shared\mhandles.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
     <ClCompile Include="..\dump_res.cpp">
     </ClCompile>
     <ClCompile Include="..\pefile.cpp">

--- a/src/plugins/peviewer/vcxproj/peviewer.vcxproj
+++ b/src/plugins/peviewer/vcxproj/peviewer.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\cfg.cpp">
     </ClCompile>
     <ClCompile Include="..\cfgdlg.cpp">

--- a/src/plugins/peviewer/vcxproj/peviewer.vcxproj
+++ b/src/plugins/peviewer/vcxproj/peviewer.vcxproj
@@ -165,6 +165,9 @@
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
+    <ClCompile Include="..\..\shared\mhandles.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\dump_res.cpp">
     </ClCompile>
     <ClCompile Include="..\pefile.cpp">

--- a/src/plugins/regedt/dialogs.cpp
+++ b/src/plugins/regedt/dialogs.cpp
@@ -383,6 +383,40 @@ CDialogEx::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         DialogStackPush(HWindow);
         SG->MultiMonCenterWindow(HWindow, CenterToHWnd, FALSE);
+        ApplyRegEdtDarkMode(HWindow);
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        ApplyRegEdtDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureRegEdtDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyRegEdtDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleRegEdtDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
         break;
     }
 

--- a/src/plugins/regedt/finddlg.cpp
+++ b/src/plugins/regedt/finddlg.cpp
@@ -26,65 +26,13 @@ CStatusBar::CStatusBar()
     Width = 0;
     TextWidth = 0;
     Height = 0;
-    HBitmap = NULL;
+    UpdateInIdle = FALSE;
 }
 
 CStatusBar::~CStatusBar()
 {
     CALL_STACK_MESSAGE_NONE
     //  CALL_STACK_MESSAGE1("CStatusBar::~CStatusBar()");
-    if (HBitmap != NULL)
-        DeleteObject(HBitmap);
-}
-
-void CStatusBar::AllocateBitmap()
-{
-    CALL_STACK_MESSAGE1("CStatusBar::AllocateBitmap()");
-    HDC screenDC = GetDC(HWindow);
-    if (screenDC != NULL)
-    {
-        if (HBitmap != NULL)
-            DeleteObject(HBitmap);
-        HBitmap = (HBITMAP)CreateCompatibleBitmap(screenDC, Width, Height);
-        // pre-draw the frame and sizing grip into the bitmap
-        HDC dc = CreateCompatibleDC(screenDC);
-        if (dc)
-        {
-            HBITMAP oldBmp = (HBITMAP)SelectObject(dc, HBitmap);
-            RECT r;
-            SetRect(&r, 0, 0, Width, Height);
-
-            const bool useDark = DarkModeShouldUseDarkColors();
-            const COLORREF backgroundColor = useDark ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE);
-            HBRUSH backgroundBrush = CreateSolidBrush(backgroundColor);
-            if (backgroundBrush != NULL)
-            {
-                FillRect(dc, &r, backgroundBrush);
-                DeleteObject(backgroundBrush);
-            }
-
-            if (!useDark)
-                DrawEdge(dc, &r, BDR_SUNKENOUTER, BF_RECT);
-
-            r.top++;
-            r.bottom--;
-            r.left = TextWidth;
-            r.right--;
-
-            DrawFrameControl(dc, &r, DFC_SCROLL, DFCS_SCROLLSIZEGRIP);
-            HPEN pen = CreatePen(PS_SOLID, 0, backgroundColor);
-            HPEN oldPen = (HPEN)SelectObject(dc, pen);
-            MoveToEx(dc, r.left + 2, r.bottom, NULL);
-            LineTo(dc, r.right, r.bottom);
-            LineTo(dc, r.right, r.bottom - GetSystemMetrics(SM_CYVSCROLL) + 3);
-            SelectObject(dc, oldPen);
-            DeleteObject(pen);
-
-            SelectObject(dc, oldBmp);
-            DeleteDC(dc);
-        }
-        ReleaseDC(HWindow, screenDC);
-    }
 }
 
 void CStatusBar::SetBase(LPCWSTR text, BOOL updateInIdle)
@@ -102,10 +50,7 @@ void CStatusBar::SetBase(LPCWSTR text, BOOL updateInIdle)
         else
         {
             Dirty = TRUE;
-            RECT r;
-            SetRect(&r, 1, 1, TextWidth, Height - 1);
-            InvalidateRect(HWindow, &r, FALSE);
-            PostMessage(HWindow, WM_PAINT, 0, 0);
+            UpdateText();
         }
     }
     Section.Leave();
@@ -125,13 +70,33 @@ void CStatusBar::Set(LPCWSTR text, BOOL updateInIdle)
         else
         {
             Dirty = TRUE;
-            RECT r;
-            SetRect(&r, 1, 1, TextWidth, Height - 1);
-            InvalidateRect(HWindow, &r, FALSE);
-            PostMessage(HWindow, WM_PAINT, 0, 0);
+            UpdateText();
         }
     }
     Section.Leave();
+}
+
+void CStatusBar::UpdateParts()
+{
+    CALL_STACK_MESSAGE1("CStatusBar::UpdateParts()");
+    if (HWindow == NULL)
+        return;
+
+    RECT r;
+    GetClientRect(HWindow, &r);
+    Width = r.right - r.left;
+    Height = r.bottom - r.top;
+    TextWidth = Width - GetSystemMetrics(SM_CXHSCROLL) + 1;
+    int parts[2] = {TextWidth, -1};
+    SendMessage(HWindow, SB_SETPARTS, 2, (LPARAM)parts);
+}
+
+void CStatusBar::UpdateText()
+{
+    CALL_STACK_MESSAGE1("CStatusBar::UpdateText()");
+    if (HWindow != NULL)
+        SendMessageW(HWindow, SB_SETTEXTW, 0, (LPARAM)Text);
+    Dirty = FALSE;
 }
 
 void CStatusBar::OnEnterIdle()
@@ -147,10 +112,7 @@ void CStatusBar::OnEnterIdle()
         if (!Dirty)
         {
             Dirty = TRUE;
-            RECT r;
-            SetRect(&r, 1, 1, TextWidth, Height - 1);
-            InvalidateRect(HWindow, &r, FALSE);
-            PostMessage(HWindow, WM_PAINT, 0, 0);
+            UpdateText();
         }
     }
     Section.Leave();
@@ -163,13 +125,19 @@ CStatusBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         lParam);
     switch (uMsg)
     {
+    case WM_CREATE:
+    {
+        LRESULT result = CWindow::WindowProc(uMsg, wParam, lParam);
+        UpdateParts();
+        UpdateText();
+        return result;
+    }
+
     case WM_SIZE:
     {
-        Width = LOWORD(lParam);
-        TextWidth = Width - GetSystemMetrics(SM_CXHSCROLL) + 1;
-        Height = HIWORD(lParam);
-        AllocateBitmap();
-        return 0;
+        LRESULT result = CWindow::WindowProc(uMsg, wParam, lParam);
+        UpdateParts();
+        return result;
     }
 
     case WM_NCHITTEST:
@@ -194,47 +162,6 @@ CStatusBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (PtInRect(&r, pt))
             return HTBOTTOMRIGHT;
         break;
-    }
-
-    case WM_ERASEBKGND:
-    {
-        return TRUE;
-    }
-
-    case WM_PAINT:
-    {
-        PAINTSTRUCT ps;
-        BeginPaint(HWindow, &ps);
-        if (HBitmap)
-        {
-            HDC dc = CreateCompatibleDC(ps.hdc);
-            if (dc)
-            {
-                HBITMAP oldBmp = (HBITMAP)SelectObject(dc, HBitmap);
-
-                HFONT oldFont = (HFONT)SelectObject(dc, EnvFont);
-                const bool useDark = DarkModeShouldUseDarkColors();
-                SetTextColor(dc, useDark ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_BTNTEXT));
-                SetBkColor(dc, useDark ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE));
-
-                Section.Enter();
-                RECT r;
-                SetRect(&r, 1, 1, TextWidth, Height - 1);
-                ExtTextOutW(dc, 2, (r.top + r.bottom - EnvFontHeight) / 2, ETO_OPAQUE | ETO_CLIPPED, &r, Text, (UINT)wcslen(Text), NULL);
-                Dirty = FALSE;
-                Section.Leave();
-
-                SelectObject(dc, oldFont);
-
-                BitBlt(ps.hdc, 0, 0, Width, Height, dc, 0, 0, SRCCOPY);
-                SelectObject(dc, oldBmp);
-                DeleteDC(dc);
-            }
-        }
-
-        EndPaint(HWindow, &ps);
-
-        return 0;
     }
     }
     return CWindow::WindowProc(uMsg, wParam, lParam);

--- a/src/plugins/regedt/finddlg.cpp
+++ b/src/plugins/regedt/finddlg.cpp
@@ -54,7 +54,17 @@ void CStatusBar::AllocateBitmap()
             RECT r;
             SetRect(&r, 0, 0, Width, Height);
 
-            DrawEdge(dc, &r, BDR_SUNKENOUTER, BF_RECT);
+            const bool useDark = DarkModeShouldUseDarkColors();
+            const COLORREF backgroundColor = useDark ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE);
+            HBRUSH backgroundBrush = CreateSolidBrush(backgroundColor);
+            if (backgroundBrush != NULL)
+            {
+                FillRect(dc, &r, backgroundBrush);
+                DeleteObject(backgroundBrush);
+            }
+
+            if (!useDark)
+                DrawEdge(dc, &r, BDR_SUNKENOUTER, BF_RECT);
 
             r.top++;
             r.bottom--;
@@ -62,7 +72,7 @@ void CStatusBar::AllocateBitmap()
             r.right--;
 
             DrawFrameControl(dc, &r, DFC_SCROLL, DFCS_SCROLLSIZEGRIP);
-            HPEN pen = CreatePen(PS_SOLID, 0, GetSysColor(COLOR_BTNFACE));
+            HPEN pen = CreatePen(PS_SOLID, 0, backgroundColor);
             HPEN oldPen = (HPEN)SelectObject(dc, pen);
             MoveToEx(dc, r.left + 2, r.bottom, NULL);
             LineTo(dc, r.right, r.bottom);
@@ -203,8 +213,9 @@ CStatusBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 HBITMAP oldBmp = (HBITMAP)SelectObject(dc, HBitmap);
 
                 HFONT oldFont = (HFONT)SelectObject(dc, EnvFont);
-                SetTextColor(dc, GetSysColor(COLOR_BTNTEXT));
-                SetBkColor(dc, GetSysColor(COLOR_BTNFACE));
+                const bool useDark = DarkModeShouldUseDarkColors();
+                SetTextColor(dc, useDark ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_BTNTEXT));
+                SetBkColor(dc, useDark ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_BTNFACE));
 
                 Section.Enter();
                 RECT r;

--- a/src/plugins/regedt/finddlg.h
+++ b/src/plugins/regedt/finddlg.h
@@ -22,12 +22,12 @@ protected:
     int Width;
     int TextWidth;
     int Height;
-    HBITMAP HBitmap;
 
 public:
     CStatusBar();
     virtual ~CStatusBar();
-    void AllocateBitmap();
+    void UpdateParts();
+    void UpdateText();
 
     // set the base to which Set appends additional text
     void SetBase(LPCWSTR text, BOOL updateInIdle = FALSE);

--- a/src/plugins/regedt/finddlg2.cpp
+++ b/src/plugins/regedt/finddlg2.cpp
@@ -730,9 +730,9 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
         }
         StatusBar->CreateEx(0,
-                            CWINDOW_CLASSNAME,
+                            STATUSCLASSNAME,
                             (LPCTSTR)NULL,
-                            WS_CHILD | WS_VISIBLE,
+                            WS_CHILD | WS_VISIBLE | SBARS_SIZEGRIP,
                             0, 0, 0, 0,
                             HWindow,
                             (HMENU)IDC_STATUS,

--- a/src/plugins/regedt/finddlg2.cpp
+++ b/src/plugins/regedt/finddlg2.cpp
@@ -760,6 +760,10 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (AlwaysOnTop)
             SetWindowPos(HWindow, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 
+        ApplyRegEdtDarkMode(HWindow);
+        if (StatusBar != NULL && StatusBar->HWindow != NULL)
+            ApplyRegEdtDarkMode(StatusBar->HWindow);
+
         break;
     }
 
@@ -781,6 +785,11 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_THEMECHANGED:
     {
         ApplyRegEdtDarkMode(HWindow);
+        if (StatusBar != NULL && StatusBar->HWindow != NULL)
+        {
+            ApplyRegEdtDarkMode(StatusBar->HWindow);
+            InvalidateRect(StatusBar->HWindow, NULL, TRUE);
+        }
         RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
         return TRUE;
     }

--- a/src/plugins/regedt/finddlg2.cpp
+++ b/src/plugins/regedt/finddlg2.cpp
@@ -684,6 +684,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_INITDIALOG:
     {
+        ApplyRegEdtDarkMode(HWindow);
         //DialogStackPush(HWindow);
 
         //InstallWordBreakProc(GetDlgItem(HWindow, IDC_PATTERN), TRUE); // install WordBreakProc into the combo box
@@ -776,6 +777,39 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
+
+    case WM_THEMECHANGED:
+    {
+        ApplyRegEdtDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureRegEdtDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyRegEdtDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleRegEdtDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
     case WM_COMMAND:
     {
         switch (LOWORD(wParam))

--- a/src/plugins/regedt/precomp.h
+++ b/src/plugins/regedt/precomp.h
@@ -31,6 +31,7 @@
 #include "spl_vers.h"
 
 #include "dbg.h"
+#include "mhandles.h"
 #include "arraylt.h"
 #include "winliblt.h"
 #include "auxtools.h"

--- a/src/plugins/regedt/precomp.h
+++ b/src/plugins/regedt/precomp.h
@@ -8,6 +8,7 @@
 #include <windows.h>
 #include <CommDlg.h>
 #include <ShellAPI.h>
+#include <objbase.h>
 #include <crtdbg.h>
 #include <ostream>
 #include <stdio.h>

--- a/src/plugins/regedt/precomp.h
+++ b/src/plugins/regedt/precomp.h
@@ -46,3 +46,5 @@
 #include "finddlg.h"
 #include "editor.h"
 #include "export.h"
+
+#include "../../darkmode.h"

--- a/src/plugins/regedt/regedt.cpp
+++ b/src/plugins/regedt/regedt.cpp
@@ -54,6 +54,131 @@ CWindowQueueEx WindowQueue;
 
 BOOL AlwaysOnTop = FALSE;
 
+namespace
+{
+HBRUSH RegEdtDarkModeDialogBrush = NULL;
+COLORREF RegEdtDarkModeDialogBrushColor = CLR_INVALID;
+BOOL RegEdtHostPolicyKnown = FALSE;
+BOOL RegEdtHostUseWindowsDarkMode = FALSE;
+COLORREF RegEdtHostSchemeText = CLR_INVALID;
+COLORREF RegEdtHostSchemeBackground = CLR_INVALID;
+DWORD RegEdtMainThreadId = 0;
+
+HBRUSH RegEdtGetDarkModeDialogBrush(COLORREF background)
+{
+    if (RegEdtDarkModeDialogBrush == NULL || RegEdtDarkModeDialogBrushColor != background)
+    {
+        if (RegEdtDarkModeDialogBrush != NULL)
+            DeleteObject(RegEdtDarkModeDialogBrush);
+        RegEdtDarkModeDialogBrush = CreateSolidBrush(background);
+        RegEdtDarkModeDialogBrushColor = background;
+    }
+    return RegEdtDarkModeDialogBrush;
+}
+
+void ReleaseRegEdtDarkModeResources()
+{
+    if (RegEdtDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(RegEdtDarkModeDialogBrush);
+        RegEdtDarkModeDialogBrush = NULL;
+        RegEdtDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+}
+
+BOOL RegEdtCanQueryHostDarkMode()
+{
+    return SG != NULL &&
+           RegEdtMainThreadId != 0 &&
+           GetCurrentThreadId() == RegEdtMainThreadId;
+}
+
+void RefreshRegEdtDarkModeFromHost()
+{
+    if (!RegEdtCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SG->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                      &useWindowsDarkMode,
+                                      sizeof(useWindowsDarkMode),
+                                      NULL))
+    {
+        RegEdtHostPolicyKnown = TRUE;
+        RegEdtHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (RegEdtHostPolicyKnown && RegEdtHostUseWindowsDarkMode)
+    {
+        RegEdtHostSchemeText = SG->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        RegEdtHostSchemeBackground = SG->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+BOOL RegEdtShouldUseWindowsDarkMode()
+{
+    return RegEdtHostPolicyKnown && RegEdtHostUseWindowsDarkMode;
+}
+
+void ConfigureRegEdtDarkModeFromHost()
+{
+    RefreshRegEdtDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = RegEdtShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && RegEdtHostSchemeText != CLR_INVALID && RegEdtHostSchemeBackground != CLR_INVALID)
+    {
+        text = RegEdtHostSchemeText;
+        background = RegEdtHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = RegEdtGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyRegEdtDarkMode(HWND hwnd)
+{
+    ConfigureRegEdtDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL ApplyRegEdtDarkModeIfSelected(HWND hwnd)
+{
+    if (!RegEdtShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ApplyRegEdtDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL HandleRegEdtDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!RegEdtShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureRegEdtDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     CALL_STACK_MESSAGE_NONE
@@ -231,7 +356,9 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain Salamander's general interface
     SG = salamander->GetSalamanderGeneral();
+    RegEdtMainThreadId = GetCurrentThreadId();
     SalGUI = salamander->GetSalamanderGUI();
+    RefreshRegEdtDarkModeFromHost();
 
     // set the help file name
     SG->SetHelpFileName("regedt.chm");
@@ -301,6 +428,7 @@ BOOL CPluginInterface::Release(HWND parent, BOOL force)
         {
             ReleaseDialogs();
             ReleaseFS();
+            ReleaseRegEdtDarkModeResources();
 
 #ifdef DUMP_MEM
             _CrtMemDumpAllObjectsSince(&___CrtMemState);

--- a/src/plugins/regedt/regedt.h
+++ b/src/plugins/regedt/regedt.h
@@ -94,6 +94,12 @@ BOOL ErrorL(int lastError, HWND parent, int error, ...);
 BOOL ErrorL(int lastError, int error, ...);
 int SalPrintf(char* buffer, unsigned count, const char* format, ...);
 int SalPrintfW(LPWSTR buffer, unsigned count, LPCWSTR format, ...);
+void RefreshRegEdtDarkModeFromHost();
+void ConfigureRegEdtDarkModeFromHost();
+void ApplyRegEdtDarkMode(HWND hwnd);
+BOOL ApplyRegEdtDarkModeIfSelected(HWND hwnd);
+BOOL HandleRegEdtDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);
+
 
 // ****************************************************************************
 //

--- a/src/plugins/regedt/vcxproj/regedt.props
+++ b/src/plugins/regedt/vcxproj/regedt.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/regedt/vcxproj/regedt.vcxproj
+++ b/src/plugins/regedt/vcxproj/regedt.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/serviceexplorer/dialogs.cpp
+++ b/src/plugins/serviceexplorer/dialogs.cpp
@@ -38,7 +38,39 @@ INT_PTR CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
       if (Parent != NULL)
         SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
+      ApplyServiceExplorerDarkMode(HWindow);
       break; // chci focus od DefDlgProc
+    }
+
+    case WM_THEMECHANGED:
+    {
+      ApplyServiceExplorerDarkMode(HWindow);
+      RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+      return TRUE;
+    }
+    case WM_SETTINGCHANGE:
+    {
+      ConfigureServiceExplorerDarkModeFromHost();
+      if (DarkModeHandleSettingChange(uMsg, lParam))
+      {
+        ApplyServiceExplorerDarkMode(HWindow);
+        InvalidateRect(HWindow, NULL, TRUE);
+        return TRUE;
+      }
+      break;
+    }
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+      INT_PTR result = 0;
+      if (HandleServiceExplorerDarkCtlColor(uMsg, wParam, lParam, &result))
+        return result;
+      break;
     }
   }
   return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -237,67 +269,98 @@ INT_PTR CConfigPageFirst::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
   switch (uMsg)
   {
-          break;
+    case WM_INITDIALOG:
+    {
+      ApplyServiceExplorerDarkMode(HWindow);
+      break;
+    }
+    case WM_THEMECHANGED:
+    {
+      ApplyServiceExplorerDarkMode(HWindow);
+      RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+      return TRUE;
+    }
+    case WM_SETTINGCHANGE:
+    {
+      ConfigureServiceExplorerDarkModeFromHost();
+      if (DarkModeHandleSettingChange(uMsg, lParam))
+      {
+        ApplyServiceExplorerDarkMode(HWindow);
+        InvalidateRect(HWindow, NULL, TRUE);
+        return TRUE;
+      }
+      break;
+    }
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+      INT_PTR result = 0;
+      if (HandleServiceExplorerDarkCtlColor(uMsg, wParam, lParam, &result))
+        return result;
+      break;
+    }
     case WM_COMMAND:
     {
-			switch (LOWORD (wParam))
+      switch (LOWORD (wParam))
       {
-                                case IDC_BUTTON_SERVICE_START:
-                                        if (RunServiceAction(HWindow, FSIGdata->ServiceName, FSIGdata->DisplayName, ServiceActionStart))
-                                                EnableButtonStates(SharedTransferInfo());
-                                        break;
-                                case IDC_BUTTON_SERVICE_STOP:
-                                        if (RunServiceAction(HWindow, FSIGdata->ServiceName, FSIGdata->DisplayName, ServiceActionStop))
-                                                EnableButtonStates(SharedTransferInfo());
-                                        break;
-                                case IDC_BUTTON_SERVICE_PAUSE:
-                                        if (RunServiceAction(HWindow, FSIGdata->ServiceName, FSIGdata->DisplayName, ServiceActionPause))
-                                                EnableButtonStates(SharedTransferInfo());
-                                        break;
-                                case IDC_BUTTON_SERVICE_RESUME:
-                                        if (RunServiceAction(HWindow, FSIGdata->ServiceName, FSIGdata->DisplayName, ServiceActionResume))
-                                                EnableButtonStates(SharedTransferInfo());
-                                        break;
-                                case IDC_BUTTON_SERVICE_DELETE:
-                                        if(SalamanderGeneral->SalMessageBox(HWindow, "Do you really want to delete the current service?", VERSINFO_PLUGINNAME, MB_YESNOCANCEL | MB_ICONQUESTION)==IDYES)
-                                        {
-                                                SetCursor(LoadCursor(NULL,IDC_WAIT));
-                                                ShowCursor(TRUE);
-                                                DWORD returnstate=DoDeleteSvc(FSIGdata->ServiceName);
-                                                EnableButtonStates(SharedTransferInfo());
-                                                ShowCursor(FALSE);
-                                                SetCursor(LoadCursor(NULL,IDC_ARROW));
-                                                if (returnstate>0)
-                                                {
-
-                                                        char errormessage[100];
-                                                        switch (returnstate)
-                                                        {
-                                                                case 5:
-                                                                        strcpy(errormessage,LoadStr(IDS_SERVICE_ERROR_INSUFFICIENTRIGHTS));
-                                                                        break;
-                                                                case 1072:
-                                                                        strcpy(errormessage,LoadStr(IDS_SERVICE_ERROR_MARKEDFORDELETION));
-                                                                        break;
-                                                                default:
-                                                                        strcpy(errormessage,LoadStr(IDS_SERVICE_ERROR_UNKNOWN));
-                                                        }
-                                                        char buf[500];
-                                                        buf[499] = 0;
-                                                        _snprintf(buf, 500,
-                                                                        "%s\n\n"
-                                                                        "%s %d: %s",LoadStr(IDS_SERVICE_ERROR_OPERATION),LoadStr(IDS_SEVICE_ERROR_CODE) ,returnstate,errormessage);
-                                                        SalamanderGeneral->SalMessageBox(HWindow, buf, VERSINFO_PLUGINNAME, MB_OK | MB_ICONWARNING);
-                                                }
-                                        }
-                                        break;
-
+        case IDC_BUTTON_SERVICE_START:
+          if (RunServiceAction(HWindow, FSIGdata->ServiceName, FSIGdata->DisplayName, ServiceActionStart))
+            EnableButtonStates(SharedTransferInfo());
+          break;
+        case IDC_BUTTON_SERVICE_STOP:
+          if (RunServiceAction(HWindow, FSIGdata->ServiceName, FSIGdata->DisplayName, ServiceActionStop))
+            EnableButtonStates(SharedTransferInfo());
+          break;
+        case IDC_BUTTON_SERVICE_PAUSE:
+          if (RunServiceAction(HWindow, FSIGdata->ServiceName, FSIGdata->DisplayName, ServiceActionPause))
+            EnableButtonStates(SharedTransferInfo());
+          break;
+        case IDC_BUTTON_SERVICE_RESUME:
+          if (RunServiceAction(HWindow, FSIGdata->ServiceName, FSIGdata->DisplayName, ServiceActionResume))
+            EnableButtonStates(SharedTransferInfo());
+          break;
+        case IDC_BUTTON_SERVICE_DELETE:
+          if(SalamanderGeneral->SalMessageBox(HWindow, "Do you really want to delete the current service?", VERSINFO_PLUGINNAME, MB_YESNOCANCEL | MB_ICONQUESTION)==IDYES)
+          {
+            SetCursor(LoadCursor(NULL,IDC_WAIT));
+            ShowCursor(TRUE);
+            DWORD returnstate=DoDeleteSvc(FSIGdata->ServiceName);
+            EnableButtonStates(SharedTransferInfo());
+            ShowCursor(FALSE);
+            SetCursor(LoadCursor(NULL,IDC_ARROW));
+            if (returnstate>0)
+            {
+              char errormessage[100];
+              switch (returnstate)
+              {
+                case 5:
+                  strcpy(errormessage,LoadStr(IDS_SERVICE_ERROR_INSUFFICIENTRIGHTS));
+                  break;
+                case 1072:
+                  strcpy(errormessage,LoadStr(IDS_SERVICE_ERROR_MARKEDFORDELETION));
+                  break;
+                default:
+                  strcpy(errormessage,LoadStr(IDS_SERVICE_ERROR_UNKNOWN));
+              }
+              char buf[500];
+              buf[499] = 0;
+              _snprintf(buf, 500,
+                        "%s\n\n"
+                        "%s %d: %s",LoadStr(IDS_SERVICE_ERROR_OPERATION),LoadStr(IDS_SEVICE_ERROR_CODE) ,returnstate,errormessage);
+              SalamanderGeneral->SalMessageBox(HWindow, buf, VERSINFO_PLUGINNAME, MB_OK | MB_ICONWARNING);
+            }
+          }
+          break;
       }
-
       break; // chci focus od DefDlgProc
     }
   }
-        return CPropSheetPage::DialogProc(uMsg, wParam, lParam);
+  return CPropSheetPage::DialogProc(uMsg, wParam, lParam);
 }
 
 
@@ -317,6 +380,18 @@ class CCenteredPropertyWindow: public CWindow
     {
       switch (uMsg)
       {
+        case WM_CREATE:
+        case WM_INITDIALOG:
+        {
+          ApplyServiceExplorerDarkMode(HWindow);
+          break;
+        }
+        case WM_THEMECHANGED:
+        {
+          ApplyServiceExplorerDarkMode(HWindow);
+          RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+          return 0;
+        }
         case WM_WINDOWPOSCHANGING:
         {
           WINDOWPOS *pos = (WINDOWPOS *)lParam;
@@ -374,6 +449,7 @@ int CALLBACK CenterCallback(HWND HWindow, UINT uMsg, LPARAM lParam)
       if (wnd->HWindow == NULL) delete wnd;  // okno neni pripojeny, zrusime ho uz tady
       else
       {
+        ApplyServiceExplorerDarkMode(wnd->HWindow);
         PostMessage(wnd->HWindow, WM_APP + 1000, 0, 0);  // pro odpojeni CCenteredPropertyWindow od dialogu
       }
     }

--- a/src/plugins/serviceexplorer/dialogs.cpp
+++ b/src/plugins/serviceexplorer/dialogs.cpp
@@ -774,6 +774,7 @@ INT_PTR CRegisterServiceDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lPar
     {
     case WM_INITDIALOG:
         InitializeControls();
+        ApplyServiceExplorerDarkMode(HWindow);
         return TRUE;
     case WM_COMMAND:
         switch (LOWORD(wParam))

--- a/src/plugins/serviceexplorer/plugin.cpp
+++ b/src/plugins/serviceexplorer/plugin.cpp
@@ -19,6 +19,131 @@ CSalamanderGUIAbstract* SalamanderGUI = NULL;
 
 namespace
 {
+HBRUSH ServiceExplorerDarkModeDialogBrush = NULL;
+COLORREF ServiceExplorerDarkModeDialogBrushColor = CLR_INVALID;
+BOOL ServiceExplorerHostPolicyKnown = FALSE;
+BOOL ServiceExplorerHostUseWindowsDarkMode = FALSE;
+COLORREF ServiceExplorerHostSchemeText = CLR_INVALID;
+COLORREF ServiceExplorerHostSchemeBackground = CLR_INVALID;
+DWORD ServiceExplorerMainThreadId = 0;
+
+HBRUSH ServiceExplorerGetDarkModeDialogBrush(COLORREF background)
+{
+    if (ServiceExplorerDarkModeDialogBrush == NULL || ServiceExplorerDarkModeDialogBrushColor != background)
+    {
+        if (ServiceExplorerDarkModeDialogBrush != NULL)
+            DeleteObject(ServiceExplorerDarkModeDialogBrush);
+        ServiceExplorerDarkModeDialogBrush = CreateSolidBrush(background);
+        ServiceExplorerDarkModeDialogBrushColor = background;
+    }
+    return ServiceExplorerDarkModeDialogBrush;
+}
+
+void ReleaseServiceExplorerDarkModeResources()
+{
+    if (ServiceExplorerDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(ServiceExplorerDarkModeDialogBrush);
+        ServiceExplorerDarkModeDialogBrush = NULL;
+        ServiceExplorerDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+}
+
+BOOL ServiceExplorerCanQueryHostDarkMode()
+{
+    return SalamanderGeneral != NULL &&
+           ServiceExplorerMainThreadId != 0 &&
+           GetCurrentThreadId() == ServiceExplorerMainThreadId;
+}
+
+void RefreshServiceExplorerDarkModeFromHost()
+{
+    if (!ServiceExplorerCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                      &useWindowsDarkMode,
+                                      sizeof(useWindowsDarkMode),
+                                      NULL))
+    {
+        ServiceExplorerHostPolicyKnown = TRUE;
+        ServiceExplorerHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (ServiceExplorerHostPolicyKnown && ServiceExplorerHostUseWindowsDarkMode)
+    {
+        ServiceExplorerHostSchemeText = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        ServiceExplorerHostSchemeBackground = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+BOOL ServiceExplorerShouldUseWindowsDarkMode()
+{
+    return ServiceExplorerHostPolicyKnown && ServiceExplorerHostUseWindowsDarkMode;
+}
+
+void ConfigureServiceExplorerDarkModeFromHost()
+{
+    RefreshServiceExplorerDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = ServiceExplorerShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && ServiceExplorerHostSchemeText != CLR_INVALID && ServiceExplorerHostSchemeBackground != CLR_INVALID)
+    {
+        text = ServiceExplorerHostSchemeText;
+        background = ServiceExplorerHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = ServiceExplorerGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyServiceExplorerDarkMode(HWND hwnd)
+{
+    ConfigureServiceExplorerDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL ApplyServiceExplorerDarkModeIfSelected(HWND hwnd)
+{
+    if (!ServiceExplorerShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ApplyServiceExplorerDarkMode(hwnd);
+    return TRUE;
+}
+
+BOOL HandleServiceExplorerDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!ServiceExplorerShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureServiceExplorerDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+namespace
+{
 HBITMAP CreateServiceBitmap()
 {
   HBITMAP bitmap = reinterpret_cast<HBITMAP>(
@@ -155,6 +280,7 @@ CPluginInterfaceAbstract * WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAb
   }
 
   SalamanderGeneral = salamander->GetSalamanderGeneral();
+  ServiceExplorerMainThreadId = GetCurrentThreadId();
   SalamanderGUI = salamander->GetSalamanderGUI();
 
   HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "ServiceExplorer");
@@ -170,6 +296,7 @@ CPluginInterfaceAbstract * WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAb
   salamander->SetPluginHomePageURL("http://www.jamik.de");
 
   SalamanderGeneral->GetPluginFSName(AssignedFSName, 0);
+  RefreshServiceExplorerDarkModeFromHost();
 
   if (!InitFS())
   {
@@ -193,6 +320,7 @@ void WINAPI CPluginInterface::About(HWND parent)
 
 BOOL WINAPI CPluginInterface::Release(HWND parent, BOOL force)
 {
+  ReleaseServiceExplorerDarkModeResources();
   return TRUE;
 }
 void WINAPI CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract *registry)

--- a/src/plugins/serviceexplorer/plugin.h
+++ b/src/plugins/serviceexplorer/plugin.h
@@ -4,6 +4,12 @@
 
 
 char *LoadStr(int resID);
+void RefreshServiceExplorerDarkModeFromHost();
+void ConfigureServiceExplorerDarkModeFromHost();
+void ApplyServiceExplorerDarkMode(HWND hwnd);
+BOOL ApplyServiceExplorerDarkModeIfSelected(HWND hwnd);
+BOOL HandleServiceExplorerDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);
+
 
 extern CSalamanderGeneralAbstract	*SalamanderGeneral;
 extern CSalamanderGUIAbstract		*SalamanderGUI;

--- a/src/plugins/serviceexplorer/precomp.h
+++ b/src/plugins/serviceexplorer/precomp.h
@@ -63,3 +63,5 @@
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 #endif // __BORLANDC__
+
+#include "../../darkmode.h"

--- a/src/plugins/serviceexplorer/vcxproj/serviceexplorer.props
+++ b/src/plugins/serviceexplorer/vcxproj/serviceexplorer.props
@@ -7,6 +7,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
     </ClCompile>

--- a/src/plugins/serviceexplorer/vcxproj/serviceexplorer.props
+++ b/src/plugins/serviceexplorer/vcxproj/serviceexplorer.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
     </ClCompile>

--- a/src/plugins/serviceexplorer/vcxproj/serviceexplorer.vcxproj
+++ b/src/plugins/serviceexplorer/vcxproj/serviceexplorer.vcxproj
@@ -78,6 +78,44 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup />
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp" />
     <ClCompile Include="..\..\shared\dbg.cpp" />
     <ClCompile Include="..\..\shared\mhandles.cpp" />

--- a/src/plugins/shared/winliblt.cpp
+++ b/src/plugins/shared/winliblt.cpp
@@ -35,6 +35,11 @@
 
 #include "winliblt.h"
 
+#ifdef USE_DARKMODELIB
+#include "spl_gen.h"
+#include "../../darkmode.h"
+#endif // USE_DARKMODELIB
+
 #ifdef _MSC_VER
 #ifndef itoa
 #define itoa _itoa
@@ -55,6 +60,146 @@ FWinLibLTHelpCallback WinLibLTHelpCallback = NULL; // callbacku pro pripojeni na
 
 //
 // ****************************************************************************
+
+
+#ifdef USE_DARKMODELIB
+namespace
+{
+CSalamanderGeneralAbstract* WinLibDarkModeGeneral = NULL;
+HBRUSH WinLibDarkModeDialogBrush = NULL;
+COLORREF WinLibDarkModeDialogBrushColor = CLR_INVALID;
+BOOL WinLibDarkModePolicyKnown = FALSE;
+BOOL WinLibDarkModeUseWindowsDarkMode = FALSE;
+COLORREF WinLibDarkModeSchemeText = CLR_INVALID;
+COLORREF WinLibDarkModeSchemeBackground = CLR_INVALID;
+DWORD WinLibDarkModeMainThreadId = 0;
+
+HBRUSH GetWinLibDarkModeDialogBrush(COLORREF background)
+{
+    if (WinLibDarkModeDialogBrush == NULL || WinLibDarkModeDialogBrushColor != background)
+    {
+        if (WinLibDarkModeDialogBrush != NULL)
+            DeleteObject(WinLibDarkModeDialogBrush);
+        WinLibDarkModeDialogBrush = CreateSolidBrush(background);
+        WinLibDarkModeDialogBrushColor = background;
+    }
+    return WinLibDarkModeDialogBrush;
+}
+
+BOOL CanQueryWinLibHostDarkMode()
+{
+    return WinLibDarkModeGeneral != NULL &&
+           WinLibDarkModeMainThreadId != 0 &&
+           GetCurrentThreadId() == WinLibDarkModeMainThreadId;
+}
+
+BOOL ShouldUseWinLibDarkMode()
+{
+    return WinLibDarkModePolicyKnown && WinLibDarkModeUseWindowsDarkMode;
+}
+
+void ConfigureWinLibDarkModeFromHost()
+{
+    if (WinLibDarkModeGeneral == NULL)
+        return;
+
+    RefreshWinLibDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = ShouldUseWinLibDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && WinLibDarkModeSchemeText != CLR_INVALID && WinLibDarkModeSchemeBackground != CLR_INVALID)
+    {
+        text = WinLibDarkModeSchemeText;
+        background = WinLibDarkModeSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = GetWinLibDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplyWinLibDarkMode(HWND hwnd)
+{
+    if (WinLibDarkModeGeneral == NULL)
+        return;
+
+    ConfigureWinLibDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL HandleWinLibDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (WinLibDarkModeGeneral == NULL || !ShouldUseWinLibDarkMode())
+        return FALSE;
+
+    ConfigureWinLibDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+}
+
+void InitializeWinLibDarkMode(CSalamanderGeneralAbstract* salamanderGeneral)
+{
+    WinLibDarkModeGeneral = salamanderGeneral;
+    WinLibDarkModeMainThreadId = GetCurrentThreadId();
+    RefreshWinLibDarkModeFromHost();
+}
+
+void RefreshWinLibDarkModeFromHost()
+{
+    if (!CanQueryWinLibHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (WinLibDarkModeGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                                  &useWindowsDarkMode,
+                                                  sizeof(useWindowsDarkMode),
+                                                  NULL))
+    {
+        WinLibDarkModePolicyKnown = TRUE;
+        WinLibDarkModeUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (WinLibDarkModePolicyKnown && WinLibDarkModeUseWindowsDarkMode)
+    {
+        WinLibDarkModeSchemeText = WinLibDarkModeGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        WinLibDarkModeSchemeBackground = WinLibDarkModeGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+void ReleaseWinLibDarkMode()
+{
+    if (WinLibDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(WinLibDarkModeDialogBrush);
+        WinLibDarkModeDialogBrush = NULL;
+        WinLibDarkModeDialogBrushColor = CLR_INVALID;
+    }
+    WinLibDarkModeGeneral = NULL;
+    WinLibDarkModeMainThreadId = 0;
+    WinLibDarkModePolicyKnown = FALSE;
+    WinLibDarkModeUseWindowsDarkMode = FALSE;
+    WinLibDarkModeSchemeText = CLR_INVALID;
+    WinLibDarkModeSchemeBackground = CLR_INVALID;
+    DarkModeSetEnabled(false);
+}
+#endif // USE_DARKMODELIB
 
 void SetWinLibStrings(const char* invalidNumber, const char* error)
 {
@@ -102,6 +247,9 @@ BOOL InitializeWinLib(const char* pluginName, HINSTANCE dllInstance)
 
 void ReleaseWinLib(HINSTANCE dllInstance)
 {
+#ifdef USE_DARKMODELIB
+    ReleaseWinLibDarkMode();
+#endif // USE_DARKMODELIB
     if (WindowsManager.WindowsCount != 0)
     {
         // pruser - po unloadu pluginu muze spadnout soft, protoze se zavola window-procedura
@@ -443,9 +591,47 @@ CDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_INITDIALOG:
     {
         TransferData(ttDataToWindow);
+#ifdef USE_DARKMODELIB
+        ApplyWinLibDarkMode(HWindow);
+#endif // USE_DARKMODELIB
         return TRUE; // chci focus od DefDlgProc
     }
 
+
+#ifdef USE_DARKMODELIB
+    case WM_THEMECHANGED:
+    {
+        ApplyWinLibDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureWinLibDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyWinLibDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleWinLibDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
+#endif // USE_DARKMODELIB
     case WM_HELP:
     {
         if (WinLibLTHelpCallback != NULL && HelpID != -1 &&
@@ -665,9 +851,48 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         ParentDialog->HWindow = Parent;
         TransferData(ttDataToWindow);
+#ifdef USE_DARKMODELIB
+        ApplyWinLibDarkMode(HWindow);
+        ApplyWinLibDarkMode(Parent);
+#endif // USE_DARKMODELIB
         return TRUE; // chci focus od DefDlgProc
     }
 
+
+#ifdef USE_DARKMODELIB
+    case WM_THEMECHANGED:
+    {
+        ApplyWinLibDarkMode(HWindow);
+        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        return TRUE;
+    }
+
+    case WM_SETTINGCHANGE:
+    {
+        ConfigureWinLibDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplyWinLibDarkMode(HWindow);
+            InvalidateRect(HWindow, NULL, TRUE);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleWinLibDarkCtlColor(uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
+#endif // USE_DARKMODELIB
     case WM_HELP:
     {
         if (WinLibLTHelpCallback != NULL && HelpID != -1 &&

--- a/src/plugins/shared/winliblt.h
+++ b/src/plugins/shared/winliblt.h
@@ -25,6 +25,12 @@ void SetWinLibStrings(const char* invalidNumber, // "neni cislo" (u transferbuff
 // jinak nastane kolize jmen trid a WinLib nemuze fungovat - bude fungovat jen prvni spusteny
 // plugin); 'dllInstance' je modul pluginu (pouziva se pri registraci univerzalnich trid WinLibu)
 BOOL InitializeWinLib(const char* pluginName, HINSTANCE dllInstance);
+#ifdef USE_DARKMODELIB
+class CSalamanderGeneralAbstract;
+void InitializeWinLibDarkMode(CSalamanderGeneralAbstract* salamanderGeneral);
+void RefreshWinLibDarkModeFromHost();
+void ReleaseWinLibDarkMode();
+#endif // USE_DARKMODELIB
 // je potreba zavolat po pouziti WinLibu; 'dllInstance' je modul pluginu (pouziva se pri zruseni
 // registrace univerzalnich trid WinLibu)
 void ReleaseWinLib(HINSTANCE dllInstance);

--- a/src/plugins/shared/winliblt.h
+++ b/src/plugins/shared/winliblt.h
@@ -353,7 +353,7 @@ public:
     // 'startPage' a 'lastPage' muze byt jen jedina promenna (hodnota in/odkaz out);
     // 'flags' viz help k 'PROPSHEETHEADER', pouzitelne hlavne konstanty
     // PSH_NOAPPLYNOW, PSH_USECALLBACK a PSH_HASHELP (jinak staci 'flags'==0)
-    CPropertyDialog(HWND parent, HINSTANCE modul, char* caption,
+    CPropertyDialog(HWND parent, HINSTANCE modul, const char* caption,
                     int startPage, DWORD flags, HICON icon = NULL,
                     DWORD* lastPage = NULL, PFNPROPSHEETCALLBACK callback = NULL)
         : TIndirectArray<CPropSheetPage>(10, 5, dtNoDelete)
@@ -378,7 +378,7 @@ protected:
     HWND HWindow;
     HINSTANCE Modul;
     HICON Icon;
-    char* Caption;
+    const char* Caption;
     int StartPage;
     DWORD Flags;
     PFNPROPSHEETCALLBACK Callback;

--- a/src/plugins/splitcbn/dialogs.cpp
+++ b/src/plugins/splitcbn/dialogs.cpp
@@ -10,6 +10,43 @@
 #include "split.h"
 #include "combine.h"
 
+
+namespace
+{
+BOOL HandleSplitCBNDarkDialogMessage(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    switch (uMsg)
+    {
+    case WM_THEMECHANGED:
+        ApplySplitCBNDarkMode(hWnd);
+        RedrawWindow(hWnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        *result = TRUE;
+        return TRUE;
+
+    case WM_SETTINGCHANGE:
+        ConfigureSplitCBNDarkModeFromHost();
+        if (DarkModeHandleSettingChange(uMsg, lParam))
+        {
+            ApplySplitCBNDarkMode(hWnd);
+            InvalidateRect(hWnd, NULL, TRUE);
+            *result = TRUE;
+            return TRUE;
+        }
+        return FALSE;
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+        return HandleSplitCBNDarkCtlColor(uMsg, wParam, lParam, result);
+    }
+    return FALSE;
+}
+}
+
 // *****************************************************************************
 //
 //  SPLIT DIALOG
@@ -231,12 +268,29 @@ namespace split
             SendMessage(h, CB_ADDSTRING, 0, (LPARAM)LoadStr(IDS_AUTODETECT));
             SendMessage(h, CB_SETCURSEL, 0, 0);
             OnComboSelChange();
+            ApplySplitCBNDarkMode(hWnd);
             SetFocus(h);
 
             /*HWND h = GetDlgItem(hWnd, IDC_EDITNUMBER);
       LONG style = GetWindowLong(h, GWL_STYLE);
       SetWindowLong(h, GWL_STYLE, style | WS_VSCROLL);*/
             return FALSE;
+        }
+
+        case WM_THEMECHANGED:
+        case WM_SETTINGCHANGE:
+        case WM_CTLCOLORDLG:
+        case WM_CTLCOLORSTATIC:
+        case WM_CTLCOLORBTN:
+        case WM_CTLCOLOREDIT:
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLORMSGBOX:
+        case WM_CTLCOLORSCROLLBAR:
+        {
+            INT_PTR result = 0;
+            if (HandleSplitCBNDarkDialogMessage(hWnd, uMsg, wParam, lParam, &result))
+                return result;
+            break;
         }
 
         case WM_HELP:
@@ -630,7 +684,24 @@ namespace combine
                                          0, 0, LR_DEFAULTCOLOR);
 
             EnableButtons();
+            ApplySplitCBNDarkMode(hWnd);
             return FALSE;
+        }
+
+        case WM_THEMECHANGED:
+        case WM_SETTINGCHANGE:
+        case WM_CTLCOLORDLG:
+        case WM_CTLCOLORSTATIC:
+        case WM_CTLCOLORBTN:
+        case WM_CTLCOLOREDIT:
+        case WM_CTLCOLORLISTBOX:
+        case WM_CTLCOLORMSGBOX:
+        case WM_CTLCOLORSCROLLBAR:
+        {
+            INT_PTR result = 0;
+            if (HandleSplitCBNDarkDialogMessage(hWnd, uMsg, wParam, lParam, &result))
+                return result;
+            break;
         }
 
         case WM_DESTROY:
@@ -734,16 +805,22 @@ namespace combine
             BOOL selected = (dis->itemState & ODS_SELECTED);
             BOOL focused = selected && GetFocus() == GetDlgItem(hWnd, dis->CtlID);
 
-            if (selected)
-                FillRect(hDC, &r, (HBRUSH)(COLOR_HIGHLIGHT + 1));
-            else
-                FillRect(hDC, &r, (HBRUSH)(COLOR_WINDOW + 1));
+            const bool useDark = DarkModeShouldUseDarkColors();
+            const COLORREF fillColor = selected ? GetSysColor(COLOR_HIGHLIGHT) :
+                                       (useDark ? DarkModeGetDialogBackgroundColor() : GetSysColor(COLOR_WINDOW));
+            HBRUSH fillBrush = CreateSolidBrush(fillColor);
+            if (fillBrush != NULL)
+            {
+                FillRect(hDC, &r, fillBrush);
+                DeleteObject(fillBrush);
+            }
 
             if (pid->index != -1)
             {
                 DrawIconEx(hDC, r.left + 2, r.top + 1, /*pid->hIcon*/ hFileIcon, 16, 16, 0, NULL, DI_NORMAL);
                 r.left += 21;
-                SetTextColor(hDC, GetSysColor(selected ? COLOR_HIGHLIGHTTEXT : COLOR_WINDOWTEXT));
+                SetTextColor(hDC, selected ? GetSysColor(COLOR_HIGHLIGHTTEXT) :
+                                    (useDark ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_WINDOWTEXT)));
                 SetBkMode(hDC, TRANSPARENT);
                 DrawText(hDC, pid->text, -1, &r, DT_SINGLELINE | DT_LEFT | DT_VCENTER);
                 r.left -= 21;
@@ -847,7 +924,24 @@ static INT_PTR CALLBACK ConfigDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
         CheckDlgButton(hWnd, IDC_CHECK_COMBINEOTHER, configCombineToOther ? BST_CHECKED : BST_UNCHECKED);
         CheckDlgButton(hWnd, IDC_CHECK_SPLITSUB, configSplitToSubdir /*&& configSplitToOther*/ ? BST_CHECKED : BST_UNCHECKED);
         //EnableWindow(GetDlgItem(hWnd, IDC_CHECK_SPLITSUB), configSplitToOther);
+        ApplySplitCBNDarkMode(hWnd);
         return TRUE;
+
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleSplitCBNDarkDialogMessage(hWnd, uMsg, wParam, lParam, &result))
+            return result;
+        break;
+    }
 
     case WM_HELP:
     {
@@ -923,6 +1017,8 @@ static INT_PTR CALLBACK CRCDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
         icon = (HICON)LoadImage(DLLInstance, MAKEINTRESOURCE(IDI_OK), IMAGE_ICON, 16, 16, LR_DEFAULTCOLOR);
         SendDlgItemMessage(hWnd, IDC_ICON_OK, STM_SETIMAGE, IMAGE_ICON, (LPARAM)icon);
 
+        ApplySplitCBNDarkMode(hWnd);
+
         if (bCrcFound)
         {
             sprintf(text, LoadStr(IDS_CRCHEX), originalCrc);
@@ -935,6 +1031,22 @@ static INT_PTR CALLBACK CRCDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             SetDlgItemText(hWnd, IDC_EDIT_CRC3, LoadStr(IDS_CRCNOTFOUND));
 
         return TRUE;
+    }
+
+    case WM_THEMECHANGED:
+    case WM_SETTINGCHANGE:
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        INT_PTR result = 0;
+        if (HandleSplitCBNDarkDialogMessage(hWnd, uMsg, wParam, lParam, &result))
+            return result;
+        break;
     }
 
     case WM_COMMAND:

--- a/src/plugins/splitcbn/dialogs.cpp
+++ b/src/plugins/splitcbn/dialogs.cpp
@@ -378,6 +378,7 @@ namespace split
         default:
             return FALSE;
         }
+        return FALSE;
     }
 
 } // namespace split
@@ -887,6 +888,7 @@ namespace combine
                 return FALSE;
         }
         }
+        return FALSE;
     }
 
 } // namespace combine
@@ -1071,6 +1073,7 @@ static INT_PTR CALLBACK CRCDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
     default:
         return FALSE;
     }
+    return FALSE;
 }
 
 void CRCDialog(TIndirectArray<char>& files, BOOL bf, UINT32 oc, HWND parent,

--- a/src/plugins/splitcbn/precomp.h
+++ b/src/plugins/splitcbn/precomp.h
@@ -31,3 +31,5 @@
 #include "dbg.h"
 #include "arraylt.h"
 #include "mhandles.h"
+
+#include "../../darkmode.h"

--- a/src/plugins/splitcbn/splitcbn.cpp
+++ b/src/plugins/splitcbn/splitcbn.cpp
@@ -35,6 +35,121 @@ BOOL configSplitToOther;
 BOOL configCombineToOther;
 BOOL configSplitToSubdir;
 
+namespace
+{
+HBRUSH SplitCBNDarkModeDialogBrush = NULL;
+COLORREF SplitCBNDarkModeDialogBrushColor = CLR_INVALID;
+BOOL SplitCBNHostPolicyKnown = FALSE;
+BOOL SplitCBNHostUseWindowsDarkMode = FALSE;
+COLORREF SplitCBNHostSchemeText = CLR_INVALID;
+COLORREF SplitCBNHostSchemeBackground = CLR_INVALID;
+DWORD SplitCBNMainThreadId = 0;
+
+HBRUSH SplitCBNGetDarkModeDialogBrush(COLORREF background)
+{
+    if (SplitCBNDarkModeDialogBrush == NULL || SplitCBNDarkModeDialogBrushColor != background)
+    {
+        if (SplitCBNDarkModeDialogBrush != NULL)
+            DeleteObject(SplitCBNDarkModeDialogBrush);
+        SplitCBNDarkModeDialogBrush = CreateSolidBrush(background);
+        SplitCBNDarkModeDialogBrushColor = background;
+    }
+    return SplitCBNDarkModeDialogBrush;
+}
+
+void ReleaseSplitCBNDarkModeResources()
+{
+    if (SplitCBNDarkModeDialogBrush != NULL)
+    {
+        DeleteObject(SplitCBNDarkModeDialogBrush);
+        SplitCBNDarkModeDialogBrush = NULL;
+        SplitCBNDarkModeDialogBrushColor = CLR_INVALID;
+    }
+}
+
+BOOL SplitCBNCanQueryHostDarkMode()
+{
+    return SalamanderGeneral != NULL && SplitCBNMainThreadId != 0 && GetCurrentThreadId() == SplitCBNMainThreadId;
+}
+
+BOOL SplitCBNShouldUseWindowsDarkMode()
+{
+    return SplitCBNHostPolicyKnown && SplitCBNHostUseWindowsDarkMode;
+}
+}
+
+void RefreshSplitCBNDarkModeFromHost()
+{
+    if (!SplitCBNCanQueryHostDarkMode())
+        return;
+
+    BOOL useWindowsDarkMode = FALSE;
+    if (SalamanderGeneral->GetConfigParameter(SALCFG_USEWINDOWSDARKMODE,
+                                              &useWindowsDarkMode,
+                                              sizeof(useWindowsDarkMode),
+                                              NULL))
+    {
+        SplitCBNHostPolicyKnown = TRUE;
+        SplitCBNHostUseWindowsDarkMode = useWindowsDarkMode;
+    }
+
+    if (SplitCBNHostPolicyKnown && SplitCBNHostUseWindowsDarkMode)
+    {
+        SplitCBNHostSchemeText = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        SplitCBNHostSchemeBackground = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+    }
+}
+
+void ConfigureSplitCBNDarkModeFromHost()
+{
+    RefreshSplitCBNDarkModeFromHost();
+
+    const BOOL useWindowsDarkMode = SplitCBNShouldUseWindowsDarkMode();
+    const COLORREF fallbackText = GetSysColor(COLOR_BTNTEXT);
+    const COLORREF fallbackBackground = GetSysColor(COLOR_BTNFACE);
+    COLORREF text = fallbackText;
+    COLORREF background = fallbackBackground;
+
+    if (useWindowsDarkMode && SplitCBNHostSchemeText != CLR_INVALID && SplitCBNHostSchemeBackground != CLR_INVALID)
+    {
+        text = SplitCBNHostSchemeText;
+        background = SplitCBNHostSchemeBackground;
+    }
+
+    const COLORREF readableText = DarkModeEnsureReadableForeground(text, background);
+    HBRUSH dialogBrush = SplitCBNGetDarkModeDialogBrush(background);
+    DarkModeSetConfiguredColors(text, background, fallbackText, fallbackBackground);
+    DarkModeConfigureDialogColors(readableText, background, dialogBrush);
+    DarkModeSetEnabled(useWindowsDarkMode != FALSE);
+}
+
+void ApplySplitCBNDarkMode(HWND hwnd)
+{
+    ConfigureSplitCBNDarkModeFromHost();
+    if (hwnd != NULL)
+    {
+        DarkModeApplyWindow(hwnd);
+        DarkModeRefreshTitleBar(hwnd);
+        DarkModeApplyTree(hwnd);
+    }
+}
+
+BOOL HandleSplitCBNDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result)
+{
+    if (!SplitCBNShouldUseWindowsDarkMode())
+        return FALSE;
+
+    ConfigureSplitCBNDarkModeFromHost();
+    LRESULT brush = 0;
+    if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+    {
+        *result = (INT_PTR)brush;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+
 static const char* KEY_INCLUDEFILEEXT = "Include Original Extension";
 static const char* KEY_CREATEBATCHFILE = "Create Batch File";
 static const char* KEY_SPLITTOOTHER = "Split To Other Panel";
@@ -90,6 +205,8 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the general Salamander interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    SplitCBNMainThreadId = GetCurrentThreadId();
+    RefreshSplitCBNDarkModeFromHost();
     SalamanderSafeFile = salamander->GetSalamanderSafeFile();
     // obtain the interface providing customized Windows controls used in Salamander
     SalamanderGUI = salamander->GetSalamanderGUI();
@@ -114,6 +231,15 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 //
 //  CPluginInterface
 //
+BOOL CPluginInterface::Release(HWND parent, BOOL force)
+{
+    CALL_STACK_MESSAGE2("CPluginInterface::Release(, %d)", force);
+    (void)parent;
+    ReleaseSplitCBNDarkModeResources();
+    return TRUE;
+}
+
+
 
 void CPluginInterface::About(HWND parent)
 {

--- a/src/plugins/splitcbn/splitcbn.h
+++ b/src/plugins/splitcbn/splitcbn.h
@@ -12,7 +12,7 @@ class CPluginInterface : public CPluginInterfaceAbstract
 public:
     virtual void WINAPI About(HWND parent);
 
-    virtual BOOL WINAPI Release(HWND parent, BOOL force) { return TRUE; }
+    virtual BOOL WINAPI Release(HWND parent, BOOL force);
 
     virtual void WINAPI LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry);
     virtual void WINAPI SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry);
@@ -54,6 +54,10 @@ extern BOOL configSplitToSubdir;
 extern HINSTANCE DLLInstance; // handle to SPL - language-independent resources
 extern HINSTANCE HLanguage;   // handle to SLG - language-dependent resources
 char* LoadStr(int resID);
+void RefreshSplitCBNDarkModeFromHost();
+void ConfigureSplitCBNDarkModeFromHost();
+void ApplySplitCBNDarkMode(HWND hwnd);
+BOOL HandleSplitCBNDarkCtlColor(UINT uMsg, WPARAM wParam, LPARAM lParam, INT_PTR* result);
 void CenterWindow(HWND hWnd);
 void GetInfo(char* buffer, CQuadWord& size);
 void StripExtension(LPTSTR fileName);

--- a/src/plugins/splitcbn/vcxproj/splitcbn.props
+++ b/src/plugins/splitcbn/vcxproj/splitcbn.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/splitcbn/vcxproj/splitcbn.vcxproj
+++ b/src/plugins/splitcbn/vcxproj/splitcbn.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">
     </ClCompile>
     <ClCompile Include="..\combine.cpp">

--- a/src/plugins/unchm/unchm.cpp
+++ b/src/plugins/unchm/unchm.cpp
@@ -97,6 +97,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the general Salamander interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
     SalamanderSafeFile = salamander->GetSalamanderSafeFile();
 
     if (!InterfaceForArchiver.Init())

--- a/src/plugins/unchm/vcxproj/unchm.props
+++ b/src/plugins/unchm/vcxproj/unchm.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/unchm/vcxproj/unchm.vcxproj
+++ b/src/plugins/unchm/vcxproj/unchm.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/unfat/unfat.cpp
+++ b/src/plugins/unfat/unfat.cpp
@@ -106,6 +106,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain the general Salamander interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
     SalamanderSafeFile = salamander->GetSalamanderSafeFile();
 
     SalamanderGeneral->GetConfigParameter(SALCFG_SORTBYEXTDIRSASFILES, &SortByExtDirsAsFiles,

--- a/src/plugins/unfat/vcxproj/unfat.props
+++ b/src/plugins/unfat/vcxproj/unfat.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;ENABLE_PROPERTYDIALOG;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/unfat/vcxproj/unfat.vcxproj
+++ b/src/plugins/unfat/vcxproj/unfat.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/uniso/uniso.cpp
+++ b/src/plugins/uniso/uniso.cpp
@@ -118,6 +118,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain Salamander's general interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
     SalZLIB = SalamanderGeneral->GetSalamanderZLIB();
     // obtain the interface providing customized Windows controls used in Salamander
     SalamanderGUI = salamander->GetSalamanderGUI();

--- a/src/plugins/uniso/vcxproj/uniso.props
+++ b/src/plugins/uniso/vcxproj/uniso.props
@@ -5,7 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/uniso/vcxproj/uniso.vcxproj
+++ b/src/plugins/uniso/vcxproj/uniso.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/wmobile/vcxproj/wmobile.props
+++ b/src/plugins/wmobile/vcxproj/wmobile.props
@@ -5,8 +5,8 @@
   <PropertyGroup Label="UserMacros"></PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\rapi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\third_party\darkmodelib\include;..\rapi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WINVER=0x0601;_WIN32_WINNT=0x0601;_WIN32_IE=0x0800;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT;USE_DARKMODELIB=1;_DARKMODELIB_NO_INI_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WINVER=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/plugins/wmobile/vcxproj/wmobile.vcxproj
+++ b/src/plugins/wmobile/vcxproj/wmobile.vcxproj
@@ -121,6 +121,44 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\darkmode.cpp" />
+    <ClCompile Include="..\..\..\darkmode_backend_darkmodelib.cpp" />
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\Darkmodelib.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibColor.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibDpi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibHook.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibPaintHelper.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclass.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassControl.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibSubclassWindow.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="..\..\..\third_party\darkmodelib\src\DmlibWinApi.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="..\..\shared\auxtools.cpp">
     </ClCompile>
     <ClCompile Include="..\..\shared\dbg.cpp">

--- a/src/plugins/wmobile/wmobile.cpp
+++ b/src/plugins/wmobile/wmobile.cpp
@@ -130,6 +130,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     // obtain Salamander's general interface
     SalamanderGeneral = salamander->GetSalamanderGeneral();
+    InitializeWinLibDarkMode(SalamanderGeneral);
     SalamanderGeneral->GetLowerAndUpperCase(&LowerCase, &UpperCase);
 
     strncpy_s(TitleWMobile, LoadStr(IDS_WMPLUGINTITLE), _TRUNCATE);

--- a/src/third_party/darkmodelib/src/DmlibSubclassControl.cpp
+++ b/src/third_party/darkmodelib/src/DmlibSubclassControl.cpp
@@ -2010,7 +2010,6 @@ static void renderComboBoxEdit(HWND hWnd, HDC hdc, dmlib_subclass::ComboBoxData&
 
 	if (comboBoxData.m_cbStyle == CBS_DROPDOWN)
 	{
-		const auto holdSeparatorPen = dmlib_paint::GdiObject{ hdc, dmlib::getEdgePen(), true };
 		const std::array<POINT, 2> edge{ {
 			{ rcArrow.left - 1, rcArrow.top },
 			{ rcArrow.left - 1, rcArrow.bottom }

--- a/src/third_party/darkmodelib/src/DmlibSubclassControl.cpp
+++ b/src/third_party/darkmodelib/src/DmlibSubclassControl.cpp
@@ -2010,6 +2010,7 @@ static void renderComboBoxEdit(HWND hWnd, HDC hdc, dmlib_subclass::ComboBoxData&
 
 	if (comboBoxData.m_cbStyle == CBS_DROPDOWN)
 	{
+		const auto holdSeparatorPen = dmlib_paint::GdiObject{ hdc, dmlib::getEdgePen(), true };
 		const std::array<POINT, 2> edge{ {
 			{ rcArrow.left - 1, rcArrow.top },
 			{ rcArrow.left - 1, rcArrow.bottom }


### PR DESCRIPTION
### Motivation
- Zajistit, aby dialogy v pluginech Windows Registry a Windows Services respektovaly vybranou hostitelskou barvu "Windows Dark Mode (experimental)" prostřednictvím stávajícího `win32-darkmodelib` backendu bez fallbacků na manuální překreslování.

### Description
- Napojil jsem oba pluginy na sdílené dark-mode helpery a `win32-darkmodelib` backend a zavedl konfigurační/brush cache + host-snapshot funkce (`Refresh*FromHost`, `Configure*FromHost`, `Apply*`, `Handle*CtlColor`) v `src/plugins/regedt/*` a `src/plugins/serviceexplorer/*`.
- Dialogové procedury byly aktualizovány tak, aby při `WM_INITDIALOG`, `WM_THEMECHANGED`, `WM_SETTINGCHANGE` volaly `Apply*`/`Configure*` a zpracovávaly `WM_CTLCOLOR*` přes `DarkModeHandleCtlColor` (nové volání v `dialogs.cpp`, `finddlg2.cpp`, `dialogs.cpp` v obou pluginech).
- Přidal jsem `#include "../../darkmode.h"` do `precomp.h` obou pluginů a projekty (`.props`/`.vcxproj`) jsem upravil pro `USE_DARKMODELIB=1`, `_DARKMODELIB_NO_INI_CONFIG`, přidání include cesty `third_party/darkmodelib/include` a kompilaci potřebných `darkmodelib` zdrojů a sdíleného `darkmode` backendu.
- Kód používá existující API: `DarkModeSetConfiguredColors`, `DarkModeConfigureDialogColors`, `DarkModeSetEnabled`, `DarkModeApplyWindow`, `DarkModeApplyTree`, `DarkModeRefreshTitleBar` a `DarkModeHandleCtlColor` pro konzistentní chování v celém projektu.

### Testing
- Spustil jsem `git diff --check` a opravil případné lokální textové problémy (výsledek bez chyb).
- Ověřil jsem, že upravené `.vcxproj`/`.props` soubory jsou validní XML parsováním pomocí Pythonu (`xml.etree.ElementTree`), což potvrdilo, že projektové změny jsou syntakticky korektní.
- Pokus o plný Visual Studio build (`msbuild`) nebyl možný v tomto Linux kontejneru, takže reálná kompilace/test běhu na Windows s Visual Studio musí být prověřena na CI nebo lokálně.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a408faba3448329a8cbe9c5212f43f6)