### PR TITLE
Add stable plugin catalog updater

### DIFF
--- a/doc/catalogs-base/plugins-stable.json
+++ b/doc/catalogs-base/plugins-stable.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "catalogName": "Stable",
-  "generatedAt": "2026-06-29T00:00:00Z",
+  "generatedAt": "2026-07-02T22:59:23Z",
   "plugins": [
     {
       "id": "7zip",
@@ -57,40 +57,6 @@
         "spanish": "Automatiza tareas comunes por medio de scripts."
       },
       "latestVersion": "1.7 (x64)",
-      "versionScheme": "fileversion",
-      "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
-      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
-    },
-    {
-      "id": "checksum",
-      "name": {
-        "english": "Checksum",
-        "chinesesimplified": "校验和",
-        "czech": "Kontrolní součet",
-        "german": "Prüfsumme",
-        "dutch": "Controlesom",
-        "hungarian": "Ellenőrzőösszeg",
-        "russian": "Контрольная сумма",
-        "french": "Checksum",
-        "slovak": "Kontrolný súčet",
-        "romanian": "Checksum",
-        "spanish": "Suma de comprobación"
-      },
-      "author": "Open Salamander Authors",
-      "description": {
-        "english": "Checksum plugin for Open Salamander",
-        "chinesesimplified": "SFV, MD5, SHA-1, SHA-256, 及 SHA-512 校验和验证器和计算器。",
-        "czech": "Ověření a výpočet SFV, MD5, SHA-1, SHA-256 a SHA-512 kontrolního součtu.",
-        "german": "SFV-, MD5-, SHA-1-, SHA-256 und SHA-512-Prüfsummen verifizieren/berechnen.",
-        "dutch": "Bereken en controleren van SFV, MD5, SHA-1, SHA-256, en SHA-512 checksum.",
-        "hungarian": "SFV, MD5, SHA-1, SHA-256, és SHA-512 ellenőrzőösszeg vizsgálata és számítása.",
-        "russian": "Вычисление и верификация контрольных сумм SFV, MD5, SHA-1, SHA-256, и SHA-512.",
-        "french": "Vérification et calcul de checksums SFV, MD5, SHA-1, SHA-256, et SHA-512.",
-        "slovak": "Overenie a výpočet SFV, MD5, SHA-1, SHA-256, a SHA-512 kontrolného súčtu.",
-        "romanian": "SFV, MD5, SHA-1, SHA-256, si SHA-512 checksum verificator si calculator.",
-        "spanish": "Verificador y calculador de sumas SFV, MD5, SHA-1, SHA-256 y SHA-512."
-      },
-      "latestVersion": "2.2 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -226,7 +192,7 @@
         "spanish": "Navega por carpetas como Escritorio, Panel de control, Papelera, etc.",
         "chinesesimplified": "浏览文件夹，如桌面、控制面板、回收站等。"
       },
-      "latestVersion": "0.1 (x64)",
+      "latestVersion": "0.2 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -260,7 +226,7 @@
         "romanian": "Transferul fisierelor si directoarelor prin FTP.",
         "spanish": "Transferencia de ficheros y directorios por FTP."
       },
-      "latestVersion": "1.35 (x64)",
+      "latestVersion": "1.36 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -294,7 +260,41 @@
         "romanian": "Afișează mașinile virtuale Hyper-V locale în panou.",
         "spanish": "Mostrar las máquinas virtuales locales de Hyper-V en el panel."
       },
-      "latestVersion": "1.05 (x64)",
+      "latestVersion": "1.06 (x64)",
+      "versionScheme": "fileversion",
+      "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
+    },
+    {
+      "id": "checksum",
+      "name": {
+        "english": "Checksum",
+        "chinesesimplified": "校验和",
+        "czech": "Kontrolní součet",
+        "german": "Prüfsumme",
+        "dutch": "Controlesom",
+        "hungarian": "Ellenőrzőösszeg",
+        "russian": "Контрольная сумма",
+        "french": "Checksum",
+        "slovak": "Kontrolný súčet",
+        "romanian": "Checksum",
+        "spanish": "Suma de comprobación"
+      },
+      "author": "Open Salamander Authors",
+      "description": {
+        "english": "Checksum plugin for Open Salamander",
+        "chinesesimplified": "SFV, MD5, SHA-1, SHA-256, 及 SHA-512 校验和验证器和计算器。",
+        "czech": "Ověření a výpočet SFV, MD5, SHA-1, SHA-256 a SHA-512 kontrolního součtu.",
+        "german": "SFV-, MD5-, SHA-1-, SHA-256 und SHA-512-Prüfsummen verifizieren/berechnen.",
+        "dutch": "Bereken en controleren van SFV, MD5, SHA-1, SHA-256, en SHA-512 checksum.",
+        "hungarian": "SFV, MD5, SHA-1, SHA-256, és SHA-512 ellenőrzőösszeg vizsgálata és számítása.",
+        "russian": "Вычисление и верификация контрольных сумм SFV, MD5, SHA-1, SHA-256, и SHA-512.",
+        "french": "Vérification et calcul de checksums SFV, MD5, SHA-1, SHA-256, et SHA-512.",
+        "slovak": "Overenie a výpočet SFV, MD5, SHA-1, SHA-256, a SHA-512 kontrolného súčtu.",
+        "romanian": "SFV, MD5, SHA-1, SHA-256, si SHA-512 checksum verificator si calculator.",
+        "spanish": "Verificador y calculador de sumas SFV, MD5, SHA-1, SHA-256 y SHA-512."
+      },
+      "latestVersion": "2.2 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -430,7 +430,7 @@
         "romanian": "Da acces computerelor la retea.",
         "spanish": "Proporciona acceso a los ordenadores de la red."
       },
-      "latestVersion": "1.08 (x64)",
+      "latestVersion": "1.09 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -566,7 +566,7 @@
         "romanian": "Gestionați dispozitivele portabile.",
         "spanish": "Administrar dispositivos portátiles."
       },
-      "latestVersion": "0.2 (x64)",
+      "latestVersion": "0.3 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -600,7 +600,7 @@
         "romanian": "Rasfoieste, vizualizeaza si modifica Registri Windows.",
         "spanish": "Hojear, ver y modificar el registro de Windows."
       },
-      "latestVersion": "1.14 (x64)",
+      "latestVersion": "1.15 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -634,7 +634,7 @@
         "romanian": "Pentru redenumire in grup complexa, cu verificare in timp real.",
         "spanish": "Potente utilidad de cambio de nombre con previsualización real."
       },
-      "latestVersion": "1.13 (x64)",
+      "latestVersion": "1.14 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -702,7 +702,7 @@
         "romanian": "Răsfoiește și configurează servicii.",
         "spanish": "Examinar y configurar servicios."
       },
-      "latestVersion": "0.012 (x64)",
+      "latestVersion": "0.013 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -818,7 +818,7 @@
       "description": {
         "english": "UnARJ plugin for Open Salamander"
       },
-      "latestVersion": "1.21 (x64)",
+      "latestVersion": "1.22 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -832,21 +832,7 @@
       "description": {
         "english": "UnCAB plugin for Open Salamander"
       },
-      "latestVersion": "1.27 (x64)",
-      "versionScheme": "fileversion",
-      "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
-      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
-    },
-    {
-      "id": "unchm",
-      "name": {
-        "english": "UnCHM"
-      },
-      "author": "Open Salamander Authors",
-      "description": {
-        "english": "UnCHM plugin for Open Salamander"
-      },
-      "latestVersion": "1.03 (x64)",
+      "latestVersion": "1.28 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -880,7 +866,7 @@
         "romanian": "Recupereaza fisiere sterse de pe partitii FAT sau NTFS.",
         "spanish": "Recupera ficheros borrados desde particiones FAT o NTFS."
       },
-      "latestVersion": "1.11 (x64)",
+      "latestVersion": "1.12 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -894,7 +880,21 @@
       "description": {
         "english": "UnFAT plugin for Open Salamander"
       },
-      "latestVersion": "1.1 (x64)",
+      "latestVersion": "1.2 (x64)",
+      "versionScheme": "fileversion",
+      "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
+    },
+    {
+      "id": "unchm",
+      "name": {
+        "english": "UnCHM"
+      },
+      "author": "Open Salamander Authors",
+      "description": {
+        "english": "UnCHM plugin for Open Salamander"
+      },
+      "latestVersion": "1.04 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -908,7 +908,7 @@
       "description": {
         "english": "UnISO plugin for Open Salamander"
       },
-      "latestVersion": "1.37 (x64)",
+      "latestVersion": "1.38 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -942,7 +942,7 @@
         "romanian": "Rasfoieste si extrage arhivele LHA.",
         "spanish": "Hojear y extraer archivos LHA."
       },
-      "latestVersion": "1.13 (x64)",
+      "latestVersion": "1.14 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -976,7 +976,7 @@
         "romanian": "Rasfoieste si extrage fisierele MIME/Base64, UU/XXEncode, yEncode si BinHex.",
         "spanish": "Hojear y extraer ficheros MIME/Base64, UU/XXEncode, yEncode y BinHex."
       },
-      "latestVersion": "1.14 (x64)",
+      "latestVersion": "1.15 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -990,7 +990,7 @@
       "description": {
         "english": "UnOLE plugin for Open Salamander"
       },
-      "latestVersion": "1.01 (x64)",
+      "latestVersion": "1.02 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -1004,7 +1004,7 @@
       "description": {
         "english": "UnRAR plugin for Open Salamander"
       },
-      "latestVersion": "3.01 (x64)",
+      "latestVersion": "3.02 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -1038,7 +1038,7 @@
         "romanian": "Vizualizator care afișează HTML redat, Markdown și documente web utilizând WebView2.",
         "spanish": "Visor que muestra HTML, Markdown y documentos web renderizados mediante WebView2."
       },
-      "latestVersion": "1.0 (x64)",
+      "latestVersion": "1.01 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -1072,7 +1072,7 @@
         "romanian": "Acceseaza fisierele pe dispozitivul dvs Windows Mobile.",
         "spanish": "Acceder a ficheros en dispositivo Windows Mobile."
       },
-      "latestVersion": "1.08 (x64)",
+      "latestVersion": "1.09 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"
@@ -1106,7 +1106,7 @@
         "romanian": "Creaza, rasfoieste, si extrage arhivele ZIP.",
         "spanish": "Crear, hojear y extraer archivos ZIP."
       },
-      "latestVersion": "1.4 (x64)",
+      "latestVersion": "1.5 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases",
       "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases"

--- a/tools/catalogs/update_stable_plugin_catalog.py
+++ b/tools/catalogs/update_stable_plugin_catalog.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Update the stable plugin catalog from the Inno Setup installer manifest.
+
+The script keeps existing catalog metadata/translations intact, synchronizes the
+plugin list with the .spl plugins shipped by the installer, refreshes versions
+from each plugin's versinfo.rh2, and updates generatedAt.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CATALOG = ROOT / "doc" / "catalogs-base" / "plugins-stable.json"
+DEFAULT_INSTALLER = ROOT / "doc" / "runbook-setup" / "inno_setup_salamander_x64.iss"
+DEFAULT_PLUGINS_ROOT = ROOT / "src" / "plugins"
+DEFAULT_RELEASE_URL = "https://github.com/KRtkovo-eu-AI/salamander/releases"
+
+SOURCE_SPL_RE = re.compile(
+    r'^\s*Source:\s*"\{#PayloadDir\}\\plugins\\(?P<id>[^\\"]+)\\(?P<file>[^\\"]+\.spl)"',
+    re.IGNORECASE | re.MULTILINE,
+)
+DEFINE_RE = re.compile(r"^\s*#define\s+(VERSINFO_(?:MAJOR|MINORA|MINORB|DESCRIPTION))\s+(.+?)\s*$", re.MULTILINE)
+
+
+def parse_installer_plugins(installer: Path) -> list[str]:
+    """Return unique plugin ids in the order their .spl files appear in [Files]."""
+    text = installer.read_text(encoding="utf-8-sig")
+    ids: list[str] = []
+    seen: set[str] = set()
+    for match in SOURCE_SPL_RE.finditer(text):
+        plugin_id = match.group("id")
+        if plugin_id not in seen:
+            ids.append(plugin_id)
+            seen.add(plugin_id)
+    if not ids:
+        raise RuntimeError(f"No .spl plugin entries found in {installer}")
+    return ids
+
+
+def _unquote_define_value(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return bytes(value[1:-1], "utf-8").decode("unicode_escape")
+    return value.split("//", 1)[0].strip()
+
+
+def read_plugin_metadata(plugin_id: str, plugins_root: Path) -> tuple[str | None, str | None]:
+    """Return (version, English description) from src/plugins/<id>/versinfo.rh2."""
+    versinfo = plugins_root / plugin_id / "versinfo.rh2"
+    if not versinfo.exists():
+        return None, None
+    text = versinfo.read_text(encoding="utf-8-sig")
+    defines = {name: _unquote_define_value(value) for name, value in DEFINE_RE.findall(text)}
+    try:
+        major = int(defines["VERSINFO_MAJOR"])
+        minora = int(defines["VERSINFO_MINORA"])
+        minorb = int(defines.get("VERSINFO_MINORB", "0"))
+    except (KeyError, ValueError) as exc:
+        raise RuntimeError(f"Cannot parse version macros in {versinfo}") from exc
+
+    version = f"{major}.{minora}" if minorb == 0 else f"{major}.{minora}{minorb}"
+    return f"{version} (x64)", defines.get("VERSINFO_DESCRIPTION")
+
+
+def now_utc() -> str:
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch is not None:
+        instant = dt.datetime.fromtimestamp(int(epoch), tz=dt.timezone.utc)
+    else:
+        instant = dt.datetime.now(dt.timezone.utc)
+    return instant.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def new_plugin_entry(plugin_id: str, version: str | None, description: str | None) -> dict[str, Any]:
+    display_name = plugin_id.replace("-", " ").replace("_", " ").title()
+    return {
+        "id": plugin_id,
+        "name": {"english": display_name},
+        "author": "Open Salamander Authors",
+        "description": {"english": description or f"{display_name} plugin for Open Salamander"},
+        "latestVersion": version or "unknown (x64)",
+        "versionScheme": "fileversion",
+        "homepageUrl": DEFAULT_RELEASE_URL,
+        "downloadPageUrl": DEFAULT_RELEASE_URL,
+    }
+
+
+def update_catalog(
+    catalog: dict[str, Any], shipped_ids: list[str], plugins_root: Path, generated_at: str | None = None
+) -> dict[str, Any]:
+    existing = {plugin["id"]: plugin for plugin in catalog.get("plugins", [])}
+    updated_plugins: list[dict[str, Any]] = []
+    for plugin_id in shipped_ids:
+        version, description = read_plugin_metadata(plugin_id, plugins_root)
+        entry = dict(existing.get(plugin_id) or new_plugin_entry(plugin_id, version, description))
+        if version is not None:
+            entry["latestVersion"] = version
+        elif "latestVersion" not in entry:
+            entry["latestVersion"] = "unknown (x64)"
+        updated_plugins.append(entry)
+
+    updated = dict(catalog)
+    updated["generatedAt"] = generated_at or now_utc()
+    updated["plugins"] = updated_plugins
+    return updated
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--installer", type=Path, default=DEFAULT_INSTALLER)
+    parser.add_argument("--plugins-root", type=Path, default=DEFAULT_PLUGINS_ROOT)
+    parser.add_argument("--check", action="store_true", help="fail if the catalog would change")
+    args = parser.parse_args()
+
+    catalog = json.loads(args.catalog.read_text(encoding="utf-8"))
+    shipped_ids = parse_installer_plugins(args.installer)
+    generated_at = catalog.get("generatedAt") if args.check else None
+    updated = update_catalog(catalog, shipped_ids, args.plugins_root, generated_at)
+    rendered = json.dumps(updated, ensure_ascii=False, indent=2) + "\n"
+
+    current = args.catalog.read_text(encoding="utf-8")
+    if args.check:
+        if rendered != current:
+            raise SystemExit(f"{args.catalog} is not up to date; run {Path(__file__).as_posix()}")
+        return 0
+
+    args.catalog.write_text(rendered, encoding="utf-8")
+    print(f"Updated {args.catalog} with {len(shipped_ids)} plugins.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Zajistit, aby `doc/catalogs-base/plugins-stable.json` vždy odpovídal seznamu pluginů obsažených v instalátoru a aby u nich byly aktuální verze a čas generování.
- Zachovat existující překlady a ostatní pole v katalogu při doplňování nových nebo odebírání starých pluginů.

### Description
- Přidán skript `tools/catalogs/update_stable_plugin_catalog.py`, který parsuje `.spl` položky v `doc/runbook-setup/inno_setup_salamander_x64.iss` a pořadí pluginů z něj používá pro katalog.
- Skript čte verze a popisy z `src/plugins/<plugin>/versinfo.rh2` a nastavuje `latestVersion` ve tvaru `"<verze> (x64)"` a zároveň ponechává existující překlady/fieldy.
- Pro nové pluginy vytvoří defaultní záznamy s rozumnými poli a odstraní pluginy, které instalátor už neshipuje, a aktualizuje `generatedAt` (podpora `SOURCE_DATE_EPOCH` pro reprodukovatelné běhy).
- Regenerován soubor `doc/catalogs-base/plugins-stable.json` tak, aby odrážel aktuální seznam a verze pluginů ze zásob instalátoru.

### Testing
- Spuštěno `python3 tools/catalogs/update_stable_plugin_catalog.py --check` a skript potvrdil, že katalog je aktuální (úspěch).
- Validace syntaxe skriptu přes `python3 -m py_compile tools/catalogs/update_stable_plugin_catalog.py` proběhla bez chyb (úspěch).
- JSON soubor byl validován příkazem `python3 -m json.tool doc/catalogs-base/plugins-stable.json` bez výstupu chyb (úspěch).
- Kontrola změn (`git diff --check`) neodhalila problémové kontextové chyby (úspěch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46ecb450688329a51180dc500f83f5)