### PR TITLE
Skip SFTP plugin in PR build

### DIFF
--- a/.github/workflows/pr-msbuild.yml
+++ b/.github/workflows/pr-msbuild.yml
@@ -30,6 +30,9 @@ jobs:
 
     env:
       BUILD_CONFIGURATION: Debug
+      # SFTP is not shipped yet; keep this off to avoid building the plugin and
+      # its vcpkg dependencies during PR validation.
+      BUILD_SFTP_PLUGIN: 'false'
       SOLUTION_PATH: '.\src\vcxproj\salamand.sln'
       LOG_DIRECTORY: build_logs
 
@@ -41,12 +44,14 @@ jobs:
           submodules: recursive
 
       - name: Provide shared plugin files for SFTP submodule
+        if: env.BUILD_SFTP_PLUGIN == 'true'
         run: |
           $sftpShared = Join-Path (Get-Location) 'src\plugins\sftp\shared'
           New-Item -ItemType Directory -Force -Path $sftpShared | Out-Null
           Copy-Item -Path '.\src\plugins\shared\*' -Destination $sftpShared -Recurse -Force
 
       - name: Configure SFTP submodule build
+        if: env.BUILD_SFTP_PLUGIN == 'true'
         run: |
           $sftpRoot = Join-Path (Get-Location) 'src\plugins\sftp'
           $directoryBuildProps = Join-Path $sftpRoot 'Directory.Build.props'
@@ -79,9 +84,28 @@ jobs:
         uses: ammaraskar/msvc-problem-matcher@master
 
       - name: Install SFTP plugin dependencies
+        if: env.BUILD_SFTP_PLUGIN == 'true'
         run: |
           $triplet = if ('${{ matrix.platform }}' -eq 'Win32') { 'x86-windows' } else { 'x64-windows' }
           .\tools\vcpkg\build-third-party-libs.ps1 -SftpPlugin -OnlySftpPlugin -Triplet $triplet
+
+      - name: Disable SFTP projects in PR solution
+        if: env.BUILD_SFTP_PLUGIN != 'true'
+        run: |
+          $solutionPath = Join-Path (Get-Location) $env:SOLUTION_PATH
+          $solution = Get-Content -LiteralPath $solutionPath
+          $sftpProjectIds = @(
+            '514DA5DF-C9D5-4A39-9BE6-CBCFA6CE0D5A', # sftp
+            '2D3A2ADD-498B-4420-8E08-6A9FC9C09D5E'  # lang_sftp
+          )
+
+          foreach ($projectId in $sftpProjectIds) {
+            $solution = $solution | Where-Object {
+              $_ -notmatch "\{$projectId\}\..*\.Build\.0\s*="
+            }
+          }
+
+          $solution | Set-Content -LiteralPath $solutionPath -Encoding UTF8
 
       - name: Build via MSBuild (Debug | ${{ matrix.platform }})
         run: |


### PR DESCRIPTION
### Motivation

- Speed up PR MSBuild runs by skipping the SFTP plugin and its vcpkg-built dependencies because SFTP is not shipped yet. 
- Avoid the long PR-time cost of cloning/bootstrapping vcpkg and installing OpenSSL/libssh2 for SFTP.

### Description

- Add a `BUILD_SFTP_PLUGIN` environment toggle (default `'false'`) to `.github/workflows/pr-msbuild.yml` so the SFTP build can be disabled. 
- Gate SFTP shared-file provisioning, SFTP-specific `Directory.Build.props` configuration, and the vcpkg dependency installation behind `if: env.BUILD_SFTP_PLUGIN == 'true'` so those steps are skipped when the toggle is off. 
- Add a step that runs when the toggle is disabled to remove the SFTP and `lang_sftp` `.Build.0` entries from the checked-out solution (project IDs `514DA5DF-C9D5-4A39-9BE6-CBCFA6CE0D5A` and `2D3A2ADD-498B-4420-8E08-6A9FC9C09D5E`) so MSBuild will skip those projects during PR validation.

### Testing

- Verified workflow text and presence of the toggle with a Python assertion and the check passed. 
- Verified the `if:` guards are present and counted correctly with a Python script and the check passed (`SFTP CI toggle structure is present`). 
- Verified the solution-edit step would remove the expected `18` SFTP `Build.0` entries with a Python check that reported `would remove 18 SFTP Build.0 entries` and that check passed, and ran `git diff --check` to ensure no syntax issues, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53112446f883299cacb327af360564)