### PR TITLE
Fix Views settings crash with Cyrillic localization

### DIFF
--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -1501,7 +1501,7 @@ void CCfgPageView::Transfer(CTransferInfo& ti)
         Config.Load(MainWindow->ViewTemplates);
 
         DisableNotification = TRUE;
-        char buff[20];
+        char hotKey[20];
         int i;
         for (i = 0; i < VIEW_TEMPLATES_COUNT; i++)
         {
@@ -1513,31 +1513,32 @@ void CCfgPageView::Transfer(CTransferInfo& ti)
             lvi.pszText = Config.Items[i].Name;
             ListView_InsertItem(HListView, &lvi);
 
+            char* modeName = NULL;
             switch (Config.Items[i].Mode)
             {
             case VIEW_MODE_TREE:
-                lstrcpy(buff, LoadStr(IDS_TREE_VIEW_NAME));
+                modeName = LoadStr(IDS_TREE_VIEW_NAME);
                 break;
             case VIEW_MODE_BRIEF:
-                lstrcpy(buff, LoadStr(IDS_BRIEF_VIEW_NAME));
+                modeName = LoadStr(IDS_BRIEF_VIEW_NAME);
                 break;
             case VIEW_MODE_DETAILED:
-                lstrcpy(buff, LoadStr(IDS_DETAILED_VIEW_NAME));
+                modeName = LoadStr(IDS_DETAILED_VIEW_NAME);
                 break;
             case VIEW_MODE_ICONS:
-                lstrcpy(buff, LoadStr(IDS_ICONS_VIEW_NAME));
+                modeName = LoadStr(IDS_ICONS_VIEW_NAME);
                 break;
             case VIEW_MODE_THUMBNAILS:
-                lstrcpy(buff, LoadStr(IDS_THUMBNAILS_VIEW_NAME));
+                modeName = LoadStr(IDS_THUMBNAILS_VIEW_NAME);
                 break;
             case VIEW_MODE_TILES:
-                lstrcpy(buff, LoadStr(IDS_TILES_VIEW_NAME));
+                modeName = LoadStr(IDS_TILES_VIEW_NAME);
                 break;
             }
-            ListView_SetItemText(HListView, i, 1, buff);
+            ListView_SetItemText(HListView, i, 1, modeName != NULL ? modeName : (char*)"");
 
-            sprintf(buff, "Alt+%d", i < VIEW_TEMPLATES_COUNT - 1 ? i + 1 : 0);
-            ListView_SetItemText(HListView, i, 2, buff);
+            sprintf(hotKey, "Alt+%d", i < VIEW_TEMPLATES_COUNT - 1 ? i + 1 : 0);
+            ListView_SetItemText(HListView, i, 2, hotKey);
         }
         // set column widths
         ListView_SetColumnWidth(HListView, 0, LVSCW_AUTOSIZE_USEHEADER);


### PR DESCRIPTION
### Motivation
- The Views (Disks) configuration dialog could crash when the UI language used Cyrillic names because localized mode names were copied into a fixed 20-byte stack buffer.
- Overflow of that small buffer when resource strings exceed the buffer length (common with multi-byte Cyrillic text) is the suspected root cause of the crash when opening the `Views` page.

### Description
- Replace the unsafe local-name copy in `CCfgPageView::Transfer` by passing localized resource strings directly to the list view instead of copying them into a 20-byte stack buffer in `src/dialogs4.cpp`.
- Keep a small stack buffer `hotKey` only for generated hotkey labels (e.g. `Alt+1`) which are bounded in size and not localization-dependent.
- Use a nullable `modeName` pointer and call `ListView_SetItemText` with `modeName != NULL ? modeName : (char*)""` to avoid passing invalid data to the list view.

### Testing
- Ran `git diff --check` to validate there are no index/whitespace issues and it passed without errors.
- Environment checks (`which msbuild` and `which x86_64-w64-mingw32-g++`) revealed Windows build tools are not available in this environment, so a native Windows build/compile test was not executed.
- Verified the changed code region in `src/dialogs4.cpp` to ensure the localized strings are no longer copied into the small stack buffer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a525ee880e88329b848d805ac997b03)