### PR TITLE
Keep panel splitter ratio independent of Tree View

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -8170,14 +8170,33 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             GetWindowSplitRect(r);
 
             int splitWidth = MainWindow->GetSplitBarWidth();
+            int treeReservedWidth = 0;
+            if (LeftPanel != NULL && LeftPanel->HTreeView != NULL && LeftPanel->TreeViewActive)
+            {
+                if (Configuration.TreeViewAutoHide)
+                {
+                    treeReservedWidth = LeftPanel->GetTreeViewHeaderHeight();
+                    if (LeftTabWindow != NULL)
+                        treeReservedWidth = LeftTabWindow->GetNeededHeight();
+                }
+                else
+                    treeReservedWidth = LeftPanel->GetTreeViewWidth(WindowWidth) + 4;
+            }
 
-            // stopper at the center
-            double splitPosition = (double)(x - DragAnchorX) / (WindowWidth - splitWidth);
+            int panelsSplitWidth = WindowWidth - 2 - splitWidth - treeReservedWidth;
+            if (panelsSplitWidth < 0)
+                panelsSplitWidth = 0;
+
+            // Stopper at the center of the two file panels. Tree View is a
+            // separate reservation on the left and must not affect the stored
+            // panel ratio.
+            int leftWidth = x - DragAnchorX - 1 - treeReservedWidth;
+            double splitPosition = panelsSplitWidth > 0 ? (double)(leftWidth + 1) / (panelsSplitWidth + 1) : 0.5;
 
             if (splitPosition >= 0.49 && splitPosition <= 0.51)
             {
-                x = (WindowWidth - splitWidth) / 2 + DragAnchorX;
                 splitPosition = 0.5;
+                leftWidth = (int)((panelsSplitWidth + 1) * splitPosition) - 1;
             }
 
             if (splitPosition < 0)
@@ -8185,15 +8204,22 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             if (splitPosition > 1)
                 splitPosition = 1;
 
-            int leftWidth = x - DragAnchorX;
-            if (leftWidth < MIN_WIN_WIDTH + 1)
-                leftWidth = MIN_WIN_WIDTH + 1;
-            int rightWidth = WindowWidth - 2 - leftWidth - splitWidth;
-            if (rightWidth < MIN_WIN_WIDTH - 1)
+            if (leftWidth < MIN_WIN_WIDTH)
+                leftWidth = MIN_WIN_WIDTH;
+            int rightWidth = panelsSplitWidth - leftWidth;
+            if (rightWidth < MIN_WIN_WIDTH)
             {
-                rightWidth = MIN_WIN_WIDTH - 1;
-                leftWidth = WindowWidth - 2 - splitWidth - rightWidth;
+                rightWidth = MIN_WIN_WIDTH;
+                leftWidth = panelsSplitWidth - rightWidth;
             }
+            if (leftWidth < 0)
+                leftWidth = 0;
+            splitPosition = panelsSplitWidth > 0 ? (double)(leftWidth + 1) / (panelsSplitWidth + 1) : 0.5;
+            if (splitPosition < 0)
+                splitPosition = 0;
+            if (splitPosition > 1)
+                splitPosition = 1;
+            int splitX = 1 + treeReservedWidth + leftWidth;
 
             TOOLINFO ti;
             ti.cbSize = sizeof(TOOLINFO);
@@ -8207,7 +8233,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             POINT p;
             GetCursorPos(&p);
             POINT p2;
-            p2.x = leftWidth;
+            p2.x = splitX;
             p2.y = 0;
             ClientToScreen(HWindow, &p2);
             p.x = p2.x;
@@ -8216,9 +8242,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
 
             if (DragFullWindows)
             {
-                if (DragSplitX != leftWidth)
+                if (DragSplitX != splitX)
                 {
-                    DragSplitX = leftWidth;
+                    DragSplitX = splitX;
                     KeepSplitPositionCenteredOnVisiblePanes = FALSE;
                     PanelZoomedState = 0;
                     SplitPosition = DragSplitPosition;
@@ -8227,8 +8253,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             }
             else
             {
-                DrawSplitLine(HWindow, leftWidth, DragSplitX, r);
-                DragSplitX = leftWidth;
+                DrawSplitLine(HWindow, splitX, DragSplitX, r);
+                DragSplitX = splitX;
             }
 
             //        ti.hinst = HInstance;
@@ -8606,15 +8632,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             if (LeftTabWindow != NULL)
                 treeHeaderHeight = LeftTabWindow->GetNeededHeight();
 
-            int tempLeftWidth = (int)((WindowWidth - splitWidth) * layoutSplitPosition) - 1;
-            if (tempLeftWidth < MIN_WIN_WIDTH)
-                tempLeftWidth = MIN_WIN_WIDTH;
-            int tempRightWidth = WindowWidth - 2 - tempLeftWidth - splitWidth;
-            if (tempRightWidth < MIN_WIN_WIDTH)
-            {
-                tempRightWidth = MIN_WIN_WIDTH;
-                tempLeftWidth = WindowWidth - 2 - tempRightWidth - splitWidth;
-            }
             if (Configuration.TreeViewAutoHide)
                 treeDisplayWidth = LeftPanel->GetTreeViewWidth(WindowWidth);
             else
@@ -8640,19 +8657,23 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             }
         }
 
-        // Calculate split widths accounting for treeview:
-        // The treeview is part of the left side, so the split ratio applies to
-        // (leftPanelContent + treeview + splitter) vs (rightPanel)
-        int leftTotalWidth = (int)((totalPanelsWidth + 1) * layoutSplitPosition) - 1;
-        if (leftTotalWidth < MIN_WIN_WIDTH)
-            leftTotalWidth = MIN_WIN_WIDTH;
-        int rightWidth = totalPanelsWidth - leftTotalWidth;
+        // Tree View is reserved outside the user panel split.  The split ratio
+        // applies only to the two file panels so a saved 50/50 stays 50/50
+        // when Tree View is pinned, collapsed, activated, hidden, or the
+        // main window is resized/restored.
+        int panelsSplitWidth = totalPanelsWidth - treeWidth - treeSplitWidth;
+        if (panelsSplitWidth < 0)
+            panelsSplitWidth = 0;
+
+        int panelLeftWidth = (int)((panelsSplitWidth + 1) * layoutSplitPosition) - 1;
+        if (panelLeftWidth < MIN_WIN_WIDTH)
+            panelLeftWidth = MIN_WIN_WIDTH;
+        int rightWidth = panelsSplitWidth - panelLeftWidth;
         if (rightWidth < MIN_WIN_WIDTH)
         {
             rightWidth = MIN_WIN_WIDTH;
-            leftTotalWidth = totalPanelsWidth - rightWidth;
+            panelLeftWidth = panelsSplitWidth - rightWidth;
         }
-        int panelLeftWidth = leftTotalWidth - treeWidth - treeSplitWidth;
         if (panelLeftWidth < 0)
             panelLeftWidth = 0;
 
@@ -8674,7 +8695,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         }
         else
         {
-            SplitPositionPix = 1 + leftTotalWidth;
+            SplitPositionPix = 1 + treeWidth + treeSplitWidth + panelLeftWidth;
         }
 
         TopRebarHeight = 0;

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -327,29 +327,11 @@ void CMainWindow::GetPanelWidthsFromSplitPosition(double splitPosition, int& lef
 
 double CMainWindow::GetVisibleLeftPanelRatio()
 {
-    int leftWidth;
-    int rightWidth;
-    GetPanelWidthsFromSplitPosition(SplitPosition, leftWidth, rightWidth);
-
-    int leftVisibleWidth = leftWidth;
-    if (LeftPanel != NULL)
-    {
-        int reservedWidth = LeftPanel->GetTreeViewReservedWidth(leftWidth);
-        if (reservedWidth > leftVisibleWidth)
-            reservedWidth = leftVisibleWidth;
-        leftVisibleWidth -= reservedWidth;
-    }
-
-    int totalVisibleWidth = leftVisibleWidth + rightWidth;
-    if (totalVisibleWidth <= 0)
-        return 0.5;
-
-    double leftVisibleRatio = (double)leftVisibleWidth / totalVisibleWidth;
-    if (leftVisibleRatio < 0)
-        leftVisibleRatio = 0;
-    if (leftVisibleRatio > 1)
-        leftVisibleRatio = 1;
-    return leftVisibleRatio;
+    // SplitPosition is the user's ratio between the two file panels.
+    // Tree View (pinned or auto-hidden) is a side reservation outside that
+    // ratio, so toggling or resizing Tree View must not rewrite the panel
+    // split and slowly move a 50/50 split left or right.
+    return SplitPosition;
 }
 
 double CMainWindow::GetSplitPositionForVisibleLeftPanelRatio(double leftVisibleRatio)
@@ -358,38 +340,7 @@ double CMainWindow::GetSplitPositionForVisibleLeftPanelRatio(double leftVisibleR
         leftVisibleRatio = 0;
     if (leftVisibleRatio > 1)
         leftVisibleRatio = 1;
-
-    int splitWidth = GetSplitBarWidth();
-    int totalPanelsWidth = WindowWidth - 2 - splitWidth;
-    if (totalPanelsWidth <= 0)
-        return 0.5;
-
-    int targetLeftWidth = (int)(totalPanelsWidth * leftVisibleRatio + 0.5);
-    if (LeftPanel != NULL)
-    {
-        int probeLeftWidth = targetLeftWidth;
-        for (int i = 0; i < 4; i++)
-        {
-            int reservedWidth = LeftPanel->GetTreeViewReservedWidth(probeLeftWidth);
-            int totalVisibleWidth = totalPanelsWidth - reservedWidth;
-            if (totalVisibleWidth < 0)
-                totalVisibleWidth = 0;
-
-            targetLeftWidth = (int)(leftVisibleRatio * totalVisibleWidth + 0.5) + reservedWidth;
-            if (targetLeftWidth < 0)
-                targetLeftWidth = 0;
-            if (targetLeftWidth > totalPanelsWidth)
-                targetLeftWidth = totalPanelsWidth;
-            probeLeftWidth = targetLeftWidth;
-        }
-    }
-
-    double splitPosition = (double)(targetLeftWidth + 1) / (WindowWidth - splitWidth);
-    if (splitPosition < 0)
-        splitPosition = 0;
-    if (splitPosition > 1)
-        splitPosition = 1;
-    return splitPosition;
+    return leftVisibleRatio;
 }
 
 double CMainWindow::GetVisiblePanesCenteredSplitPosition()


### PR DESCRIPTION
### Motivation
- Users reported that a saved splitter ratio (e.g. 50/50) drifts left/right when the Tree View is pinned/collapsed/activated/deactivated or when the window is resized/maximized/restored. The intent is to preserve the user-set split between the two file panels regardless of Tree View changes.

### Description
- Treat `SplitPosition` as the ratio between the two file panels only, and reserve Tree View width outside of that ratio so toggling/resizing the Tree View does not alter the user splitter setting (changes in `src/mainwnd3.cpp` and `src/mainwnd4.cpp`).
- Update the layout calculation to compute a `panelsSplitWidth` = total panels width minus the Tree View reservation, then compute `panelLeftWidth` and `rightWidth` from that area and place the split bar at `1 + treeWidth + treeSplitWidth + panelLeftWidth`.
- Update drag handling so the drag ratio is calculated relative to the file-panel area (subtracting the Tree View reservation), compute a `splitX` screen position accordingly, and use `splitX` for drawing and live updates during drag.
- Simplify `GetVisibleLeftPanelRatio()` / `GetSplitPositionForVisibleLeftPanelRatio()` to return and accept the user `SplitPosition` directly so visibility changes do not progressively rewrite the stored ratio.

### Testing
- Ran `git diff --check` and verified there are no whitespace/errors reported by the diff checker (succeeded). 
- Checked for available build tools with `command -v msbuild || command -v xbuild || command -v cmake` and found only `/usr/bin/cmake` in the environment, so no full Windows/MSBuild build was executed here (toolchain for full native build not available). 
- No automated unit/integration tests exist for this UI behavior in the repo, so no further automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48ea0d37208329858f70b01cf78d21)