### PR TITLE
Zero-initialize 7zip CFileData to prevent crash when opening archives

### DIFF
--- a/src/plugins/7zip/7zclient.cpp
+++ b/src/plugins/7zip/7zclient.cpp
@@ -240,7 +240,7 @@ BOOL C7zClient::AddFileDir(IInArchive* archive, UINT32 idx,
         }
         LPTSTR filePath = p;
 
-        CFileData fd;
+        CFileData fd = {0};
         fd.Name = SalamanderGeneral->DupStr(fileName);
         if (fd.Name == NULL)
         {

--- a/src/plugins/7zip/versinfo.rh2
+++ b/src/plugins/7zip/versinfo.rh2
@@ -11,7 +11,7 @@
 
 #define VERSINFO_MAJOR       1
 #define VERSINFO_MINORA      3
-#define VERSINFO_MINORB      1
+#define VERSINFO_MINORB      2
 
 #include "spl_vers.h" // retrieve version and build numbers
 


### PR DESCRIPTION
### Motivation
- Fix a crash/regression when opening 7z archives (and navigating back) caused by uninitialized fields in `CFileData` (e.g. `NameW`) introduced by a newly added member being left with garbage data.

### Description
- Replace `CFileData fd;` with `CFileData fd = {0};` in `src/plugins/7zip/7zclient.cpp` so the archive item structure is zero-initialized before populating its fields.

### Testing
- Ran `git diff --check`, which reported no issues and passed. 
- Attempted to build with `msbuild src/vcxproj/salamand.sln /t:Build /p:Configuration=Debug /p:Platform=x64`, but `msbuild` is not available in this container so the build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b77020d288329aeeea603fb8464d5)