### PR TITLE
Disable bottom toolbar shortcut text in dark mode

### DIFF
--- a/src/toolbar.h
+++ b/src/toolbar.h
@@ -11,6 +11,10 @@
 class CToolBar;
 class CTBCustomizeDialog;
 
+// Internal toolbar item style: when a grayed item is drawn in dark mode,
+// render its image using the same disabled color as the label text.
+#define TLBI_STYLE_DARK_DISABLED_IMAGE_TEXT 0x80000000
+
 class CToolBarItem
 {
 protected:

--- a/src/toolbar2.cpp
+++ b/src/toolbar2.cpp
@@ -55,6 +55,26 @@ static COLORREF GetDisabledToolBarTextColor()
     return GetSysColor(COLOR_BTNSHADOW);
 }
 
+static BOOL DrawDarkDisabledImageText(HDC hDC, int imageIndex, int x, int y, int width, int height)
+{
+    if (!DarkModeShouldUseDarkColors() || imageIndex < 0 || imageIndex >= 12)
+        return FALSE;
+
+    char text[4];
+    wsprintf(text, "F%d", imageIndex + 1);
+
+    RECT textRect = {x, y, x + width, y + height};
+    COLORREF oldText = SetTextColor(hDC, GetDisabledToolBarTextColor());
+    int oldBkMode = SetBkMode(hDC, TRANSPARENT);
+    HFONT oldFont = (HFONT)SelectObject(hDC, EnvFont);
+    DrawText(hDC, text, -1, &textRect, DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
+    if (oldFont != NULL)
+        SelectObject(hDC, oldFont);
+    SetBkMode(hDC, oldBkMode);
+    SetTextColor(hDC, oldText);
+    return TRUE;
+}
+
 void CToolBar::SetFont()
 {
     CALL_STACK_MESSAGE1("CToolBar::SetFont()");
@@ -658,8 +678,12 @@ void CToolBar::DrawItem(HDC hDC, int index)
                 else
                 {
                     HIMAGELIST hImageList = HImageList;
-                    ImageList_Draw(hImageList, item->ImageIndex, CacheBitmap->HMemDC,
-                                   x, y, checked ? ILD_TRANSPARENT : ILD_NORMAL);
+                    if (!(item->Style & TLBI_STYLE_DARK_DISABLED_IMAGE_TEXT) ||
+                        !DrawDarkDisabledImageText(CacheBitmap->HMemDC, item->ImageIndex, x, y, imgW, imgH))
+                    {
+                        ImageList_Draw(hImageList, item->ImageIndex, CacheBitmap->HMemDC,
+                                       x, y, checked ? ILD_TRANSPARENT : ILD_NORMAL);
+                    }
                 }
                 if (item->HOverlay != NULL)
                     DrawIconEx(CacheBitmap->HMemDC, x, y, item->HOverlay, iconSize, iconSize, 0, NULL, DI_NORMAL);

--- a/src/toolbar4.cpp
+++ b/src/toolbar4.cpp
@@ -1495,7 +1495,7 @@ BOOL CBottomToolBar::CreateWnd(HWND hParent)
     {
         TLBI_ITEM_INFO2 tii;
         tii.Mask = TLBI_MASK_STYLE | TLBI_MASK_IMAGEINDEX | TLBI_MASK_WIDTH;
-        tii.Style = TLBI_STYLE_SHOWTEXT | TLBI_STYLE_FIXEDWIDTH | TLBI_STYLE_NOPREFIX;
+        tii.Style = TLBI_STYLE_SHOWTEXT | TLBI_STYLE_FIXEDWIDTH | TLBI_STYLE_NOPREFIX | TLBI_STYLE_DARK_DISABLED_IMAGE_TEXT;
         tii.ImageIndex = i;
         tii.Width = 60;
         if (!InsertItem2(i, TRUE, &tii))


### PR DESCRIPTION
### Motivation
- When the bottom toolbar is in dark mode we already render disabled labels (like Rename/View/Edit) with a muted color, and the function-key shortcut text (F1..F12) should use the same disabled appearance when the corresponding action is grayed.

### Description
- Add a new internal toolbar item style `TLBI_STYLE_DARK_DISABLED_IMAGE_TEXT` to mark items whose image area should render the shortcut text in the disabled color in dark mode (`src/toolbar.h`).
- Implement `DrawDarkDisabledImageText()` to draw `F1`..`F12` text using the dark-mode disabled text color and reuse existing font/painting helpers (`src/toolbar2.cpp`).
- Use the new renderer when drawing grayed toolbar icons so the image-list fallback is preserved if the special drawing is not applicable (`src/toolbar2.cpp`).
- Apply the new internal style to the bottom toolbar items so disabled bottom-toolbar actions gray both the label and the `F1`–`F12` shortcut text (`src/toolbar4.cpp`).

### Testing
- Ran `git diff --check` on the changes and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53148fe66883298c10af07969771b0)