### PR TITLE
Add manual Certum/SimplySign code-signing tooling and runbook updates

### DIFF
--- a/doc/runbook-setup/README.md
+++ b/doc/runbook-setup/README.md
@@ -58,9 +58,18 @@ Samandarin.
    - Optionally run the installer in a VM or use `setup.exe /extract` to review
      the embedded file list and ensure all new plugins are packaged.
 
-5. **Package for distribution**
-   - Archive or sign the `setup.exe` (and optionally `setup.inf`) as required.
-     Keep the matching `remove.exe` so the uninstaller remains branded for your
+5. **Sign and package for distribution**
+   - Code signing is a manual release step because Certum/SimplySign may prompt
+     for a PIN. Before compiling the final Inno installer, sign only the
+     installable x64 binaries listed by `inno_setup_salamander_x64.iss`:
+     ```cmd
+     tools\codesign\codesign_certum.cmd --inno-x64 --payload-dir "%OPENSAL_BUILD_DIR%\salamander\Release_x64"
+     ```
+   - After the final installer is built, sign that installer explicitly:
+     ```cmd
+     tools\codesign\codesign_certum.cmd --file "path\to\setup.exe"
+     ```
+   - Keep the matching `remove.exe` so the uninstaller remains branded for your
      fork.
 
 Re-run the sequence whenever plugin outputs or `setup.inf` change. Keeping the

--- a/tools/codesign/codesign-cz.md
+++ b/tools/codesign/codesign-cz.md
@@ -1,0 +1,89 @@
+# Digitální podepisování
+
+Tento projekt podepisuje Windows release binárky pomocí Authenticode a certifikátu Certum Open Source Code Signing in the Cloud na SimplySign.
+
+Podepisování je záměrně **ruční release krok**. Certum/SimplySign může chtít PIN pro každý podpis, takže podepisování z Visual Studio post-build eventů je ve výchozím stavu vypnuté. Post-build entry point `tools\codesign\sign_with_retry.cmd` skončí bez podpisu, pokud výslovně nenastavíte `CODESIGN_ALLOW_POSTBUILD=1`.
+
+Až budete chtít podepisovat release artefakty, spusťte ručně `tools\codesign\codesign_certum.cmd`.
+
+## Certifikát a nástroje
+
+Na Windows release stroji nainstalujte a aktivujte:
+
+1. mobilní aplikaci SimplySign,
+2. SimplySign Desktop,
+3. aktuální Windows SDK včetně nástroje `signtool.exe`.
+
+Před podepisováním se přihlaste do SimplySign Desktop a ověřte, že je certifikát vidět v certificate store aktuálního uživatele. V detailu certifikátu zkopírujte thumbprint. Před uložením do `CODESIGN_CERT_SHA1` z něj odstraňte mezery.
+
+## Povinné prostředí
+
+```cmd
+set CODESIGN_ENABLED=1
+set CODESIGN_CERT_SHA1=THUMBPRINT_CERTUM_CERTIFIKATU_BEZ_MEZER
+```
+
+Volitelné proměnné:
+
+| Proměnná | Výchozí hodnota | Popis |
+| --- | --- | --- |
+| `CODESIGN_SIGNTOOL` | `signtool.exe` | Plná cesta k `signtool.exe`, pokud není v `PATH`. |
+| `CODESIGN_TIMESTAMP_URL` | `http://time.certum.pl` | RFC 3161 timestamp server. |
+| `CODESIGN_DIGEST_ALGORITHM` | `sha256` | Digest algoritmus podepisovaného souboru. |
+| `CODESIGN_TIMESTAMP_DIGEST_ALGORITHM` | `sha256` | Digest algoritmus timestampu. |
+| `CODESIGN_RETRIES` | `3` | Počet pokusů o podpis. Hodí se kvůli dočasným výpadkům timestamp serverů. |
+| `CODESIGN_RETRY_DELAY_SECONDS` | `10` | Pauza mezi pokusy. |
+| `CODESIGN_DESCRIPTION` | prázdné | Volitelný popis `/d`, který může zobrazit Windows. |
+| `CODESIGN_DESCRIPTION_URL` | prázdné | Volitelná URL `/du`, kterou může zobrazit Windows. |
+| `CODESIGN_ALLOW_POSTBUILD` | prázdné | Nastavte na `1` jen tehdy, pokud opravdu chcete podepisování z Visual Studio post-build eventů. |
+
+## Ruční test jednoho souboru
+
+Tímto nejdřív ověřte, že funguje SimplySign, certifikát, SignTool i náš script:
+
+```cmd
+tools\codesign\codesign_certum.cmd --file "H:\_projects\salamander\output\salamander\Release_x64\salamand.exe"
+```
+
+Script podepisuje jen soubory `.exe`, `.dll` a `.spl`. Výsledek ověřuje příkazem:
+
+```cmd
+signtool verify /pa /all /v "cesta\k\souboru.exe"
+```
+
+## Ruční podepsání Inno x64 payloadu
+
+Použijte po naplnění x64 payload adresáře a před sestavením nebo publikováním instalátoru:
+
+```cmd
+tools\codesign\codesign_certum.cmd --inno-x64 --payload-dir "H:\_projects\salamander\output\salamander\Release_x64"
+```
+
+Pokud `--payload-dir` vynecháte, script použije `%OPENSAL_BUILD_DIR%\salamander\Release_x64`.
+
+Script čte `doc\runbook-setup\inno_setup_salamander_x64.iss` a podepisuje jen soubory, které jsou v tomto instalačním scriptu explicitně uvedené a mají jednu z těchto přípon:
+
+- `.exe`
+- `.dll`
+- `.spl`
+
+Odpovídající soubory se předají do jednoho volání `signtool sign`, takže PIN-based SimplySign karta by se měla pro celý payload batch zeptat jen jednou. Ověření podpisu pak stále probíhá pro každý podepsaný soubor.
+
+Externí DLL se přeskakují. Exclusion list obsahuje:
+
+- `7za.dll`, `7zwrapper.dll`, `unrar.dll`, `chmlib.dll`, `sqlite.dll`, `libeay32.dll`, `ssleay32.dll`
+- `Newtonsoft.Json.dll`, `Markdig.dll`, `PrismSharp.dll`
+- `WebView2*.dll`, `System.*.dll`, `Microsoft.Web.WebView2.*.dll`
+- VC/UCRT/API-set runtime DLL jako `api-ms-win-*.dll`, `ucrtbase.dll`, `vcruntime140.dll`, `msvcp140.dll`, `concrt140.dll`
+- `dbghelp.dll`
+
+## Pořadí při release
+
+1. Sestavit a naplnit release payload adresář.
+2. Volitelně otestovat jeden soubor přes `--file`.
+3. Podepsat Inno x64 payload přes `--inno-x64`.
+4. Sestavit Inno installer.
+5. Finální installer podepsat zvlášť přes `--file`.
+6. Finální installer ověřit přes `signtool verify /pa /all /v`.
+
+Podepsaný soubor už neupravujte. Jakákoliv změna po podepsání zneplatní Authenticode podpis.

--- a/tools/codesign/codesign.md
+++ b/tools/codesign/codesign.md
@@ -1,0 +1,89 @@
+# Code signing
+
+This project signs Windows release binaries with Authenticode and Certum Open Source Code Signing in the Cloud on SimplySign.
+
+Signing is intentionally a **manual release step**. Certum/SimplySign may ask for a PIN for every signature, so Visual Studio post-build signing is disabled by default. The post-build entry point `tools\codesign\sign_with_retry.cmd` now exits without signing unless `CODESIGN_ALLOW_POSTBUILD=1` is explicitly set.
+
+Use `tools\codesign\codesign_certum.cmd` manually when you are ready to sign release artifacts.
+
+## Certificate and tools
+
+Install and activate on the Windows release machine:
+
+1. SimplySign mobile application.
+2. SimplySign Desktop.
+3. The current Windows SDK, including `signtool.exe`.
+
+Before signing, sign in to SimplySign Desktop and confirm that the certificate is visible in the current user's certificate store. Open the certificate details and copy the certificate thumbprint. Remove spaces from the thumbprint before assigning it to `CODESIGN_CERT_SHA1`.
+
+## Required environment
+
+```cmd
+set CODESIGN_ENABLED=1
+set CODESIGN_CERT_SHA1=YOUR_CERTUM_CERTIFICATE_THUMBPRINT_WITHOUT_SPACES
+```
+
+Optional variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `CODESIGN_SIGNTOOL` | `signtool.exe` | Full path to `signtool.exe` if it is not on `PATH`. |
+| `CODESIGN_TIMESTAMP_URL` | `http://time.certum.pl` | RFC 3161 timestamp server. |
+| `CODESIGN_DIGEST_ALGORITHM` | `sha256` | File digest algorithm. |
+| `CODESIGN_TIMESTAMP_DIGEST_ALGORITHM` | `sha256` | Timestamp digest algorithm. |
+| `CODESIGN_RETRIES` | `3` | Number of signing attempts. Useful because timestamp servers can fail temporarily. |
+| `CODESIGN_RETRY_DELAY_SECONDS` | `10` | Delay between retries. |
+| `CODESIGN_DESCRIPTION` | empty | Optional `/d` file description shown by Windows. |
+| `CODESIGN_DESCRIPTION_URL` | empty | Optional `/du` URL shown by Windows. |
+| `CODESIGN_ALLOW_POSTBUILD` | empty | Set to `1` only if you intentionally want Visual Studio post-build signing. |
+
+## Manual single-file test
+
+Use this first to verify that SimplySign, the certificate, SignTool and the script are working:
+
+```cmd
+tools\codesign\codesign_certum.cmd --file "H:\_projects\salamander\output\salamander\Release_x64\salamand.exe"
+```
+
+The script signs only `.exe`, `.dll`, and `.spl` files. It verifies the result with:
+
+```cmd
+signtool verify /pa /all /v "path\to\file.exe"
+```
+
+## Manual Inno x64 payload signing
+
+Use this after the x64 payload directory has been populated and before building or publishing the installer:
+
+```cmd
+tools\codesign\codesign_certum.cmd --inno-x64 --payload-dir "H:\_projects\salamander\output\salamander\Release_x64"
+```
+
+If `--payload-dir` is omitted, the script uses `%OPENSAL_BUILD_DIR%\salamander\Release_x64`.
+
+The script reads `doc\runbook-setup\inno_setup_salamander_x64.iss` and signs only files that are explicitly listed in that installer script and have one of these extensions:
+
+- `.exe`
+- `.dll`
+- `.spl`
+
+The matching files are passed to one `signtool sign` invocation, so a PIN-based SimplySign card should prompt only once for the payload batch. Verification still runs for each signed file.
+
+External DLLs are skipped. The exclusion list includes:
+
+- `7za.dll`, `7zwrapper.dll`, `unrar.dll`, `chmlib.dll`, `sqlite.dll`, `libeay32.dll`, `ssleay32.dll`
+- `Newtonsoft.Json.dll`, `Markdig.dll`, `PrismSharp.dll`
+- `WebView2*.dll`, `System.*.dll`, `Microsoft.Web.WebView2.*.dll`
+- VC/UCRT/API-set runtime DLLs such as `api-ms-win-*.dll`, `ucrtbase.dll`, `vcruntime140.dll`, `msvcp140.dll`, `concrt140.dll`
+- `dbghelp.dll`
+
+## Release order
+
+1. Build and populate the release payload directory.
+2. Sign a single file with `--file` if you want a smoke test.
+3. Sign the Inno x64 payload with `--inno-x64`.
+4. Build the Inno installer.
+5. Sign the final installer separately with `--file`.
+6. Verify the final installer with `signtool verify /pa /all /v`.
+
+Do not modify a signed file after signing it. Any post-signing modification invalidates the Authenticode signature.

--- a/tools/codesign/codesign_certum.cmd
+++ b/tools/codesign/codesign_certum.cmd
@@ -1,0 +1,29 @@
+@echo off
+setlocal EnableExtensions DisableDelayedExpansion
+
+set "SCRIPT_DIR=%~dp0"
+set "POWERSHELL=%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe"
+if not exist "%POWERSHELL%" set "POWERSHELL=powershell.exe"
+
+if "%~1"=="" goto usage
+if /i "%~1"=="--help" goto usage
+if /i "%~1"=="/help" goto usage
+if /i "%~1"=="-h" goto usage
+
+"%POWERSHELL%" -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%codesign_certum.ps1" %*
+exit /b %ERRORLEVEL%
+
+:usage
+echo Usage:
+echo   %~nx0 --file ^<path-to-exe-dll-or-spl^>
+echo   %~nx0 --inno-x64 --payload-dir ^<Release_x64 payload directory^>
+echo.
+echo Required environment:
+echo   CODESIGN_ENABLED=1
+echo   CODESIGN_CERT_SHA1=^<Certum certificate thumbprint without spaces^>
+echo.
+echo Optional environment:
+echo   CODESIGN_SIGNTOOL, CODESIGN_TIMESTAMP_URL, CODESIGN_RETRIES,
+echo   CODESIGN_RETRY_DELAY_SECONDS, CODESIGN_DESCRIPTION, CODESIGN_DESCRIPTION_URL
+echo.
+exit /b 2

--- a/tools/codesign/codesign_certum.ps1
+++ b/tools/codesign/codesign_certum.ps1
@@ -1,0 +1,320 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Arguments
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
+$defaultInnoScript = Join-Path $repoRoot 'doc\runbook-setup\inno_setup_salamander_x64.iss'
+
+function Write-Usage {
+    Write-Host 'Usage:'
+    Write-Host '  codesign_certum.cmd --file <path-to-exe-dll-or-spl>'
+    Write-Host '  codesign_certum.cmd --inno-x64 --payload-dir <Release_x64 payload directory>'
+    Write-Host ''
+    Write-Host 'Required environment:'
+    Write-Host '  CODESIGN_ENABLED=1'
+    Write-Host '  CODESIGN_CERT_SHA1=<Certum certificate thumbprint without spaces>'
+}
+
+function Get-RequiredValue([string] $name) {
+    $value = [Environment]::GetEnvironmentVariable($name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        throw "Environment variable $name is required."
+    }
+    return $value
+}
+
+function Get-OptionalValue([string] $name, [string] $defaultValue) {
+    $value = [Environment]::GetEnvironmentVariable($name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $defaultValue
+    }
+    return $value
+}
+
+function Get-SignToolPath {
+    $configured = [Environment]::GetEnvironmentVariable('CODESIGN_SIGNTOOL')
+    if (-not [string]::IsNullOrWhiteSpace($configured)) {
+        return $configured
+    }
+    return 'signtool.exe'
+}
+
+function Test-SignableExtension([string] $path) {
+    $extension = [IO.Path]::GetExtension($path).ToLowerInvariant()
+    return $extension -eq '.exe' -or $extension -eq '.dll' -or $extension -eq '.spl'
+}
+
+function Test-ExcludedExternalBinary([string] $path) {
+    $name = [IO.Path]::GetFileName($path).ToLowerInvariant()
+    $exactExclusions = @(
+        '7za.dll',
+        '7zwrapper.dll',
+        'unrar.dll',
+        'chmlib.dll',
+        'sqlite.dll',
+        'libeay32.dll',
+        'ssleay32.dll',
+        'newtonsoft.json.dll',
+        'markdig.dll',
+        'prismsharp.dll',
+        'ucrtbase.dll',
+        'vcruntime140.dll',
+        'msvcp140.dll',
+        'concrt140.dll',
+        'dbghelp.dll'
+    )
+    if ($exactExclusions -contains $name) {
+        return $true
+    }
+
+    $wildcardExclusions = @(
+        'api-ms-win-*.dll',
+        'webview2*.dll',
+        'system.*.dll',
+        'microsoft.web.webview2.*.dll'
+    )
+    foreach ($pattern in $wildcardExclusions) {
+        if ($name -like $pattern) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Get-InnoSourcePaths([string] $innoScript, [string] $payloadDir) {
+    if (-not (Test-Path -LiteralPath $innoScript)) {
+        throw "Inno Setup script not found: $innoScript"
+    }
+    if (-not (Test-Path -LiteralPath $payloadDir)) {
+        throw "Payload directory not found: $payloadDir"
+    }
+
+    $payloadRoot = (Resolve-Path -LiteralPath $payloadDir).Path.TrimEnd('\')
+    $paths = New-Object System.Collections.Generic.List[string]
+
+    foreach ($line in Get-Content -LiteralPath $innoScript) {
+        if ($line -match '^Source:\s*"([^"]+)"') {
+            $source = $Matches[1]
+            if ($source.StartsWith('{#PayloadDir}\', [StringComparison]::OrdinalIgnoreCase)) {
+                $relative = $source.Substring('{#PayloadDir}\'.Length)
+                $paths.Add((Join-Path $payloadRoot $relative))
+            }
+        }
+    }
+
+    return $paths
+}
+
+function Get-InnoSignTargets([string] $innoScript, [string] $payloadDir) {
+    $sourcePaths = Get-InnoSourcePaths -innoScript $innoScript -payloadDir $payloadDir
+    $targets = New-Object System.Collections.Generic.List[string]
+    $missing = New-Object System.Collections.Generic.List[string]
+
+    foreach ($path in $sourcePaths) {
+        if (-not (Test-SignableExtension $path)) {
+            continue
+        }
+        if (Test-ExcludedExternalBinary $path) {
+            continue
+        }
+        if (Test-Path -LiteralPath $path) {
+            $targets.Add((Resolve-Path -LiteralPath $path).Path)
+        }
+        else {
+            $missing.Add($path)
+        }
+    }
+
+    if ($missing.Count -gt 0) {
+        Write-Warning "Skipped $($missing.Count) signable file(s) listed by Inno Setup because they do not exist in the payload directory."
+        foreach ($path in $missing) {
+            Write-Warning "  missing: $path"
+        }
+    }
+
+    return $targets | Sort-Object -Unique
+}
+
+function Invoke-SignTool([string[]] $arguments) {
+    $signTool = Get-SignToolPath
+    Write-Host "> $signTool $($arguments -join ' ')"
+
+    # Native command output is part of a PowerShell function's success stream.
+    # Capture and re-emit it so callers assigning this function's result receive
+    # only the numeric process exit code, not SignTool's verbose text plus the code.
+    $output = & $signTool @arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    foreach ($line in $output) {
+        Write-Host $line
+    }
+    return [int] $exitCode
+}
+
+function New-SignArguments([string[]] $paths) {
+    if ([Environment]::GetEnvironmentVariable('CODESIGN_ENABLED') -ne '1') {
+        throw 'Code signing is disabled. Set CODESIGN_ENABLED=1 before running this manual signing script.'
+    }
+
+    $thumbprint = (Get-RequiredValue 'CODESIGN_CERT_SHA1') -replace '\s', ''
+    $timestampUrl = Get-OptionalValue 'CODESIGN_TIMESTAMP_URL' 'http://time.certum.pl'
+    $digestAlgorithm = Get-OptionalValue 'CODESIGN_DIGEST_ALGORITHM' 'sha256'
+    $timestampDigestAlgorithm = Get-OptionalValue 'CODESIGN_TIMESTAMP_DIGEST_ALGORITHM' 'sha256'
+    $description = [Environment]::GetEnvironmentVariable('CODESIGN_DESCRIPTION')
+    $descriptionUrl = [Environment]::GetEnvironmentVariable('CODESIGN_DESCRIPTION_URL')
+
+    $signArguments = @(
+        'sign',
+        '/sha1', $thumbprint,
+        '/tr', $timestampUrl,
+        '/td', $timestampDigestAlgorithm,
+        '/fd', $digestAlgorithm,
+        '/v'
+    )
+    if (-not [string]::IsNullOrWhiteSpace($description)) {
+        $signArguments += @('/d', $description)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($descriptionUrl)) {
+        $signArguments += @('/du', $descriptionUrl)
+    }
+    $signArguments += $paths
+    return $signArguments
+}
+
+function Get-RetryCount {
+    return [int] (Get-OptionalValue 'CODESIGN_RETRIES' '3')
+}
+
+function Get-RetryDelaySeconds {
+    return [int] (Get-OptionalValue 'CODESIGN_RETRY_DELAY_SECONDS' '10')
+}
+
+function Test-SigningTarget([string] $path) {
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "Signing target does not exist: $path"
+    }
+    if (-not (Test-SignableExtension $path)) {
+        throw "Signing target must be .exe, .dll, or .spl: $path"
+    }
+}
+
+function Verify-OneFile([string] $path) {
+    Write-Host "Verifying $path ..."
+    $verifyExitCode = Invoke-SignTool @('verify', '/pa', '/all', '/v', $path)
+    if ($verifyExitCode -ne 0) {
+        throw "Signature verification failed for $path with exit code $verifyExitCode."
+    }
+}
+
+function Invoke-SignWithRetry([string[]] $paths, [string] $label) {
+    $retries = Get-RetryCount
+    $retryDelaySeconds = Get-RetryDelaySeconds
+    $signArguments = New-SignArguments $paths
+
+    for ($attempt = 1; $attempt -le $retries; $attempt++) {
+        Write-Host "Signing $label (attempt $attempt of $retries) ..."
+        $exitCode = Invoke-SignTool $signArguments
+        if ($exitCode -eq 0) {
+            foreach ($path in $paths) {
+                Verify-OneFile $path
+            }
+            return
+        }
+
+        if ($attempt -lt $retries) {
+            Write-Warning "Signing failed with exit code $exitCode. Retrying in $retryDelaySeconds second(s)."
+            Start-Sleep -Seconds $retryDelaySeconds
+        }
+        else {
+            throw "Signing failed for $label after $retries attempt(s). Last exit code: $exitCode."
+        }
+    }
+}
+
+function Sign-OneFile([string] $path) {
+    Test-SigningTarget $path
+    $resolvedPath = (Resolve-Path -LiteralPath $path).Path
+    Invoke-SignWithRetry -paths @($resolvedPath) -label $resolvedPath
+}
+
+function Sign-ManyFiles([string[]] $paths) {
+    if ($paths.Count -eq 0) {
+        throw 'No files were provided for signing.'
+    }
+
+    $resolvedPaths = foreach ($path in $paths) {
+        Test-SigningTarget $path
+        (Resolve-Path -LiteralPath $path).Path
+    }
+
+    Invoke-SignWithRetry -paths @($resolvedPaths) -label "$($resolvedPaths.Count) Inno payload file(s)"
+}
+
+function Sign-InnoPayload([string] $payloadDir, [string] $innoScript) {
+    $targets = @(Get-InnoSignTargets -innoScript $innoScript -payloadDir $payloadDir)
+    if ($targets.Count -eq 0) {
+        throw "No signable non-external .exe/.dll/.spl files were found in $payloadDir from $innoScript."
+    }
+
+    Write-Host "Found $($targets.Count) file(s) to sign from Inno Setup payload."
+    foreach ($target in $targets) {
+        Write-Host "  $target"
+    }
+
+    Sign-ManyFiles @($targets)
+}
+
+if ($Arguments.Count -eq 0) {
+    Write-Usage
+    exit 2
+}
+
+$mode = $Arguments[0].ToLowerInvariant()
+switch ($mode) {
+    '--file' {
+        if ($Arguments.Count -ne 2) {
+            Write-Usage
+            exit 2
+        }
+        Sign-OneFile $Arguments[1]
+    }
+    '--inno-x64' {
+        $payloadDir = $null
+        $innoScript = $defaultInnoScript
+        for ($i = 1; $i -lt $Arguments.Count; $i++) {
+            switch ($Arguments[$i].ToLowerInvariant()) {
+                '--payload-dir' {
+                    $i++
+                    if ($i -ge $Arguments.Count) { throw '--payload-dir requires a value.' }
+                    $payloadDir = $Arguments[$i]
+                }
+                '--inno-script' {
+                    $i++
+                    if ($i -ge $Arguments.Count) { throw '--inno-script requires a value.' }
+                    $innoScript = $Arguments[$i]
+                }
+                default {
+                    throw "Unknown argument for --inno-x64: $($Arguments[$i])"
+                }
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($payloadDir)) {
+            $buildRoot = [Environment]::GetEnvironmentVariable('OPENSAL_BUILD_DIR')
+            if (-not [string]::IsNullOrWhiteSpace($buildRoot)) {
+                $payloadDir = Join-Path $buildRoot 'salamander\Release_x64'
+            }
+        }
+        if ([string]::IsNullOrWhiteSpace($payloadDir)) {
+            throw 'Use --payload-dir or set OPENSAL_BUILD_DIR.'
+        }
+        Sign-InnoPayload -payloadDir $payloadDir -innoScript $innoScript
+    }
+    default {
+        Write-Usage
+        exit 2
+    }
+}

--- a/tools/codesign/sign_with_retry.cmd
+++ b/tools/codesign/sign_with_retry.cmd
@@ -1,1 +1,15 @@
-@rem placeholder
+@echo off
+setlocal
+
+rem Visual Studio post-build entry point. Signing is intentionally disabled here
+rem by default because Certum/SimplySign may require an interactive PIN prompt.
+rem Run tools\codesign\codesign_certum.cmd manually for release signing.
+
+if /i not "%CODESIGN_ALLOW_POSTBUILD%"=="1" (
+  echo Code signing skipped by post-build hook. Run tools\codesign\codesign_certum.cmd manually, or set CODESIGN_ALLOW_POSTBUILD=1.
+  exit /b 0
+)
+
+set "SCRIPT_DIR=%~dp0"
+call "%SCRIPT_DIR%codesign_certum.cmd" --file %*
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
### Motivation

- Provide a supported, manual workflow for Authenticode signing of Windows release artifacts using Certum Open Source Code Signing on SimplySign and document the required steps. 
- Prevent accidental interactive PIN prompts during normal builds by disabling automatic post-build signing by default.

### Description

- Add high-level documentation covering code-signing (`tools/codesign/codesign.md`) and a Czech translation (`tools/codesign/codesign-cz.md`).
- Implement a thin launcher `tools\codesign\codesign_certum.cmd` and a full PowerShell signing implementation `tools\codesign\codesign_certum.ps1` that can sign a single file or an Inno x64 payload parsed from `doc\runbook-setup\inno_setup_salamander_x64.iss`, with retry, timestamp, verification, and an exclusion list for external runtime DLLs.
- Replace the placeholder post-build hook with `tools\codesign\sign_with_retry.cmd` that skips signing unless `CODESIGN_ALLOW_POSTBUILD=1` is explicitly set to avoid unintentional interactive signing in CI or developer builds.
- Update the runbook `doc/runbook-setup/README.md` to document signing the x64 payload and final installer with the provided scripts.

### Testing

- Ran `tools\codesign\codesign_certum.cmd --help` and the PowerShell script usage path to validate the CLI entry points produced usage output (success).
- Executed script-based smoke checks that exercised the Inno parsing and exclusion logic against a sample payload layout and confirmed no signable files were incorrectly selected (success).
- No unit tests were added to the repository as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33e8ab13f08329a9f894d3b909b4bf)