### PR TITLE
Fix CodeQL checkout path

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,6 @@ jobs:
     defaults:
       run:
         shell: pwsh
-        working-directory: s
 
     env:
       BUILD_CONFIGURATION: Release
@@ -38,7 +37,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          path: s
           ref: ${{ github.event.inputs['target-ref'] || github.ref }}
           fetch-depth: 2
 


### PR DESCRIPTION
### Motivation
- CodeQL uploads and git-based post-processing were failing with repeated "checkout path does not appear to be a git repository" errors when the workflow used a custom checkout subdirectory.
- Restore the repository to the expected `GITHUB_WORKSPACE` location so CodeQL can access the git metadata and compute base/compare SHAs for SARIF uploads. 

### Description
- Removed the custom `path: s` argument from `actions/checkout@v4` so the repository is checked out at the default workspace.
- Removed the `working-directory: s` override under `defaults.run` so PowerShell steps execute from the repository root.
- Preserved the existing `PROJECT_PATH` and MSBuild steps so the build and analysis target remain unchanged.

### Testing
- Ran `git diff --check`, which reported no whitespace or diff issues and succeeded.
- Ran a small `python` assertion script that verified `working-directory: s` and `path: s` are not present and that `PROJECT_PATH` remains unchanged, and the assertions passed.
- Attempted to parse the workflow with `yaml.safe_load` in the container, but that check failed due to the environment missing the `PyYAML` package (module `yaml` not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a471576c74c83299eb3edc62af12fe6)