### PR TITLE
Disconnect dialog: switch to WNetCancelConnection2 and add dark-mode support

### DIFF
--- a/src/dialogs6.cpp
+++ b/src/dialogs6.cpp
@@ -788,22 +788,12 @@ BOOL CDisconnectDialog::OnDisconnect()
         if (Connections[index].Type == citNetwork)
         {
             // NETWORK
-            DISCDLGSTRUCT conn;
-            conn.cbStructure = sizeof(conn);
-            conn.hwndOwner = HWindow;
-            if (stricmp(Connections[index].Name, LoadStr(IDS_NETWORK_NONE)) == 0)
+            const char* connectionName = stricmp(Connections[index].Name, LoadStr(IDS_NETWORK_NONE)) == 0 ? Connections[index].Path
+                                                                                                           : Connections[index].Name;
+            DWORD err = WNetCancelConnection2(connectionName, CONNECT_UPDATE_PROFILE, FALSE);
+            if (err != NO_ERROR)
             {
-                conn.lpLocalName = Connections[index].Path;
-                conn.lpRemoteName = NULL;
-            }
-            else
-            {
-                conn.lpLocalName = Connections[index].Name;
-                conn.lpRemoteName = Connections[index].Path;
-            }
-            conn.dwFlags = DISC_UPDATE_PROFILE;
-            if (WNetDisconnectDialog1(&conn) != NO_ERROR)
-            {
+                SalMessageBox(HWindow, GetErrorText(err), LoadStr(IDS_NETWORKERROR), MB_OK | MB_ICONEXCLAMATION);
                 Refresh(); // we must rebuild the array and list view to remove already disconnected items
                 // without invalidating and updating the main window, the area under the Disconnect dialog isn't redrawn after closing
                 // (the dialog uses save-bits and its remembered background probably won't be invalidated,
@@ -1361,6 +1351,15 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         InitColumns();
         Refresh();
 
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeUpdateListViewColors(HListView);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            WinLib_DarkMode_PostDeferredRedraw(HWindow);
+        }
+
         if (ListView_GetItemCount(HListView) == 0)
         {
             SendMessage(HWindow, WM_COMMAND, IDCANCEL, 0);
@@ -1407,6 +1406,43 @@ CDisconnectDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
             }
         }
+        break;
+    }
+
+    case WM_THEMECHANGED:
+    {
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+        {
+            DarkModeApplyTree(HWindow);
+            DarkModeRefreshTitleBar(HWindow);
+            DarkModeUpdateListViewColors(HListView);
+            DarkModeApplyStaticTextColors(HWindow, NULL);
+            RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+            return TRUE;
+        }
+        break;
+    }
+
+    case WM_SYSCOLORCHANGE:
+    {
+        if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
+            DarkModeUpdateListViewColors(HListView);
+        else
+            ListView_SetBkColor(HListView, GetSysColor(COLOR_WINDOW));
+        break;
+    }
+
+    case WM_CTLCOLORDLG:
+    case WM_CTLCOLORMSGBOX:
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORSCROLLBAR:
+    {
+        LRESULT brush;
+        if (DarkModeHandleCtlColor(uMsg, wParam, lParam, brush))
+            return brush;
         break;
     }
 


### PR DESCRIPTION
### Motivation
- Replace the legacy network disconnect dialog API with a direct programmatic call to reliably cancel network connections and improve error handling.
- Ensure the Disconnect dialog integrates with the application's dark mode/theme features and updates listview/control colors when themes change.
- Reduce unexpected UI artifacts by refreshing the main window after connection changes.

### Description
- Replaced the `DISCDLGSTRUCT` + `WNetDisconnectDialog1` flow with a direct `WNetCancelConnection2(connectionName, CONNECT_UPDATE_PROFILE, FALSE)` call and show an error message via `SalMessageBox` when it fails.
- Determined the connection name using the previous `Name`/`Path` logic and preserved the existing refresh/invalidate behavior after disconnect failures or successes.
- Applied dark-mode styling during `WM_INITDIALOG` by calling `WinLib_DarkMode_ShouldApplyDialogTree`, `DarkModeApplyTree`, `DarkModeRefreshTitleBar`, `DarkModeUpdateListViewColors`, and related helpers.
- Added handlers for `WM_THEMECHANGED`, `WM_SYSCOLORCHANGE`, and all `WM_CTLCOLOR*` messages to update dialog and listview colors via `DarkModeUpdateListViewColors` and `DarkModeHandleCtlColor`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41066db3688329beef0262edd70dcf)