### PR TITLE
Fix dark title bar refresh for shutdown dialogs

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2556,17 +2556,23 @@ void DarkModeRefreshTitleBar(HWND hwnd)
     if (!gSupported || hwnd == NULL)
         return;
 
-    BOOL useDark = FALSE;
-    if (gIsDarkModeAllowedForWindow && gIsDarkModeAllowedForWindow(hwnd) && ShouldUseDarkColorsInternal())
-        useDark = TRUE;
+    // Keep the per-window native opt-in synchronized here too, not only in
+    // DarkModeApplyWindow().  Shutdown/close dialogs can be created while the
+    // main window is already tearing down; setting the DWM attribute without
+    // first reasserting the opt-in can leave the caption on the native light
+    // path for one paint and causes a white title-bar flash.
+    if (gAllowDarkModeForWindow)
+        gAllowDarkModeForWindow(hwnd, gEnabled);
 
-    if (gBuildNumber < 18362)
+    BOOL useDark = ShouldUseDarkColorsInternal() ? TRUE : FALSE;
+
+    SetPropW(hwnd, L"UseImmersiveDarkModeColors", reinterpret_cast<HANDLE>(static_cast<INT_PTR>(useDark)));
+
+    if (gDwmSetWindowAttribute)
     {
-        SetPropW(hwnd, L"UseImmersiveDarkModeColors", reinterpret_cast<HANDLE>(static_cast<INT_PTR>(useDark)));
-    }
-    else if (gDwmSetWindowAttribute)
-    {
-        gDwmSetWindowAttribute(hwnd, 20 /* DWMWA_USE_IMMERSIVE_DARK_MODE */, &useDark, sizeof(useDark));
+        HRESULT hr = gDwmSetWindowAttribute(hwnd, 20 /* DWMWA_USE_IMMERSIVE_DARK_MODE */, &useDark, sizeof(useDark));
+        if (FAILED(hr))
+            gDwmSetWindowAttribute(hwnd, 19 /* DWMWA_USE_IMMERSIVE_DARK_MODE before 20H1 */, &useDark, sizeof(useDark));
     }
     else if (gSetWindowCompositionAttribute)
     {


### PR DESCRIPTION
### Motivation
- Prevent a brief white/light title-bar flash on shutdown/close dialogs when the app is running with the Windows Dark Mode scheme by ensuring the window title bar is consistently opted into dark mode.

### Description
- Reassert per-window native dark-mode opt-in in `DarkModeRefreshTitleBar()` by calling the platform opt-in helper before updating decorations.
- Always set the `UseImmersiveDarkModeColors` window property and compute `useDark` from `ShouldUseDarkColorsInternal()`.
- Apply the modern DWM attribute and fall back to the older pre-20H1 attribute when needed, and preserve the existing `SetWindowCompositionAttribute` fallback; changes are in `src/darkmode.cpp`.

### Testing
- Ran repository hygiene checks for whitespace/format and local status; checks passed.
- No unit or GUI automation was executed as part of this change (manual/interactive verification recommended for window-paint behavior on target Windows builds).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5193d9557c8329911a7a306a982408)