### PR TITLE
Force-refresh Tree View after filesystem change notifications

### DIFF
--- a/.github/workflows/pr-msbuild.yml
+++ b/.github/workflows/pr-msbuild.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: s
+          submodules: recursive
 
       - name: Setup MSBuild in PATH (VS2022)
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/pr-msbuild.yml
+++ b/.github/workflows/pr-msbuild.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Register MSVC problem matcher
         uses: ammaraskar/msvc-problem-matcher@master
 
+      - name: Install SFTP plugin dependencies
+        run: |
+          $triplet = if ('${{ matrix.platform }}' -eq 'Win32') { 'x86-windows' } else { 'x64-windows' }
+          .\tools\vcpkg\build-third-party-libs.ps1 -SftpPlugin -OnlySftpPlugin -Triplet $triplet
+
       - name: Build via MSBuild (Debug | ${{ matrix.platform }})
         run: |
           $logDir = Join-Path (Get-Location) $env:LOG_DIRECTORY

--- a/.github/workflows/pr-msbuild.yml
+++ b/.github/workflows/pr-msbuild.yml
@@ -40,6 +40,12 @@ jobs:
           path: s
           submodules: recursive
 
+      - name: Provide shared plugin files for SFTP submodule
+        run: |
+          $sftpShared = Join-Path (Get-Location) 'src\plugins\sftp\shared'
+          New-Item -ItemType Directory -Force -Path $sftpShared | Out-Null
+          Copy-Item -Path '.\src\plugins\shared\*' -Destination $sftpShared -Recurse -Force
+
       - name: Setup MSBuild in PATH (VS2022)
         uses: microsoft/setup-msbuild@v2
 

--- a/.github/workflows/pr-msbuild.yml
+++ b/.github/workflows/pr-msbuild.yml
@@ -46,6 +46,27 @@ jobs:
           New-Item -ItemType Directory -Force -Path $sftpShared | Out-Null
           Copy-Item -Path '.\src\plugins\shared\*' -Destination $sftpShared -Recurse -Force
 
+      - name: Configure SFTP submodule build
+        run: |
+          $sftpRoot = Join-Path (Get-Location) 'src\plugins\sftp'
+          $directoryBuildProps = Join-Path $sftpRoot 'Directory.Build.props'
+          @'
+          <Project>
+            <ItemDefinitionGroup>
+              <ClCompile>
+                <PreprocessorDefinitions>OPENSSL_SUPPRESS_DEPRECATED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+              </ClCompile>
+            </ItemDefinitionGroup>
+          </Project>
+          '@ | Set-Content -Path $directoryBuildProps -Encoding UTF8
+
+          if ('${{ matrix.platform }}' -eq 'Win32') {
+            $sftpProps = Join-Path $sftpRoot 'src\vcxproj\sftp.props'
+            (Get-Content -LiteralPath $sftpProps) |
+              ForEach-Object { $_ -replace 'libcrypto-3-x64\.dll', 'libcrypto-3.dll' } |
+              Set-Content -LiteralPath $sftpProps -Encoding UTF8
+          }
+
       - name: Setup MSBuild in PATH (VS2022)
         uses: microsoft/setup-msbuild@v2
 

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -806,7 +806,7 @@ void CFilesWindowAncestor::SetPath(const char* path)
     // CommonRefresh(), so the file list loads first (responsive UI).
 }
 
-void CFilesWindow::RefreshTreeView()
+void CFilesWindow::RefreshTreeView(BOOL forceRefresh)
 {
     CALL_STACK_MESSAGE1("CFilesWindow::RefreshTreeView()");
 
@@ -880,7 +880,7 @@ void CFilesWindow::RefreshTreeView()
         if (hCurrent == NULL)
             break;
 
-        PopulateTreeViewItem(hCurrent);
+        PopulateTreeViewItem(hCurrent, forceRefresh);
         TreeView_Expand(HTreeView, hCurrent, TVE_EXPAND);
 
         if (!IsTheSamePath(root, sourcePath))
@@ -916,7 +916,7 @@ void CFilesWindow::RefreshTreeView()
 
                 hCurrent = hChild;
                 lstrcpyn(currentPath, nextPath, _countof(currentPath));
-                PopulateTreeViewItem(hCurrent);
+                PopulateTreeViewItem(hCurrent, forceRefresh);
                 TreeView_Expand(HTreeView, hCurrent, TVE_EXPAND);
 
                 segment += len;
@@ -925,7 +925,7 @@ void CFilesWindow::RefreshTreeView()
             }
         }
 
-        PopulateTreeViewItem(hCurrent);
+        PopulateTreeViewItem(hCurrent, forceRefresh);
 
         HTREEITEM hSelect = hCurrent;
         if (hadSelectedFile && IsTheSamePath(selectedFileFocusPath, sourcePath))

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1360,7 +1360,7 @@ public:
     void CreateTreeView();
     void DestroyTreeView();
     void UpdateTreeView(BOOL active);
-    void RefreshTreeView();
+    void RefreshTreeView(BOOL forceRefresh = FALSE);
     BOOL PopulateTreeViewItem(HTREEITEM hItem, BOOL forceRefresh = FALSE, BOOL async = FALSE);
 
     void ConnectNet(BOOL readOnlyUNC, const char* netRootPath = NULL, BOOL changeToNewDrive = TRUE, char* newlyMappedDrive = NULL);

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -514,6 +514,7 @@ protected:
         DragSplitPosition;             // shown in the tooltip
     CToolTipWindow ToolTipWindow;
     BOOL KeepSplitPositionCenteredOnVisiblePanes;
+    int PanelZoomedState; // 0 = none, 1 = left panel, 2 = right panel
 
     BOOL FirstActivateApp; // WM_ACTIVATEAPP uses this variable during startup
 

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -508,9 +508,10 @@ protected:
         PanelsHeight,
         SplitPositionPix,
         DragAnchorX;
-    double SplitPosition,        // current split position (0..1)
-        BeforeZoomSplitPosition, // split position before panel zoom
-        DragSplitPosition;       // shown in the tooltip
+    double SplitPosition,              // current split position (0..1)
+        BeforeZoomSplitPosition,       // split position before panel zoom
+        BeforeZoomVisibleLeftRatio,    // visible left panel ratio before panel zoom (tree view aware)
+        DragSplitPosition;             // shown in the tooltip
     CToolTipWindow ToolTipWindow;
     BOOL KeepSplitPositionCenteredOnVisiblePanes;
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -340,6 +340,7 @@ CMainWindow::CMainWindow()
     BeforeZoomSplitPosition = 0.5;
     BeforeZoomVisibleLeftRatio = 0.5;
     KeepSplitPositionCenteredOnVisiblePanes = FALSE;
+    PanelZoomedState = 0;
     DragMode = FALSE;
     ContextMenuNew = new CMenuNew;
     ContextMenuChngDrv = NULL;

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -338,6 +338,7 @@ CMainWindow::CMainWindow()
     WindowWidth = WindowHeight = EditHeight = 0;
     SplitPosition = 0.5; // split is in the middle
     BeforeZoomSplitPosition = 0.5;
+    BeforeZoomVisibleLeftRatio = 0.5;
     KeepSplitPositionCenteredOnVisiblePanes = FALSE;
     DragMode = FALSE;
     ContextMenuNew = new CMenuNew;

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -4125,6 +4125,7 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                         BeforeZoomSplitPosition = 0;
                     if (BeforeZoomSplitPosition > 1)
                         BeforeZoomSplitPosition = 1;
+                    BeforeZoomVisibleLeftRatio = BeforeZoomSplitPosition;
                 }
                 useWinPlacement = TRUE;
             }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -2957,6 +2957,11 @@ int CMainWindow::GetSplitBarWidth()
 
 BOOL CMainWindow::IsPanelZoomed(BOOL leftPanel)
 {
+    if (PanelZoomedState == 1)
+        return leftPanel;
+    if (PanelZoomedState == 2)
+        return !leftPanel;
+
     if (leftPanel)
         return SplitPosition >= 0.99;
     else
@@ -7361,6 +7366,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 // better protect ourselves against a bad value in the stored pre-zoom position
                 if (SplitPosition <= 0.0 || SplitPosition >= 1.0)
                     SplitPosition = 0.5;
+                PanelZoomedState = 0;
             }
             else
             {
@@ -7370,6 +7376,12 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 int splitWidth = GetSplitBarWidth();
                 int totalPanelsWidth = WindowWidth - 2 - splitWidth;
                 int treeLeftWidth = 0;
+                if (LOWORD(wParam) == CM_LEFTZOOMPANEL ||
+                    (LOWORD(wParam) == CM_ACTIVEZOOMPANEL && activePanel == LeftPanel))
+                    PanelZoomedState = 1;
+                else
+                    PanelZoomedState = 2;
+
                 if (LeftPanel != NULL && LeftPanel->HTreeView != NULL && LeftPanel->TreeViewActive)
                 {
                     int treeHeaderH = LeftPanel->GetTreeViewHeaderHeight();
@@ -8134,6 +8146,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 if (fabs(SplitPosition - targetSplitPosition) > 0.0001)
                 {
                     KeepSplitPositionCenteredOnVisiblePanes = TRUE;
+                    PanelZoomedState = 0;
                     SplitPosition = targetSplitPosition;
                     LayoutWindows();
                     FocusPanel(GetActivePanel());
@@ -8207,6 +8220,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 {
                     DragSplitX = leftWidth;
                     KeepSplitPositionCenteredOnVisiblePanes = FALSE;
+                    PanelZoomedState = 0;
                     SplitPosition = DragSplitPosition;
                     LayoutWindows();
                 }
@@ -8246,6 +8260,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 //          int splitWidth = MainWindow->GetSplitBarWidth();
                 //          SplitPosition = (double)DragSplitX / (WindowWidth - splitWidth);
                 KeepSplitPositionCenteredOnVisiblePanes = FALSE;
+                PanelZoomedState = 0;
                 SplitPosition = DragSplitPosition;
                 LayoutWindows();
             }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -7569,6 +7569,13 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                             }
                             LeavePlugin();
                         }
+
+                        // The active-panel tree view caches directory children once they are
+                        // expanded.  Force-refresh the visible path after filesystem change
+                        // notifications so created, moved, renamed, and deleted folders do
+                        // not leave stale tree nodes behind.
+                        if (Configuration.TreeViewVisible && LeftPanel != NULL)
+                            LeftPanel->RefreshTreeView(TRUE);
                     }
                     else
                         break; // end of loop

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -8561,6 +8561,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (SplitPosition > 1)
             SplitPosition = 1;
 
+        double layoutSplitPosition = SplitPosition;
+
         int splitWidth = GetSplitBarWidth();
         int middleToolbarWidth = 0;
         if (MiddleToolBar->HWindow != NULL)
@@ -8585,7 +8587,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             if (LeftTabWindow != NULL)
                 treeHeaderHeight = LeftTabWindow->GetNeededHeight();
 
-            int tempLeftWidth = (int)((WindowWidth - splitWidth) * SplitPosition) - 1;
+            int tempLeftWidth = (int)((WindowWidth - splitWidth) * layoutSplitPosition) - 1;
             if (tempLeftWidth < MIN_WIN_WIDTH)
                 tempLeftWidth = MIN_WIN_WIDTH;
             int tempRightWidth = WindowWidth - 2 - tempLeftWidth - splitWidth;
@@ -8613,16 +8615,16 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             // content would start, preventing left panel bleed and flickering.
             if (rightZoomed && totalPanelsWidth > 0)
             {
-                SplitPosition = (double)(treeWidth + treeSplitWidth + 1 - splitWidth) / (totalPanelsWidth + 1);
-                if (SplitPosition < 0.001)
-                    SplitPosition = 0.001;
+                layoutSplitPosition = (double)(treeWidth + treeSplitWidth + 1 - splitWidth) / (totalPanelsWidth + 1);
+                if (layoutSplitPosition < 0.001)
+                    layoutSplitPosition = 0.001;
             }
         }
 
         // Calculate split widths accounting for treeview:
         // The treeview is part of the left side, so the split ratio applies to
         // (leftPanelContent + treeview + splitter) vs (rightPanel)
-        int leftTotalWidth = (int)((totalPanelsWidth + 1) * SplitPosition) - 1;
+        int leftTotalWidth = (int)((totalPanelsWidth + 1) * layoutSplitPosition) - 1;
         if (leftTotalWidth < MIN_WIN_WIDTH)
             leftTotalWidth = MIN_WIN_WIDTH;
         int rightWidth = totalPanelsWidth - leftTotalWidth;
@@ -8635,10 +8637,10 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (panelLeftWidth < 0)
             panelLeftWidth = 0;
 
-        // When left panel is zoomed (SplitPosition >= 1.0), extend left panel content
+        // When left panel is zoomed (layoutSplitPosition >= 1.0), extend left panel content
         // to cover the split bar area and one extra pixel, preventing the split bar
         // from flickering at the right edge.
-        if (SplitPosition >= 1.0)
+        if (layoutSplitPosition >= 1.0)
             panelLeftWidth += splitWidth + 1;
 
         // When right panel is zoomed and no tree view is active, override the split

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -7353,15 +7353,19 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         {
             if (IsPanelZoomed(TRUE) || IsPanelZoomed(FALSE))
             {
-                SplitPosition = BeforeZoomSplitPosition;
+                if (LeftPanel != NULL && LeftPanel->HTreeView != NULL && LeftPanel->TreeViewActive)
+                    SplitPosition = GetSplitPositionForVisibleLeftPanelRatio(BeforeZoomVisibleLeftRatio);
+                else
+                    SplitPosition = BeforeZoomSplitPosition;
                 KeepSplitPositionCenteredOnVisiblePanes = FALSE;
-                // better protect ourselves against a bad value in BeforeZoomSplitPosition
-                if (IsPanelZoomed(TRUE) || IsPanelZoomed(FALSE))
+                // better protect ourselves against a bad value in the stored pre-zoom position
+                if (SplitPosition <= 0.0 || SplitPosition >= 1.0)
                     SplitPosition = 0.5;
             }
             else
             {
                 BeforeZoomSplitPosition = SplitPosition;
+                BeforeZoomVisibleLeftRatio = GetVisibleLeftPanelRatio();
                 KeepSplitPositionCenteredOnVisiblePanes = FALSE;
                 int splitWidth = GetSplitBarWidth();
                 int totalPanelsWidth = WindowWidth - 2 - splitWidth;

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -408,6 +408,7 @@ void CMainWindow::RestoreVisiblePanelRatio(double visibleLeftRatio)
         UpdateCenteredSplitPosition();
     else
         SplitPosition = GetSplitPositionForVisibleLeftPanelRatio(visibleLeftRatio);
+    PanelZoomedState = 0;
     LayoutWindows();
 }
 
@@ -1494,7 +1495,8 @@ void CMainWindow::ChangePanel(BOOL force)
         // if a panel is ZOOMed, minimize it and ZOOM the other one
         if (IsPanelZoomed(TRUE) || IsPanelZoomed(FALSE))
         {
-            if (IsPanelZoomed(TRUE))
+            BOOL leftZoomed = IsPanelZoomed(TRUE);
+            if (leftZoomed)
             {
                 int splitWidth = GetSplitBarWidth();
                 int totalPanelsWidth = WindowWidth - 2 - splitWidth;
@@ -1520,6 +1522,7 @@ void CMainWindow::ChangePanel(BOOL force)
             }
             else
                 SplitPosition = 1.0;
+            PanelZoomedState = leftZoomed ? 2 : 1;
             KeepSplitPositionCenteredOnVisiblePanes = FALSE;
             LayoutWindows();
             change = TRUE;

--- a/src/plugins/shared/baseaddr_x64.txt
+++ b/src/plugins/shared/baseaddr_x64.txt
@@ -115,4 +115,6 @@ serviceexplorer   0x000001002a300000
 lang_serviceexplorer 0x000001003a300000
 hypervm         0x000001002a400000
 lang_hypervm    0x000001003a400000
+sftp            0x000001002a500000
+lang_sftp       0x000001003a500000
 

--- a/src/plugins/shared/baseaddr_x86.txt
+++ b/src/plugins/shared/baseaddr_x86.txt
@@ -115,4 +115,6 @@ serviceexplorer 0x2a300000
 lang_serviceexplorer 0x3a300000
 hypervm         0x2a400000
 lang_hypervm    0x3a400000
+sftp            0x2a500000
+lang_sftp       0x3a500000
 

--- a/tools/vcpkg/README.md
+++ b/tools/vcpkg/README.md
@@ -38,6 +38,7 @@ Run from a Visual Studio Developer PowerShell on Windows:
 ```powershell
 .\tools\vcpkg\build-third-party-libs.ps1
 .\tools\vcpkg\build-third-party-libs.ps1 -SftpPlugin    # incl. libssh2 + OpenSSL 3.x for SFTP plugin
+.\tools\vcpkg\build-third-party-libs.ps1 -SftpPlugin -OnlySftpPlugin  # only SFTP deps
 .\tools\vcpkg\build-third-party-libs.ps1 -PrebuiltDllsDir C:\path\to\dlls  # fallback for non-vcpkg DLLs
 ```
 
@@ -79,7 +80,8 @@ utils\dbghelp.dll
 ```
 
 With `-SftpPlugin`, the following are also installed into
-`build\vcpkg_installed_sftp\`:
+`build\vcpkg_installed_sftp\`. Use `-OnlySftpPlugin` when you only need
+these SFTP dependencies and want to skip the legacy third-party DLL manifest:
 
 ```text
 build\vcpkg_installed_sftp\x64-windows\include\  (headers)

--- a/tools/vcpkg/build-third-party-libs.ps1
+++ b/tools/vcpkg/build-third-party-libs.ps1
@@ -99,15 +99,23 @@ if (!(Test-Path -LiteralPath $VcpkgRoot))
     Invoke-LoggedCommand -FilePath 'git' -Arguments @('clone', $VcpkgRepository, $VcpkgRoot)
 }
 
-if (!(Test-Path -LiteralPath (Join-Path $VcpkgRoot '.git')))
+$vcpkgIsGitCheckout = Test-Path -LiteralPath (Join-Path $VcpkgRoot '.git')
+
+if ($vcpkgIsGitCheckout)
 {
-    throw "VcpkgRoot does not look like a git checkout: $VcpkgRoot"
+    Invoke-LoggedCommand -FilePath 'git' -Arguments @('fetch', '--tags', '--prune', 'origin') -WorkingDirectory $VcpkgRoot
+    Invoke-LoggedCommand -FilePath 'git' -Arguments @('checkout', $VcpkgBaseline) -WorkingDirectory $VcpkgRoot
+}
+elseif (Test-Path -LiteralPath $vcpkgExe)
+{
+    Write-Warning "Using existing non-git vcpkg root: $VcpkgRoot"
+}
+else
+{
+    throw "VcpkgRoot is neither a git checkout nor an existing vcpkg installation: $VcpkgRoot"
 }
 
-Invoke-LoggedCommand -FilePath 'git' -Arguments @('fetch', '--tags', '--prune', 'origin') -WorkingDirectory $VcpkgRoot
-Invoke-LoggedCommand -FilePath 'git' -Arguments @('checkout', $VcpkgBaseline) -WorkingDirectory $VcpkgRoot
-
-if (!$NoBootstrap -or !(Test-Path -LiteralPath $vcpkgExe))
+if ((!$NoBootstrap -and $vcpkgIsGitCheckout) -or !(Test-Path -LiteralPath $vcpkgExe))
 {
     $bootstrap = Join-Path $VcpkgRoot 'bootstrap-vcpkg.bat'
     if (!(Test-Path -LiteralPath $bootstrap))

--- a/tools/vcpkg/build-third-party-libs.ps1
+++ b/tools/vcpkg/build-third-party-libs.ps1
@@ -6,7 +6,8 @@ param(
     [string]$PrebuiltDllsDir,
     [switch]$NoBootstrap,
     [switch]$SkipInstall,
-    [switch]$SftpPlugin
+    [switch]$SftpPlugin,
+    [switch]$OnlySftpPlugin
 )
 
 $ErrorActionPreference = 'Stop'
@@ -85,9 +86,12 @@ $vcpkgExe = Join-Path $VcpkgRoot 'vcpkg.exe'
 
 Write-Host "Repository root: $repoRoot"
 Write-Host "vcpkg root:     $VcpkgRoot"
-Write-Host "Manifest root:  $manifestRoot"
+if (!$OnlySftpPlugin)
+{
+    Write-Host "Manifest root:  $manifestRoot"
+    Write-Host "Output dir:     $OutputDir"
+}
 Write-Host "Triplet:        $Triplet"
-Write-Host "Output dir:     $OutputDir"
 
 if (!(Test-Path -LiteralPath $VcpkgRoot))
 {
@@ -119,84 +123,87 @@ if (!(Test-Path -LiteralPath $vcpkgExe))
     throw "Unable to find vcpkg executable: $vcpkgExe"
 }
 
-if (!$SkipInstall)
+if (!$OnlySftpPlugin)
 {
-    Invoke-LoggedCommand -FilePath $vcpkgExe -Arguments @(
-        'install',
-        '--triplet', $Triplet,
-        '--x-install-root', $installRoot
-    ) -WorkingDirectory $manifestRoot
-}
-
-if (!(Test-Path -LiteralPath $tripletBinDir))
-{
-    throw "vcpkg bin directory does not exist: $tripletBinDir"
-}
-
-New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
-
-foreach ($dllName in $RequiredDlls)
-{
-    $source = Join-Path $tripletBinDir $dllName
-    if (!(Test-Path -LiteralPath $source))
+    if (!$SkipInstall)
     {
-        $matches = @(Get-ChildItem -LiteralPath (Join-Path $installRoot $Triplet) -Recurse -File -Filter $dllName -ErrorAction SilentlyContinue)
-        if ($matches.Count -eq 1)
+        Invoke-LoggedCommand -FilePath $vcpkgExe -Arguments @(
+            'install',
+            '--triplet', $Triplet,
+            '--x-install-root', $installRoot
+        ) -WorkingDirectory $manifestRoot
+    }
+
+    if (!(Test-Path -LiteralPath $tripletBinDir))
+    {
+        throw "vcpkg bin directory does not exist: $tripletBinDir"
+    }
+
+    New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+    foreach ($dllName in $RequiredDlls)
+    {
+        $source = Join-Path $tripletBinDir $dllName
+        if (!(Test-Path -LiteralPath $source))
         {
-            $source = $matches[0].FullName
-        }
-        elseif ($matches.Count -gt 1)
-        {
-            throw "Found multiple candidates for ${dllName}: $($matches.FullName -join ', ')"
-        }
-        else
-        {
-            # Not produced by vcpkg - try prebuilt DLLs directory
-            if (![string]::IsNullOrWhiteSpace($PrebuiltDllsDir))
+            $matches = @(Get-ChildItem -LiteralPath (Join-Path $installRoot $Triplet) -Recurse -File -Filter $dllName -ErrorAction SilentlyContinue)
+            if ($matches.Count -eq 1)
             {
-                $prebuilt = Join-Path $PrebuiltDllsDir $dllName
-                if (Test-Path -LiteralPath $prebuilt)
-                {
-                    $source = $prebuilt
-                }
-                elseif (Test-Path -LiteralPath (Join-Path $OutputDir $dllName))
-                {
-                    Write-Warning "DLL '$dllName' not in vcpkg or prebuilt dir, keeping existing copy in output dir"
-                    continue
-                }
-                else
-                {
-                    throw "Required DLL was not produced by vcpkg and not found in prebuilt dir: $dllName"
-                }
+                $source = $matches[0].FullName
+            }
+            elseif ($matches.Count -gt 1)
+            {
+                throw "Found multiple candidates for ${dllName}: $($matches.FullName -join ', ')"
             }
             else
             {
-                # Fallback: some DLLs are standard Windows system DLLs
-                $systemDll = Join-Path "$env:SystemRoot\System32" $dllName
-                if (Test-Path -LiteralPath $systemDll)
+                # Not produced by vcpkg - try prebuilt DLLs directory
+                if (![string]::IsNullOrWhiteSpace($PrebuiltDllsDir))
                 {
-                    Write-Host "Using system DLL: $systemDll"
-                    $source = $systemDll
-                }
-                elseif (Test-Path -LiteralPath (Join-Path $OutputDir $dllName))
-                {
-                    Write-Warning "DLL '$dllName' not produced by vcpkg, keeping existing copy in output dir"
-                    continue
+                    $prebuilt = Join-Path $PrebuiltDllsDir $dllName
+                    if (Test-Path -LiteralPath $prebuilt)
+                    {
+                        $source = $prebuilt
+                    }
+                    elseif (Test-Path -LiteralPath (Join-Path $OutputDir $dllName))
+                    {
+                        Write-Warning "DLL '$dllName' not in vcpkg or prebuilt dir, keeping existing copy in output dir"
+                        continue
+                    }
+                    else
+                    {
+                        throw "Required DLL was not produced by vcpkg and not found in prebuilt dir: $dllName"
+                    }
                 }
                 else
                 {
-                    throw "Required DLL was not produced by vcpkg: $dllName"
+                    # Fallback: some DLLs are standard Windows system DLLs
+                    $systemDll = Join-Path "$env:SystemRoot\System32" $dllName
+                    if (Test-Path -LiteralPath $systemDll)
+                    {
+                        Write-Host "Using system DLL: $systemDll"
+                        $source = $systemDll
+                    }
+                    elseif (Test-Path -LiteralPath (Join-Path $OutputDir $dllName))
+                    {
+                        Write-Warning "DLL '$dllName' not produced by vcpkg, keeping existing copy in output dir"
+                        continue
+                    }
+                    else
+                    {
+                        throw "Required DLL was not produced by vcpkg: $dllName"
+                    }
                 }
             }
         }
+
+        $destination = Join-Path $OutputDir $dllName
+        Copy-Item -LiteralPath $source -Destination $destination -Force
+        Write-Host "Copied $source -> $destination"
     }
 
-    $destination = Join-Path $OutputDir $dllName
-    Copy-Item -LiteralPath $source -Destination $destination -Force
-    Write-Host "Copied $source -> $destination"
+    Write-Host "Done. Third-party DLLs are available in $OutputDir"
 }
-
-Write-Host "Done. Third-party DLLs are available in $OutputDir"
 
 # --- SFTP plugin dependencies (libssh2 + OpenSSL 3.x) ---
 


### PR DESCRIPTION
### Motivation
- The Tree View caches expanded directory children which can become stale after folder create/move/rename/delete operations reported by the shell notifications. 
- Make it possible to re-enumerate already-populated nodes so the Tree View correctly reflects the filesystem after such changes.

### Description
- Added an optional `forceRefresh` argument to `CFilesWindow::RefreshTreeView` (default `FALSE`) and updated its declaration in `src/fileswnd.h` so existing callers keep original behavior.  
- Propagated `forceRefresh` into the traversal so `PopulateTreeViewItem` is called with `forceRefresh` on each node along the visible/current path in `src/fileswn1.cpp`.  
- After distributing shell change notifications, explicitly call `LeftPanel->RefreshTreeView(TRUE)` when the Tree View is visible in `src/mainwnd3.cpp` to force re-enumeration of cached children and avoid stale nodes.

### Testing
- Ran `git diff --check` which reported no whitespace or trivial issues and completed successfully.  
- Changes were committed to the repository as a single commit titled `Refresh tree view on filesystem changes`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a489c16919c8329978daf09ffd8cd69)