### PR TITLE
Potential fix for code scanning alert no. 1158: Non-constant format string

### DIFF
--- a/src/salamdr4.cpp
+++ b/src/salamdr4.cpp
@@ -226,7 +226,11 @@ BOOL CTruncatedString::Set(const char* str, const char* subStr)
     Text = text;
     if (subStrIndex != -1)
     {
-        sprintf(Text, str, subStr);
+        int prefixLen = subStrIndex;
+        memcpy(Text, str, prefixLen);
+        memcpy(Text + prefixLen, subStr, subStrLen);
+        const char* suffix = str + prefixLen + 2; // skip "%s"
+        strcpy(Text + prefixLen + subStrLen, suffix);
         SubStrIndex = subStrIndex;
         SubStrLen = subStrLen;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/KRtkovo-eu-AI/salamander/security/code-scanning/1158](https://github.com/KRtkovo-eu-AI/salamander/security/code-scanning/1158)

Use constant-format-free string assembly instead of `sprintf` with dynamic format.  
Best fix: keep existing `%s` detection logic, but replace the vulnerable `sprintf(Text, str, subStr)` with explicit concatenation:

- copy prefix before `%s`
- copy `subStr`
- copy suffix after `%s`
- NUL-terminate

This preserves current functionality (including prior handling of `%%` in displayed text as literal `%%`, same as current behavior outside `sprintf` parsing side effects) while removing format-string interpretation entirely.

Edit only `src/salamdr4.cpp`, in `CTruncatedString::Set`, at the `if (subStrIndex != -1)` block around current line 229.  
No new imports/dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
