### PR TITLE
Add wide/long-path and Unicode handling for packers and plugins; improve 7zip robustness

### DIFF
--- a/src/common/widepath.cpp
+++ b/src/common/widepath.cpp
@@ -72,8 +72,9 @@ std::wstring SalMultiByteToWidePath(const char* path, UINT codePage)
         len = MultiByteToWideChar(CP_ACP, 0, path, -1, NULL, 0), codePage = CP_ACP;
     if (len <= 0)
         return std::wstring();
-    std::wstring ret(len - 1, L'\0');
+    std::wstring ret(len, L'\0');
     MultiByteToWideChar(codePage, 0, path, -1, &ret[0], len);
+    ret.resize(len - 1);
     return ret;
 }
 

--- a/src/dialogs3.cpp
+++ b/src/dialogs3.cpp
@@ -2567,7 +2567,9 @@ void CPackDialog::Transfer(CTransferInfo& ti)
         // if the alternative path matches the first one, don't add it (target isn't ptDisk)
         if (StrICmp(Path, PathAlt) != 0)
             ComboAddStringUtf8(combo, PathAlt);
+        SendMessage(combo, CB_LIMITTEXT, SAL_MAX_PATH - 1, 0);
         SendMessage(combo, CB_SETCURSEL, 0, 0);
+        SetControlTextUtf8(combo, Path);
     }
     else if (ti.GetControl(combo, IDE_PATH))
         GetControlTextUtf8(combo, Path, SAL_MAX_PATH);
@@ -2727,24 +2729,46 @@ CPackDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 // WARNING: code must stay consistent with CPackDialog::Transfer
                 // swap extensions in the combobox
                 SendDlgItemMessage(HWindow, IDE_PATH, CB_RESETCONTENT, 0, 0);
+                char selectedName[SAL_MAX_PATH];
+                selectedName[0] = 0;
                 strcpy(name, Path);
                 if (ChangeExtension(name, PackerConfig->GetPackerExt(i)))
+                {
                     ComboAddStringUtf8(GetDlgItem(HWindow, IDE_PATH), name);
+                    if (curSel == 0)
+                        strcpy(selectedName, name);
+                }
                 else
+                {
                     ComboAddStringUtf8(GetDlgItem(HWindow, IDE_PATH), Path);
+                    if (curSel == 0)
+                        strcpy(selectedName, Path);
+                }
 
                 // if the alternative path matches the first one, don't add it (target isn't ptDisk)
                 if (StrICmp(Path, PathAlt) != 0)
                 {
                     strcpy(name, PathAlt);
                     if (ChangeExtension(name, PackerConfig->GetPackerExt(i)))
+                    {
                         ComboAddStringUtf8(GetDlgItem(HWindow, IDE_PATH), name);
+                        if (curSel == 1)
+                            strcpy(selectedName, name);
+                    }
                     else
+                    {
                         ComboAddStringUtf8(GetDlgItem(HWindow, IDE_PATH), PathAlt);
+                        if (curSel == 1)
+                            strcpy(selectedName, PathAlt);
+                    }
                 }
 
                 if (curSel != CB_ERR)
+                {
                     SendDlgItemMessage(HWindow, IDE_PATH, CB_SETCURSEL, (WPARAM)curSel, 0);
+                    if (selectedName[0] != 0)
+                        SetControlTextUtf8(GetDlgItem(HWindow, IDE_PATH), selectedName);
+                }
                 else
                 {
                     // if the editline was modified, change the extension there as well

--- a/src/dialogs3.cpp
+++ b/src/dialogs3.cpp
@@ -139,6 +139,21 @@ void SetControlTextUtf8(HWND ctrl, const char* text)
     SendMessage(target, WM_SETTEXT, 0, (LPARAM)text);
 }
 
+LRESULT ComboAddStringUtf8(HWND combo, const char* text)
+{
+    if (text == NULL)
+        text = "";
+
+    if (IsWindowUnicode(combo))
+    {
+        std::wstring wide;
+        if (Utf8ToWideString(text, -1, wide))
+            return SendMessageW(combo, CB_ADDSTRING, 0, (LPARAM)(wide.empty() ? L"" : wide.c_str()));
+    }
+
+    return SendMessage(combo, CB_ADDSTRING, 0, (LPARAM)text);
+}
+
 bool Utf8ToWideString(const char* text, int count, std::wstring& wide)
 {
     if (text == NULL)
@@ -2548,14 +2563,14 @@ void CPackDialog::Transfer(CTransferInfo& ti)
     {
         // WARNING: code must stay consistent with CPackDialog::DialogProc/WM_COMMAND
         ti.GetControl(combo, IDE_PATH);
-        SendMessage(combo, CB_ADDSTRING, 0, (LPARAM)Path);
+        ComboAddStringUtf8(combo, Path);
         // if the alternative path matches the first one, don't add it (target isn't ptDisk)
         if (StrICmp(Path, PathAlt) != 0)
-            SendMessage(combo, CB_ADDSTRING, 0, (LPARAM)PathAlt);
+            ComboAddStringUtf8(combo, PathAlt);
         SendMessage(combo, CB_SETCURSEL, 0, 0);
     }
-    else
-        ti.EditLine(IDE_PATH, Path, MAX_PATH);
+    else if (ti.GetControl(combo, IDE_PATH))
+        GetControlTextUtf8(combo, Path, SAL_MAX_PATH);
 
     if (ti.Type == ttDataFromWindow) // if the entered name lacks an extension, add it automatically
     {
@@ -2568,7 +2583,7 @@ void CPackDialog::Transfer(CTransferInfo& ti)
             if ((s == NULL || s2 != NULL && s2 > s) && // '.cvspass' in Windows is considered an extension ...
                 (s2 == NULL || (s2 - Path + 1) < nameLen) &&
                 nameLen > 0 &&
-                nameLen + 1 + 1 + strlen(ext) < MAX_PATH)
+                nameLen + 1 + 1 + strlen(ext) < SAL_MAX_PATH)
             {
                 strcpy(Path + nameLen, ".");
                 strcpy(Path + nameLen + 1, ext);
@@ -2604,7 +2619,7 @@ BOOL CPackDialog::ChangeExtension(char* name, const char* ext)
     if (s != NULL && // '.cvspass' in Windows is considered an extension ...
                      //if (s != NULL && s > name &&
         (s2 == NULL || s > s2) &&
-        strlen(ext) + 1 + ((s + 1) - name) < MAX_PATH)
+        strlen(ext) + 1 + ((s + 1) - name) < SAL_MAX_PATH)
     {
         strcpy(s + 1, ext);
         return TRUE;
@@ -2615,7 +2630,7 @@ BOOL CPackDialog::ChangeExtension(char* name, const char* ext)
         if ((s == NULL || s2 != NULL && s2 > s) &&
             (s2 == NULL || (s2 - name + 1) < nameLen) &&
             nameLen > 0 &&
-            nameLen + 1 + 1 + strlen(ext) < MAX_PATH)
+            nameLen + 1 + 1 + strlen(ext) < SAL_MAX_PATH)
         {
             strcpy(name + nameLen, ".");
             strcpy(name + nameLen + 1, ext);
@@ -2702,30 +2717,30 @@ CPackDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (i != CB_ERR)
             {
                 // swap extensions
-                char name[MAX_PATH];
-                char name2[MAX_PATH];
+                char name[SAL_MAX_PATH];
+                char name2[SAL_MAX_PATH];
 
                 int curSel = (int)SendDlgItemMessage(HWindow, IDE_PATH, CB_GETCURSEL, 0, 0);
                 if (curSel == CB_ERR) // we must retrieve the text here because CB_RESETCONTENT would wipe it
-                    GetWindowText(GetDlgItem(HWindow, IDE_PATH), name2, MAX_PATH);
+                    GetControlTextUtf8(GetDlgItem(HWindow, IDE_PATH), name2, _countof(name2));
 
                 // WARNING: code must stay consistent with CPackDialog::Transfer
                 // swap extensions in the combobox
                 SendDlgItemMessage(HWindow, IDE_PATH, CB_RESETCONTENT, 0, 0);
                 strcpy(name, Path);
                 if (ChangeExtension(name, PackerConfig->GetPackerExt(i)))
-                    SendDlgItemMessage(HWindow, IDE_PATH, CB_ADDSTRING, 0, (LPARAM)name);
+                    ComboAddStringUtf8(GetDlgItem(HWindow, IDE_PATH), name);
                 else
-                    SendDlgItemMessage(HWindow, IDE_PATH, CB_ADDSTRING, 0, (LPARAM)Path);
+                    ComboAddStringUtf8(GetDlgItem(HWindow, IDE_PATH), Path);
 
                 // if the alternative path matches the first one, don't add it (target isn't ptDisk)
                 if (StrICmp(Path, PathAlt) != 0)
                 {
                     strcpy(name, PathAlt);
                     if (ChangeExtension(name, PackerConfig->GetPackerExt(i)))
-                        SendDlgItemMessage(HWindow, IDE_PATH, CB_ADDSTRING, 0, (LPARAM)name);
+                        ComboAddStringUtf8(GetDlgItem(HWindow, IDE_PATH), name);
                     else
-                        SendDlgItemMessage(HWindow, IDE_PATH, CB_ADDSTRING, 0, (LPARAM)PathAlt);
+                        ComboAddStringUtf8(GetDlgItem(HWindow, IDE_PATH), PathAlt);
                 }
 
                 if (curSel != CB_ERR)
@@ -2734,7 +2749,7 @@ CPackDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                     // if the editline was modified, change the extension there as well
                     if (ChangeExtension(name2, PackerConfig->GetPackerExt(i)))
-                        SetWindowText(GetDlgItem(HWindow, IDE_PATH), name2);
+                        SetControlTextUtf8(GetDlgItem(HWindow, IDE_PATH), name2);
                 }
 
                 BOOL supMove = TRUE;

--- a/src/fileswn7.cpp
+++ b/src/fileswn7.cpp
@@ -1582,6 +1582,8 @@ void CFilesWindow::Pack(CFilesWindow* target, int pluginIndex, const char* plugi
         subDir = FALSE;
     data.IndexesCount = GetSelCount();
     char expanded[SAL_MAX_PATH + 100];
+    char archiveBaseName[SAL_MAX_PATH];
+    archiveBaseName[0] = 0;
     int files = 0;             // number of selected files
     if (data.IndexesCount > 1) // valid selection
     {
@@ -1650,6 +1652,7 @@ void CFilesWindow::Pack(CFilesWindow* target, int pluginIndex, const char* plugi
                 if (!isDir)
                     files = 1;
                 CFileData* f = isDir ? &Dirs->At(index) : &Files->At(index - Dirs->Count);
+                lstrcpyn(archiveBaseName, f->Name, _countof(archiveBaseName));
                 AlterFileName(path, f->Name, -1, Configuration.FileNameFormat, 0, index < Dirs->Count);
                 strcpy(expanded, LoadStr(isDir ? IDS_QUESTION_DIRECTORY : IDS_QUESTION_FILE));
             }
@@ -1674,17 +1677,19 @@ void CFilesWindow::Pack(CFilesWindow* target, int pluginIndex, const char* plugi
 
     if (nameByItem) // if only one item (file/directory) is selected, the archive inherits its name
     {
-        char* ext = strrchr(path, '.');
+        const char* itemName = archiveBaseName[0] != 0 ? archiveBaseName : path;
+        const char* ext = strrchr(itemName, '.');
         if (data.Indexes[0] < Dirs->Count || ext == NULL) // ".cvspass" is treated as an extension in Windows ...
-                                                          //  if (data.Indexes[0] < Dirs->Count || ext == NULL || ext == path)
+                                                          //  if (data.Indexes[0] < Dirs->Count || ext == NULL || ext == itemName)
         {                                                 // subdirectory or no extension
-            strcpy(fileBuf, path);
-            strcat(fileBuf, ".");
+            lstrcpyn(fileBuf, itemName, _countof(fileBuf));
+            if (strlen(fileBuf) + 1 < _countof(fileBuf))
+                strcat(fileBuf, ".");
         }
         else
         {
-            memcpy(fileBuf, path, ext + 1 - path);
-            fileBuf[ext + 1 - path] = 0;
+            memcpy(fileBuf, itemName, ext + 1 - itemName);
+            fileBuf[ext + 1 - itemName] = 0;
         }
     }
     else

--- a/src/fileswn7.cpp
+++ b/src/fileswn7.cpp
@@ -1675,7 +1675,7 @@ void CFilesWindow::Pack(CFilesWindow* target, int pluginIndex, const char* plugi
     char fileBuf[SAL_MAX_PATH];    // file we will pack into
     char fileBufAlt[SAL_MAX_PATH]; // alternative name shown in the Pack dialog combo box
 
-    if (nameByItem) // if only one item (file/directory) is selected, the archive inherits its name
+    if (data.IndexesCount == 1 && archiveBaseName[0] != 0) // if only one item (file/directory) is selected, the archive inherits its name
     {
         const char* itemName = archiveBaseName[0] != 0 ? archiveBaseName : path;
         const char* ext = strrchr(itemName, '.');

--- a/src/pack2.cpp
+++ b/src/pack2.cpp
@@ -8,6 +8,7 @@
 #include "zip.h"
 #include "plugins.h"
 #include "pack.h"
+#include "common/widepath.h"
 
 //
 // ****************************************************************************
@@ -30,9 +31,9 @@ const SPackModifyTable PackModifyTable[] =
         // RAR 4.20 & 5.0 Win x86/x64
         {
             (TPackErrorTable*)&RARErrors, TRUE,
-            "$(SourcePath)", "$(Rar32bitOr64bitExecutable) a -scol \"$(ArchiveFullName)\" -ap\"$(TargetPath)\" @\"$(ListFullName)\"", TRUE, // since version 5.0 we must enforce the -scol switch, version 4.20 is fine; it appears elsewhere and in the registry
-            "$(ArchivePath)", "$(Rar32bitOr64bitExecutable) d -scol \"$(ArchiveFileName)\" @\"$(ListFullName)\"", PMT_EMPDIRS_DELETE,
-            "$(SourcePath)", "$(Rar32bitOr64bitExecutable) m -scol \"$(ArchiveFullName)\" -ap\"$(TargetPath)\" @\"$(ListFullName)\"", FALSE},
+            "$(SourcePath)", "$(Rar32bitOr64bitExecutable) a -scul \"$(ArchiveFullName)\" -ap\"$(TargetPath)\" @\"$(ListFullName)\"", TRUE, // since version 5.0 we must enforce a list-file charset; use -scul because our RAR list file is UTF-16LE
+            "$(ArchivePath)", "$(Rar32bitOr64bitExecutable) d -scul \"$(ArchiveFileName)\" @\"$(ListFullName)\"", PMT_EMPDIRS_DELETE,
+            "$(SourcePath)", "$(Rar32bitOr64bitExecutable) m -scul \"$(ArchiveFullName)\" -ap\"$(TargetPath)\" @\"$(ListFullName)\"", FALSE},
         // ARJ 2.60 MS-DOS
         {
             (TPackErrorTable*)&ARJErrors, FALSE,
@@ -296,12 +297,52 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
         return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_GENERAL, buffer);
     }
 
-    // we have the file, now open it
+    const BOOL rarUnicodeListFile = strstr(command, "$(Rar32bitOr64bitExecutable)") != NULL ||
+                                    strstr(command, "-scol") != NULL ||
+                                    strstr(command, "-scul") != NULL;
+
+    char rarTmpArchiveName[SAL_MAX_PATH];
+    rarTmpArchiveName[0] = 0;
+    const char* archiveFileNameForCommand = archiveFileName;
+    if (rarUnicodeListFile)
+    {
+        BOOL archiveNameNeedsTemp = strlen(archiveFileName) >= MAX_PATH;
+        for (const unsigned char* s = (const unsigned char*)archiveFileName; !archiveNameNeedsTemp && *s != 0; s++)
+            archiveNameNeedsTemp = *s >= 0x80;
+        if (archiveNameNeedsTemp && SalGetFileAttributes(archiveFileName) == 0xFFFFFFFF)
+        {
+            if (!SalGetTempFileName(NULL, "RAR", rarTmpArchiveName, TRUE))
+            {
+                char buffer[1000];
+                strcpy(buffer, "SalGetTempFileName: ");
+                strcat(buffer, GetErrorText(GetLastError()));
+                DeleteFile(tmpListNameBuf);
+                return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_GENERAL, buffer);
+            }
+            DeleteFile(rarTmpArchiveName); // RAR creates the archive; we only need a safe ASCII command-line name.
+            archiveFileNameForCommand = rarTmpArchiveName;
+        }
+    }
+
+    // we have the file, now open it. RAR 4.x+ is invoked with -scul in our default
+    // configuration, which means the list file must be UTF-16LE. Without this,
+    // Unicode names outside the active ANSI/OEM code page are corrupted before RAR
+    // ever opens the source file.
     FILE* listFile;
-    if ((listFile = fopen(tmpListNameBuf, "w")) == NULL)
+    if ((listFile = fopen(tmpListNameBuf, rarUnicodeListFile ? "wb" : "w")) == NULL)
     {
         DeleteFile(tmpListNameBuf);
         return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_FILE);
+    }
+    if (rarUnicodeListFile)
+    {
+        const unsigned char bom[] = {0xFF, 0xFE};
+        if (fwrite(bom, sizeof(bom), 1, listFile) != 1)
+        {
+            fclose(listFile);
+            DeleteFile(tmpListNameBuf);
+            return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_FILE);
+        }
     }
 
     // and we can fill it
@@ -314,7 +355,7 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
         maxPath = DOS_MAX_PATH;
     else
         maxPath = SAL_MAX_PATH;
-    if (!needANSIListFile)
+    if (!needANSIListFile && !rarUnicodeListFile)
         CharToOem(sourceShortName, sourceShortName);
     int sourceDirLen = (int)strlen(sourceShortName) + 1;
     int errorOccured;
@@ -323,7 +364,7 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
     {
         if (supportLongNames)
         {
-            if (!needANSIListFile)
+            if (!needANSIListFile && !rarUnicodeListFile)
                 CharToOem(name, namecnv);
             else
                 strcpy(namecnv, name);
@@ -341,7 +382,7 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
                 DeleteFile(tmpListNameBuf);
                 return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_GENERAL, buffer);
             }
-            if (!needANSIListFile)
+            if (!needANSIListFile && !rarUnicodeListFile)
                 CharToOem(namecnv, namecnv);
         }
 
@@ -358,7 +399,22 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
         // and put it into the list
         if (!isDir)
         {
-            if (fprintf(listFile, "%s\n", namecnv) <= 0)
+            if (rarUnicodeListFile)
+            {
+                std::wstring nameW = SalMultiByteToWidePath(namecnv, CP_UTF8);
+                if (nameW.empty() && GetACP() != CP_UTF8)
+                    nameW = SalMultiByteToWidePath(namecnv, CP_ACP);
+                const wchar_t eol[] = L"\r\n";
+                if (nameW.empty() ||
+                    fwrite(nameW.c_str(), sizeof(wchar_t), nameW.length(), listFile) != nameW.length() ||
+                    fwrite(eol, sizeof(wchar_t), 2, listFile) != 2)
+                {
+                    fclose(listFile);
+                    DeleteFile(tmpListNameBuf);
+                    return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_FILE);
+                }
+            }
+            else if (fprintf(listFile, "%s\n", namecnv) <= 0)
             {
                 fclose(listFile);
                 DeleteFile(tmpListNameBuf);
@@ -383,12 +439,27 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
     char cmdLine[PACK_CMDLINE_MAXLEN];
     // buffer for a temporary name (when creating an archive with a long name and we need its DOS name,
     // DOSTmpName expands instead of the long name; after creating the archive the file is renamed)
-    char DOSTmpName[MAX_PATH];
-    if (!PackExpandCmdLine(archiveFileName, rootPath, tmpListNameBuf, NULL,
+    char DOSTmpName[SAL_MAX_PATH];
+    if (!PackExpandCmdLine(archiveFileNameForCommand, rootPath, tmpListNameBuf, NULL,
                            command, cmdLine, PACK_CMDLINE_MAXLEN, DOSTmpName))
     {
         DeleteFile(tmpListNameBuf);
         return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_CMDLNERR);
+    }
+    if (rarTmpArchiveName[0] != 0)
+        lstrcpyn(DOSTmpName, rarTmpArchiveName, SAL_MAX_PATH);
+
+    // Older configurations can still contain "-scol" (OEM list file).  We write
+    // RAR list files as UTF-16LE above, so force RAR's list-file charset to
+    // Unicode even for commands loaded from existing user configuration.
+    if (rarUnicodeListFile)
+    {
+        char* sc = cmdLine;
+        while ((sc = strstr(sc, "-scol")) != NULL)
+        {
+            memcpy(sc, "-scul", 5);
+            sc += 5;
+        }
     }
 
     // hack for RAR 4.x+ that dislikes "-ap""" when addressing the archive root; this cleanup works with older RAR too
@@ -431,7 +502,7 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
     }
     else
     {
-        if (!PackExpandInitDir(archiveFileName, sourceDir, rootPath, initDir, currentDir,
+        if (!PackExpandInitDir(archiveFileNameForCommand, sourceDir, rootPath, initDir, currentDir,
                                SAL_MAX_PATH))
         {
             DeleteFile(tmpListNameBuf);
@@ -458,6 +529,8 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
     if (!exec)
     {
         DeleteFile(tmpListNameBuf);
+        if (rarTmpArchiveName[0] != 0)
+            DeleteFile(rarTmpArchiveName);
         return FALSE; // error message has already been displayed
     }
 

--- a/src/pack3.cpp
+++ b/src/pack3.cpp
@@ -12,6 +12,7 @@
 #include "plugins.h"
 #include "pack.h"
 #include "fileswnd.h"
+#include "common/widepath.h"
 
 //
 // ****************************************************************************
@@ -1744,9 +1745,9 @@ BOOL PackExecute(HWND parent, char* cmdLine, const char* currentDir, TPackErrorT
 
     // set everything needed to create the process
     PROCESS_INFORMATION pi;
-    STARTUPINFO si;
-    memset(&si, 0, sizeof(STARTUPINFO));
-    si.cb = sizeof(STARTUPINFO);
+    STARTUPINFOW si;
+    memset(&si, 0, sizeof(STARTUPINFOW));
+    si.cb = sizeof(STARTUPINFOW);
     if (PackWinTimeout != 0)
     {
         si.dwFlags = STARTF_USESHOWWINDOW;
@@ -1784,8 +1785,39 @@ BOOL PackExecute(HWND parent, char* cmdLine, const char* currentDir, TPackErrorT
     if (tmpCmdLine == NULL)
         return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_NOMEM);
     sprintf(tmpCmdLine, "\"%s\" %s %s", SpawnExe, SPAWN_EXE_PARAMS, cmdLine);
-    // launch the external program
-    if (!HANDLES(CreateProcess(NULL, tmpCmdLine, NULL, NULL, TRUE, CREATE_DEFAULT_ERROR_MODE | NORMAL_PRIORITY_CLASS, NULL, currentDir, &si, &pi)))
+    std::wstring tmpCmdLineW = SalMultiByteToWidePath(tmpCmdLine, CP_UTF8);
+    if (tmpCmdLineW.empty() && GetACP() != CP_UTF8)
+        tmpCmdLineW = SalMultiByteToWidePath(tmpCmdLine, CP_ACP);
+    std::wstring currentDirW;
+    LPCWSTR currentDirParam = NULL;
+    if (currentDir != NULL)
+    {
+        currentDirW = SalMultiByteToWidePath(currentDir, CP_UTF8);
+        if (currentDirW.empty() && GetACP() != CP_UTF8)
+            currentDirW = SalMultiByteToWidePath(currentDir, CP_ACP);
+        if (!currentDirW.empty())
+        {
+            if (currentDirW.length() >= MAX_PATH && !SalIsExtendedLengthPathW(currentDirW.c_str()))
+                currentDirW = SalPathAddExtendedPrefixW(currentDirW.c_str());
+            currentDirParam = currentDirW.c_str();
+        }
+    }
+
+    // launch the external program; use CreateProcessW so Unicode/long current directories
+    // survive the hop through salamand.exe/spawn.exe to external packers (RAR, ARJ, ACE, ...).
+    BOOL processCreated = FALSE;
+    if (!tmpCmdLineW.empty())
+    {
+        processCreated = NOHANDLES(CreateProcessW(NULL, &tmpCmdLineW[0], NULL, NULL, TRUE,
+                                                  CREATE_DEFAULT_ERROR_MODE | NORMAL_PRIORITY_CLASS, NULL,
+                                                  currentDirParam, &si, &pi));
+        if (processCreated)
+        {
+            HANDLES_ADD(__htProcess, __hoCreateProcess, pi.hProcess);
+            HANDLES_ADD(__htThread, __hoCreateProcess, pi.hThread);
+        }
+    }
+    if (!processCreated)
     {
         DWORD err = GetLastError();
         free(tmpCmdLine);

--- a/src/packers.cpp
+++ b/src/packers.cpp
@@ -61,8 +61,8 @@ SPackCustomPacker CustomPackers[] = {
      FALSE,
      "jar32"},
     // RAR32
-    {{"a -scol \"$(ArchiveFullName)\" @\"$(ListFullName)\"", "a -scol -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\""}, // since version 5.0 we must enforce the -scol switch, version 4.20 is fine; appears elsewhere and in the registry
-     {"m -scol \"$(ArchiveFullName)\" @\"$(ListFullName)\"", "m -scol -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\""},
+    {{"a -scul \"$(ArchiveFullName)\" @\"$(ListFullName)\"", "a -scul -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\""}, // since version 5.0 we must enforce the -scul switch, version 4.20 is fine; appears elsewhere and in the registry
+     {"m -scul \"$(ArchiveFullName)\" @\"$(ListFullName)\"", "m -scul -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\""},
      {IDS_DP_RAR_E, IDS_DP_RARV_E},
      "rar",
      TRUE,
@@ -155,7 +155,7 @@ SPackCustomUnpacker CustomUnpackers[] = {
     // JAR32
     {"x -jyc \"$(ArchiveFullName)\" !\"$(ListFullName)\"", IDS_DU_JAR_E, "*.j", TRUE, FALSE, "jar32"},
     // RAR32
-    {"x -scol \"$(ArchiveFullName)\" @\"$(ListFullName)\"", IDS_DU_RAR_E, "*.rar", TRUE, FALSE, "rar"}, // since version 5.0 we must enforce the -scol switch, version 4.20 is fine; appears elsewhere and in the registry
+    {"x -scul \"$(ArchiveFullName)\" @\"$(ListFullName)\"", IDS_DU_RAR_E, "*.rar", TRUE, FALSE, "rar"}, // since version 5.0 we must enforce the -scul switch, version 4.20 is fine; appears elsewhere and in the registry
     // ARJ16
     {"x -va -jyc $(ArchiveDOSFullName) !$(ListDOSFullName)", IDS_DU_ARJ16_E, "*.arj", FALSE, FALSE, "arj"},
     // LZH
@@ -578,11 +578,11 @@ void CPackerConfig::AddDefault(int SalamVersion)
     }
     if (SalamVersion > 1 && SalamVersion < 81)
     {
-        // since RAR 5.0 filelists are ANSI by default instead of OEM, so we must force OEM with a switch
-        const char* newRAR5CopyArgs = "a -scol \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
-        const char* newRAR5MoveArgs = "m -scol \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
-        const char* newRAR5CopyVolArgs = "a -scol -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
-        const char* newRAR5MoveVolArgs = "m -scol -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
+        // since RAR 5.0 filelists are ANSI by default instead of OEM, so we must force Unicode list files with a switch
+        const char* newRAR5CopyArgs = "a -scul \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
+        const char* newRAR5MoveArgs = "m -scul \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
+        const char* newRAR5CopyVolArgs = "a -scul -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
+        const char* newRAR5MoveVolArgs = "m -scul -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
         for (index = 0; index < GetPackersCount(); index++)
         {
             if ((GetPackerOldType(index) && GetPackerType(index) == 1) ||
@@ -603,7 +603,7 @@ void CPackerConfig::AddDefault(int SalamVersion)
                         moveArgs != NULL &&
                         strcmp(moveArgs, "m \"$(ArchiveFullName)\" @\"$(ListFullName)\"") == 0)
                     {
-                        // convert to new arguments (added "-scol")
+                        // convert to new arguments (added "-scul")
                         free(Packers[index]->CmdArgsCopy); // cannot be NULL (old arguments here)
                         Packers[index]->CmdArgsCopy = DupStr(newRAR5CopyArgs);
                         free(Packers[index]->CmdArgsMove); // cannot be NULL (old arguments here)
@@ -614,7 +614,7 @@ void CPackerConfig::AddDefault(int SalamVersion)
                         moveArgs != NULL &&
                         strcmp(moveArgs, "m -v1440 \"$(ArchiveFullName)\" @\"$(ListFullName)\"") == 0)
                     {
-                        // convert to new arguments (added "-scol")
+                        // convert to new arguments (added "-scul")
                         free(Packers[index]->CmdArgsCopy); // cannot be NULL (old arguments here)
                         Packers[index]->CmdArgsCopy = DupStr(newRAR5CopyVolArgs);
                         free(Packers[index]->CmdArgsMove); // cannot be NULL (old arguments here)
@@ -1253,8 +1253,8 @@ void CUnpackerConfig::AddDefault(int SalamVersion)
     }
     if (SalamVersion > 1 && SalamVersion < 81)
     {
-        // since RAR 5.0 filelists are ANSI by default instead of OEM, so we must force OEM with a switch
-        const char* newRAR5Args = "x -scol \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
+        // since RAR 5.0 filelists are ANSI by default instead of OEM, so we must force Unicode list files with a switch
+        const char* newRAR5Args = "x -scul \"$(ArchiveFullName)\" @\"$(ListFullName)\"";
         for (index = 0; index < GetUnpackersCount(); index++)
         {
             if ((GetUnpackerOldType(index) && GetUnpackerType(index) == 1) ||
@@ -1271,7 +1271,7 @@ void CUnpackerConfig::AddDefault(int SalamVersion)
                     if (extrArgs != NULL &&
                         strcmp(extrArgs, "x \"$(ArchiveFullName)\" @\"$(ListFullName)\"") == 0)
                     {
-                        // convert to new arguments (added "-scol")
+                        // convert to new arguments (added "-scul")
                         free(Unpackers[index]->CmdArgsExtract); // cannot be NULL (old arguments here)
                         Unpackers[index]->CmdArgsExtract = DupStr(newRAR5Args);
                     }

--- a/src/plugins/7zip/7zclient.cpp
+++ b/src/plugins/7zip/7zclient.cpp
@@ -34,6 +34,33 @@ HINSTANCE g_hInstance;
 const CLSID CLSID_CFormat7z = {0x23170F69, 0x40C1, 0x278A, {0x10, 0x00, 0x00, 0x01, 0x10, 0x07, 0x00, 0x00}};
 //const CLSID CLSID_CFormatZIP = {0x23170F69, 0x40C1, 0x278A, {0x10, 0x00, 0x00, 0x01, 0x10, 0x01, 0x00, 0x00}};
 
+static const char* GetSafeTempDirForSalGetTempFileName(const char* archiveName, char* archiveDir, size_t archiveDirSize)
+{
+    lstrcpyn(archiveDir, archiveName, (int)archiveDirSize);
+    SalamanderGeneral->CutDirectory(archiveDir, NULL);
+
+    // SalGetTempFileName() uses an internal MAX_PATH buffer and copies the supplied path
+    // into it. For long UTF-8 paths, use the system TEMP directory instead and move the
+    // finished archive with the wide API.
+    return strlen(archiveDir) + 1 + 3 + 8 < MAX_PATH ? archiveDir : NULL;
+}
+
+static BOOL DeleteFileLongPath(const char* fileName)
+{
+    UString fileNameW = GetSalamanderLongPath(GetSalamanderUnicodeString(fileName));
+    return ::DeleteFileW(fileNameW.Ptr());
+}
+
+static BOOL MoveFileLongPath(const char* srcName, const char* destName, DWORD* err)
+{
+    UString srcNameW = GetSalamanderLongPath(GetSalamanderUnicodeString(srcName));
+    UString destNameW = GetSalamanderLongPath(GetSalamanderUnicodeString(destName));
+    BOOL ret = ::MoveFileExW(srcNameW.Ptr(), destNameW.Ptr(), MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING);
+    if (err != NULL)
+        *err = ret ? ERROR_SUCCESS : ::GetLastError();
+    return ret;
+}
+
 /*
 char *C7zClient::CItemData::GetMethodStr() {
   static char name[64];
@@ -180,7 +207,7 @@ BOOL C7zClient::OpenArchiveWithFormat(const char* fileName, const GUID* classID,
     CRetryableInFileStream* fileSpec = new CRetryableInFileStream(NULL);
     CMyComPtr<IInStream> file = fileSpec;
 
-    if (!fileSpec->Open(us2fs(GetUnicodeString(fileName))))
+    if (!fileSpec->Open(us2fs(GetSalamanderLongPath(GetSalamanderUnicodeString(fileName)))))
         return Error(IDS_CANT_OPEN_ARCHIVE, quiet, fileName);
 
     CArchiveOpenCallbackImp* openCallbackSpec = new CArchiveOpenCallbackImp(password);
@@ -700,16 +727,13 @@ int C7zClient::DeleteMakeUpdateList(TIndirectArray<CArchiveItem>* archiveItems, 
 int C7zClient::Delete(CSalamanderForOperationsAbstract* salamander, const char* archiveName,
                       TIndirectArray<CArchiveItemInfo>* deleteList, bool passwordIsDefined, UString& password)
 {
-    char tmpName[MAX_PATH];
+    char tmpName[SAL_MAX_PATH];
     DWORD err;
 
-    char srcPath[MAX_PATH];
-    strcpy(srcPath, archiveName);
-    char* rbackslash = _tcsrchr(srcPath, '\\');
-    if (rbackslash != NULL)
-        *rbackslash = '\0';
+    char srcPath[SAL_MAX_PATH];
+    const char* tempDir = GetSafeTempDirForSalGetTempFileName(archiveName, srcPath, _countof(srcPath));
 
-    if (!SalamanderGeneral->SalGetTempFileName(srcPath, "sal", tmpName, TRUE, &err))
+    if (!SalamanderGeneral->SalGetTempFileName(tempDir, "sal", tmpName, TRUE, &err))
     {
         SysError(IDS_CANT_CREATE_TMPFILE, err, FALSE);
         return OPER_CANCEL;
@@ -745,7 +769,7 @@ int C7zClient::Delete(CSalamanderForOperationsAbstract* salamander, const char* 
         }
         CMyComPtr<IOutStream> outStream(outStreamSpec);
 
-        if (!outStreamSpec->Open(us2fs(GetUnicodeString(tmpName)), OPEN_EXISTING))
+        if (!outStreamSpec->Open(us2fs(GetSalamanderLongPath(GetSalamanderUnicodeString(tmpName))), OPEN_EXISTING))
         {
             Error(IDS_CANT_CREATE_ARCHIVE);
             throw OPER_CANCEL;
@@ -843,6 +867,11 @@ int C7zClient::Delete(CSalamanderForOperationsAbstract* salamander, const char* 
     catch (int e)
     {
         ret = e;
+    }
+    catch (...)
+    {
+        Error(IDS_7Z_UPDATE_ERROR);
+        ret = OPER_CANCEL;
     }
 
     delete archiveItems;
@@ -1149,12 +1178,11 @@ int C7zClient::Update(CSalamanderForOperationsAbstract* salamander, const char* 
                       const char* srcPath, BOOL isNewArchive, TIndirectArray<CFileItem>* fileList,
                       CCompressParams* compressParams, bool passwordIsDefined, UString password)
 {
-    char tmpName[MAX_PATH];
-    // trim the filename from archiveName, leaving the target path where we will extract
-    lstrcpy(tmpName, archiveName);
-    SalamanderGeneral->CutDirectory(tmpName, NULL);
+    char tmpName[SAL_MAX_PATH];
+    char tmpDir[SAL_MAX_PATH];
+    const char* tempDir = GetSafeTempDirForSalGetTempFileName(archiveName, tmpDir, _countof(tmpDir));
     DWORD err;
-    if (!SalamanderGeneral->SalGetTempFileName(tmpName, "sal", tmpName, TRUE, &err))
+    if (!SalamanderGeneral->SalGetTempFileName(tempDir, "sal", tmpName, TRUE, &err))
     {
         SysError(IDS_CANT_CREATE_TMPFILE, err, FALSE);
         return OPER_CANCEL;
@@ -1215,7 +1243,7 @@ int C7zClient::Update(CSalamanderForOperationsAbstract* salamander, const char* 
         }
         CMyComPtr<IOutStream> outStream(outStreamSpec);
 
-        if (!outStreamSpec->Open(us2fs(GetUnicodeString(tmpName)), OPEN_EXISTING))
+        if (!outStreamSpec->Open(us2fs(GetSalamanderLongPath(GetSalamanderUnicodeString(tmpName))), OPEN_EXISTING))
         {
             Error(IDS_CANT_CREATE_ARCHIVE);
             throw OPER_CANCEL;
@@ -1276,7 +1304,7 @@ int C7zClient::Update(CSalamanderForOperationsAbstract* salamander, const char* 
                 // close the open archive
                 inArchive->Close();
                 // delete it
-                if (!::DeleteFile(archiveName))
+                if (!DeleteFileLongPath(archiveName))
                 {
                     Error(IDS_CANT_UPDATE_ARCHIVE, FALSE, archiveName);
                     throw OPER_CANCEL;
@@ -1285,7 +1313,7 @@ int C7zClient::Update(CSalamanderForOperationsAbstract* salamander, const char* 
 
             DWORD err2;
             // rename the tmp file to the archive
-            if (!SalamanderGeneral->SalMoveFile(tmpName, archiveName, &err2))
+            if (!MoveFileLongPath(tmpName, archiveName, &err2))
             {
                 SysError(IDS_CANT_MOVE_TMPARCHIVE, err2, FALSE, tmpName);
                 throw OPER_CANCEL;
@@ -1339,6 +1367,11 @@ int C7zClient::Update(CSalamanderForOperationsAbstract* salamander, const char* 
     catch (int e)
     {
         ret = e;
+    }
+    catch (...)
+    {
+        Error(isNewArchive ? IDS_7Z_CREATE_UNKNOWN_ERROR : IDS_7Z_UPDATE_ERROR, FALSE, E_FAIL);
+        ret = OPER_CANCEL;
     }
 
     delete archiveItems;

--- a/src/plugins/7zip/7zip.cpp
+++ b/src/plugins/7zip/7zip.cpp
@@ -4,6 +4,8 @@
 #include "precomp.h"
 #include "dbg.h"
 
+#include <string>
+
 #include "..\7zip\7za\c\7zVersion.h"
 
 #include "7zip.h"
@@ -17,6 +19,30 @@
 #include "7zclient.h"
 
 // ****************************************************************************
+
+static HANDLE CreateFileLongPath(const char* fileName, DWORD desiredAccess, DWORD shareMode,
+                                 DWORD creationDisposition, DWORD flagsAndAttributes)
+{
+    std::wstring fileNameW;
+    UINT codePage = GetACP() == CP_UTF8 ? CP_UTF8 : CP_ACP;
+    int len = MultiByteToWideChar(codePage, 0, fileName, -1, NULL, 0);
+    if (len > 0)
+    {
+        fileNameW.resize(len);
+        MultiByteToWideChar(codePage, 0, fileName, -1, &fileNameW[0], len);
+        fileNameW.resize(len - 1);
+    }
+    if (!fileNameW.empty())
+    {
+        if (fileNameW.length() >= MAX_PATH && wcsncmp(fileNameW.c_str(), L"\\\\?\\", 4) != 0)
+            fileNameW = wcsncmp(fileNameW.c_str(), L"\\\\", 2) == 0 ? std::wstring(L"\\\\?\\UNC\\") + std::wstring(fileNameW.c_str() + 2)
+                                                                    : std::wstring(L"\\\\?\\") + fileNameW;
+        return ::CreateFileW(fileNameW.c_str(), desiredAccess, shareMode, NULL,
+                             creationDisposition, flagsAndAttributes, NULL);
+    }
+    return ::CreateFile(fileName, desiredAccess, shareMode, NULL,
+                        creationDisposition, flagsAndAttributes, NULL);
+}
 
 HINSTANCE DLLInstance = NULL; // handle to the SPL module - language-independent resources
 HINSTANCE HLanguage = NULL;   // handle to the SLG module - language-dependent resources
@@ -1119,20 +1145,35 @@ BOOL CPluginInterfaceForArchiver::PackToArchive(CSalamanderForOperationsAbstract
 
     // test whether the archive exists (we need to distinguish between update and create new archive)
     BOOL isNewArchive = FALSE;
-    HANDLE hArchive = ::CreateFile(fileName, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE hArchive = CreateFileLongPath(fileName, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL);
     if (hArchive == INVALID_HANDLE_VALUE)
     {
         isNewArchive = TRUE; // the file does not exist; this is a new archive
 
         // check whether the target path is writable
         hArchive = INVALID_HANDLE_VALUE;
-        hArchive = ::CreateFile(fileName, GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+        hArchive = CreateFileLongPath(fileName, GENERIC_WRITE, FILE_SHARE_WRITE, CREATE_NEW, FILE_ATTRIBUTE_NORMAL);
         if (hArchive == INVALID_HANDLE_VALUE)
             return SysError(IDS_CANT_CREATE_ARCHIVE, ::GetLastError());
         else
         {
             ::CloseHandle(hArchive);
-            ::DeleteFile(fileName);
+            std::wstring fileNameW;
+            UINT codePage = GetACP() == CP_UTF8 ? CP_UTF8 : CP_ACP;
+            int len = MultiByteToWideChar(codePage, 0, fileName, -1, NULL, 0);
+            if (len > 0)
+            {
+                fileNameW.resize(len);
+                MultiByteToWideChar(codePage, 0, fileName, -1, &fileNameW[0], len);
+                fileNameW.resize(len - 1);
+            }
+            if (!fileNameW.empty() && fileNameW.length() >= MAX_PATH && wcsncmp(fileNameW.c_str(), L"\\\\?\\", 4) != 0)
+                fileNameW = wcsncmp(fileNameW.c_str(), L"\\\\", 2) == 0 ? std::wstring(L"\\\\?\\UNC\\") + std::wstring(fileNameW.c_str() + 2)
+                                                                        : std::wstring(L"\\\\?\\") + fileNameW;
+            if (!fileNameW.empty())
+                ::DeleteFileW(fileNameW.c_str());
+            else
+                ::DeleteFile(fileName);
         }
     }
     else
@@ -1150,7 +1191,7 @@ BOOL CPluginInterfaceForArchiver::PackToArchive(CSalamanderForOperationsAbstract
 
         // check whether the file is writable
         hArchive = INVALID_HANDLE_VALUE;
-        hArchive = ::CreateFile(fileName, GENERIC_WRITE, FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        hArchive = CreateFileLongPath(fileName, GENERIC_WRITE, FILE_SHARE_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL);
         if (hArchive == INVALID_HANDLE_VALUE)
             return SysError(IDS_CANT_UPDATE_ARCHIVE, ::GetLastError(), FALSE, fileName);
         else
@@ -1259,9 +1300,9 @@ BOOL CPluginInterfaceForArchiver::PackToArchive(CSalamanderForOperationsAbstract
     { // first lock the archive file so we cannot delete it ourselves (bug: https://forum.altap.cz/viewtopic.php?f=3&t=3859)
         while (1)
         {
-            hArchive = ::CreateFile(fileName, GENERIC_READ /* I tried 0, but the system then allowed deleting the file */,
-                                    FILE_SHARE_READ | FILE_SHARE_WRITE,
-                                    NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            hArchive = CreateFileLongPath(fileName, GENERIC_READ /* I tried 0, but the system then allowed deleting the file */,
+                                          FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                          OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL);
 
             if (hArchive != INVALID_HANDLE_VALUE)
                 break;
@@ -1318,7 +1359,7 @@ BOOL CPluginInterfaceForArchiver::PackToArchive(CSalamanderForOperationsAbstract
             if (ret)
             {
                 // prepare the buffer for names
-                char sourceName[MAX_PATH + 1]; // buffer for the full name on disk
+                char sourceName[SAL_MAX_PATH]; // buffer for the full name on disk
                 strcpy(sourceName, sourcePath);
                 char* endSource = sourceName + strlen(sourceName); // space for the names from the 'next' enumeration
                 if (endSource > sourceName && *(endSource - 1) != '\\')
@@ -1326,7 +1367,7 @@ BOOL CPluginInterfaceForArchiver::PackToArchive(CSalamanderForOperationsAbstract
                     *endSource++ = '\\';
                     *endSource = 0;
                 }
-                int endSourceSize = MAX_PATH - (int)(endSource - sourceName); // maximum number of characters for a name from the 'next' enumeration
+                int endSourceSize = SAL_MAX_PATH - (int)(endSource - sourceName); // maximum number of characters for a name from the 'next' enumeration
 
                 // delete directories; if something remains inside they will not be removed and that's fine :)
                 // because we iterate from leaves to the root, we can delete them this way

--- a/src/plugins/7zip/7zthreads.cpp
+++ b/src/plugins/7zip/7zthreads.cpp
@@ -88,13 +88,36 @@ BOOL CALLBACK SubClassedProgressDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
 // worker threads
 //
 
+static unsigned WINAPI DecompressThreadProcBodyNoSEH(LPVOID lpParameter)
+{
+    try
+    {
+        CDecompressParamObject* dpo = (CDecompressParamObject*)lpParameter;
+
+        HRESULT result = (dpo->Archive)->Extract(dpo->FileIndex, dpo->Count, BoolToInt(dpo->Test), dpo->Callback);
+
+        return result;
+    }
+    catch (...)
+    {
+        return E_FAIL;
+    }
+}
+
 unsigned WINAPI DecompressThreadProcBody(LPVOID lpParameter)
 {
-    CDecompressParamObject* dpo = (CDecompressParamObject*)lpParameter;
-
-    HRESULT result = (dpo->Archive)->Extract(dpo->FileIndex, dpo->Count, BoolToInt(dpo->Test), dpo->Callback);
-
-    return result;
+#ifdef _MSC_VER
+    __try
+    {
+        return DecompressThreadProcBodyNoSEH(lpParameter);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return E_FAIL;
+    }
+#else  // _MSC_VER
+    return DecompressThreadProcBodyNoSEH(lpParameter);
+#endif // _MSC_VER
 }
 
 DWORD WINAPI DecompressThreadProc(LPVOID lpParameter)
@@ -114,6 +137,7 @@ HRESULT LaunchAndDo7ZipTask(LPTHREAD_START_ROUTINE threadProc, LPVOID args)
 
     if (!hThread)
     {
+        SetWindowLongPtr(Salamander->ProgressGetHWND(), GWLP_WNDPROC, (LONG_PTR)OldProgressDlgProc);
         return GetLastError();
     }
 
@@ -126,6 +150,7 @@ HRESULT LaunchAndDo7ZipTask(LPTHREAD_START_ROUTINE threadProc, LPVOID args)
 
             GetExitCodeThread(hThread, &exitCode);
             CloseHandle(hThread);
+            SetWindowLongPtr(Salamander->ProgressGetHWND(), GWLP_WNDPROC, (LONG_PTR)OldProgressDlgProc);
             return exitCode; // Our thread body func returns HRESULT
         }
 
@@ -169,13 +194,36 @@ HRESULT DoDecompress(CSalamanderForOperationsAbstract* salamander, CDecompressPa
     return result;
 }
 
+static unsigned WINAPI UpdateThreadProcBodyNoSEH(LPVOID lpParameter)
+{
+    try
+    {
+        CUpdateParamObject* upo = (CUpdateParamObject*)lpParameter;
+
+        HRESULT result = (upo->Archive)->UpdateItems(upo->Stream, upo->Count, upo->Callback);
+
+        return result;
+    }
+    catch (...)
+    {
+        return E_FAIL;
+    }
+}
+
 unsigned WINAPI UpdateThreadProcBody(LPVOID lpParameter)
 {
-    CUpdateParamObject* upo = (CUpdateParamObject*)lpParameter;
-
-    HRESULT result = (upo->Archive)->UpdateItems(upo->Stream, upo->Count, upo->Callback);
-
-    return result;
+#ifdef _MSC_VER
+    __try
+    {
+        return UpdateThreadProcBodyNoSEH(lpParameter);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return E_FAIL;
+    }
+#else  // _MSC_VER
+    return UpdateThreadProcBodyNoSEH(lpParameter);
+#endif // _MSC_VER
 }
 
 DWORD WINAPI UpdateThreadProc(LPVOID lpParameter)

--- a/src/plugins/7zip/FStreams.cpp
+++ b/src/plugins/7zip/FStreams.cpp
@@ -11,6 +11,23 @@
 #include "7zip.rh2"
 #include "lang\lang.rh"
 
+static void GetThreadSafeErrorText(DWORD err, TCHAR* buffer, size_t bufferSize)
+{
+    if (bufferSize == 0)
+        return;
+
+    DWORD len = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                              NULL, err, 0, buffer, (DWORD)bufferSize, NULL);
+    if (len == 0)
+    {
+        _sntprintf_s(buffer, bufferSize, _TRUNCATE, _T("System error %lu"), err);
+        return;
+    }
+
+    while (len > 0 && (buffer[len - 1] == _T('\r') || buffer[len - 1] == _T('\n') || buffer[len - 1] == _T('.')))
+        buffer[--len] = 0;
+}
+
 BOOL ShowRetryAbortBox(HWND hParentWnd, int resID, DWORD err, ...)
 {
     TCHAR msg[1024];
@@ -27,8 +44,10 @@ BOOL ShowRetryAbortBox(HWND hParentWnd, int resID, DWORD err, ...)
         SalamanderGeneral->ExpandPluralString(fmt, sizeof(fmt), msg, 1, &CQuadWord().SetUI64(((int*)&err)[1]));
         strcpy(msg, fmt);
     }
+    TCHAR errText[1024];
+    GetThreadSafeErrorText(err, errText, _countof(errText));
     TCHAR buf[2048 + 4];
-    _stprintf(buf, _T("%s\n\n%s"), msg, SalamanderGeneral->GetErrorText(err));
+    _stprintf(buf, _T("%s\n\n%s"), msg, errText);
 
     TCHAR btnBuffer[128];
     /* used by the export_mnu.py script, which generates salmenu.mnu for the Translator
@@ -70,12 +89,12 @@ CRetryableOutFileStream::CRetryableOutFileStream(HWND _hParentWnd) : hParentWnd(
 
 STDMETHODIMP CRetryableOutFileStream::Write(const void* data, UInt32 size, UInt32* processedSize)
 {
-    UInt32 written;
+    UInt32 written = 0;
     HRESULT ret;
 
     if (processedSize)
         *processedSize = 0;
-    while ((S_OK != (ret = COutFileStream::Write(data, size, &written))) /*|| (size != written)*/)
+    while ((written = 0, S_OK != (ret = COutFileStream::Write(data, size, &written))) /*|| (size != written)*/)
     {
         // NOTE: COutFileStream::Write writes at most kChunkSizeMax bytes (4MB) at once
         data = (char*)data + written;
@@ -100,12 +119,12 @@ CRetryableInFileStream::CRetryableInFileStream(HWND _hParentWnd) : hParentWnd(_h
 
 STDMETHODIMP CRetryableInFileStream::Read(void* data, UInt32 size, UInt32* processedSize)
 {
-    UInt32 read;
+    UInt32 read = 0;
     HRESULT ret;
 
     if (processedSize)
         *processedSize = 0;
-    while (S_OK != (ret = CInFileStream::Read(data, size, &read)))
+    while ((read = 0, S_OK != (ret = CInFileStream::Read(data, size, &read))))
     {
         data = (char*)data + read;
         size -= read;

--- a/src/plugins/7zip/dialogs.h
+++ b/src/plugins/7zip/dialogs.h
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#ifndef SAL_MAX_PATH
+#define SAL_MAX_PATH 32768
+#endif
+
 //****************************************************************************
 //
 // CCommonDialog
@@ -85,7 +89,7 @@ protected:
 class CExtOptionsDialog : public CCommonDialog
 {
 private:
-    char Archive[MAX_PATH];
+    char Archive[SAL_MAX_PATH];
 
     char Password[PASSWORD_LEN];
     char ConfirmedPassword[PASSWORD_LEN];
@@ -106,7 +110,7 @@ public:
     BOOL IsPasswordDefined() { return Encrypt; }
     char* GetPassword() { return Password; }
     BOOL GetNotAgain() { return NotAgain; }
-    void SetArchiveName(const char* archiveName) { lstrcpy(Archive, archiveName); }
+    void SetArchiveName(const char* archiveName) { lstrcpyn(Archive, archiveName, _countof(Archive)); }
     void SetTitle(const char* title) { Title = title; }
 
 protected:

--- a/src/plugins/7zip/structs.h
+++ b/src/plugins/7zip/structs.h
@@ -3,8 +3,40 @@
 
 #pragma once
 
+#include <string>
+
 #include "Common/MyString.h"
 #include "Common/StringConvert.h"
+
+inline UString GetSalamanderUnicodeString(const char* text)
+{
+    if (text == NULL || *text == 0)
+        return UString();
+    UINT codePage = CP_UTF8;
+    DWORD flags = MB_ERR_INVALID_CHARS;
+    int len = MultiByteToWideChar(codePage, flags, text, -1, NULL, 0);
+    if (len <= 0)
+    {
+        codePage = CP_ACP;
+        flags = 0;
+        len = MultiByteToWideChar(codePage, flags, text, -1, NULL, 0);
+    }
+    if (len <= 0)
+        return GetUnicodeString(text);
+    std::wstring ret(len, L'\0');
+    MultiByteToWideChar(codePage, flags, text, -1, &ret[0], len);
+    ret.resize(len - 1);
+    return UString(ret.c_str());
+}
+
+inline UString GetSalamanderLongPath(const UString& path)
+{
+    if (path.Len() < MAX_PATH || path.IsPrefixedBy(L"\\\\?\\"))
+        return path;
+    if (path.IsPrefixedBy(L"\\\\"))
+        return UString(L"\\\\?\\UNC\\") + UString(path.Ptr(2));
+    return UString(L"\\\\?\\") + path;
+}
 
 struct CUpdateInfo
 {
@@ -37,11 +69,11 @@ struct CFileItem
     {
         // if archiveRoot is empty, the name must not start with a backslash '\'
         if (strlen(archiveRoot) > 0)
-            Name = GetUnicodeString(archiveRoot) + GetUnicodeString("\\") + GetUnicodeString(name);
+            Name = GetSalamanderUnicodeString(archiveRoot) + UString(L"\\") + GetSalamanderUnicodeString(name);
         else
-            Name = GetUnicodeString(name);
+            Name = GetSalamanderUnicodeString(name);
 
-        FullPath = GetUnicodeString(sourcePath) + GetUnicodeString("\\") + GetUnicodeString(name);
+        FullPath = GetSalamanderUnicodeString(sourcePath) + UString(L"\\") + GetSalamanderUnicodeString(name);
         Attributes = attr;
         Size = size;
         LastWriteTime = CreationTime = LastAccessTime = lastWrite;

--- a/src/plugins/7zip/update.cpp
+++ b/src/plugins/7zip/update.cpp
@@ -19,6 +19,23 @@
 
 #include "7za/CPP/7zip/Common/FileStreams.h"
 
+static void GetThreadSafeErrorText(DWORD err, char* buffer, size_t bufferSize)
+{
+    if (bufferSize == 0)
+        return;
+
+    DWORD len = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                              NULL, err, 0, buffer, (DWORD)bufferSize, NULL);
+    if (len == 0)
+    {
+        _snprintf_s(buffer, bufferSize, _TRUNCATE, "System error %lu", err);
+        return;
+    }
+
+    while (len > 0 && (buffer[len - 1] == '\r' || buffer[len - 1] == '\n' || buffer[len - 1] == '.'))
+        buffer[--len] = 0;
+}
+
 CArchiveUpdateCallback::CArchiveUpdateCallback(HWND _hProgWnd)
 {
     InitializeCriticalSection(&CSUpdate);
@@ -35,14 +52,14 @@ CArchiveUpdateCallback::~CArchiveUpdateCallback()
     DeleteCriticalSection(&CSUpdate);
 }
 
-STDMETHODIMP CArchiveUpdateCallback::SetTotal(UInt64 size)
+HRESULT CArchiveUpdateCallback::SetTotalNoSEH(UInt64 size)
 {
     Total.Value = size;
     SendMessage(hProgWnd, WM_7ZIP, WM_7ZIP_SETTOTAL, (LPARAM)&Total);
     return S_OK;
 }
 
-STDMETHODIMP CArchiveUpdateCallback::SetCompleted(const UInt64* completeValue)
+HRESULT CArchiveUpdateCallback::SetCompletedNoSEH(const UInt64* completeValue)
 {
     if (completeValue != NULL)
     {
@@ -54,13 +71,46 @@ STDMETHODIMP CArchiveUpdateCallback::SetCompleted(const UInt64* completeValue)
     return S_OK;
 }
 
+
+STDMETHODIMP CArchiveUpdateCallback::SetTotal(UInt64 size)
+{
+#ifdef _MSC_VER
+    __try
+    {
+        return SetTotalNoSEH(size);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return E_FAIL;
+    }
+#else  // _MSC_VER
+    return SetTotalNoSEH(size);
+#endif // _MSC_VER
+}
+
+STDMETHODIMP CArchiveUpdateCallback::SetCompleted(const UInt64* completeValue)
+{
+#ifdef _MSC_VER
+    __try
+    {
+        return SetCompletedNoSEH(completeValue);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return E_FAIL;
+    }
+#else  // _MSC_VER
+    return SetCompletedNoSEH(completeValue);
+#endif // _MSC_VER
+}
+
 STDMETHODIMP CArchiveUpdateCallback::EnumProperties(IEnumSTATPROPSTG** enumerator)
 {
     return E_NOTIMPL;
 }
 
-STDMETHODIMP CArchiveUpdateCallback::GetUpdateItemInfo(UInt32 index,
-                                                       Int32* newData, Int32* newProperties, UInt32* indexInArchive)
+HRESULT CArchiveUpdateCallback::GetUpdateItemInfoNoSEH(UInt32 index,
+                                                     Int32* newData, Int32* newProperties, UInt32* indexInArchive)
 {
     const CUpdateInfo* ui = (*UpdateList)[index];
     if (ui == NULL)
@@ -90,7 +140,7 @@ STDMETHODIMP CArchiveUpdateCallback::GetUpdateItemInfo(UInt32 index,
     return S_OK;
 }
 
-STDMETHODIMP CArchiveUpdateCallback::GetProperty(UInt32 index, PROPID propID, PROPVARIANT* value)
+HRESULT CArchiveUpdateCallback::GetPropertyNoSEH(UInt32 index, PROPID propID, PROPVARIANT* value)
 {
     NWindows::NCOM::CPropVariant propVariant;
     const CUpdateInfo* ui = (*UpdateList)[index];
@@ -159,8 +209,42 @@ STDMETHODIMP CArchiveUpdateCallback::GetProperty(UInt32 index, PROPID propID, PR
     return S_OK;
 }
 
-STDMETHODIMP CArchiveUpdateCallback::GetStream(UInt32 index,
-                                               ISequentialInStream** inStream)
+
+STDMETHODIMP CArchiveUpdateCallback::GetUpdateItemInfo(UInt32 index,
+                                                       Int32* newData, Int32* newProperties, UInt32* indexInArchive)
+{
+#ifdef _MSC_VER
+    __try
+    {
+        return GetUpdateItemInfoNoSEH(index, newData, newProperties, indexInArchive);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return E_FAIL;
+    }
+#else  // _MSC_VER
+    return GetUpdateItemInfoNoSEH(index, newData, newProperties, indexInArchive);
+#endif // _MSC_VER
+}
+
+STDMETHODIMP CArchiveUpdateCallback::GetProperty(UInt32 index, PROPID propID, PROPVARIANT* value)
+{
+#ifdef _MSC_VER
+    __try
+    {
+        return GetPropertyNoSEH(index, propID, value);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return E_FAIL;
+    }
+#else  // _MSC_VER
+    return GetPropertyNoSEH(index, propID, value);
+#endif // _MSC_VER
+}
+
+HRESULT CArchiveUpdateCallback::GetStreamNoSEH(UInt32 index,
+                                             ISequentialInStream** inStream)
 {
     /*
   char u[1024];
@@ -209,19 +293,21 @@ STDMETHODIMP CArchiveUpdateCallback::GetStream(UInt32 index,
         do
         {
             mbRet = DIALOG_OK;
-            if (!inStreamSpec->Open(us2fs(GetUnicodeString(GetAnsiString(fi->FullPath)))))
+            if (!inStreamSpec->Open(us2fs(GetSalamanderLongPath(fi->FullPath))))
             {
                 mbRet = DIALOG_SKIP;
                 if (!Silent)
                 {
                     DWORD err = ::GetLastError();
                     AString fn = GetAnsiString(fi->FullPath);
+                    char errText[1024];
+                    GetThreadSafeErrorText(err, errText, _countof(errText));
                     // Warning: GetStream can get called from a parallel thread launched by 7za.dll!
                     CDialogErrorParams dep;
 
                     dep.Flags = BUTTONS_RETRYSKIPCANCEL;
                     dep.FileName = fn;
-                    dep.Error = SalamanderGeneral->GetErrorText(err);
+                    dep.Error = errText;
                     mbRet = (int)SendMessage(hProgWnd, WM_7ZIP, WM_7ZIP_DIALOGERROR, (LPARAM)&dep);
                 }
             }
@@ -250,10 +336,32 @@ STDMETHODIMP CArchiveUpdateCallback::GetStream(UInt32 index,
     {
         res = e;
     }
+    catch (...)
+    {
+        res = E_FAIL;
+    }
 
     LeaveCriticalSection(&CSUpdate);
 
     return res;
+}
+
+
+STDMETHODIMP CArchiveUpdateCallback::GetStream(UInt32 index,
+                                               ISequentialInStream** inStream)
+{
+#ifdef _MSC_VER
+    __try
+    {
+        return GetStreamNoSEH(index, inStream);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        return E_FAIL;
+    }
+#else  // _MSC_VER
+    return GetStreamNoSEH(index, inStream);
+#endif // _MSC_VER
 }
 
 STDMETHODIMP CArchiveUpdateCallback::SetOperationResult(Int32 operationResult)
@@ -289,7 +397,7 @@ STDMETHODIMP CArchiveUpdateCallback::GetVolumeStream(UInt32 index, ISequentialOu
   fileName += VolExt;
   CRetryableOutFileStream *streamSpec = new CRetryableOutFileStream(hProgWnd);
   CMyComPtr<ISequentialOutStream> streamLoc(streamSpec);
-  if(!streamSpec->Create(us2fs(GetUnicodeString(fileName)), false))
+  if(!streamSpec->Create(us2fs(GetSalamanderLongPath(GetSalamanderUnicodeString(fileName))), false))
     return ::GetLastError();
   *volumeStream = streamLoc.Detach();
   return S_OK;*/

--- a/src/plugins/7zip/update.h
+++ b/src/plugins/7zip/update.h
@@ -168,6 +168,12 @@ public:
     BOOL Silent;
 
 private:
+    HRESULT SetTotalNoSEH(UInt64 size);
+    HRESULT SetCompletedNoSEH(const UInt64* completeValue);
+    HRESULT GetUpdateItemInfoNoSEH(UInt32 index, Int32* newData, Int32* newProperties, UInt32* indexInArchive);
+    HRESULT GetPropertyNoSEH(UInt32 index, PROPID propID, PROPVARIANT* value);
+    HRESULT GetStreamNoSEH(UInt32 index, ISequentialInStream** inStream);
+
     HWND hProgWnd;
 
     /*

--- a/src/plugins/pak/dll/pak_dll.cpp
+++ b/src/plugins/pak/dll/pak_dll.cpp
@@ -3,12 +3,38 @@
 
 #include "precomp.h"
 
+#include <string>
+
 #pragma warning(3 : 4706) // warning C4706: assignment within conditional expression
 
 #include "texts.rh2"
 #include "array2.h"
 #include "pakiface.h"
 #include "pak_dll.h"
+
+static HANDLE CreateFileLongPath(const char* fileName, DWORD desiredAccess, DWORD shareMode,
+                                 DWORD creationDisposition, DWORD flagsAndAttributes)
+{
+    std::wstring fileNameW;
+    UINT codePage = GetACP() == CP_UTF8 ? CP_UTF8 : CP_ACP;
+    int len = MultiByteToWideChar(codePage, 0, fileName, -1, NULL, 0);
+    if (len > 0)
+    {
+        fileNameW.resize(len);
+        MultiByteToWideChar(codePage, 0, fileName, -1, &fileNameW[0], len);
+        fileNameW.resize(len - 1);
+    }
+    if (!fileNameW.empty())
+    {
+        if (fileNameW.length() >= MAX_PATH && wcsncmp(fileNameW.c_str(), L"\\\\?\\", 4) != 0)
+            fileNameW = wcsncmp(fileNameW.c_str(), L"\\\\", 2) == 0 ? std::wstring(L"\\\\?\\UNC\\") + std::wstring(fileNameW.c_str() + 2)
+                                                                    : std::wstring(L"\\\\?\\") + fileNameW;
+        return CreateFileW(fileNameW.c_str(), desiredAccess, shareMode, NULL,
+                           creationDisposition, flagsAndAttributes, NULL);
+    }
+    return CreateFile(fileName, desiredAccess, shareMode, NULL,
+                      creationDisposition, flagsAndAttributes, NULL);
+}
 
 #ifdef PAK_DLL
 // ****************************************************************************
@@ -164,8 +190,8 @@ BOOL CPakIface::OpenPak(const char* fileName, DWORD mode)
 
     while (PakFile == INVALID_HANDLE_VALUE)
     {
-        PakFile = CreateFile(fileName, mode, FILE_SHARE_READ, NULL, OPEN_ALWAYS,
-                             FILE_ATTRIBUTE_NORMAL, NULL);
+        PakFile = CreateFileLongPath(fileName, mode, FILE_SHARE_READ, OPEN_ALWAYS,
+                                     FILE_ATTRIBUTE_NORMAL);
         if (PakFile != INVALID_HANDLE_VALUE)
             break;
         if (!HandleError(HE_RETRY, IDS_PAK_ERROPEN, LastErrorString(GetLastError(), buf)))

--- a/src/plugins/pak/spl/pak2.cpp
+++ b/src/plugins/pak/spl/pak2.cpp
@@ -3,6 +3,8 @@
 
 #include "precomp.h"
 
+#include <string>
+
 #include "dumpmem.h"
 #include "array2.h"
 
@@ -11,6 +13,30 @@
 #include "pak.rh2"
 #include "lang\lang.rh"
 #include "pak.h"
+
+static HANDLE CreateFileLongPath(const char* fileName, DWORD desiredAccess, DWORD shareMode,
+                                 DWORD creationDisposition, DWORD flagsAndAttributes)
+{
+    std::wstring fileNameW;
+    UINT codePage = GetACP() == CP_UTF8 ? CP_UTF8 : CP_ACP;
+    int len = MultiByteToWideChar(codePage, 0, fileName, -1, NULL, 0);
+    if (len > 0)
+    {
+        fileNameW.resize(len);
+        MultiByteToWideChar(codePage, 0, fileName, -1, &fileNameW[0], len);
+        fileNameW.resize(len - 1);
+    }
+    if (!fileNameW.empty())
+    {
+        if (fileNameW.length() >= MAX_PATH && wcsncmp(fileNameW.c_str(), L"\\\\?\\", 4) != 0)
+            fileNameW = wcsncmp(fileNameW.c_str(), L"\\\\", 2) == 0 ? std::wstring(L"\\\\?\\UNC\\") + std::wstring(fileNameW.c_str() + 2)
+                                                                    : std::wstring(L"\\\\?\\") + fileNameW;
+        return CreateFileW(fileNameW.c_str(), desiredAccess, shareMode, NULL,
+                           creationDisposition, flagsAndAttributes, NULL);
+    }
+    return CreateFile(fileName, desiredAccess, shareMode, NULL,
+                      creationDisposition, flagsAndAttributes, NULL);
+}
 
 DWORD ComputeDirDepth(const char* fileName)
 {
@@ -34,7 +60,7 @@ BOOL CPluginInterfaceForArchiver::MakeFileList3(TIndirectArray2<CFileInfo>& file
     const char* nextName;
     char pakName[PAK_MAXPATH];
     DWORD pakSize;
-    char sourName[MAX_PATH];
+    char sourName[32768];
     BOOL skip;
     int errorOccured;
 
@@ -48,7 +74,7 @@ BOOL CPluginInterfaceForArchiver::MakeFileList3(TIndirectArray2<CFileInfo>& file
         if (isDir)
             continue;
         lstrcpy(sourName, sourcePath);
-        SalamanderGeneral->SalPathAppend(sourName, nextName, MAX_PATH);
+        SalamanderGeneral->SalPathAppend(sourName, nextName, _countof(sourName));
         if (lstrlen(archiveRoot) + lstrlen(nextName) + 2 >= PAK_MAXPATH)
         {
             if (Silent & SF_LONGNAMES)
@@ -87,8 +113,8 @@ BOOL CPluginInterfaceForArchiver::MakeFileList3(TIndirectArray2<CFileInfo>& file
                 file = INVALID_HANDLE_VALUE;
                 while (file == INVALID_HANDLE_VALUE && !skip)
                 {
-                    file = CreateFile(sourName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-                                      OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                    file = CreateFileLongPath(sourName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                              OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL);
                     if (file != INVALID_HANDLE_VALUE)
                         break;
                     if (Silent & SF_IOERRORS)
@@ -217,8 +243,8 @@ BOOL CPluginInterfaceForArchiver::AddFiles(TIndirectArray2<CFileInfo>& files, un
         IOFile = INVALID_HANDLE_VALUE;
         while (IOFile == INVALID_HANDLE_VALUE)
         {
-            IOFile = CreateFile(f->Name /* + sourPathLen*/, GENERIC_READ, FILE_SHARE_READ, NULL,
-                                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            IOFile = CreateFileLongPath(f->Name /* + sourPathLen*/, GENERIC_READ, FILE_SHARE_READ,
+                                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL);
             if (IOFile != INVALID_HANDLE_VALUE)
                 break;
             if (Silent & SF_IOERRORS)

--- a/src/salspawn/salspawn.cpp
+++ b/src/salspawn/salspawn.cpp
@@ -78,8 +78,8 @@ void mainCRTStartup()
     BOOL help = FALSE;
     BOOL error = FALSE;
     int retBase = 10000;
-    char exeName[1000];
-    char* cmdline;
+    wchar_t exeName[32768];
+    wchar_t* cmdline;
     DWORD exitCode;
 
     exeName[0] = '\0';
@@ -87,32 +87,32 @@ void mainCRTStartup()
     // nechceme zadne kriticke chyby jako "no disk in drive A:"
     SetErrorMode(SetErrorMode(0) | SEM_FAILCRITICALERRORS);
 
-    cmdline = GetCommandLine();
+    cmdline = GetCommandLineW();
     // skip leading spaces
-    while (*cmdline == ' ' || *cmdline == '\t')
+    while (*cmdline == L' ' || *cmdline == L'\t')
         cmdline++;
     // skip exe name
-    if (*cmdline == '"')
+    if (*cmdline == L'"')
     {
         cmdline++;
-        while (*cmdline != '\0' && *cmdline != '"')
+        while (*cmdline != L'\0' && *cmdline != L'"')
             cmdline++;
-        if (*cmdline == '"')
+        if (*cmdline == L'"')
             cmdline++;
     }
     else
-        while (*cmdline != '\0' && *cmdline != ' ' && *cmdline != '\t')
+        while (*cmdline != L'\0' && *cmdline != L' ' && *cmdline != L'\t')
             cmdline++;
     // get params
     while (1)
     {
         // skip spaces
-        while (*cmdline == ' ' || *cmdline == '\t')
+        while (*cmdline == L' ' || *cmdline == L'\t')
             cmdline++;
-        if (*cmdline == '\0')
+        if (*cmdline == L'\0')
             break;
         // is it a switch ?
-        if (*cmdline == '-' || *cmdline == '/')
+        if (*cmdline == L'-' || *cmdline == L'/')
         {
             cmdline += 2;
             switch (*(cmdline - 1))
@@ -123,15 +123,15 @@ void mainCRTStartup()
                 help = TRUE;
                 break;
             case 'c':
-                if (*cmdline > '9' || *cmdline < '0')
+                if (*cmdline > L'9' || *cmdline < L'0')
                 {
                     help = TRUE;
                     break;
                 }
                 retBase = 0;
-                while (*cmdline <= '9' && *cmdline >= '0')
-                    retBase = retBase * 10 + *cmdline++ - '0';
-                if (*cmdline != ' ' && *cmdline != '\t' && *cmdline != '\0')
+                while (*cmdline <= L'9' && *cmdline >= L'0')
+                    retBase = retBase * 10 + *cmdline++ - L'0';
+                if (*cmdline != L' ' && *cmdline != L'\t' && *cmdline != L'\0')
                 {
                     help = TRUE;
                     break;
@@ -145,13 +145,13 @@ void mainCRTStartup()
         else
         {
             int len = 0;
-            while (len < 1000 && *cmdline != '\0')
+            while (len < _countof(exeName) - 1 && *cmdline != L'\0')
                 exeName[len++] = *cmdline++;
-            exeName[len] = '\0';
+            exeName[len] = L'\0';
         }
     }
 
-    if (exeName[0] == '\0' || help)
+    if (exeName[0] == L'\0' || help)
     {
         DWORD written;
         WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),
@@ -161,7 +161,7 @@ void mainCRTStartup()
     }
 
     PROCESS_INFORMATION pi;
-    STARTUPINFO si;
+    STARTUPINFOW si;
     si.cb = sizeof(si);
     si.lpReserved = NULL;
     si.lpTitle = NULL;
@@ -169,7 +169,7 @@ void mainCRTStartup()
     si.cbReserved2 = 0;
     si.lpReserved2 = 0;
     si.dwFlags = 0;
-    if (!CreateProcess(NULL, exeName, NULL, NULL, TRUE, CREATE_NEW_PROCESS_GROUP,
+    if (!CreateProcessW(NULL, exeName, NULL, NULL, TRUE, CREATE_NEW_PROCESS_GROUP,
                        NULL, NULL, &si, &pi))
     {
         ExitProcess(GetLastError() + retBase * 2);


### PR DESCRIPTION
### Motivation
- Ensure correct handling of Unicode and long (\>MAX_PATH) paths across pack/unpack flows and external packers (RAR, 7z, etc.).
- Fix RAR list-file charset problems that corrupted non-ANSI filenames and support writing Unicode list files for RAR invocation.
- Harden the 7zip plugin against crashes and improve thread-safe error reporting and temp-file handling for long paths.

### Description
- General: introduce long/unicode path handling utilities and use `SAL_MAX_PATH` in places previously limited to `MAX_PATH`, and include `common/widepath.h` where needed.
- RAR/file-list: switch default RAR switches from `-scol` to `-scul`, detect when a RAR list file must be Unicode, write a UTF-16LE BOM and UTF-16LE entries, and create a temporary ASCII archive name when the real archive name contains non-ASCII/long characters.
- Process creation and command lines: convert command lines to wide strings and call `CreateProcessW` (via `PackExecute`) so Unicode/long current directories and commands survive the spawn hop.
- 7zip plugin: add helpers to convert Salamander UTF-8/ANSI strings to `UString` and long path variants, use wide APIs for opening/renaming/deleting temporary archives, add thread/SEH guards around 7zip thread bodies and update callbacks, and improve retryable stream error reporting with thread-safe `FormatMessage` usage.
- Miscellaneous: fix `SalMultiByteToWidePath` allocation/resizing bug; replace many `CreateFile` usages with `CreateFileW` wrappers for long-path support in `pak` and other plugins; adjust dialog buffer sizes and safe string copy calls; add catch-all `catch(...)` handlers to translate unexpected exceptions to HRESULT failures.

### Testing
- Built the full project with MSVC (x86/x64) successfully after the changes.
- Ran automated smoke/integration tests for archiving operations (pack/update/delete) covering RAR list-file creation and 7z update/delete paths with Unicode and long filenames, and the tests completed successfully.
- No automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a505c39dec88329ac96d1b5f8105142)