### PR TITLE
Fix archiver autoconfiguration list text

### DIFF
--- a/src/pack.h
+++ b/src/pack.h
@@ -155,8 +155,13 @@ class CPackACDialog;
 class CPackACListView : public CWindow
 {
 protected:
+    enum
+    {
+        DISPINFO_TEXT_MAX = 4 * MAX_PATH
+    };
     const CPackACDialog* ACDialog;
     APackACPackersTable* PackersTable;
+    WCHAR DispInfoTextW[4][DISPINFO_TEXT_MAX];
 
 public:
     CPackACListView(const CPackACDialog* acDialog) : CWindow()
@@ -183,6 +188,7 @@ public:
     int GetCount();
     int GetPackersCount() { return PackersTable->Count; }
     CPackACPacker* GetPacker(int item, int* index);
+    WCHAR* GetDispInfoTextW(const char* text, int column);
     CPackACPacker* GetPacker(int index)
     {
         return PackersTable != NULL ? PackersTable->At(index) : NULL;

--- a/src/packac.cpp
+++ b/src/packac.cpp
@@ -224,17 +224,42 @@ CPackACDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             switch (((LPNMHDR)lParam)->code)
             {
-            case LVN_GETDISPINFO:
+            case LVN_GETDISPINFOA:
             {
                 // show the item and its state (we hold the data, not the listview)
-                LV_DISPINFO* info = (LV_DISPINFO*)lParam;
+                LV_DISPINFOA* info = (LV_DISPINFOA*)lParam;
                 int index;
                 CPackACPacker* packer = ListView->GetPacker(info->item.iItem, &index);
                 // if text was requested, provide it
-                if (info->item.mask & LVIF_TEXT)
+                if ((info->item.mask & LVIF_TEXT) && packer != NULL)
                     info->item.pszText = (char*)packer->GetText(index, info->item.iSubItem);
                 // if the checkbox icon was requested, provide it too
-                if ((info->item.mask & LVIF_STATE) &&
+                if (packer != NULL &&
+                    (info->item.mask & LVIF_STATE) &&
+                    (info->item.stateMask & LVIS_STATEIMAGEMASK))
+                {
+                    info->item.state &= ~LVIS_STATEIMAGEMASK;
+                    info->item.state |= packer->GetSelectState(index) << 12;
+                }
+                break;
+            }
+
+            case LVN_GETDISPINFOW:
+            {
+                // The main window and some common controls are Unicode now.  A Unicode
+                // list-view asks for WCHAR text in LVN_GETDISPINFOW; returning our
+                // historical char* strings through the generic LV_DISPINFO alias makes
+                // the owner-data rows render empty.
+                LV_DISPINFOW* info = (LV_DISPINFOW*)lParam;
+                int index;
+                CPackACPacker* packer = ListView->GetPacker(info->item.iItem, &index);
+                // if text was requested, provide it
+                if ((info->item.mask & LVIF_TEXT) && packer != NULL)
+                    info->item.pszText = ListView->GetDispInfoTextW(packer->GetText(index, info->item.iSubItem),
+                                                                    info->item.iSubItem);
+                // if the checkbox icon was requested, provide it too
+                if (packer != NULL &&
+                    (info->item.mask & LVIF_STATE) &&
                     (info->item.stateMask & LVIS_STATEIMAGEMASK))
                 {
                     info->item.state &= ~LVIS_STATEIMAGEMASK;
@@ -1454,6 +1479,31 @@ CPackACListView::GetPacker(int item, int* index)
         *index = arcIndex;
     // return the desired archiver
     return PackersTable->At(archiver);
+}
+
+// convert owner-data text to Unicode for Unicode list-view notifications
+WCHAR*
+CPackACListView::GetDispInfoTextW(const char* text, int column)
+{
+    CALL_STACK_MESSAGE2("CPackACListView::GetDispInfoTextW(, %d)", column);
+    if (column < 0 || column >= 4)
+        column = 0;
+
+    WCHAR* buffer = DispInfoTextW[column];
+    buffer[0] = 0;
+    if (text == NULL)
+        return buffer;
+
+    if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, text, -1, buffer, DISPINFO_TEXT_MAX) == 0)
+    {
+        if (MultiByteToWideChar(CP_ACP, 0, text, -1, buffer, DISPINFO_TEXT_MAX) == 0)
+        {
+            TRACE_E("CPackACListView::GetDispInfoTextW(): MultiByteToWideChar error: " << GetLastError());
+            buffer[0] = 0;
+        }
+    }
+    buffer[DISPINFO_TEXT_MAX - 1] = 0;
+    return buffer;
 }
 
 // find an archiver by the index in the list view


### PR DESCRIPTION
### Motivation
- The owner-data list in Archivers Autoconfiguration rendered blank rows when the main window/control started sending Unicode (`LVN_GETDISPINFOW`) notifications because code returned `char*` strings instead of `WCHAR*` buffers. 

### Description
- Handle both ANSI and Unicode list-view notifications by adding explicit cases for `LVN_GETDISPINFOA` and `LVN_GETDISPINFOW` and using `LV_DISPINFOA`/`LV_DISPINFOW` respectively in `src/packac.cpp`.
- Add a per-column `WCHAR` display buffer and declare `GetDispInfoTextW(const char* text, int column)` on `CPackACListView` in `src/pack.h` to provide stable Unicode text pointers to Unicode list-view callbacks.
- Implement `GetDispInfoTextW` in `src/packac.cpp` to convert the historical `char*` owner-data strings to `WCHAR` via `MultiByteToWideChar` with a fallback and proper buffer length handling.
- Add `packer != NULL` guards before filling `LVIF_TEXT`/`LVIF_STATE` fields so notifications are handled safely.

### Testing
- Ran `git diff --check` to validate patch formatting and there were no whitespace/errors reported (succeeded).
- Attempted to build with MSBuild (`msbuild src/vcxproj/salamand.sln /p:Configuration=Debug /p:Platform=Win32`), but the CI/build toolchain was not available in this environment so a full compile could not be executed (`msbuild: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e087764d083298757b3d1ad88703c)