### PR TITLE
Draw active tab border on bottom and use Active Panel background color

### DIFF
--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -2193,19 +2193,16 @@ void CTabWindow::DrawColoredTab(HDC hdc, const RECT& itemRect, const wchar_t* te
     if (selected && Configuration.TabActiveBorder)
     {
         COLORREF borderColor;
-        if (useDark)
-        {
-            if (CurrentColors != NULL)
-                borderColor = GetCOLORREF(CurrentColors[ITEM_FG_FOCUSED]);
-            else
-                borderColor = DarkModeGetDialogTextColor();
-        }
+        if (CurrentColors != NULL)
+            borderColor = GetCOLORREF(CurrentColors[ACTIVE_CAPTION_BK]);
+        else if (useDark)
+            borderColor = DarkModeGetDialogBackgroundColor();
         else
-            borderColor = GetSysColor(COLOR_BTNTEXT);
+            borderColor = GetSysColor(COLOR_ACTIVECAPTION);
 
         int borderHeight = 3;
         RECT borderRect;
-        SetRect(&borderRect, fillRect.left, fillRect.top - 1, fillRect.right, fillRect.top - 1 + borderHeight);
+        SetRect(&borderRect, fillRect.left, fillRect.bottom - borderHeight, fillRect.right, fillRect.bottom);
         HBRUSH borderBrush = CreateSolidBrush(borderColor);
         if (borderBrush != NULL)
         {
@@ -2229,6 +2226,13 @@ void CTabWindow::DrawColoredTab(HDC hdc, const RECT& itemRect, const wchar_t* te
     if (verticalLift < 2)
         verticalLift = 2;
     ++verticalLift;
+    if (selected && Configuration.TabActiveBorder)
+    {
+        int activeBorderTextLift = EnvFontCharHeight / 8;
+        if (activeBorderTextLift < 2)
+            activeBorderTextLift = 2;
+        verticalLift += activeBorderTextLift;
+    }
     int bottomPadding = topPadding + verticalLift;
 
     textRect.top += topPadding;

--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -2190,27 +2190,6 @@ void CTabWindow::DrawColoredTab(HDC hdc, const RECT& itemRect, const wchar_t* te
         DeleteObject(brush);
     }
 
-    if (selected && Configuration.TabActiveBorder)
-    {
-        COLORREF borderColor;
-        if (CurrentColors != NULL)
-            borderColor = GetCOLORREF(CurrentColors[ACTIVE_CAPTION_BK]);
-        else if (useDark)
-            borderColor = DarkModeGetDialogBackgroundColor();
-        else
-            borderColor = GetSysColor(COLOR_ACTIVECAPTION);
-
-        int borderHeight = 3;
-        RECT borderRect;
-        SetRect(&borderRect, fillRect.left, fillRect.bottom - borderHeight, fillRect.right, fillRect.bottom);
-        HBRUSH borderBrush = CreateSolidBrush(borderColor);
-        if (borderBrush != NULL)
-        {
-            FillRect(hdc, &borderRect, borderBrush);
-            DeleteObject(borderBrush);
-        }
-    }
-
     RECT textRect = fillRect;
     InflateRect(&textRect, -4, 0);
     if (textRect.right <= textRect.left)
@@ -2330,6 +2309,38 @@ void CTabWindow::DrawColoredTab(HDC hdc, const RECT& itemRect, const wchar_t* te
             if (oldPen != NULL)
                 SelectObject(hdc, oldPen);
             DeleteObject(closePen);
+        }
+    }
+
+    if (selected && Configuration.TabActiveBorder)
+    {
+        COLORREF borderColor;
+        if (CurrentColors != NULL)
+            borderColor = GetCOLORREF(CurrentColors[ACTIVE_CAPTION_BK]);
+        else if (useDark)
+            borderColor = DarkModeGetDialogBackgroundColor();
+        else
+            borderColor = GetSysColor(COLOR_ACTIVECAPTION);
+
+        int borderHeight = 3;
+        RECT borderRect = fillRect;
+        if (HWindow != NULL)
+        {
+            RECT clientRect;
+            if (GetClientRect(HWindow, &clientRect) && borderRect.bottom > clientRect.bottom - 1)
+                borderRect.bottom = clientRect.bottom - 1;
+        }
+        borderRect.top = borderRect.bottom - borderHeight;
+        if (borderRect.top < fillRect.top)
+            borderRect.top = fillRect.top;
+        if (borderRect.right > borderRect.left && borderRect.bottom > borderRect.top)
+        {
+            HBRUSH borderBrush = CreateSolidBrush(borderColor);
+            if (borderBrush != NULL)
+            {
+                FillRect(hdc, &borderRect, borderBrush);
+                DeleteObject(borderBrush);
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- The optional active-tab border was drawn on the top edge and used the tab text color, which is visually inconsistent with the panel "Active Panel" background color setting.
- The goal is to render the border at the bottom of the active tab and use the configured Active Panel background color so the tab visually ties to the active panel.

### Description
- Update drawing logic in `src/tabwnd.cpp` so when `Configuration.TabActiveBorder` is enabled the border is rendered on the bottom edge of the selected tab instead of the top edge. 
- Resolve the border color from `CurrentColors[ACTIVE_CAPTION_BK]` when available, otherwise fall back to dark-mode dialog background or `GetSysColor(COLOR_ACTIVECAPTION)` for light mode. 
- Keep the border height at `3` pixels and draw it at `fillRect.bottom - borderHeight` to place it on the bottom edge. 
- Increase the vertical lift of active tab text when the active border is shown by adding `EnvFontCharHeight / 8` (minimum 2px) to the computed `verticalLift`, so the text visually moves up a few pixels.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff issues, and it succeeded. 
- Ran `git status --short` to confirm working tree state after the change, and it reported no outstanding problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50153c22048329869dbfb65635602e)