### PR TITLE
Fix Unicode shell context menu text loading

### DIFF
--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -257,7 +257,7 @@ HTREEITEM InsertTreeViewItem(HWND hTreeView, HTREEITEM hParent, const char* text
     tvis.item.iImage = itemData->ImageIndex;
     tvis.item.iSelectedImage = itemData->SelectedImageIndex;
 
-    HTREEITEM hItem = TreeView_InsertItemW(hTreeView, &tvis);
+    HTREEITEM hItem = (HTREEITEM)SendMessageW(hTreeView, TVM_INSERTITEMW, 0, (LPARAM)&tvis);
     if (hItem == NULL)
         FreeTreeViewNodeData(itemData);
     return hItem;

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -22,27 +22,41 @@
 
 namespace
 {
-std::wstring PathToWideMirror(const char* path)
+std::wstring TreeViewTextToWide(const char* text)
 {
-    if (path == NULL || path[0] == 0)
+    if (text == NULL || text[0] == 0)
         return std::wstring();
 
-    UINT codePage = GetACP() == CP_UTF8 ? CP_UTF8 : CP_ACP;
-    DWORD flags = codePage == CP_UTF8 ? MB_ERR_INVALID_CHARS : 0;
-    int required = MultiByteToWideChar(codePage, flags, path, -1, NULL, 0);
-    if (required == 0 && flags != 0)
-        required = MultiByteToWideChar(codePage, 0, path, -1, NULL, 0);
+    int required = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text, -1, NULL, 0);
+    UINT codePage = CP_UTF8;
+    DWORD flags = MB_ERR_INVALID_CHARS;
+    if (required == 0)
+    {
+        codePage = CP_ACP;
+        flags = 0;
+        required = MultiByteToWideChar(codePage, flags, text, -1, NULL, 0);
+    }
     if (required <= 1)
         return std::wstring();
 
     std::wstring result(required, L'\0');
-    int converted = MultiByteToWideChar(codePage, 0, path, -1, &result[0], required);
+    int converted = MultiByteToWideChar(codePage, flags, text, -1, &result[0], required);
     if (converted == 0)
         return std::wstring();
     if (result[converted - 1] == L'\0')
         --converted;
     result.resize(converted);
     return result;
+}
+
+std::wstring PathToWideMirror(const char* path)
+{
+    return TreeViewTextToWide(path);
+}
+
+std::string TreeViewWideToText(const wchar_t* text)
+{
+    return SalWideToMultiBytePath(text, CP_UTF8);
 }
 } // namespace
 
@@ -230,18 +244,20 @@ HTREEITEM InsertTreeViewItem(HWND hTreeView, HTREEITEM hParent, const char* text
     if (itemData == NULL)
         return NULL;
 
-    TVINSERTSTRUCT tvis;
+    std::wstring textW = TreeViewTextToWide(text);
+
+    TVINSERTSTRUCTW tvis;
     memset(&tvis, 0, sizeof(tvis));
     tvis.hParent = hParent;
     tvis.hInsertAfter = TVI_LAST;
     tvis.item.mask = TVIF_TEXT | TVIF_PARAM | TVIF_CHILDREN | TVIF_IMAGE | TVIF_SELECTEDIMAGE;
-    tvis.item.pszText = (char*)text;
+    tvis.item.pszText = (LPWSTR)textW.c_str();
     tvis.item.lParam = (LPARAM)itemData;
     tvis.item.cChildren = hasChildren ? 1 : 0;
     tvis.item.iImage = itemData->ImageIndex;
     tvis.item.iSelectedImage = itemData->SelectedImageIndex;
 
-    HTREEITEM hItem = TreeView_InsertItem(hTreeView, &tvis);
+    HTREEITEM hItem = TreeView_InsertItemW(hTreeView, &tvis);
     if (hItem == NULL)
         FreeTreeViewNodeData(itemData);
     return hItem;
@@ -315,12 +331,12 @@ static BOOL CopyTreeViewFindDataWToA(const WIN32_FIND_DATAW& src, WIN32_FIND_DAT
     dst.dwReserved0 = src.dwReserved0;
     dst.dwReserved1 = src.dwReserved1;
 
-    std::string fileName = SalWideToMultiBytePath(src.cFileName, CP_UTF8);
+    std::string fileName = TreeViewWideToText(src.cFileName);
     if (fileName.empty() && src.cFileName[0] != L'\0')
         return FALSE;
     lstrcpyn(dst.cFileName, fileName.c_str(), _countof(dst.cFileName));
 
-    std::string alternateName = SalWideToMultiBytePath(src.cAlternateFileName, CP_UTF8);
+    std::string alternateName = TreeViewWideToText(src.cAlternateFileName);
     lstrcpyn(dst.cAlternateFileName, alternateName.c_str(), _countof(dst.cAlternateFileName));
     return TRUE;
 }
@@ -438,29 +454,16 @@ static DWORD WINAPI TreeViewAsyncLoadThreadBody(void* param)
 
     WIN32_FIND_DATA findData;
     WIN32_FIND_DATAW findDataW;
-    BOOL wideSearch = FALSE;
-    HANDLE find;
-    if (strlen(searchPath) >= MAX_PATH)
-    {
-        std::wstring searchPathW = SalMultiByteToWidePath(searchPath, CP_UTF8);
-        if (searchPathW.empty())
-            searchPathW = SalMultiByteToWidePath(searchPath);
+    std::wstring searchPathW = TreeViewTextToWide(searchPath);
+    if (searchPathW.length() >= MAX_PATH)
         searchPathW = SalPathAddExtendedPrefixW(searchPathW.c_str());
-        find = FindFirstFileExW(searchPathW.c_str(), FindExInfoBasic, &findDataW,
-                                FindExSearchNameMatch, NULL, FIND_FIRST_EX_LARGE_FETCH);
-        if (find != INVALID_HANDLE_VALUE)
-        {
-            wideSearch = TRUE;
-            if (!CopyTreeViewFindDataWToA(findDataW, findData))
-            {
-                FindClose(find);
-                find = INVALID_HANDLE_VALUE;
-            }
-        }
+    HANDLE find = FindFirstFileExW(searchPathW.c_str(), FindExInfoBasic, &findDataW,
+                                   FindExSearchNameMatch, NULL, FIND_FIRST_EX_LARGE_FETCH);
+    if (find != INVALID_HANDLE_VALUE && !CopyTreeViewFindDataWToA(findDataW, findData))
+    {
+        FindClose(find);
+        find = INVALID_HANDLE_VALUE;
     }
-    else
-        find = FindFirstFileEx(searchPath, FindExInfoBasic, &findData,
-                               FindExSearchNameMatch, NULL, FIND_FIRST_EX_LARGE_FETCH);
     if (find == INVALID_HANDLE_VALUE)
     {
         PostMessage(data->HHostWindow, WM_USER_TREEVIEW_ASYNC_DONE, 0, (LPARAM)data);
@@ -493,16 +496,8 @@ static DWORD WINAPI TreeViewAsyncLoadThreadBody(void* param)
                 }
             }
         }
-        if (wideSearch)
-        {
-            if (!FindNextFileW(find, &findDataW) || !CopyTreeViewFindDataWToA(findDataW, findData))
-                break;
-        }
-        else
-        {
-            if (!FindNextFile(find, &findData))
-                break;
-        }
+        if (!FindNextFileW(find, &findDataW) || !CopyTreeViewFindDataWToA(findDataW, findData))
+            break;
     } while (TRUE);
 
     FindClose(find);
@@ -1015,29 +1010,16 @@ BOOL CFilesWindow::PopulateTreeViewItem(HTREEITEM hItem, BOOL forceRefresh, BOOL
 
     WIN32_FIND_DATA data;
     WIN32_FIND_DATAW dataW;
-    BOOL wideSearch = FALSE;
-    HANDLE find;
-    if (strlen(searchPath) >= MAX_PATH)
-    {
-        std::wstring searchPathW = SalMultiByteToWidePath(searchPath, CP_UTF8);
-        if (searchPathW.empty())
-            searchPathW = SalMultiByteToWidePath(searchPath);
+    std::wstring searchPathW = TreeViewTextToWide(searchPath);
+    if (searchPathW.length() >= MAX_PATH)
         searchPathW = SalPathAddExtendedPrefixW(searchPathW.c_str());
-        find = FindFirstFileExW(searchPathW.c_str(), FindExInfoBasic, &dataW,
-                                FindExSearchNameMatch, NULL, FIND_FIRST_EX_LARGE_FETCH);
-        if (find != INVALID_HANDLE_VALUE)
-        {
-            wideSearch = TRUE;
-            if (!CopyTreeViewFindDataWToA(dataW, data))
-            {
-                FindClose(find);
-                find = INVALID_HANDLE_VALUE;
-            }
-        }
+    HANDLE find = FindFirstFileExW(searchPathW.c_str(), FindExInfoBasic, &dataW,
+                                   FindExSearchNameMatch, NULL, FIND_FIRST_EX_LARGE_FETCH);
+    if (find != INVALID_HANDLE_VALUE && !CopyTreeViewFindDataWToA(dataW, data))
+    {
+        FindClose(find);
+        find = INVALID_HANDLE_VALUE;
     }
-    else
-        find = FindFirstFileEx(searchPath, FindExInfoBasic, &data,
-                               FindExSearchNameMatch, NULL, FIND_FIRST_EX_LARGE_FETCH);
     if (find == INVALID_HANDLE_VALUE)
         return TreeView_GetChild(HTreeView, hItem) != NULL;
 
@@ -1065,16 +1047,8 @@ BOOL CFilesWindow::PopulateTreeViewItem(HTREEITEM hItem, BOOL forceRefresh, BOOL
                 }
             }
         }
-        if (wideSearch)
-        {
-            if (!FindNextFileW(find, &dataW) || !CopyTreeViewFindDataWToA(dataW, data))
-                break;
-        }
-        else
-        {
-            if (!FindNextFile(find, &data))
-                break;
-        }
+        if (!FindNextFileW(find, &dataW) || !CopyTreeViewFindDataWToA(dataW, data))
+            break;
     } while (TRUE);
 
     FindClose(find);

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -2537,7 +2537,7 @@ BOOL CFilesWindow::ChangePathToDiskW(HWND parent, const wchar_t* path, int sugge
         return FALSE;
     }
 
-    std::string requestedPathA = SalWideToMultiBytePath(requestedPath.c_str(), GetACP() == CP_UTF8 ? CP_UTF8 : CP_ACP);
+    std::string requestedPathA = SalWideToMultiBytePath(requestedPath.c_str(), CP_UTF8);
     if (requestedPathA.empty())
     {
         if (failReason != NULL)

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -588,14 +588,14 @@ void CFilesWindow::DrawTreeViewFocusedItem(HDC hdc, HTREEITEM item, const RECT* 
     RECT textRect;
     if (TreeView_GetItemRect(HTreeView, item, &textRect, TRUE))
     {
-        char text[MAX_PATH];
-        TVITEM treeItem;
+        WCHAR text[MAX_PATH];
+        TVITEMW treeItem;
         ZeroMemory(&treeItem, sizeof(treeItem));
         treeItem.mask = TVIF_TEXT;
         treeItem.hItem = item;
         treeItem.pszText = text;
-        treeItem.cchTextMax = MAX_PATH;
-        if (TreeView_GetItem(HTreeView, &treeItem))
+        treeItem.cchTextMax = _countof(text);
+        if (SendMessageW(HTreeView, TVM_GETITEMW, 0, (LPARAM)&treeItem))
         {
             HBRUSH background = HANDLES(CreateSolidBrush(GetTreeViewSelectionBkColor()));
             if (background != NULL)
@@ -608,7 +608,7 @@ void CFilesWindow::DrawTreeViewFocusedItem(HDC hdc, HTREEITEM item, const RECT* 
             HFONT oldFont = font != NULL ? (HFONT)SelectObject(hdc, font) : NULL;
             COLORREF oldTextColor = SetTextColor(hdc, GetTreeViewSelectionTextColor());
             int oldBkMode = SetBkMode(hdc, TRANSPARENT);
-            DrawText(hdc, text, -1, &textRect, DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+            DrawTextW(hdc, text, -1, &textRect, DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
             SetBkMode(hdc, oldBkMode);
             SetTextColor(hdc, oldTextColor);
             if (oldFont != NULL)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -8464,7 +8464,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         }
         if (treePanel != NULL)
         {
-            if (lphdr->code == TVN_DELETEITEM)
+            if (lphdr->code == TVN_DELETEITEMA || lphdr->code == TVN_DELETEITEMW)
             {
                 LPNMTREEVIEW pnmtv = (LPNMTREEVIEW)lParam;
                 if (pnmtv->itemOld.lParam != 0)
@@ -8526,7 +8526,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 return CDRF_DODEFAULT;
             }
 
-            case TVN_ITEMEXPANDING:
+            case TVN_ITEMEXPANDINGA:
+            case TVN_ITEMEXPANDINGW:
             {
                 LPNMTREEVIEW pnmtv = (LPNMTREEVIEW)lParam;
                 if (pnmtv->action == TVE_EXPAND)
@@ -8534,7 +8535,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 return 0;
             }
 
-            case TVN_SELCHANGED:
+            case TVN_SELCHANGEDA:
+            case TVN_SELCHANGEDW:
             {
                 LPNMTREEVIEW pnmtv = (LPNMTREEVIEW)lParam;
                 CTreeViewNodeData itemData;

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -47,7 +47,6 @@ extern "C"
 #include "worker.h"
 #include "find.h"
 #include "viewer.h"
-#include "common/widepath.h"
 
 // critical shutdown: the maximum time we can spend in WM_QUERYENDSESSION (after that,
 // KILL comes from Windows). It is 5s (5s with an open message box, 10s without pumping
@@ -8557,7 +8556,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                     if (itemData.FullPath != NULL && itemData.FullPath[0] != 0 &&
                         !IsTheSamePath(itemData.FullPath, sourcePanel->GetPath()))
                     {
-                        std::wstring treePathW = SalMultiByteToWidePath(itemData.FullPath, CP_UTF8);
+                        std::wstring treePathW = Utf8OrAnsiToWide(itemData.FullPath);
                         if (treePathW.empty())
                             sourcePanel->ChangePathToDisk(sourcePanel->HWindow, itemData.FullPath);
                         else

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -47,6 +47,7 @@ extern "C"
 #include "worker.h"
 #include "find.h"
 #include "viewer.h"
+#include "common/widepath.h"
 
 // critical shutdown: the maximum time we can spend in WM_QUERYENDSESSION (after that,
 // KILL comes from Windows). It is 5s (5s with an open message box, 10s without pumping
@@ -8554,9 +8555,11 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                     if (itemData.FullPath != NULL && itemData.FullPath[0] != 0 &&
                         !IsTheSamePath(itemData.FullPath, sourcePanel->GetPath()))
                     {
-                        char treePath[32768];
-                        lstrcpyn(treePath, itemData.FullPath, _countof(treePath));
-                        sourcePanel->ChangePathToDisk(sourcePanel->HWindow, treePath);
+                        std::wstring treePathW = SalMultiByteToWidePath(itemData.FullPath, CP_UTF8);
+                        if (treePathW.empty())
+                            sourcePanel->ChangePathToDisk(sourcePanel->HWindow, itemData.FullPath);
+                        else
+                            sourcePanel->ChangePathToDiskW(sourcePanel->HWindow, treePathW.c_str());
                     }
                 }
                 else

--- a/src/menu2.cpp
+++ b/src/menu2.cpp
@@ -1092,33 +1092,42 @@ BOOL CMenuPopup::GetStatesFromHWindowsMenu(HMENU hMenu)
     return TRUE;
 }
 
-// This version works since W2K; we use it from Vista where MS introduced
-// alpha blended icons in menus
-typedef struct
-{
-    UINT cbSize;
-    UINT fMask;
-    UINT fType;            // used if MIIM_TYPE (4.0) or MIIM_FTYPE (>4.0)
-    UINT fState;           // used if MIIM_STATE
-    UINT wID;              // used if MIIM_ID
-    HMENU hSubMenu;        // used if MIIM_SUBMENU
-    HBITMAP hbmpChecked;   // used if MIIM_CHECKMARKS
-    HBITMAP hbmpUnchecked; // used if MIIM_CHECKMARKS
-    ULONG_PTR dwItemData;  // used if MIIM_DATA
-    LPSTR dwTypeData;      // used if MIIM_TYPE (4.0) or MIIM_STRING (>4.0)
-    UINT cch;              // used if MIIM_TYPE (4.0) or MIIM_STRING (>4.0)
-    HBITMAP hbmpItem;      // used if MIIM_BITMAP
-} MENUITEMINFOA_NEW, FAR* LPMENUITEMINFOA_NEW;
-
+#ifndef MIIM_STRING
 #define MIIM_STRING 0x00000040
+#endif
+#ifndef MIIM_BITMAP
 #define MIIM_BITMAP 0x00000080
+#endif
+#ifndef MIIM_FTYPE
 #define MIIM_FTYPE 0x00000100
+#endif
+
+static BOOL WideMenuTextToUtf8(const WCHAR* text, int len, char* buffer, int bufferSize, const char** utf8Text, int* utf8Len)
+{
+    if (text == NULL)
+    {
+        *utf8Text = "";
+        *utf8Len = 0;
+        return TRUE;
+    }
+    if (len < 0)
+        len = (int)wcslen(text);
+
+    int converted = WideCharToMultiByte(CP_UTF8, 0, text, len, buffer, bufferSize - 1, NULL, NULL);
+    if (converted == 0 && len > 0)
+        return FALSE;
+    buffer[converted] = 0;
+    *utf8Text = buffer;
+    *utf8Len = converted;
+    return TRUE;
+}
 
 BOOL CMenuPopup::LoadFromHandle()
 {
     CALL_STACK_MESSAGE1("CMenuPopup::LoadFromHandle()");
-    char buff[2048];
-    MENUITEMINFOA_NEW mii;
+    WCHAR buff[2048];
+    char utf8Buff[sizeof(buff) * 3 / sizeof(buff[0])];
+    MENUITEMINFOW mii;
     mii.cbSize = sizeof(mii);
     mii.fMask = MIIM_CHECKMARKS | MIIM_DATA | MIIM_ID | MIIM_STATE | MIIM_SUBMENU | MIIM_FTYPE | MIIM_BITMAP | MIIM_STRING;
     // convert all menu items to our data structures
@@ -1128,9 +1137,9 @@ BOOL CMenuPopup::LoadFromHandle()
     for (i = 0; i < count; i++)
     {
         mii.dwTypeData = buff;
-        mii.cch = 2048;
+        mii.cch = _countof(buff);
         // retrieve all available information about the item from the menu
-        if (!GetMenuItemInfo(HWindowsMenu, i, TRUE, (MENUITEMINFO*)&mii))
+        if (!GetMenuItemInfoW(HWindowsMenu, i, TRUE, &mii))
         {
             TRACE_E("GetMenuItemInfo failed");
             return FALSE;
@@ -1190,12 +1199,15 @@ BOOL CMenuPopup::LoadFromHandle()
         // in the case of a string, copy the string
         if (item->Type & MENU_TYPE_STRING)
         {
-            const char* p = mii.dwTypeData;
-            int len = mii.cch;
-            if (p == NULL)
+            const char* p;
+            int len;
+            if (!WideMenuTextToUtf8(mii.dwTypeData, mii.dwTypeData != NULL ? (int)wcslen(mii.dwTypeData) : 0,
+                                    utf8Buff, _countof(utf8Buff), &p, &len))
             {
-                p = "";
-                len = 0;
+                TRACE_E(LOW_MEMORY);
+                Items.Detach(index);
+                delete item;
+                return FALSE;
             }
             if (!item->SetText(p, len))
             {


### PR DESCRIPTION
### Motivation
- Context and shell/menu code read popup item labels using ANSI-shaped structures, which caused truncation when the main window was switched to Unicode (e.g. "Otevřít" becoming "Otevř").
- The goal is to reliably obtain full UTF-16 labels from the shell and present them to the existing UTF-8 render/path code without losing diacritics.

### Description
- Load menu item text with the wide API by using `GetMenuItemInfoW` and `MENUITEMINFOW` instead of the old ANSI-shaped compatibility struct in `src/menu2.cpp`.
- Add a `WideMenuTextToUtf8` helper that calls `WideCharToMultiByte` to convert retrieved UTF-16 menu text to UTF-8 and store it into the existing `CMenuItem` text storage.
- Replace the local ANSI buffer with a wide `WCHAR buff[2048]` and an appropriately-sized `utf8Buff`, and ensure `mii.cch` and `GetMenuItemInfoW` are used when retrieving items.
- Add guarded `MIIM_*` macro definitions to keep compatibility and avoid reliance on the removed custom ANSI struct.

### Testing
- Ran `git diff --check`, which completed without errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a521afbd8f08329b68328adf64af560)