### PR TITLE
Fix Inno Setup upgrade path for Samandarin (preserve install dir and remove old uninstall entries)

### DIFF
--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -25,7 +25,7 @@
 #endif
 
 [Setup]
-AppId=OpenSalamanderSamandarin-x64-{#MyAppVersion}
+AppId=OpenSalamanderSamandarin-x64
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppVerName={#MyAppDisplayName}
@@ -1381,6 +1381,7 @@ var
   DeleteUserConfiguration: Boolean;
   DeleteUserConfigurationFromFile: Boolean;
   DeleteUserConfigurationFilePath: String;
+  PreviousVersionUninstallKeys: array of String;
 
 function IsPortableInstall(): Boolean;
 begin
@@ -1403,6 +1404,64 @@ begin
     Result := GetPortableDefaultDir()
   else
     Result := GetStandardDefaultDir();
+end;
+
+
+procedure AddPreviousVersionUninstallKey(const RootKey: Integer; const SubKeyName: String);
+var
+  InstallLocation: String;
+  DisplayName: String;
+  UninstallString: String;
+begin
+  if RegQueryStringValue(RootKey, SubKeyName, 'InstallLocation', InstallLocation) and
+     (CompareText(RemoveBackslashUnlessRoot(InstallLocation), RemoveBackslashUnlessRoot(ExpandConstant('{app}'))) = 0) and
+     RegQueryStringValue(RootKey, SubKeyName, 'DisplayName', DisplayName) and
+     (Pos('Open Salamander', DisplayName) = 1) and
+     RegQueryStringValue(RootKey, SubKeyName, 'UninstallString', UninstallString) and
+     FileExists(RemoveQuotes(UninstallString)) then
+  begin
+    SetArrayLength(PreviousVersionUninstallKeys, GetArrayLength(PreviousVersionUninstallKeys) + 1);
+    PreviousVersionUninstallKeys[GetArrayLength(PreviousVersionUninstallKeys) - 1] := SubKeyName;
+  end;
+end;
+
+procedure CollectPreviousVersionUninstallKeys(const RootKey: Integer; const UninstallRoot: String);
+var
+  Names: array of String;
+  I: Integer;
+begin
+  if not RegGetSubkeyNames(RootKey, UninstallRoot, Names) then
+    Exit;
+
+  for I := 0 to GetArrayLength(Names) - 1 do
+  begin
+    if (CompareText(Names[I], ExpandConstant('{#SetupSetting("AppId")}') + '_is1') <> 0) and
+       (Pos('OpenSalamanderSamandarin-x64-', Names[I]) = 1) then
+    begin
+      AddPreviousVersionUninstallKey(RootKey, UninstallRoot + '\' + Names[I]);
+    end;
+  end;
+end;
+
+procedure CollectPreviousVersionUninstallKeysForAppDir;
+begin
+  SetArrayLength(PreviousVersionUninstallKeys, 0);
+  if IsPortableInstall() then
+    Exit;
+
+  CollectPreviousVersionUninstallKeys(HKLM, 'Software\Microsoft\Windows\CurrentVersion\Uninstall');
+  CollectPreviousVersionUninstallKeys(HKLM64, 'Software\Microsoft\Windows\CurrentVersion\Uninstall');
+end;
+
+procedure RemovePreviousVersionUninstallKeys;
+var
+  I: Integer;
+begin
+  for I := 0 to GetArrayLength(PreviousVersionUninstallKeys) - 1 do
+  begin
+    RegDeleteKeyIncludingSubkeys(HKLM, PreviousVersionUninstallKeys[I]);
+    RegDeleteKeyIncludingSubkeys(HKLM64, PreviousVersionUninstallKeys[I]);
+  end;
 end;
 
 function GetACP: DWORD;
@@ -1505,6 +1564,14 @@ begin
     else if (not IsPortableInstall()) and (WizardDirValue = GetPortableDefaultDir()) then
       WizardForm.DirEdit.Text := GetStandardDefaultDir();
   end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssInstall then
+    CollectPreviousVersionUninstallKeysForAppDir
+  else if CurStep = ssPostInstall then
+    RemovePreviousVersionUninstallKeys;
 end;
 
 function IsFileConfigurationStorageSelected(): Boolean;

--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -1656,10 +1656,9 @@ procedure CurStepChanged(CurStep: TSetupStep);
 var
   PluginsVer: String;
 begin
-  if CurStep = ssInstall then
-    CollectPreviousVersionUninstallKeysForAppDir
-  else if CurStep = ssPostInstall then
+  if CurStep = ssPostInstall then
   begin
+    CollectPreviousVersionUninstallKeysForAppDir;
     RemovePreviousVersionUninstallKeys;
 
     { Mirrors the setup_x64.inf IncrementFileContent metadata by ensuring plugins.ver exists.

--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -1566,14 +1566,6 @@ begin
   end;
 end;
 
-procedure CurStepChanged(CurStep: TSetupStep);
-begin
-  if CurStep = ssInstall then
-    CollectPreviousVersionUninstallKeysForAppDir
-  else if CurStep = ssPostInstall then
-    RemovePreviousVersionUninstallKeys;
-end;
-
 function IsFileConfigurationStorageSelected(): Boolean;
 var
   StorageType: String;
@@ -1664,8 +1656,12 @@ procedure CurStepChanged(CurStep: TSetupStep);
 var
   PluginsVer: String;
 begin
-  if CurStep = ssPostInstall then
+  if CurStep = ssInstall then
+    CollectPreviousVersionUninstallKeysForAppDir
+  else if CurStep = ssPostInstall then
   begin
+    RemovePreviousVersionUninstallKeys;
+
     { Mirrors the setup_x64.inf IncrementFileContent metadata by ensuring plugins.ver exists.
       The legacy installer used the registry value
       HKCU\Software\Open Salamander Samandarin\5.0-samandarin-0.7\Configuration\Plugins.ver Version (x64)


### PR DESCRIPTION
### Motivation
- Ensure that running a newer Samandarin installer over an existing installation path performs an upgrade instead of creating a separate installation entry. 
- Avoid leaving stale/versioned Programs/uninstaller entries when upgrading from older Samandarin versions. 

### Description
- Use a stable `AppId` (`OpenSalamanderSamandarin-x64`) instead of a versioned one so installers are recognized as the same product across versions in `doc/runbook-setup/inno_setup_salamander_x64.iss`.  
- Add `PreviousVersionUninstallKeys` array and helper procedures `AddPreviousVersionUninstallKey`, `CollectPreviousVersionUninstallKeys`, `CollectPreviousVersionUninstallKeysForAppDir`, and `RemovePreviousVersionUninstallKeys` to detect older versioned uninstall registry entries that point to the selected install directory.  
- Hook a new `CurStepChanged` handler to run collection at `ssInstall` and removal at `ssPostInstall`, so obsolete uninstall keys are removed only after successful install.  
- Keep portable-install behavior unchanged (collection is skipped for portable installs).  

### Testing
- Ran `git diff --check` which reported no issues (passed).  
- Executed a `python3` smoke assertion script that verified the stable `AppId` and presence of the upgrade migration code (assertions passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43efa08da08329a5fe9f9c27b6b554)