### PR TITLE
Keep active tab visible after title updates

### DIFF
--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -413,6 +413,7 @@ void CTabWindow::SetTabText(int index, const wchar_t* text)
 
     std::wstring finalText = desired;
     setItemText(finalText);
+    bool ensureSelectedVisible = (index == TabCtrl_GetCurSel(HWindow));
 
     int closeBtnExtraPx = 0;
     if (ShouldShowCloseButton(index, TabCtrl_GetCurSel(HWindow)))
@@ -427,7 +428,11 @@ void CTabWindow::SetTabText(int index, const wchar_t* text)
 
     HDC hdc = GetDC(HWindow);
     if (hdc == NULL)
+    {
+        if (ensureSelectedVisible)
+            EnsureSelectedTabVisible();
         return;
+    }
     HFONT oldFont = NULL;
     bool selected = (index == TabCtrl_GetCurSel(HWindow));
     HFONT fontToUse = (selected && EnvFontBold != NULL) ? EnvFontBold : EnvFont;
@@ -448,6 +453,8 @@ void CTabWindow::SetTabText(int index, const wchar_t* text)
         if (oldFont != NULL)
             SelectObject(hdc, oldFont);
         ReleaseDC(HWindow, hdc);
+        if (ensureSelectedVisible)
+            EnsureSelectedTabVisible();
         return;
     }
     int currentWidth = rect.right - rect.left;
@@ -514,6 +521,8 @@ void CTabWindow::SetTabText(int index, const wchar_t* text)
     if (oldFont != NULL)
         SelectObject(hdc, oldFont);
     ReleaseDC(HWindow, hdc);
+    if (ensureSelectedVisible)
+        EnsureSelectedTabVisible();
 }
 
 void CTabWindow::SetCurSel(int index)


### PR DESCRIPTION
### Motivation
- When a panel changes its content (e.g. switching folders or opening plugin FS) the tab caption can change and the tab strip may reset its visible range, causing the active tab button to be scrolled out of view; the existing `EnsureSelectedTabVisible()` must be invoked after title updates as well.

### Description
- When setting a tab text in `CTabWindow::SetTabText`, compute whether the updated index is the current selection and store it in `ensureSelectedVisible`.
- Call `EnsureSelectedTabVisible()` on the three early/fallback exit paths (no HDC, item rect unavailable) and after the normal update path so the active tab is scrolled into view when its title changes.
- Change is localized to `src/tabwnd.cpp` and does not alter other behavior.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues (no errors).
- Attempted a full Windows build with `msbuild`, but MSBuild is not available in this Linux environment so a native build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b640662748329b995979500c7d6a3)