### PR TITLE
Polish third-party software notices

### DIFF
--- a/doc/third_party.md
+++ b/doc/third_party.md
@@ -1,173 +1,75 @@
-# Open Salamander Third Party Software Notices
-
-## Igor Pavlov and Brian Gladman
-
-* The 7-ZIP plugin utilizes 7-Zip file archiver library.
-* 7-Zip Copyright (C) 1999-2026 Igor Pavlov.
-* 7-Zip is distributed under the GNU LGPL, with unRAR restriction for the RAR code.
-
-## Jean-loup Gailly and Mark Adler
-
-* Portions of ZIP plugin utilizes zlib library.
-* ZLIB Library Copyright (C) 1995-2002 Jean-loup Gailly and Mark Adler.
-
-## Tomas Jelinek
-
-* The Multimedia Viewer plugin includes software written by Tomas Jelinek.
-* Copyright (C) 2003-2026 Tomas Jelinek.
-
-## Jan Patera
-
-* Portions of PictView plugin licensed from Jan Patera.
-* Copyright (C) 1994-2026 Jan Patera.
-
-## Curtis Galloway and Lutz Muller
-
-* Portions of PictView plugin utilizes libexif library.
-* Libexif Library Copyright (C) 2001-2019 Curtis Galloway and Lutz Muller.
-
-## Julian R Seward
-
-* The TAR plugin utilizes bzip2 library.
-* Bzip2 Library Copyright (C) 1996-2000 Julian R Seward.
-
-## ARJ Software, Inc
-
-* Portions of UnARJ plugin utilizes decompression library written by ARJ Software, Inc.
-* Copyright (C) 1990-97 ARJ Software, Inc.
-
-## Microsoft Corporation
-
-* Portions of UnCAB plugin utilizes decompression library written by Microsoft Corporation.
-* Copyright (C) Microsoft Corporation 1993-1997.
-
-## Alexander Roshal
-
-* Portions of UnRAR plugin utilizes decompression library written by Alexander Roshal.
-* Copyright (C) 1993-2026 Alexander Roshal.
-* UnRAR is distributed under the unRAR license.
-* The vcpkg pipeline installs the unrar package for the UnRAR plugin runtime DLL.
-
-## Martin Prikryl
-
-* Portions of WinSCP plugin licensed from Martin Prikryl.
-* Copyright (C) 2000-2026 Martin Prikryl.
-
-## Juraj Rojko
-
-* The Windows Mobile plugin includes software written by Juraj Rojko.
-* Copyright (C) 2003-2026 Juraj Rojko.
-
-## Jed Wing
-
-* The UnCHM plugin utilizes CHMLIB library.
-* CHMLIB Library Copyright (C) 2001-2010 Jed Wing.
-
-## LGPL Libraries
-
-* LGPL Libraries are licensed under the GNU Library General Public License.
-* A copy of the GNU Library General Public License is included with this software.
-
-## Dr Brian Gladman
-
-* Crypto library utilizes AES code written by Dr Brian Gladman.
-* Copyright (C) 2001, Dr Brian Gladman.
-
-## Henry Spencer
-
-* Regular expression matching uses REGEXP library.
-* REGEXP Library Copyright (C) 1986 Henry Spencer, University of Toronto.
-
-## Daniel Karling
-
-* PNG library is based on PNGLite library.
-* PNGLite Library Copyright (C) 2007 Daniel Karling.
-
-## EZB Systems, Inc.
-
-* Portion of UnISO plugin utilizes ISZ SDK.
-* ISZ SDK Copyright (C) 2002-2006 EZB Systems, Inc., All Rights Reserved.
-
-## OpenSSL Project
-
-* The FTP Client plugin can utilize OpenSSL library.
-* Copyright (c) 1998-2026 The OpenSSL Project Authors. All rights reserved.
-* OpenSSL 1.0.x is distributed under the OpenSSL and original SSLeay licenses.
-* OpenSSL 3.x is distributed under the Apache License 2.0.
-* The vcpkg pipeline installs OpenSSL for the FTP plugin compatibility DLLs and for the SFTP plugin dependencies.
-
-## Daniel Stenberg, Simon Josefsson and libssh2 contributors
-
-* The SFTP plugin utilizes libssh2 library.
-* libssh2 is distributed under the BSD 3-Clause License.
-* The vcpkg pipeline installs the libssh2 package for the SFTP plugin dependencies.
-
-## SQLite
-
-* Open Salamander uses SQLite.
-* SQLite is in the Public Domain.
-
-## LibTomCrypt
-
-* The Checksum plugin utilizes LibTomCrypt library.
-* LibTomCrypt is public domain. As should all quality software be. Tom St Denis.
-
-## Nano SVG
-
-* Copyright (c) 2013-14 Mikko Mononen.
-
-## github/cmark-gfm
-
-* GitHub's fork of commonmark/cmark, a CommonMark parsing and rendering library and program in C.
-* Copyright (C) 2009 Public Software Group e. V., Berlin, Germany.
-* Copyright (C) 2012 Vicent Marti.
-* Copyright (C) 2012 Github, Inc.
-* Copyright (C) 2014-15 John MacFarlane.
-* Copyright (c) 2013 Karl Dubost.
-
-## Sally fork
-
-* Samandarin includes code and implementation work derived from or substantially informed by Sally by 0xeb.
-* Sally repository: https://github.com/0xeb/sally
-* In particular, portions of the Unicode viewer/filename handling and localization tooling were adapted from or substantially informed by Sally.
-* Copyright and license notices are preserved in the relevant source files.
-
-## Tree View panel
-
-* Based on changes proposed by fgodoy.
-
-## sindresorhus/github-markdown-css
-
-* Copyright (c) 2014 Dave Liepmann.
-* Copyright (c) Sindre Sorhus.
-* Copyright (c) 2016 Osmo Salomaa.
-
-## JSON Viewer Plugin
-
-The JSON Viewer plugin utilizes the following third-party software:
-
-* Microsoft .NET Framework 4.8, provided by Microsoft Corporation under the Microsoft .NET Framework license terms.
-* Newtonsoft.Json 13.0.3 by James Newton-King, released under the MIT License.
-
-## PrismSharp Text Viewer Plugin
-
-The PrismSharp Text Viewer plugin utilizes the following third-party software:
-
-* Microsoft .NET Framework 4.8, provided by Microsoft Corporation under the Microsoft .NET Framework license terms.
-* Microsoft.Web.WebView2 1.0.2420.47 by Microsoft Corporation, distributed under the BSD 3-Clause License.
-* PrismSharp 1.0.0-beta by Tom� Kubec, released under the MIT License, which includes Prism.js by Lea Verou and the PrismJS contributors under the MIT License.
-* Newtonsoft.Json 13.0.3 by James Newton-King, released under the MIT License.
-
-## WebView2 Render Viewer Plugin
-
-The WebView2 Render Viewer plugin utilizes the following third-party software:
-
-* Microsoft .NET Framework 4.8, provided by Microsoft Corporation under the Microsoft .NET Framework license terms.
-* Microsoft.Web.WebView2 1.0.2420.47 by Microsoft Corporation, distributed under the BSD 3-Clause License.
-* Markdig 0.36.2 by Alexandre Mutel and contributors, released under the BSD 2-Clause License.
-
-## Samandarin Update Notifier Plugin
-
-The Samandarin Update Notifier plugin utilizes the following third-party software:
-
-* Microsoft .NET Framework 4.8, provided by Microsoft Corporation under the Microsoft .NET Framework license terms.
+# Third-Party Software Notices
+
+Open Salamander Samandarin builds on the work of many authors, maintainers, and
+projects. This page records the components, code, ideas, and tooling that are
+used by the application and its plugins. Thank you to everyone listed here for
+making their work available.
+
+## Core Application and Shared Libraries
+
+| Component | Used for | Attribution and license notes |
+| --- | --- | --- |
+| REGEXP | Regular expression matching | Copyright (C) 1986 Henry Spencer, University of Toronto. |
+| AES code | Cryptographic routines | Written by Dr Brian Gladman. Copyright (C) 2001 Dr Brian Gladman. |
+| PNGLite | PNG image support | Based on PNGLite by Daniel Karling. Copyright (C) 2007 Daniel Karling. |
+| Nano SVG | SVG parsing/rendering support | Copyright (c) 2013-2014 Mikko Mononen. |
+| SQLite | Embedded database support | SQLite is in the Public Domain. |
+| LibTomCrypt | Checksum plugin cryptographic primitives | LibTomCrypt is public domain. As Tom St Denis wrote: "As should all quality software be." |
+| LGPL libraries | Shared third-party libraries | Licensed under the GNU Library General Public License. A copy of the license is included with this software. |
+
+## Archiving, Compression, and Disk Image Plugins
+
+| Component | Used in | Attribution and license notes |
+| --- | --- | --- |
+| 7-Zip | 7-ZIP plugin | 7-Zip file archiver library. Copyright (C) 1999-2026 Igor Pavlov. Distributed under the GNU LGPL, with the unRAR restriction for the RAR code. |
+| zlib | ZIP plugin | Portions of the ZIP plugin use zlib. Copyright (C) 1995-2002 Jean-loup Gailly and Mark Adler. |
+| bzip2 | TAR plugin | bzip2 library. Copyright (C) 1996-2000 Julian R Seward. |
+| ARJ decompression library | UnARJ plugin | Decompression library written by ARJ Software, Inc. Copyright (C) 1990-1997 ARJ Software, Inc. |
+| Microsoft CAB decompression library | UnCAB plugin | Decompression library written by Microsoft Corporation. Copyright (C) Microsoft Corporation 1993-1997. |
+| UnRAR | UnRAR plugin | Decompression library written by Alexander Roshal. Copyright (C) 1993-2026 Alexander Roshal. Distributed under the unRAR license. The vcpkg pipeline installs the `unrar` package for the UnRAR plugin runtime DLL. |
+| ISZ SDK | UnISO plugin | Portions of the UnISO plugin use ISZ SDK. Copyright (C) 2002-2006 EZB Systems, Inc. All rights reserved. |
+| CHMLIB | UnCHM plugin | CHMLIB library. Copyright (C) 2001-2010 Jed Wing. |
+
+## Viewer, Media, and File Format Plugins
+
+| Component or author | Used in | Attribution and license notes |
+| --- | --- | --- |
+| Tomas Jelinek | Multimedia Viewer plugin | Includes software written by Tomas Jelinek. Copyright (C) 2003-2026 Tomas Jelinek. |
+| Jan Patera | PictView plugin | Portions of the PictView plugin are licensed from Jan Patera. Copyright (C) 1994-2026 Jan Patera. |
+| libexif | PictView plugin | Portions of the PictView plugin use libexif. Copyright (C) 2001-2019 Curtis Galloway and Lutz Muller. |
+| Newtonsoft.Json 13.0.3 | JSON Viewer plugin | By James Newton-King, released under the MIT License. |
+| Microsoft .NET Framework 4.8 | JSON Viewer plugin | Provided by Microsoft Corporation under the Microsoft .NET Framework license terms. |
+| PrismSharp 1.0.0-beta | PrismSharp Text Viewer plugin | By Tomáš Kubec, released under the MIT License. Includes Prism.js by Lea Verou and the PrismJS contributors under the MIT License. |
+| Microsoft.Web.WebView2 1.0.2420.47 | PrismSharp Text Viewer plugin | By Microsoft Corporation, distributed under the BSD 3-Clause License. |
+| Microsoft .NET Framework 4.8 | PrismSharp Text Viewer plugin | Provided by Microsoft Corporation under the Microsoft .NET Framework license terms. |
+| Newtonsoft.Json 13.0.3 | PrismSharp Text Viewer plugin | By James Newton-King, released under the MIT License. |
+| Markdig 0.36.2 | WebView2 Render Viewer plugin | By Alexandre Mutel and contributors, released under the BSD 2-Clause License. |
+| Microsoft.Web.WebView2 1.0.2420.47 | WebView2 Render Viewer plugin | By Microsoft Corporation, distributed under the BSD 3-Clause License. |
+| Microsoft .NET Framework 4.8 | WebView2 Render Viewer plugin | Provided by Microsoft Corporation under the Microsoft .NET Framework license terms. |
+
+## Network, Synchronization, and Device Plugins
+
+| Component or author | Used in | Attribution and license notes |
+| --- | --- | --- |
+| OpenSSL | FTP Client plugin and SFTP dependencies | Copyright (c) 1998-2026 The OpenSSL Project Authors. All rights reserved. OpenSSL 1.0.x is distributed under the OpenSSL and original SSLeay licenses. OpenSSL 3.x is distributed under the Apache License 2.0. The vcpkg pipeline installs OpenSSL for the FTP plugin compatibility DLLs and for the SFTP plugin dependencies. |
+| libssh2 | SFTP plugin | By Daniel Stenberg, Simon Josefsson, and libssh2 contributors. Distributed under the BSD 3-Clause License. The vcpkg pipeline installs the `libssh2` package for the SFTP plugin dependencies. |
+| Martin Prikryl | WinSCP plugin | Portions of the WinSCP plugin are licensed from Martin Prikryl. Copyright (C) 2000-2026 Martin Prikryl. |
+| Juraj Rojko | Windows Mobile plugin | Includes software written by Juraj Rojko. Copyright (C) 2003-2026 Juraj Rojko. |
+| Microsoft .NET Framework 4.8 | Samandarin Update Notifier plugin | Provided by Microsoft Corporation under the Microsoft .NET Framework license terms. |
+
+## User Interface, Documentation, and Markdown Rendering
+
+| Component or contribution | Used for | Attribution and license notes |
+| --- | --- | --- |
+| cmark-gfm | CommonMark and GitHub-Flavored Markdown parsing/rendering | GitHub's fork of `commonmark/cmark`, a CommonMark parsing and rendering library and program in C. Copyright (C) 2009 Public Software Group e. V., Berlin, Germany; Copyright (C) 2012 Vicent Marti; Copyright (C) 2012 GitHub, Inc.; Copyright (C) 2014-2015 John MacFarlane; Copyright (c) 2013 Karl Dubost. |
+| github-markdown-css | Markdown document styling | Copyright (c) 2014 Dave Liepmann; Copyright (c) Sindre Sorhus; Copyright (c) 2016 Osmo Salomaa. |
+| Tree View panel changes | Tree View panel | Based on changes proposed by fgodoy. |
+
+## Sally-Derived Work
+
+Samandarin includes code and implementation work derived from, or substantially
+informed by, [Sally](https://github.com/0xeb/sally) by 0xeb. In particular,
+portions of the Unicode viewer, filename handling, and localization tooling were
+adapted from or substantially informed by Sally.
+
+Copyright and license notices are preserved in the relevant source files.


### PR DESCRIPTION
### Motivation

- Make the third-party notices page visually consistent and more informative so it displays well inside the application and properly represents authors and components. 
- Replace mixed ad-hoc sections with a structured, maintainable layout to improve readability and future updates.

### Description

- Rewrote `doc/third_party.md` with a short thank-you introduction and grouped thematic sections (Core, Archiving, Viewer, Network, UI) for easier navigation. 
- Converted the previous mixed headings and bullet lists into uniform Markdown tables with columns `Component`, `Used for`, and `Attribution and license notes`. 
- Fixed the encoding/author name for `PrismSharp` to `Tomáš Kubec` and normalised other attribution lines while preserving original copyright/license information. 
- Retained the Sally-derived work notice and all existing attributions while standardising formatting for program display.

### Testing

- Verified UTF-8 validity and absence of replacement characters with a Python check: `python - <<'PY' ... PY` (asserts no `�` and verifies the header). 
- Confirmed the document begins with the expected header `# Third-Party Software Notices`. 
- Ran `git diff --check` to ensure there are no whitespace or formatting issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ffbaa35688329bbd33e63d60b20a7)