### PR TITLE
Fix clean configuration bottom toolbar default

### DIFF
--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -5036,7 +5036,10 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
 
             GetValue(actKey, CONFIG_BOTTOMTOOLBARVISIBLE_REG, REG_DWORD,
                      &Configuration.BottomToolBarVisible, sizeof(DWORD));
-            if (Configuration.BottomToolBarVisible)
+            // If mandatory layout data is missing, LoadConfig returns FALSE and the caller
+            // builds the default UI. Do not create the bottom toolbar here too, otherwise
+            // the caller's default pass toggles it back off.
+            if (ret && Configuration.BottomToolBarVisible)
                 ToggleBottomToolBar();
 
             //      GetValue(actKey, CONFIG_SPACESELCALCSPACE, REG_DWORD,


### PR DESCRIPTION
### Motivation
- Ensure that when the Welcome dialog creates a "Clean configuration with default values" (which writes `"Show Bottom ToolBar"=dword:00000001`), the startup flow does not accidentally hide the bottom toolbar due to `LoadConfig` creating it while mandatory layout data is missing.

### Description
- In `src/mainwnd2.cpp` change `LoadConfig` to only call `ToggleBottomToolBar()` when `ret` is `TRUE` (`if (ret && Configuration.BottomToolBarVisible)`), and add a comment explaining that if `LoadConfig` returns `FALSE` the caller will build the default UI and creating the toolbar here would be reverted.

### Testing
- Ran `git diff --check` which passed and committed the change as `Fix clean config bottom toolbar default`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40a57abc788329b3b00d625628267e)