### PR TITLE
Fix shell context menu recovery and directory history persistence

### DIFF
--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -2240,14 +2240,11 @@ void CFilesWindow::CloseCurrentPath(HWND parent, BOOL cancel, BOOL detachFS, BOO
     {
         if (!cancel)
         {
-            if (UserWorkedOnThisPath)
-            {
-                const char* path = GetPath();
-                // HICON hIcon = GetFileOrPathIconAux(path, FALSE, TRUE); // we retrieve the icon
-                MainWindow->DirHistoryAddPathUnique(this, 0, path, NULL, NULL /*hIcon*/, NULL, NULL);
-                if (!newPathIsTheSame)
-                    UserWorkedOnThisPath = FALSE;
-            }
+            const char* path = GetPath();
+            // HICON hIcon = GetFileOrPathIconAux(path, FALSE, TRUE); // we retrieve the icon
+            MainWindow->DirHistoryAddPathUnique(this, 0, path, NULL, NULL /*hIcon*/, NULL, NULL);
+            if (UserWorkedOnThisPath && !newPathIsTheSame)
+                UserWorkedOnThisPath = FALSE;
 
             if (!newPathIsTheSame)
             {
@@ -2269,12 +2266,9 @@ void CFilesWindow::CloseCurrentPath(HWND parent, BOOL cancel, BOOL detachFS, BOO
         {
             if (!cancel)
             {
-                if (UserWorkedOnThisPath)
-                {
-                    MainWindow->DirHistoryAddPathUnique(this, 1, GetZIPArchive(), GetZIPPath(), NULL, NULL, NULL);
-                    if (!newPathIsTheSame)
-                        UserWorkedOnThisPath = FALSE;
-                }
+                MainWindow->DirHistoryAddPathUnique(this, 1, GetZIPArchive(), GetZIPPath(), NULL, NULL, NULL);
+                if (UserWorkedOnThisPath && !newPathIsTheSame)
+                    UserWorkedOnThisPath = FALSE;
 
                 if (!newPathIsTheSame)
                 {
@@ -2319,13 +2313,10 @@ void CFilesWindow::CloseCurrentPath(HWND parent, BOOL cancel, BOOL detachFS, BOO
                     char buf[MAX_PATH];
                     if (GetPluginFS()->GetCurrentPath(buf))
                     {
-                        if (UserWorkedOnThisPath)
-                        {
-                            MainWindow->DirHistoryAddPathUnique(this, 2, GetPluginFS()->GetPluginFSName(), buf, NULL,
-                                                                GetPluginFS()->GetInterface(), GetPluginFS());
-                            if (!newPathIsTheSame)
-                                UserWorkedOnThisPath = FALSE;
-                        }
+                        MainWindow->DirHistoryAddPathUnique(this, 2, GetPluginFS()->GetPluginFSName(), buf, NULL,
+                                                            GetPluginFS()->GetInterface(), GetPluginFS());
+                        if (UserWorkedOnThisPath && !newPathIsTheSame)
+                            UserWorkedOnThisPath = FALSE;
                         if (!newPathIsTheSame)
                         {
                             // we're leaving the path

--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -1981,7 +1981,11 @@ CHANGE_AGAIN:
 
         UpdateWindow(MainWindow->HWindow);
         if (newDir != NULL)
+        {
             lstrcpyn(path, newDir, 2 * MAX_PATH);
+            if (mode == 3) // explicit Change Directory command (command line, hot path, etc.)
+                AddValueToStdHistoryValues(Configuration.ChangeDirHistory, CHANGEDIR_HISTORY_SIZE, path, FALSE);
+        }
         else // focus and top-index setting won't be done for path from dialog
         {
             suggestedTopIndex = -1;

--- a/src/shellsup.cpp
+++ b/src/shellsup.cpp
@@ -1130,6 +1130,33 @@ HRESULT AuxGetCommandString(IContextMenu2* menu, UINT_PTR idCmd, UINT uType, UIN
     return ret;
 }
 
+
+static BOOL ShellContextMenuContainsVerb(IContextMenu2* contextMenu, HMENU menu, const char* verb)
+{
+    if (contextMenu == NULL || menu == NULL || verb == NULL)
+        return FALSE;
+
+    int count = GetMenuItemCount(menu);
+    for (int i = 0; i < count; i++)
+    {
+        MENUITEMINFO mi;
+        ZeroMemory(&mi, sizeof(mi));
+        mi.cbSize = sizeof(mi);
+        mi.fMask = MIIM_ID | MIIM_TYPE;
+        if (!GetMenuItemInfo(menu, i, TRUE, &mi) || (mi.fType & MFT_SEPARATOR) != 0)
+            continue;
+
+        char cmdName[200];
+        cmdName[0] = 0;
+        if (AuxGetCommandString(contextMenu, mi.wID, GCS_VERB, NULL, cmdName, _countof(cmdName)) == NOERROR &&
+            stricmp(cmdName, verb) == 0)
+        {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 void ShellActionAux5(UINT flags, CFilesWindow* panel, HMENU h)
 { // ATTENTION: also used from CSalamanderGeneral::OpenNetworkContextMenu()
     CALL_STACK_MESSAGE_NONE
@@ -2201,6 +2228,9 @@ void ShellAction(CFilesWindow* panel, CShellAction action, BOOL useSelection,
                     flags |= CMF_CANRENAME;
 
                 BOOL alreadyHaveContextMenu = FALSE;
+                CTmpEnumData selectionEnumData;
+                selectionEnumData.Indexes = (count == 0) ? &index : indexes;
+                selectionEnumData.Panel = panel;
 
                 if (onlyPanelMenu)
                 {
@@ -2252,11 +2282,8 @@ void ShellAction(CFilesWindow* panel, CShellAction action, BOOL useSelection,
                         else
                         {
 #endif // _WIN64
-                            CTmpEnumData data;
-                            data.Indexes = (count == 0) ? &index : indexes;
-                            data.Panel = panel;
                             panel->ContextMenu = CreateIContextMenu2(MainWindow->HWindow, panel->GetPath(), (count == 0) ? 1 : count,
-                                                                     EnumFileNames, &data);
+                                                                     EnumFileNames, &selectionEnumData);
 #ifndef _WIN64
                         }
 #endif // _WIN64
@@ -2290,7 +2317,29 @@ void ShellAction(CFilesWindow* panel, CShellAction action, BOOL useSelection,
                 if (panel->ContextMenu != NULL && h != NULL)
                 {
                     if (!alreadyHaveContextMenu)
+                    {
                         ShellActionAux5(flags, panel, h);
+                        if (useSelection && !ShellContextMenuContainsVerb(panel->ContextMenu, h, "open"))
+                        {
+                            // Occasionally a shell extension leaves QueryContextMenu with only a partial
+                            // menu (typically Open and several third-party verbs are missing) until the
+                            // application is restarted. Drop the bad COM object and ask the shell once
+                            // more for a fresh context menu before showing the incomplete menu.
+                            TRACE_E("ShellAction::context_menu: incomplete shell context menu, retrying QueryContextMenu");
+                            panel->ContextMenu->Release();
+                            panel->ContextMenu = NULL;
+                            DestroyMenu(h);
+                            h = CreatePopupMenu();
+                            if (h != NULL)
+                            {
+                                panel->ContextMenu = CreateIContextMenu2(MainWindow->HWindow, panel->GetPath(),
+                                                                         (count == 0) ? 1 : count, EnumFileNames,
+                                                                         &selectionEnumData);
+                                if (panel->ContextMenu != NULL)
+                                    ShellActionAux5(flags, panel, h);
+                            }
+                        }
+                    }
                     RemoveUselessSeparatorsFromMenu(h);
 
                     char cmdName[2000]; // we intentionally use 2000 instead of 200; shell extensions sometimes write twice as much (idea: Unicode = 2 * "number of characters"), etc.


### PR DESCRIPTION
### Motivation

- Context menus for files/folders could lose third-party items during runtime and only be restored after restarting the app, indicating a broken/incomplete shell IContextMenu object was occasionally used. 
- Working-directory / ChangeDir history was not consistently recorded according to configuration, so Back/Forward and per-tab/shared history behaved unexpectedly after restarts.

### Description

- Added `ShellContextMenuContainsVerb()` and detection logic to verify the shell menu contains the expected `open` verb and, on detection of an incomplete menu, drop the COM object, recreate the menu and retry `QueryContextMenu` before showing the UI (`src/shellsup.cpp`).
- Kept the selection enumeration data alive across the initial Query and a potential retry so the re-query uses valid parameters (`src/shellsup.cpp`).
- Always record the current working directory into the Dir/WorkDir history when leaving a disk, archive, or plugin path (instead of requiring `UserWorkedOnThisPath`), so working-directory history is preserved for Back/Forward and after restart as configured (`src/fileswn2.cpp`).
- When `ChangeDir` is invoked programmatically (mode == 3), append the path into `ChangeDirHistory` so explicit change-directory commands are visible in the ChangeDir history (`src/fileswn3.cpp`).
- Modified files: `src/shellsup.cpp`, `src/fileswn2.cpp`, `src/fileswn3.cpp`.

### Testing

- Ran `git diff --check` which completed without issues.
- Performed repository checks (`git status`, `git commit`) and created the changeset `Fix shell context menu and directory history` successfully.
- Full Windows build / MSVC (MSBuild) could not be run in this Linux container, so an end-to-end build/test was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40af472f2083299b5bd72b007ed287)