### PR TITLE
Fix title bar truncation with long paths and guard against NULL plugin drive text

### DIFF
--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -2073,6 +2073,13 @@ BOOL CDrivesList::BuildData(BOOL noTimeout, TDirectArray<CDriveData>* copyDrives
                 BOOL destroyIcon = FALSE;
                 if (fs->GetChangeDriveOrDisconnectItem(fs->GetPluginFSName(), txt, icon, destroyIcon))
                 {
+                    if (txt == NULL)
+                    {
+                        TRACE_E("CDrivesList::BuildData(): plug-in returned a NULL change-drive item text");
+                        if (destroyIcon && icon != NULL)
+                            HANDLES(DestroyIcon(icon));
+                        continue;
+                    }
                     drv.DriveText = txt;
                     drv.HIcon = icon;
                     drv.HGrayIcon = NULL;

--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -1067,7 +1067,7 @@ CDrivesList::CDrivesList(CFilesWindow* filesWindow, const char* currentPath,
     FilesWindow = filesWindow;
     DriveType = driveType;
     DriveTypeParam = driveTypeParam;
-    lstrcpy(CurrentPath, currentPath);
+    lstrcpyn(CurrentPath, currentPath != NULL ? currentPath : "", _countof(CurrentPath));
     PostCmd = postCmd;
     PostCmdParam = postCmdParam;
     FromContextMenu = fromContextMenu;

--- a/src/drivelst.h
+++ b/src/drivelst.h
@@ -6,6 +6,10 @@
 
 //*****************************************************************************
 
+#ifndef SAL_MAX_PATH
+#define SAL_MAX_PATH 32768
+#endif
+
 #define ONEDRIVE_MAXBUSINESSDISPLAYNAME 500
 
 struct COneDriveBusinessStorage
@@ -116,7 +120,7 @@ protected:
     int* PostCmd;              // post-cmd for context menu of a FS plugin
     void** PostCmdParam;       // post-cmd-parameter for context menu of a FS plugin
     BOOL* FromContextMenu;     // set to TRUE if the menu was invoked from a context menu
-    char CurrentPath[MAX_PATH];
+    char CurrentPath[SAL_MAX_PATH];
     TDirectArray<CDriveData>* Drives;
     CMenuPopup* MenuPopup;
     int FocusIndex; // what item from the Drives array should be focused

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -759,8 +759,8 @@ public:
     void MakeFileList();
 
     static void FormatPanelPathForDisplay(CFilesWindow* panel, int mode, char* text, int textSize);
-    // helper method for SetTitle; 'text' must be at least 2 * MAX_PATH characters long
-    void GetFormatedPathForTitle(char* text);
+    // helper method for SetTitle; 'textSize' is the size of 'text' in bytes
+    void GetFormatedPathForTitle(char* text, int textSize);
 
     // if 'text' == NULL the default content will be set
     void SetWindowTitle(const char* text = NULL);

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2051,7 +2051,7 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
     int captionWidth = wndRect.right - wndRect.left;
     captionWidth -= GetSystemMetrics(SM_CXSIZE) * 3;
     captionWidth -= GetSystemMetrics(SM_CXSMICON);
-    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 80;
+    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 220;
     if (captionWidth <= 0)
         return;
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2024,7 +2024,7 @@ static void EnsureAppNameSuffixInTitle(std::wstring& title, const std::wstring& 
 
     const std::wstring separator = L" - ";
     const std::wstring ellipsis = L"...";
-    const int maxTitleChars = 96;
+    const int maxTitleChars = 70;
 
     if ((int)title.length() <= maxTitleChars)
         return;

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1976,6 +1976,36 @@ static void TrimTrailingWindowTitleSpaces(char* title)
         *(--end) = 0;
 }
 
+static void UseUnicodeLeafPathForTitle(char* path)
+{
+    if (path == NULL || path[0] == 0)
+        return;
+
+    bool hasNonAscii = false;
+    char* leaf = path;
+    for (char* p = path; *p != 0; p++)
+    {
+        if ((unsigned char)*p >= 0x80)
+            hasNonAscii = true;
+        if (*p == '\\' || *p == '/')
+            leaf = p + 1;
+    }
+
+    if (hasNonAscii && leaf > path && *leaf != 0)
+        memmove(path, leaf, strlen(leaf) + 1);
+
+    const int maxTitlePathBytes = 64;
+    int len = (int)strlen(path);
+    if (hasNonAscii && len > maxTitlePathBytes)
+    {
+        int cut = maxTitlePathBytes;
+        while (cut > 0 && ((unsigned char)path[cut] & 0xC0) == 0x80)
+            cut--;
+        path[cut] = 0;
+        lstrcat(path, "...");
+    }
+}
+
 static std::wstring MultiByteToWindowTitleWide(const char* text)
 {
     if (text == NULL)
@@ -2247,6 +2277,7 @@ void CMainWindow::SetWindowTitle(const char* text)
         {
             char path[SAL_MAX_PATH];
             GetFormatedPathForTitle(path, sizeof(path));
+            UseUnicodeLeafPathForTitle(path);
             AppendUtf8ToWindowTitle(prefixAndPath, prefixAndPathSize + 1, path);
         }
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1984,7 +1984,7 @@ void CMainWindow::SetWindowTitle(const char* text)
     ::GetWindowText(HWindow, buff, 1000);
     buff[999] = 0;
 
-    char stdWndName[2 * MAX_PATH + 300];
+    char stdWndName[SAL_MAX_PATH + 300];
     if (text == NULL)
     {
         char stdSuffix[300];
@@ -2038,7 +2038,7 @@ void CMainWindow::SetWindowTitle(const char* text)
         // path
         if (Configuration.TitleBarShowPath)
         {
-            char path[2 * MAX_PATH];
+            char path[SAL_MAX_PATH];
             GetFormatedPathForTitle(path, sizeof(path));
             AppendUtf8ToWindowTitle(stdWndName, prefixAndPathSize + 1, path);
             if (stdWndName[0] != 0)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2058,12 +2058,12 @@ void CMainWindow::SetWindowTitle(const char* text)
 
         TruncateUtf8WindowTitle(prefixAndPath, prefixAndPathSize);
         stdWndName[0] = 0;
-        AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
         if (prefixAndPath[0] != 0)
         {
-            AppendToWindowTitle(stdWndName, sizeof(stdWndName), " - ");
             AppendToWindowTitle(stdWndName, sizeof(stdWndName), prefixAndPath);
+            AppendToWindowTitle(stdWndName, sizeof(stdWndName), " - ");
         }
+        AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
 
         text = stdWndName;
     }

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2002,54 +2002,6 @@ static std::wstring MultiByteToWindowTitleWide(const char* text)
     return result;
 }
 
-static int AvoidTrailingHighSurrogate(const std::wstring& text, int length)
-{
-    if (length > 0)
-    {
-        wchar_t ch = text[length - 1];
-        if (ch >= 0xD800 && ch <= 0xDBFF)
-            length--;
-    }
-    return length;
-}
-
-static void EnsureAppNameVisibleInTitle(HWND hwnd, std::wstring& title, const std::wstring& appSuffix)
-{
-    if (hwnd == NULL || title.empty() || appSuffix.empty() ||
-        title.length() <= appSuffix.length() ||
-        title.compare(title.length() - appSuffix.length(), appSuffix.length(), appSuffix) != 0)
-    {
-        return;
-    }
-
-    const std::wstring separator = L" - ";
-    size_t suffixStart = title.length() - appSuffix.length();
-    size_t prefixEnd = suffixStart;
-    if (prefixEnd >= separator.length() &&
-        title.compare(prefixEnd - separator.length(), separator.length(), separator) == 0)
-    {
-        prefixEnd -= separator.length();
-    }
-
-    std::wstring prefix = title.substr(0, prefixEnd);
-    const std::wstring ellipsis = L"...";
-    const int maxTitleChars = 96; // keep app suffix inside the real caption text
-    if ((int)title.length() > maxTitleChars)
-    {
-        int maxPrefixChars = maxTitleChars - (int)(ellipsis.length() + separator.length() + appSuffix.length());
-        if (maxPrefixChars <= 0)
-            title = appSuffix;
-        else
-        {
-            maxPrefixChars = AvoidTrailingHighSurrogate(prefix, min(maxPrefixChars, (int)prefix.length()));
-            title.assign(prefix, 0, maxPrefixChars);
-            title += ellipsis;
-            title += separator;
-            title += appSuffix;
-        }
-    }
-}
-
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
 {
     if (path == NULL || textSize <= 0)
@@ -2071,8 +2023,6 @@ void CMainWindow::SetWindowTitle(const char* text)
     buff[999] = 0;
 
     char stdWndName[SAL_MAX_PATH + 300];
-    char appTitleSuffix[300];
-    appTitleSuffix[0] = 0;
     if (text == NULL)
     {
         char stdSuffix[300];
@@ -2136,23 +2086,17 @@ void CMainWindow::SetWindowTitle(const char* text)
 
         TruncateUtf8WindowTitle(prefixAndPath, prefixAndPathSize);
         stdWndName[0] = 0;
+        AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
         if (prefixAndPath[0] != 0)
         {
-            AppendToWindowTitle(stdWndName, sizeof(stdWndName), prefixAndPath);
             AppendToWindowTitle(stdWndName, sizeof(stdWndName), " - ");
+            AppendToWindowTitle(stdWndName, sizeof(stdWndName), prefixAndPath);
         }
-        AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
-        lstrcpyn(appTitleSuffix, stdSuffix, _countof(appTitleSuffix));
 
         text = stdWndName;
     }
 
     std::wstring wideText = MultiByteToWindowTitleWide(text);
-    if (appTitleSuffix[0] != 0)
-    {
-        std::wstring wideAppSuffix = MultiByteToWindowTitleWide(appTitleSuffix);
-        EnsureAppNameVisibleInTitle(HWindow, wideText, wideAppSuffix);
-    }
     std::wstring wideBuff;
     int wideBuffLen = GetWindowTextLengthW(HWindow);
     if (wideBuffLen > 0)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2066,6 +2066,16 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
         size_t slash = prefix.find_last_of(L"\\/");
         if (slash != std::wstring::npos && slash + 1 < prefix.length())
             prefix = prefix.substr(slash + 1);
+        const int maxUnicodePrefixChars = 16;
+        if ((int)prefix.length() > maxUnicodePrefixChars)
+        {
+            int cut = AvoidTrailingHighSurrogate(prefix, maxUnicodePrefixChars);
+            title.assign(prefix, 0, cut);
+            title += ellipsis;
+            title += separator;
+            title += appSuffix;
+            return;
+        }
     }
     RECT wndRect;
     if (!GetWindowRect(hwnd, &wndRect))

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2002,26 +2002,6 @@ static std::wstring MultiByteToWindowTitleWide(const char* text)
     return result;
 }
 
-static BOOL GetTextWidth(HDC dc, HFONT font, const std::wstring& text, int& width)
-{
-    width = 0;
-    if (dc == NULL || text.empty())
-        return TRUE;
-
-    HFONT oldFont = NULL;
-    if (font != NULL)
-        oldFont = (HFONT)SelectObject(dc, font);
-
-    SIZE size = {0, 0};
-    BOOL ok = GetTextExtentPoint32W(dc, text.c_str(), (int)text.length(), &size);
-    if (ok)
-        width = size.cx;
-
-    if (oldFont != NULL)
-        SelectObject(dc, oldFont);
-    return ok;
-}
-
 static int AvoidTrailingHighSurrogate(const std::wstring& text, int length)
 {
     if (length > 0)
@@ -2053,9 +2033,7 @@ static void EnsureAppNameVisibleInTitle(HWND hwnd, std::wstring& title, const st
 
     std::wstring prefix = title.substr(0, prefixEnd);
     const std::wstring ellipsis = L"...";
-    std::wstring suffixOnly = ellipsis + separator + appSuffix;
-
-    const int maxTitleChars = 240; // keep comfortably below common caption/control text limits
+    const int maxTitleChars = 160; // keep comfortably below common caption/control text limits
     if ((int)title.length() > maxTitleChars)
     {
         int maxPrefixChars = maxTitleChars - (int)(ellipsis.length() + separator.length() + appSuffix.length());
@@ -2070,78 +2048,6 @@ static void EnsureAppNameVisibleInTitle(HWND hwnd, std::wstring& title, const st
             title += appSuffix;
         }
     }
-
-    RECT wndRect;
-    if (!GetWindowRect(hwnd, &wndRect))
-        return;
-
-    int captionWidth = wndRect.right - wndRect.left;
-    captionWidth -= GetSystemMetrics(SM_CXSIZE) * 3; // minimize, maximize/restore, close
-    captionWidth -= GetSystemMetrics(SM_CXSMICON);
-    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 32;
-    if (captionWidth <= 0)
-        return;
-
-    NONCLIENTMETRICS ncm;
-    ZeroMemory(&ncm, sizeof(ncm));
-    ncm.cbSize = sizeof(ncm);
-    HFONT captionFont = NULL;
-    if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0))
-        captionFont = CreateFontIndirect(&ncm.lfCaptionFont);
-
-    HDC dc = GetWindowDC(hwnd);
-    if (dc == NULL)
-    {
-        if (captionFont != NULL)
-            DeleteObject(captionFont);
-        return;
-    }
-
-    int fullWidth = 0;
-    if (!GetTextWidth(dc, captionFont, title, fullWidth) || fullWidth <= captionWidth)
-    {
-        ReleaseDC(hwnd, dc);
-        if (captionFont != NULL)
-            DeleteObject(captionFont);
-        return;
-    }
-
-    int suffixOnlyWidth = 0;
-    GetTextWidth(dc, captionFont, suffixOnly, suffixOnlyWidth);
-    if (suffixOnlyWidth > captionWidth)
-    {
-        title = appSuffix;
-        ReleaseDC(hwnd, dc);
-        if (captionFont != NULL)
-            DeleteObject(captionFont);
-        return;
-    }
-
-    int low = 0;
-    int high = (int)prefix.length();
-    std::wstring best = suffixOnly;
-    while (low <= high)
-    {
-        int mid = AvoidTrailingHighSurrogate(prefix, (low + high) / 2);
-        std::wstring candidate(prefix, 0, mid);
-        candidate += ellipsis;
-        candidate += separator;
-        candidate += appSuffix;
-
-        int candidateWidth = 0;
-        if (GetTextWidth(dc, captionFont, candidate, candidateWidth) && candidateWidth <= captionWidth)
-        {
-            best = candidate;
-            low = mid + 1;
-        }
-        else
-            high = mid - 1;
-    }
-
-    title = best;
-    ReleaseDC(hwnd, dc);
-    if (captionFont != NULL)
-        DeleteObject(captionFont);
 }
 
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -5,8 +5,6 @@
 #include "precomp.h"
 
 #include <string>
-#include <shlwapi.h>
-#undef PathIsPrefix
 
 #include "tooltip.h"
 #include "stswnd.h"
@@ -2004,103 +2002,6 @@ static std::wstring MultiByteToWindowTitleWide(const char* text)
     return result;
 }
 
-static BOOL GetTextWidth(HDC dc, HFONT font, const std::wstring& text, int& width)
-{
-    width = 0;
-    if (dc == NULL || text.empty())
-        return TRUE;
-
-    HFONT oldFont = NULL;
-    if (font != NULL)
-        oldFont = (HFONT)SelectObject(dc, font);
-
-    SIZE size = {0, 0};
-    BOOL ok = GetTextExtentPoint32W(dc, text.c_str(), (int)text.length(), &size);
-    if (ok)
-        width = size.cx;
-
-    if (oldFont != NULL)
-        SelectObject(dc, oldFont);
-    return ok;
-}
-
-static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std::wstring& appSuffix)
-{
-    if (hwnd == NULL || title.empty() || appSuffix.empty() ||
-        title.length() <= appSuffix.length() ||
-        title.compare(title.length() - appSuffix.length(), appSuffix.length(), appSuffix) != 0)
-    {
-        return;
-    }
-
-    const std::wstring separator = L" - ";
-    size_t prefixEnd = title.length() - appSuffix.length();
-    if (prefixEnd >= separator.length() &&
-        title.compare(prefixEnd - separator.length(), separator.length(), separator) == 0)
-    {
-        prefixEnd -= separator.length();
-    }
-    std::wstring prefix = title.substr(0, prefixEnd);
-    if (prefix.empty())
-        return;
-
-    RECT wndRect;
-    if (!GetWindowRect(hwnd, &wndRect))
-        return;
-
-    int captionWidth = wndRect.right - wndRect.left;
-    captionWidth -= GetSystemMetrics(SM_CXSIZE) * 3;
-    captionWidth -= GetSystemMetrics(SM_CXSMICON);
-    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 220;
-    if (captionWidth <= 0)
-        return;
-
-    NONCLIENTMETRICS ncm;
-    ZeroMemory(&ncm, sizeof(ncm));
-    ncm.cbSize = sizeof(ncm);
-    HFONT captionFont = NULL;
-    if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0))
-        captionFont = CreateFontIndirect(&ncm.lfCaptionFont);
-
-    HDC dc = GetWindowDC(hwnd);
-    if (dc == NULL)
-    {
-        if (captionFont != NULL)
-            DeleteObject(captionFont);
-        return;
-    }
-
-    int titleWidth = 0;
-    if (!GetTextWidth(dc, captionFont, title, titleWidth) || titleWidth <= captionWidth)
-    {
-        ReleaseDC(hwnd, dc);
-        if (captionFont != NULL)
-            DeleteObject(captionFont);
-        return;
-    }
-
-    int suffixWidth = 0;
-    int separatorWidth = 0;
-    GetTextWidth(dc, captionFont, appSuffix, suffixWidth);
-    GetTextWidth(dc, captionFont, separator, separatorWidth);
-    int prefixWidth = captionWidth - suffixWidth - separatorWidth;
-    if (prefixWidth <= 0)
-    {
-        title = appSuffix;
-        ReleaseDC(hwnd, dc);
-        if (captionFont != NULL)
-            DeleteObject(captionFont);
-        return;
-    }
-
-    std::wstring compacted = prefix;
-    PathCompactPathW(dc, &compacted[0], prefixWidth);
-    title = compacted + separator + appSuffix;
-
-    ReleaseDC(hwnd, dc);
-    if (captionFont != NULL)
-        DeleteObject(captionFont);
-}
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
 {
     if (path == NULL || textSize <= 0)
@@ -2121,9 +2022,7 @@ void CMainWindow::SetWindowTitle(const char* text)
     ::GetWindowText(HWindow, buff, 1000);
     buff[999] = 0;
 
-    char stdWndName[SAL_MAX_PATH + 300];
-    char appTitleSuffix[300];
-    appTitleSuffix[0] = 0;
+    char stdWndName[4 * SAL_MAX_PATH + 300];
     if (text == NULL)
     {
         char stdSuffix[300];
@@ -2152,7 +2051,7 @@ void CMainWindow::SetWindowTitle(const char* text)
 
         TrimTrailingWindowTitleSpaces(stdSuffix);
 
-        char prefixAndPath[SAL_MAX_PATH];
+        char prefixAndPath[4 * SAL_MAX_PATH];
         int prefixAndPathSize = min((int)sizeof(prefixAndPath) - 1,
                                     (int)sizeof(stdWndName) - (int)strlen(stdSuffix) - 4);
         if (prefixAndPathSize < 1)
@@ -2180,7 +2079,7 @@ void CMainWindow::SetWindowTitle(const char* text)
         // path
         if (Configuration.TitleBarShowPath)
         {
-            char path[SAL_MAX_PATH];
+            char path[4 * SAL_MAX_PATH];
             GetFormatedPathForTitle(path, sizeof(path));
             AppendUtf8ToWindowTitle(prefixAndPath, prefixAndPathSize + 1, path);
         }
@@ -2193,17 +2092,11 @@ void CMainWindow::SetWindowTitle(const char* text)
             AppendToWindowTitle(stdWndName, sizeof(stdWndName), " - ");
         }
         AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
-        lstrcpyn(appTitleSuffix, stdSuffix, _countof(appTitleSuffix));
 
         text = stdWndName;
     }
 
     std::wstring wideText = MultiByteToWindowTitleWide(text);
-    if (appTitleSuffix[0] != 0)
-    {
-        std::wstring wideAppSuffix = MultiByteToWindowTitleWide(appTitleSuffix);
-        EnsureAppNameSuffixInTitle(HWindow, wideText, wideAppSuffix);
-    }
     std::wstring wideBuff;
     int wideBuffLen = GetWindowTextLengthW(HWindow);
     if (wideBuffLen > 0)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2042,6 +2042,35 @@ static void EnsureAppNameVisibleInTitle(HWND hwnd, std::wstring& title, const st
         return;
     }
 
+    const std::wstring separator = L" - ";
+    size_t suffixStart = title.length() - appSuffix.length();
+    size_t prefixEnd = suffixStart;
+    if (prefixEnd >= separator.length() &&
+        title.compare(prefixEnd - separator.length(), separator.length(), separator) == 0)
+    {
+        prefixEnd -= separator.length();
+    }
+
+    std::wstring prefix = title.substr(0, prefixEnd);
+    const std::wstring ellipsis = L"...";
+    std::wstring suffixOnly = ellipsis + separator + appSuffix;
+
+    const int maxTitleChars = 240; // keep comfortably below common caption/control text limits
+    if ((int)title.length() > maxTitleChars)
+    {
+        int maxPrefixChars = maxTitleChars - (int)(ellipsis.length() + separator.length() + appSuffix.length());
+        if (maxPrefixChars <= 0)
+            title = appSuffix;
+        else
+        {
+            maxPrefixChars = AvoidTrailingHighSurrogate(prefix, min(maxPrefixChars, (int)prefix.length()));
+            title.assign(prefix, 0, maxPrefixChars);
+            title += ellipsis;
+            title += separator;
+            title += appSuffix;
+        }
+    }
+
     RECT wndRect;
     if (!GetWindowRect(hwnd, &wndRect))
         return;
@@ -2077,18 +2106,6 @@ static void EnsureAppNameVisibleInTitle(HWND hwnd, std::wstring& title, const st
         return;
     }
 
-    const std::wstring separator = L" - ";
-    size_t suffixStart = title.length() - appSuffix.length();
-    size_t prefixEnd = suffixStart;
-    if (prefixEnd >= separator.length() &&
-        title.compare(prefixEnd - separator.length(), separator.length(), separator) == 0)
-    {
-        prefixEnd -= separator.length();
-    }
-
-    std::wstring prefix = title.substr(0, prefixEnd);
-    const std::wstring ellipsis = L"...";
-    std::wstring suffixOnly = ellipsis + separator + appSuffix;
     int suffixOnlyWidth = 0;
     GetTextWidth(dc, captionFont, suffixOnly, suffixOnlyWidth);
     if (suffixOnlyWidth > captionWidth)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2078,7 +2078,7 @@ void CMainWindow::SetWindowTitle(const char* text)
     {
         char stdSuffix[300];
         stdSuffix[0] = 0;
-        AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), SALAMANDER_TEXT_VERSION);
+        AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), "Open Salamander");
 
         if (RunningAsAdmin)
         {

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2052,6 +2052,21 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
     }
 
     std::wstring prefix = title.substr(0, prefixEnd);
+    bool prefixHasNonAscii = false;
+    for (size_t i = 0; i < prefix.length(); i++)
+    {
+        if (prefix[i] > 0x7F)
+        {
+            prefixHasNonAscii = true;
+            break;
+        }
+    }
+    if (prefixHasNonAscii)
+    {
+        size_t slash = prefix.find_last_of(L"\\/");
+        if (slash != std::wstring::npos && slash + 1 < prefix.length())
+            prefix = prefix.substr(slash + 1);
+    }
     RECT wndRect;
     if (!GetWindowRect(hwnd, &wndRect))
         return;
@@ -2079,7 +2094,7 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
     }
 
     int titleWidth = 0;
-    if (!GetTextWidth(dc, captionFont, title, titleWidth) || titleWidth <= captionWidth)
+    if (!GetTextWidth(dc, captionFont, title, titleWidth) || (!prefixHasNonAscii && titleWidth <= captionWidth))
     {
         ReleaseDC(hwnd, dc);
         if (captionFont != NULL)
@@ -2097,6 +2112,20 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
         if (captionFont != NULL)
             DeleteObject(captionFont);
         return;
+    }
+
+    if (prefixHasNonAscii && !prefix.empty())
+    {
+        std::wstring leafTitle = prefix + separator + appSuffix;
+        int leafWidth = 0;
+        if (GetTextWidth(dc, captionFont, leafTitle, leafWidth) && leafWidth <= captionWidth)
+        {
+            title = leafTitle;
+            ReleaseDC(hwnd, dc);
+            if (captionFont != NULL)
+                DeleteObject(captionFont);
+            return;
+        }
     }
 
     int low = 0;

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1964,6 +1964,16 @@ static void TruncateUtf8WindowTitle(char* title, int maxLen)
     title[cut] = 0;
 }
 
+static void TrimTrailingWindowTitleSpaces(char* title)
+{
+    if (title == NULL)
+        return;
+
+    char* end = title + strlen(title);
+    while (end > title && *(end - 1) == ' ')
+        *(--end) = 0;
+}
+
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
 {
     if (path == NULL || textSize <= 0)
@@ -2011,27 +2021,30 @@ void CMainWindow::SetWindowTitle(const char* text)
         AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), expire);
 #endif // USE_BETA_EXPIRATION_DATE
 
-        int prefixAndPathSize = sizeof(stdWndName) - (int)strlen(stdSuffix) - 1;
+        TrimTrailingWindowTitleSpaces(stdSuffix);
+
+        char prefixAndPath[SAL_MAX_PATH];
+        int prefixAndPathSize = min((int)sizeof(prefixAndPath) - 1,
+                                    (int)sizeof(stdWndName) - (int)strlen(stdSuffix) - 4);
         if (prefixAndPathSize < 1)
             prefixAndPathSize = 1;
 
-        // provide default content
-        stdWndName[0] = 0;
+        prefixAndPath[0] = 0;
 
         // prefix
         if (Configuration.UseTitleBarPrefixForced)
         {
-            AppendUtf8ToWindowTitle(stdWndName, prefixAndPathSize + 1, Configuration.TitleBarPrefixForced);
-            if (stdWndName[0] != 0)
-                AppendToWindowTitle(stdWndName, prefixAndPathSize + 1, " - ");
+            AppendUtf8ToWindowTitle(prefixAndPath, prefixAndPathSize + 1, Configuration.TitleBarPrefixForced);
+            if (prefixAndPath[0] != 0)
+                AppendToWindowTitle(prefixAndPath, prefixAndPathSize + 1, " - ");
         }
         else
         {
             if (Configuration.UseTitleBarPrefix)
             {
-                AppendUtf8ToWindowTitle(stdWndName, prefixAndPathSize + 1, Configuration.TitleBarPrefix);
-                if (stdWndName[0] != 0)
-                    AppendToWindowTitle(stdWndName, prefixAndPathSize + 1, " - ");
+                AppendUtf8ToWindowTitle(prefixAndPath, prefixAndPathSize + 1, Configuration.TitleBarPrefix);
+                if (prefixAndPath[0] != 0)
+                    AppendToWindowTitle(prefixAndPath, prefixAndPathSize + 1, " - ");
             }
         }
 
@@ -2040,13 +2053,17 @@ void CMainWindow::SetWindowTitle(const char* text)
         {
             char path[SAL_MAX_PATH];
             GetFormatedPathForTitle(path, sizeof(path));
-            AppendUtf8ToWindowTitle(stdWndName, prefixAndPathSize + 1, path);
-            if (stdWndName[0] != 0)
-                AppendToWindowTitle(stdWndName, prefixAndPathSize + 1, " - ");
+            AppendUtf8ToWindowTitle(prefixAndPath, prefixAndPathSize + 1, path);
         }
 
-        TruncateUtf8WindowTitle(stdWndName, prefixAndPathSize);
+        TruncateUtf8WindowTitle(prefixAndPath, prefixAndPathSize);
+        stdWndName[0] = 0;
         AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
+        if (prefixAndPath[0] != 0)
+        {
+            AppendToWindowTitle(stdWndName, sizeof(stdWndName), " - ");
+            AppendToWindowTitle(stdWndName, sizeof(stdWndName), prefixAndPath);
+        }
 
         text = stdWndName;
     }

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -4,6 +4,8 @@
 
 #include "precomp.h"
 
+#include <string>
+
 #include "tooltip.h"
 #include "stswnd.h"
 #include "plugins.h"
@@ -1797,7 +1799,7 @@ void CMainWindow::FormatPanelPathForDisplay(CFilesWindow* panel, int mode, char*
             mode = TITLE_BAR_MODE_FULLPATH;
     }
 
-    char generalPath[2 * MAX_PATH];
+    char generalPath[SAL_MAX_PATH];
     generalPath[0] = 0;
     panel->GetGeneralPath(generalPath, _countof(generalPath));
 
@@ -1819,7 +1821,7 @@ void CMainWindow::FormatPanelPathForDisplay(CFilesWindow* panel, int mode, char*
             char* trimEnd = NULL;
             if (panel->Is(ptDisk) || panel->Is(ptZIPArchive))
             {
-                char rootPath[MAX_PATH];
+                char rootPath[SAL_MAX_PATH];
                 GetRootPath(rootPath, buffer);
                 int chars = (int)strlen(rootPath);
                 trimStart = buffer + chars;
@@ -1873,7 +1875,7 @@ void CMainWindow::FormatPanelPathForDisplay(CFilesWindow* panel, int mode, char*
             const char forwardSlash = 0x2F;   // '/'
             if (panel->Is(ptDisk) || panel->Is(ptZIPArchive))
             {
-                char rootPath[MAX_PATH];
+                char rootPath[SAL_MAX_PATH];
                 GetRootPath(rootPath, buffer);
                 int chars = (int)strlen(rootPath);
                 char* p = buffer + strlen(buffer);
@@ -1974,6 +1976,32 @@ static void TrimTrailingWindowTitleSpaces(char* title)
         *(--end) = 0;
 }
 
+static std::wstring MultiByteToWindowTitleWide(const char* text)
+{
+    if (text == NULL)
+        return std::wstring();
+
+    int textLen = (int)strlen(text);
+    if (textLen == 0)
+        return std::wstring();
+
+    int wideLen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text, textLen, NULL, 0);
+    UINT codePage = CP_UTF8;
+    DWORD flags = MB_ERR_INVALID_CHARS;
+    if (wideLen <= 0)
+    {
+        codePage = CP_ACP;
+        flags = 0;
+        wideLen = MultiByteToWideChar(codePage, flags, text, textLen, NULL, 0);
+    }
+    if (wideLen <= 0)
+        return std::wstring();
+
+    std::wstring result(wideLen, L'\0');
+    MultiByteToWideChar(codePage, flags, text, textLen, &result[0], wideLen);
+    return result;
+}
+
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
 {
     if (path == NULL || textSize <= 0)
@@ -2068,9 +2096,23 @@ void CMainWindow::SetWindowTitle(const char* text)
         text = stdWndName;
     }
 
-    if (strcmp(text, buff) != 0)
+    std::wstring wideText = MultiByteToWindowTitleWide(text);
+    std::wstring wideBuff;
+    int wideBuffLen = GetWindowTextLengthW(HWindow);
+    if (wideBuffLen > 0)
     {
-        ::SetWindowText(HWindow, text);
+        wideBuff.resize(wideBuffLen + 1);
+        int copied = GetWindowTextW(HWindow, &wideBuff[0], wideBuffLen + 1);
+        if (copied >= 0)
+            wideBuff.resize(copied);
+    }
+
+    if (wideText.empty() ? strcmp(text, buff) != 0 : wideText != wideBuff)
+    {
+        if (!wideText.empty())
+            ::SetWindowTextW(HWindow, wideText.c_str());
+        else
+            ::SetWindowText(HWindow, text);
         if (Configuration.StatusArea)
             SetTrayIconText(text);
     }

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2033,7 +2033,7 @@ static void EnsureAppNameVisibleInTitle(HWND hwnd, std::wstring& title, const st
 
     std::wstring prefix = title.substr(0, prefixEnd);
     const std::wstring ellipsis = L"...";
-    const int maxTitleChars = 160; // keep comfortably below common caption/control text limits
+    const int maxTitleChars = 96; // keep app suffix inside the real caption text
     if ((int)title.length() > maxTitleChars)
     {
         int maxPrefixChars = maxTitleChars - (int)(ellipsis.length() + separator.length() + appSuffix.length());

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2002,6 +2002,55 @@ static std::wstring MultiByteToWindowTitleWide(const char* text)
     return result;
 }
 
+static int AvoidTrailingHighSurrogate(const std::wstring& text, int length)
+{
+    if (length > 0)
+    {
+        wchar_t ch = text[length - 1];
+        if (ch >= 0xD800 && ch <= 0xDBFF)
+            length--;
+    }
+    return length;
+}
+
+static void EnsureAppNameSuffixInTitle(std::wstring& title, const std::wstring& appSuffix)
+{
+    if (title.empty() || appSuffix.empty() ||
+        title.length() <= appSuffix.length() ||
+        title.compare(title.length() - appSuffix.length(), appSuffix.length(), appSuffix) != 0)
+    {
+        return;
+    }
+
+    const std::wstring separator = L" - ";
+    const std::wstring ellipsis = L"...";
+    const int maxTitleChars = 96;
+
+    if ((int)title.length() <= maxTitleChars)
+        return;
+
+    size_t prefixEnd = title.length() - appSuffix.length();
+    if (prefixEnd >= separator.length() &&
+        title.compare(prefixEnd - separator.length(), separator.length(), separator) == 0)
+    {
+        prefixEnd -= separator.length();
+    }
+
+    std::wstring prefix = title.substr(0, prefixEnd);
+    int maxPrefixChars = maxTitleChars - (int)(ellipsis.length() + separator.length() + appSuffix.length());
+    if (maxPrefixChars <= 0)
+    {
+        title = appSuffix;
+        return;
+    }
+
+    maxPrefixChars = AvoidTrailingHighSurrogate(prefix, min(maxPrefixChars, (int)prefix.length()));
+    title.assign(prefix, 0, maxPrefixChars);
+    title += ellipsis;
+    title += separator;
+    title += appSuffix;
+}
+
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
 {
     if (path == NULL || textSize <= 0)
@@ -2023,6 +2072,8 @@ void CMainWindow::SetWindowTitle(const char* text)
     buff[999] = 0;
 
     char stdWndName[SAL_MAX_PATH + 300];
+    char appTitleSuffix[300];
+    appTitleSuffix[0] = 0;
     if (text == NULL)
     {
         char stdSuffix[300];
@@ -2086,17 +2137,23 @@ void CMainWindow::SetWindowTitle(const char* text)
 
         TruncateUtf8WindowTitle(prefixAndPath, prefixAndPathSize);
         stdWndName[0] = 0;
-        AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
         if (prefixAndPath[0] != 0)
         {
-            AppendToWindowTitle(stdWndName, sizeof(stdWndName), " - ");
             AppendToWindowTitle(stdWndName, sizeof(stdWndName), prefixAndPath);
+            AppendToWindowTitle(stdWndName, sizeof(stdWndName), " - ");
         }
+        AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
+        lstrcpyn(appTitleSuffix, stdSuffix, _countof(appTitleSuffix));
 
         text = stdWndName;
     }
 
     std::wstring wideText = MultiByteToWindowTitleWide(text);
+    if (appTitleSuffix[0] != 0)
+    {
+        std::wstring wideAppSuffix = MultiByteToWindowTitleWide(appTitleSuffix);
+        EnsureAppNameSuffixInTitle(wideText, wideAppSuffix);
+    }
     std::wstring wideBuff;
     int wideBuffLen = GetWindowTextLengthW(HWindow);
     if (wideBuffLen > 0)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2114,7 +2114,7 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
     int captionWidth = wndRect.right - wndRect.left;
     captionWidth -= GetSystemMetrics(SM_CXSIZE) * 3;
     captionWidth -= GetSystemMetrics(SM_CXSMICON);
-    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 48;
+    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 140;
     if (captionWidth <= 0)
         return;
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1991,19 +1991,8 @@ static void UseUnicodeLeafPathForTitle(char* path)
             leaf = p + 1;
     }
 
-    if (hasNonAscii && leaf > path && *leaf != 0)
-        memmove(path, leaf, strlen(leaf) + 1);
-
-    const int maxTitlePathBytes = 64;
-    int len = (int)strlen(path);
-    if (hasNonAscii && len > maxTitlePathBytes)
-    {
-        int cut = maxTitlePathBytes;
-        while (cut > 0 && ((unsigned char)path[cut] & 0xC0) == 0x80)
-            cut--;
-        path[cut] = 0;
-        lstrcat(path, "...");
-    }
+    if (hasNonAscii)
+        lstrcpyn(path, "...", 4);
 }
 
 static std::wstring MultiByteToWindowTitleWide(const char* text)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -5,6 +5,8 @@
 #include "precomp.h"
 
 #include <string>
+#include <shlwapi.h>
+#undef PathIsPrefix
 
 #include "tooltip.h"
 #include "stswnd.h"
@@ -1976,25 +1978,6 @@ static void TrimTrailingWindowTitleSpaces(char* title)
         *(--end) = 0;
 }
 
-static void UseUnicodeLeafPathForTitle(char* path)
-{
-    if (path == NULL || path[0] == 0)
-        return;
-
-    bool hasNonAscii = false;
-    char* leaf = path;
-    for (char* p = path; *p != 0; p++)
-    {
-        if ((unsigned char)*p >= 0x80)
-            hasNonAscii = true;
-        if (*p == '\\' || *p == '/')
-            leaf = p + 1;
-    }
-
-    if (hasNonAscii)
-        lstrcpyn(path, "...", 4);
-}
-
 static std::wstring MultiByteToWindowTitleWide(const char* text)
 {
     if (text == NULL)
@@ -2019,17 +2002,6 @@ static std::wstring MultiByteToWindowTitleWide(const char* text)
     std::wstring result(wideLen, L'\0');
     MultiByteToWideChar(codePage, flags, text, textLen, &result[0], wideLen);
     return result;
-}
-
-static int AvoidTrailingHighSurrogate(const std::wstring& text, int length)
-{
-    if (length > 0)
-    {
-        wchar_t ch = text[length - 1];
-        if (ch >= 0xD800 && ch <= 0xDBFF)
-            length--;
-    }
-    return length;
 }
 
 static BOOL GetTextWidth(HDC dc, HFONT font, const std::wstring& text, int& width)
@@ -2062,40 +2034,16 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
     }
 
     const std::wstring separator = L" - ";
-    const std::wstring ellipsis = L"...";
     size_t prefixEnd = title.length() - appSuffix.length();
     if (prefixEnd >= separator.length() &&
         title.compare(prefixEnd - separator.length(), separator.length(), separator) == 0)
     {
         prefixEnd -= separator.length();
     }
-
     std::wstring prefix = title.substr(0, prefixEnd);
-    bool prefixHasNonAscii = false;
-    for (size_t i = 0; i < prefix.length(); i++)
-    {
-        if (prefix[i] > 0x7F)
-        {
-            prefixHasNonAscii = true;
-            break;
-        }
-    }
-    if (prefixHasNonAscii)
-    {
-        size_t slash = prefix.find_last_of(L"\\/");
-        if (slash != std::wstring::npos && slash + 1 < prefix.length())
-            prefix = prefix.substr(slash + 1);
-        const int maxUnicodePrefixChars = 16;
-        if ((int)prefix.length() > maxUnicodePrefixChars)
-        {
-            int cut = AvoidTrailingHighSurrogate(prefix, maxUnicodePrefixChars);
-            title.assign(prefix, 0, cut);
-            title += ellipsis;
-            title += separator;
-            title += appSuffix;
-            return;
-        }
-    }
+    if (prefix.empty())
+        return;
+
     RECT wndRect;
     if (!GetWindowRect(hwnd, &wndRect))
         return;
@@ -2103,7 +2051,7 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
     int captionWidth = wndRect.right - wndRect.left;
     captionWidth -= GetSystemMetrics(SM_CXSIZE) * 3;
     captionWidth -= GetSystemMetrics(SM_CXSMICON);
-    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 140;
+    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 80;
     if (captionWidth <= 0)
         return;
 
@@ -2123,7 +2071,7 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
     }
 
     int titleWidth = 0;
-    if (!GetTextWidth(dc, captionFont, title, titleWidth) || (!prefixHasNonAscii && titleWidth <= captionWidth))
+    if (!GetTextWidth(dc, captionFont, title, titleWidth) || titleWidth <= captionWidth)
     {
         ReleaseDC(hwnd, dc);
         if (captionFont != NULL)
@@ -2132,9 +2080,11 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
     }
 
     int suffixWidth = 0;
-    std::wstring suffixTitle = ellipsis + separator + appSuffix;
-    GetTextWidth(dc, captionFont, suffixTitle, suffixWidth);
-    if (suffixWidth > captionWidth)
+    int separatorWidth = 0;
+    GetTextWidth(dc, captionFont, appSuffix, suffixWidth);
+    GetTextWidth(dc, captionFont, separator, separatorWidth);
+    int prefixWidth = captionWidth - suffixWidth - separatorWidth;
+    if (prefixWidth <= 0)
     {
         title = appSuffix;
         ReleaseDC(hwnd, dc);
@@ -2143,48 +2093,14 @@ static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std
         return;
     }
 
-    if (prefixHasNonAscii && !prefix.empty())
-    {
-        std::wstring leafTitle = prefix + separator + appSuffix;
-        int leafWidth = 0;
-        if (GetTextWidth(dc, captionFont, leafTitle, leafWidth) && leafWidth <= captionWidth)
-        {
-            title = leafTitle;
-            ReleaseDC(hwnd, dc);
-            if (captionFont != NULL)
-                DeleteObject(captionFont);
-            return;
-        }
-    }
+    std::wstring compacted = prefix;
+    PathCompactPathW(dc, &compacted[0], prefixWidth);
+    title = compacted + separator + appSuffix;
 
-    int low = 0;
-    int high = (int)prefix.length();
-    std::wstring best = suffixTitle;
-    while (low <= high)
-    {
-        int rawMid = (low + high) / 2;
-        int mid = AvoidTrailingHighSurrogate(prefix, rawMid);
-        std::wstring candidate(prefix, 0, mid);
-        candidate += ellipsis;
-        candidate += separator;
-        candidate += appSuffix;
-
-        int candidateWidth = 0;
-        if (GetTextWidth(dc, captionFont, candidate, candidateWidth) && candidateWidth <= captionWidth)
-        {
-            best = candidate;
-            low = rawMid + 1;
-        }
-        else
-            high = rawMid - 1;
-    }
-
-    title = best;
     ReleaseDC(hwnd, dc);
     if (captionFont != NULL)
         DeleteObject(captionFont);
 }
-
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
 {
     if (path == NULL || textSize <= 0)
@@ -2266,7 +2182,6 @@ void CMainWindow::SetWindowTitle(const char* text)
         {
             char path[SAL_MAX_PATH];
             GetFormatedPathForTitle(path, sizeof(path));
-            UseUnicodeLeafPathForTitle(path);
             AppendUtf8ToWindowTitle(prefixAndPath, prefixAndPathSize + 1, path);
         }
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2002,6 +2002,131 @@ static std::wstring MultiByteToWindowTitleWide(const char* text)
     return result;
 }
 
+static BOOL GetTextWidth(HDC dc, HFONT font, const std::wstring& text, int& width)
+{
+    width = 0;
+    if (dc == NULL || text.empty())
+        return TRUE;
+
+    HFONT oldFont = NULL;
+    if (font != NULL)
+        oldFont = (HFONT)SelectObject(dc, font);
+
+    SIZE size = {0, 0};
+    BOOL ok = GetTextExtentPoint32W(dc, text.c_str(), (int)text.length(), &size);
+    if (ok)
+        width = size.cx;
+
+    if (oldFont != NULL)
+        SelectObject(dc, oldFont);
+    return ok;
+}
+
+static int AvoidTrailingHighSurrogate(const std::wstring& text, int length)
+{
+    if (length > 0)
+    {
+        wchar_t ch = text[length - 1];
+        if (ch >= 0xD800 && ch <= 0xDBFF)
+            length--;
+    }
+    return length;
+}
+
+static void EnsureAppNameVisibleInTitle(HWND hwnd, std::wstring& title, const std::wstring& appSuffix)
+{
+    if (hwnd == NULL || title.empty() || appSuffix.empty() ||
+        title.length() <= appSuffix.length() ||
+        title.compare(title.length() - appSuffix.length(), appSuffix.length(), appSuffix) != 0)
+    {
+        return;
+    }
+
+    RECT wndRect;
+    if (!GetWindowRect(hwnd, &wndRect))
+        return;
+
+    int captionWidth = wndRect.right - wndRect.left;
+    captionWidth -= GetSystemMetrics(SM_CXSIZE) * 3; // minimize, maximize/restore, close
+    captionWidth -= GetSystemMetrics(SM_CXSMICON);
+    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 32;
+    if (captionWidth <= 0)
+        return;
+
+    NONCLIENTMETRICS ncm;
+    ZeroMemory(&ncm, sizeof(ncm));
+    ncm.cbSize = sizeof(ncm);
+    HFONT captionFont = NULL;
+    if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0))
+        captionFont = CreateFontIndirect(&ncm.lfCaptionFont);
+
+    HDC dc = GetWindowDC(hwnd);
+    if (dc == NULL)
+    {
+        if (captionFont != NULL)
+            DeleteObject(captionFont);
+        return;
+    }
+
+    int fullWidth = 0;
+    if (!GetTextWidth(dc, captionFont, title, fullWidth) || fullWidth <= captionWidth)
+    {
+        ReleaseDC(hwnd, dc);
+        if (captionFont != NULL)
+            DeleteObject(captionFont);
+        return;
+    }
+
+    const std::wstring separator = L" - ";
+    size_t suffixStart = title.length() - appSuffix.length();
+    size_t prefixEnd = suffixStart;
+    if (prefixEnd >= separator.length() &&
+        title.compare(prefixEnd - separator.length(), separator.length(), separator) == 0)
+    {
+        prefixEnd -= separator.length();
+    }
+
+    std::wstring prefix = title.substr(0, prefixEnd);
+    const std::wstring ellipsis = L"...";
+    std::wstring suffixOnly = ellipsis + separator + appSuffix;
+    int suffixOnlyWidth = 0;
+    GetTextWidth(dc, captionFont, suffixOnly, suffixOnlyWidth);
+    if (suffixOnlyWidth > captionWidth)
+    {
+        title = appSuffix;
+        ReleaseDC(hwnd, dc);
+        if (captionFont != NULL)
+            DeleteObject(captionFont);
+        return;
+    }
+
+    int low = 0;
+    int high = (int)prefix.length();
+    std::wstring best = suffixOnly;
+    while (low <= high)
+    {
+        int mid = AvoidTrailingHighSurrogate(prefix, (low + high) / 2);
+        std::wstring candidate(prefix, 0, mid);
+        candidate += ellipsis;
+        candidate += separator;
+        candidate += appSuffix;
+
+        int candidateWidth = 0;
+        if (GetTextWidth(dc, captionFont, candidate, candidateWidth) && candidateWidth <= captionWidth)
+        {
+            best = candidate;
+            low = mid + 1;
+        }
+        else
+            high = mid - 1;
+    }
+
+    title = best;
+    ReleaseDC(hwnd, dc);
+    if (captionFont != NULL)
+        DeleteObject(captionFont);
+}
+
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
 {
     if (path == NULL || textSize <= 0)
@@ -2023,6 +2148,8 @@ void CMainWindow::SetWindowTitle(const char* text)
     buff[999] = 0;
 
     char stdWndName[SAL_MAX_PATH + 300];
+    char appTitleSuffix[300];
+    appTitleSuffix[0] = 0;
     if (text == NULL)
     {
         char stdSuffix[300];
@@ -2092,11 +2219,17 @@ void CMainWindow::SetWindowTitle(const char* text)
             AppendToWindowTitle(stdWndName, sizeof(stdWndName), " - ");
         }
         AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
+        lstrcpyn(appTitleSuffix, stdSuffix, _countof(appTitleSuffix));
 
         text = stdWndName;
     }
 
     std::wstring wideText = MultiByteToWindowTitleWide(text);
+    if (appTitleSuffix[0] != 0)
+    {
+        std::wstring wideAppSuffix = MultiByteToWindowTitleWide(appTitleSuffix);
+        EnsureAppNameVisibleInTitle(HWindow, wideText, wideAppSuffix);
+    }
     std::wstring wideBuff;
     int wideBuffLen = GetWindowTextLengthW(HWindow);
     if (wideBuffLen > 0)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1918,8 +1918,56 @@ void CMainWindow::FormatPanelPathForDisplay(CFilesWindow* panel, int mode, char*
         lstrcpyn(buffer, generalPath, bufferSize);
 }
 
-void CMainWindow::GetFormatedPathForTitle(char* path)
+static void AppendToWindowTitle(char* title, int titleSize, const char* text)
 {
+    if (title == NULL || titleSize <= 0 || text == NULL)
+        return;
+
+    int len = (int)strlen(title);
+    if (len >= titleSize - 1)
+        return;
+
+    lstrcpyn(title + len, text, titleSize - len);
+}
+
+static void AppendUtf8ToWindowTitle(char* title, int titleSize, const char* text)
+{
+    if (title == NULL || titleSize <= 0 || text == NULL)
+        return;
+
+    int len = (int)strlen(title);
+    if (len >= titleSize - 1)
+        return;
+
+    int copy = min((int)strlen(text), titleSize - len - 1);
+    while (copy > 0 && ((unsigned char)text[copy] & 0xC0) == 0x80)
+        copy--; // do not cut in the middle of a UTF-8 character
+    if (copy <= 0)
+        return;
+
+    memcpy(title + len, text, copy);
+    title[len + copy] = 0;
+}
+
+static void TruncateUtf8WindowTitle(char* title, int maxLen)
+{
+    if (title == NULL || maxLen < 0)
+        return;
+
+    int len = (int)strlen(title);
+    if (len <= maxLen)
+        return;
+
+    int cut = maxLen;
+    while (cut > 0 && ((unsigned char)title[cut] & 0xC0) == 0x80)
+        cut--; // do not cut in the middle of a UTF-8 character
+    title[cut] = 0;
+}
+
+void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
+{
+    if (path == NULL || textSize <= 0)
+        return;
     path[0] = 0;
     CFilesWindow* panel = GetActivePanel();
     if (panel == NULL)
@@ -1927,7 +1975,7 @@ void CMainWindow::GetFormatedPathForTitle(char* path)
         path[0] = 0;
         return;
     }
-    FormatPanelPathForDisplay(panel, Configuration.TitleBarMode, path, 2 * MAX_PATH);
+    FormatPanelPathForDisplay(panel, Configuration.TitleBarMode, path, textSize);
 }
 void CMainWindow::SetWindowTitle(const char* text)
 {
@@ -1939,52 +1987,66 @@ void CMainWindow::SetWindowTitle(const char* text)
     char stdWndName[2 * MAX_PATH + 300];
     if (text == NULL)
     {
+        char stdSuffix[300];
+        stdSuffix[0] = 0;
+        AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), SALAMANDER_TEXT_VERSION);
+
+        if (RunningAsAdmin)
+        {
+            AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), " (");
+            AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), LoadStr(IDS_AS_ADMIN_TITLE));
+            AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), ")");
+        }
+
+#ifdef X64_STRESS_TEST
+        AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), " ST");
+#endif //X64_STRESS_TEST
+
+#ifdef USE_BETA_EXPIRATION_DATE
+        // beta version Expires on
+        AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), " - Expires on ");
+        char expire[100];
+        if (GetDateFormat(LOCALE_USER_DEFAULT, DATE_LONGDATE, &BETA_EXPIRATION_DATE, NULL, expire, 100) == 0)
+            sprintf(expire, "%u.%u.%u", BETA_EXPIRATION_DATE.wDay, BETA_EXPIRATION_DATE.wMonth, BETA_EXPIRATION_DATE.wYear);
+        AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), expire);
+#endif // USE_BETA_EXPIRATION_DATE
+
+        int prefixAndPathSize = sizeof(stdWndName) - (int)strlen(stdSuffix) - 1;
+        if (prefixAndPathSize < 1)
+            prefixAndPathSize = 1;
+
         // provide default content
         stdWndName[0] = 0;
 
         // prefix
         if (Configuration.UseTitleBarPrefixForced)
         {
-            strcpy(stdWndName, Configuration.TitleBarPrefixForced);
+            AppendUtf8ToWindowTitle(stdWndName, prefixAndPathSize + 1, Configuration.TitleBarPrefixForced);
             if (stdWndName[0] != 0)
-                strcat(stdWndName, " - ");
+                AppendToWindowTitle(stdWndName, prefixAndPathSize + 1, " - ");
         }
         else
         {
             if (Configuration.UseTitleBarPrefix)
             {
-                strcpy(stdWndName, Configuration.TitleBarPrefix);
+                AppendUtf8ToWindowTitle(stdWndName, prefixAndPathSize + 1, Configuration.TitleBarPrefix);
                 if (stdWndName[0] != 0)
-                    strcat(stdWndName, " - ");
+                    AppendToWindowTitle(stdWndName, prefixAndPathSize + 1, " - ");
             }
         }
 
         // path
         if (Configuration.TitleBarShowPath)
         {
-            GetFormatedPathForTitle(stdWndName + strlen(stdWndName));
+            char path[2 * MAX_PATH];
+            GetFormatedPathForTitle(path, sizeof(path));
+            AppendUtf8ToWindowTitle(stdWndName, prefixAndPathSize + 1, path);
             if (stdWndName[0] != 0)
-                strcat(stdWndName, " - ");
+                AppendToWindowTitle(stdWndName, prefixAndPathSize + 1, " - ");
         }
 
-        // Open Salamander full product name + ver/platform variant
-        lstrcat(stdWndName, SALAMANDER_TEXT_VERSION);
-
-        if (RunningAsAdmin)
-            sprintf(stdWndName + lstrlen(stdWndName), " (%s)", LoadStr(IDS_AS_ADMIN_TITLE));
-
-#ifdef X64_STRESS_TEST
-        lstrcat(stdWndName, " ST");
-#endif //X64_STRESS_TEST
-
-#ifdef USE_BETA_EXPIRATION_DATE
-        // beta version Expires on
-        lstrcat(stdWndName, " - Expires on ");
-        char expire[100];
-        if (GetDateFormat(LOCALE_USER_DEFAULT, DATE_LONGDATE, &BETA_EXPIRATION_DATE, NULL, expire, 100) == 0)
-            sprintf(expire, "%u.%u.%u", BETA_EXPIRATION_DATE.wDay, BETA_EXPIRATION_DATE.wMonth, BETA_EXPIRATION_DATE.wYear);
-        lstrcat(stdWndName, expire);
-#endif // USE_BETA_EXPIRATION_DATE
+        TruncateUtf8WindowTitle(stdWndName, prefixAndPathSize);
+        AppendToWindowTitle(stdWndName, sizeof(stdWndName), stdSuffix);
 
         text = stdWndName;
     }

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2013,9 +2013,29 @@ static int AvoidTrailingHighSurrogate(const std::wstring& text, int length)
     return length;
 }
 
-static void EnsureAppNameSuffixInTitle(std::wstring& title, const std::wstring& appSuffix)
+static BOOL GetTextWidth(HDC dc, HFONT font, const std::wstring& text, int& width)
 {
-    if (title.empty() || appSuffix.empty() ||
+    width = 0;
+    if (dc == NULL || text.empty())
+        return TRUE;
+
+    HFONT oldFont = NULL;
+    if (font != NULL)
+        oldFont = (HFONT)SelectObject(dc, font);
+
+    SIZE size = {0, 0};
+    BOOL ok = GetTextExtentPoint32W(dc, text.c_str(), (int)text.length(), &size);
+    if (ok)
+        width = size.cx;
+
+    if (oldFont != NULL)
+        SelectObject(dc, oldFont);
+    return ok;
+}
+
+static void EnsureAppNameSuffixInTitle(HWND hwnd, std::wstring& title, const std::wstring& appSuffix)
+{
+    if (hwnd == NULL || title.empty() || appSuffix.empty() ||
         title.length() <= appSuffix.length() ||
         title.compare(title.length() - appSuffix.length(), appSuffix.length(), appSuffix) != 0)
     {
@@ -2024,11 +2044,6 @@ static void EnsureAppNameSuffixInTitle(std::wstring& title, const std::wstring& 
 
     const std::wstring separator = L" - ";
     const std::wstring ellipsis = L"...";
-    const int maxTitleChars = 70;
-
-    if ((int)title.length() <= maxTitleChars)
-        return;
-
     size_t prefixEnd = title.length() - appSuffix.length();
     if (prefixEnd >= separator.length() &&
         title.compare(prefixEnd - separator.length(), separator.length(), separator) == 0)
@@ -2037,18 +2052,79 @@ static void EnsureAppNameSuffixInTitle(std::wstring& title, const std::wstring& 
     }
 
     std::wstring prefix = title.substr(0, prefixEnd);
-    int maxPrefixChars = maxTitleChars - (int)(ellipsis.length() + separator.length() + appSuffix.length());
-    if (maxPrefixChars <= 0)
+    RECT wndRect;
+    if (!GetWindowRect(hwnd, &wndRect))
+        return;
+
+    int captionWidth = wndRect.right - wndRect.left;
+    captionWidth -= GetSystemMetrics(SM_CXSIZE) * 3;
+    captionWidth -= GetSystemMetrics(SM_CXSMICON);
+    captionWidth -= GetSystemMetrics(SM_CXFRAME) * 2 + 48;
+    if (captionWidth <= 0)
+        return;
+
+    NONCLIENTMETRICS ncm;
+    ZeroMemory(&ncm, sizeof(ncm));
+    ncm.cbSize = sizeof(ncm);
+    HFONT captionFont = NULL;
+    if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0))
+        captionFont = CreateFontIndirect(&ncm.lfCaptionFont);
+
+    HDC dc = GetWindowDC(hwnd);
+    if (dc == NULL)
     {
-        title = appSuffix;
+        if (captionFont != NULL)
+            DeleteObject(captionFont);
         return;
     }
 
-    maxPrefixChars = AvoidTrailingHighSurrogate(prefix, min(maxPrefixChars, (int)prefix.length()));
-    title.assign(prefix, 0, maxPrefixChars);
-    title += ellipsis;
-    title += separator;
-    title += appSuffix;
+    int titleWidth = 0;
+    if (!GetTextWidth(dc, captionFont, title, titleWidth) || titleWidth <= captionWidth)
+    {
+        ReleaseDC(hwnd, dc);
+        if (captionFont != NULL)
+            DeleteObject(captionFont);
+        return;
+    }
+
+    int suffixWidth = 0;
+    std::wstring suffixTitle = ellipsis + separator + appSuffix;
+    GetTextWidth(dc, captionFont, suffixTitle, suffixWidth);
+    if (suffixWidth > captionWidth)
+    {
+        title = appSuffix;
+        ReleaseDC(hwnd, dc);
+        if (captionFont != NULL)
+            DeleteObject(captionFont);
+        return;
+    }
+
+    int low = 0;
+    int high = (int)prefix.length();
+    std::wstring best = suffixTitle;
+    while (low <= high)
+    {
+        int rawMid = (low + high) / 2;
+        int mid = AvoidTrailingHighSurrogate(prefix, rawMid);
+        std::wstring candidate(prefix, 0, mid);
+        candidate += ellipsis;
+        candidate += separator;
+        candidate += appSuffix;
+
+        int candidateWidth = 0;
+        if (GetTextWidth(dc, captionFont, candidate, candidateWidth) && candidateWidth <= captionWidth)
+        {
+            best = candidate;
+            low = rawMid + 1;
+        }
+        else
+            high = rawMid - 1;
+    }
+
+    title = best;
+    ReleaseDC(hwnd, dc);
+    if (captionFont != NULL)
+        DeleteObject(captionFont);
 }
 
 void CMainWindow::GetFormatedPathForTitle(char* path, int textSize)
@@ -2078,7 +2154,7 @@ void CMainWindow::SetWindowTitle(const char* text)
     {
         char stdSuffix[300];
         stdSuffix[0] = 0;
-        AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), "Open Salamander");
+        AppendToWindowTitle(stdSuffix, sizeof(stdSuffix), SALAMANDER_TEXT_VERSION);
 
         if (RunningAsAdmin)
         {
@@ -2152,7 +2228,7 @@ void CMainWindow::SetWindowTitle(const char* text)
     if (appTitleSuffix[0] != 0)
     {
         std::wstring wideAppSuffix = MultiByteToWindowTitleWide(appTitleSuffix);
-        EnsureAppNameSuffixInTitle(wideText, wideAppSuffix);
+        EnsureAppNameSuffixInTitle(HWindow, wideText, wideAppSuffix);
     }
     std::wstring wideBuff;
     int wideBuffLen = GetWindowTextLengthW(HWindow);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -519,16 +519,29 @@ void CMainWindow::InvalidateDirectoryLine(CFilesWindow* panel, BOOL update)
         dirLine->InvalidateAndUpdate(update);
 }
 
-static std::wstring AnsiToWide(const char* text)
+static std::wstring Utf8OrAnsiToWide(const char* text)
 {
     if (text == NULL)
         return std::wstring();
-    int length = MultiByteToWideChar(CP_ACP, 0, text, -1, NULL, 0);
+
+    int textLen = (int)strlen(text);
+    if (textLen == 0)
+        return std::wstring();
+
+    UINT codePage = CP_UTF8;
+    DWORD flags = MB_ERR_INVALID_CHARS;
+    int length = MultiByteToWideChar(codePage, flags, text, textLen, NULL, 0);
+    if (length <= 0)
+    {
+        codePage = CP_ACP;
+        flags = 0;
+        length = MultiByteToWideChar(codePage, flags, text, textLen, NULL, 0);
+    }
     if (length <= 0)
         return std::wstring();
-    std::wstring result(length - 1, L'\0');
-    if (length > 1)
-        MultiByteToWideChar(CP_ACP, 0, text, -1, &result[0], length);
+
+    std::wstring result(length, L'\0');
+    MultiByteToWideChar(codePage, flags, text, textLen, &result[0], length);
     return result;
 }
 
@@ -548,9 +561,9 @@ static void BuildTabCaption(CFilesWindow* panel, char* buffer, int bufferSize)
 
 static std::wstring BuildTabDisplayText(CFilesWindow* panel, int index)
 {
-    char text[2 * MAX_PATH];
+    char text[SAL_MAX_PATH];
     BuildTabCaption(panel, text, _countof(text));
-    std::wstring caption = AnsiToWide(text);
+    std::wstring caption = Utf8OrAnsiToWide(text);
     std::wstring prefix;
     if (panel != NULL && panel->HasCustomTabPrefix())
         prefix = panel->GetCustomTabPrefix();

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -1864,7 +1864,7 @@ void CMainWindow::CommandSetPanelTabPrefix(CFilesWindow* panel)
     if ((int)dlg.Execute() != IDOK)
         return;
 
-    std::wstring prefix = AnsiToWide(buffer);
+    std::wstring prefix = Utf8OrAnsiToWide(buffer);
     size_t start = 0;
     while (start < prefix.length() && iswspace(prefix[start]))
         ++start;

--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -56,7 +56,6 @@ namespace
     constexpr LPARAM kNewTabButtonParam = static_cast<LPARAM>(-1);
     constexpr wchar_t kTabWidthPaddingChar = L'\x2007';
     const wchar_t kNewTabButtonText[] = L"+";
-    const wchar_t kEllipsisText[] = L"...";
 
     COLORREF BlendColor(COLORREF from, COLORREF to, int weight)
     {
@@ -138,59 +137,6 @@ namespace
     {
         while (!text.empty() && text[text.length() - 1] == kTabWidthPaddingChar)
             text.erase(text.length() - 1);
-    }
-
-    std::wstring EllipsizeTextToWidth(const std::wstring& text, HDC hdc, int maxWidth)
-    {
-        if (maxWidth <= 0)
-            return std::wstring(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
-        if (text.empty())
-            return text;
-
-        SIZE textSize = {0, 0};
-        if (!GetTextExtentPoint32W(hdc, text.c_str(), (int)text.length(), &textSize))
-            return text;
-        if (textSize.cx <= maxWidth)
-            return text;
-
-        SIZE ellipsisSize = {0, 0};
-        if (!GetTextExtentPoint32W(hdc, kEllipsisText, _countof(kEllipsisText) - 1, &ellipsisSize))
-            ellipsisSize.cx = 0;
-        if (ellipsisSize.cx > maxWidth)
-            return std::wstring(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
-
-        int low = 0;
-        int high = (int)text.length() - 1;
-        std::wstring best(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
-        while (low <= high)
-        {
-            int mid = (low + high) / 2;
-            std::wstring candidate;
-            if (mid <= 0)
-                candidate.assign(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
-            else
-            {
-                candidate.assign(text, 0, mid);
-                candidate.append(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
-            }
-
-            SIZE candidateSize = {0, 0};
-            if (!GetTextExtentPoint32W(hdc, candidate.c_str(), (int)candidate.length(), &candidateSize))
-            {
-                high = mid - 1;
-                continue;
-            }
-
-            if (candidateSize.cx <= maxWidth)
-            {
-                best = candidate;
-                low = mid + 1;
-            }
-            else
-                high = mid - 1;
-        }
-
-        return best;
     }
 
 }
@@ -426,14 +372,6 @@ void CTabWindow::SetTabText(int index, const wchar_t* text)
     if (fontToUse != NULL)
         oldFont = (HFONT)SelectObject(hdc, fontToUse);
 
-    int desiredWidth = 0;
-    if (!desired.empty() && hdc != NULL)
-    {
-        SIZE desiredSize = {0, 0};
-        if (GetTextExtentPoint32W(hdc, desired.c_str(), (int)desired.length(), &desiredSize))
-            desiredWidth = desiredSize.cx;
-    }
-
     RECT rect;
     if (!TabCtrl_GetItemRect(HWindow, index, &rect))
     {
@@ -443,32 +381,6 @@ void CTabWindow::SetTabText(int index, const wchar_t* text)
         return;
     }
     int currentWidth = rect.right - rect.left;
-
-    if (maxWidthPx > 0 && currentWidth > maxWidthPx && !desired.empty())
-    {
-        int extraWidth = currentWidth - desiredWidth;
-        int allowedTextWidth = maxWidthPx - extraWidth - closeBtnExtraPx;
-        if (allowedTextWidth <= 0)
-            finalText.assign(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
-        else if (desiredWidth > allowedTextWidth)
-            finalText = EllipsizeTextToWidth(desired, hdc, allowedTextWidth);
-
-        for (int attempt = 0; attempt < 3; ++attempt)
-        {
-            setItemText(finalText);
-            if (!TabCtrl_GetItemRect(HWindow, index, &rect))
-                break;
-            currentWidth = rect.right - rect.left;
-            if (currentWidth <= maxWidthPx)
-                break;
-
-            allowedTextWidth -= (currentWidth - maxWidthPx);
-            if (allowedTextWidth <= 0)
-                finalText.assign(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
-            else
-                finalText = EllipsizeTextToWidth(desired, hdc, allowedTextWidth);
-        }
-    }
 
     if (minWidthPx > 0 || closeBtnExtraPx > 0)
     {

--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -56,6 +56,7 @@ namespace
     constexpr LPARAM kNewTabButtonParam = static_cast<LPARAM>(-1);
     constexpr wchar_t kTabWidthPaddingChar = L'\x2007';
     const wchar_t kNewTabButtonText[] = L"+";
+    const wchar_t kEllipsisText[] = L"...";
 
     COLORREF BlendColor(COLORREF from, COLORREF to, int weight)
     {
@@ -137,6 +138,67 @@ namespace
     {
         while (!text.empty() && text[text.length() - 1] == kTabWidthPaddingChar)
             text.erase(text.length() - 1);
+    }
+
+    std::wstring EllipsizeTextToWidth(const std::wstring& text, HDC hdc, int maxWidth)
+    {
+        if (maxWidth <= 0)
+            return std::wstring(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
+        if (text.empty())
+            return text;
+
+        SIZE textSize = {0, 0};
+        if (!GetTextExtentPoint32W(hdc, text.c_str(), (int)text.length(), &textSize))
+            return text;
+        if (textSize.cx <= maxWidth)
+            return text;
+
+        SIZE ellipsisSize = {0, 0};
+        if (!GetTextExtentPoint32W(hdc, kEllipsisText, _countof(kEllipsisText) - 1, &ellipsisSize))
+            ellipsisSize.cx = 0;
+        if (ellipsisSize.cx > maxWidth)
+            return std::wstring(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
+
+        int low = 0;
+        int high = (int)text.length();
+        std::wstring best(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
+        while (low <= high)
+        {
+            int rawMid = (low + high) / 2;
+            int mid = rawMid;
+            if (mid > 0)
+            {
+                wchar_t ch = text[mid - 1];
+                if (ch >= 0xD800 && ch <= 0xDBFF)
+                    mid--;
+            }
+
+            std::wstring candidate;
+            if (mid <= 0)
+                candidate.assign(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
+            else
+            {
+                candidate.assign(text, 0, mid);
+                candidate.append(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
+            }
+
+            SIZE candidateSize = {0, 0};
+            if (!GetTextExtentPoint32W(hdc, candidate.c_str(), (int)candidate.length(), &candidateSize))
+            {
+                high = mid - 1;
+                continue;
+            }
+
+            if (candidateSize.cx <= maxWidth)
+            {
+                best = candidate;
+                low = rawMid + 1;
+            }
+            else
+                high = rawMid - 1;
+        }
+
+        return best;
     }
 
 }
@@ -372,6 +434,14 @@ void CTabWindow::SetTabText(int index, const wchar_t* text)
     if (fontToUse != NULL)
         oldFont = (HFONT)SelectObject(hdc, fontToUse);
 
+    int desiredWidth = 0;
+    if (!desired.empty())
+    {
+        SIZE desiredSize = {0, 0};
+        if (GetTextExtentPoint32W(hdc, desired.c_str(), (int)desired.length(), &desiredSize))
+            desiredWidth = desiredSize.cx;
+    }
+
     RECT rect;
     if (!TabCtrl_GetItemRect(HWindow, index, &rect))
     {
@@ -381,6 +451,32 @@ void CTabWindow::SetTabText(int index, const wchar_t* text)
         return;
     }
     int currentWidth = rect.right - rect.left;
+
+    if (maxWidthPx > 0 && currentWidth > maxWidthPx && !desired.empty())
+    {
+        int extraWidth = currentWidth - desiredWidth;
+        int allowedTextWidth = maxWidthPx - extraWidth - closeBtnExtraPx;
+        if (allowedTextWidth <= 0)
+            finalText.assign(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
+        else if (desiredWidth > allowedTextWidth)
+            finalText = EllipsizeTextToWidth(desired, hdc, allowedTextWidth);
+
+        for (int attempt = 0; attempt < 3; ++attempt)
+        {
+            setItemText(finalText);
+            if (!TabCtrl_GetItemRect(HWindow, index, &rect))
+                break;
+            currentWidth = rect.right - rect.left;
+            if (currentWidth <= maxWidthPx)
+                break;
+
+            allowedTextWidth -= (currentWidth - maxWidthPx);
+            if (allowedTextWidth <= 0)
+                finalText.assign(kEllipsisText, kEllipsisText + _countof(kEllipsisText) - 1);
+            else
+                finalText = EllipsizeTextToWidth(desired, hdc, allowedTextWidth);
+        }
+    }
 
     if (minWidthPx > 0 || closeBtnExtraPx > 0)
     {


### PR DESCRIPTION
### Motivation
- Prevent the app title from being trimmed or disappearing when very long or Unicode paths are shown in the title bar. 
- Avoid cutting UTF-8 sequences when truncating title text so multibyte characters are not corrupted. 
- Prevent an access-violation crash when a plug-in returns a successful change-drive item with a `NULL` text pointer. 

### Description
- Add bounded helpers `AppendToWindowTitle`, `AppendUtf8ToWindowTitle` and `TruncateUtf8WindowTitle` to safely append and truncate title parts without splitting UTF-8 characters in `src/mainwnd1.cpp`. 
- Reserve space for the product/version suffix (`SALAMANDER_TEXT_VERSION`) and compose the prefix/path into a limited buffer region so the app name remains visible even when the path is long. 
- Change `GetFormatedPathForTitle` signature to `void GetFormatedPathForTitle(char* text, int textSize)` and pass explicit buffer sizes to avoid implicit assumptions about destination length. 
- Add a defensive check in `CDrivesList::BuildData` to skip drive entries when a plug-in returns `txt == NULL`, destroying the icon when appropriate to avoid later dereference crashes in `src/drivelst.cpp`. 

### Testing
- Ran `git diff --check` to validate whitespace/patch consistency and it completed with no issues. 
- No full build was performed in this change set, so compilation and runtime verification should be run in CI or locally before release.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d53e57b483298b301483b1579db0)