### PR TITLE
Preserve archiver paths when opening autoconfiguration

### DIFF
--- a/src/packac.cpp
+++ b/src/packac.cpp
@@ -1116,12 +1116,10 @@ void CPackACDialog::Transfer(CTransferInfo& ti)
     // are we starting or ending?
     if (ti.Type == ttDataToWindow)
     {
-        // Autoconfiguration must always start from the built-in external
-        // archiver templates.  Older/broken registry data may have the right
-        // count but empty variables/executables, which produced an empty
-        // virtual list and prevented ARC_UID_* entries from being searched.
-        ArchiverConfig->DeleteAllArchivers();
-        ArchiverConfig->AddDefault(0);
+        // Make sure the built-in archiver templates exist, but do not reset
+        // already configured executable locations merely because the
+        // autoconfiguration window was opened.
+        ArchiverConfig->EnsureDefaultValues();
         // create a table of packers to search for
         APackACPackersTable* table = new APackACPackersTable(20, 10);
         int i;
@@ -2055,11 +2053,10 @@ void PackAutoconfig(HWND parent)
 
     // stop refreshes in the main window
     BeginStopRefresh();
-    // PackAutoconfig must always start from the built-in external archiver definitions;
-    // otherwise an incomplete in-memory/registry state leaves the virtual list without
-    // the heading rows (Jar32bitExecutable, Rar32bitExecutable, ..., Ace16bitExecutable).
-    ArchiverConfig.DeleteAllArchivers();
-    ArchiverConfig.AddDefault(0);
+    // Ensure the built-in external archiver definitions are available without
+    // discarding executable locations saved by the user or by a previous
+    // autoconfiguration run.
+    ArchiverConfig.EnsureDefaultValues();
 
     if (PackACSavedDrivesList == NULL)
     {


### PR DESCRIPTION
### Motivation
- Opening the "Archivers Autoconfiguration" window unconditionally reset saved external archiver executable locations to defaults, causing user-configured `locations` to be lost; the intent is to keep previously stored archiver paths intact when merely opening the dialog.

### Description
- Replace unconditional `DeleteAllArchivers()`/`AddDefault(0)` calls with `EnsureDefaultValues()` so built-in archiver templates exist but saved executable locations are not overwritten in `CPackACDialog::Transfer` and in `PackAutoconfig`.

### Testing
- Ran `git diff --check` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e107652788329a91f2d5ab4fed8df)