### PR TITLE
Use registered plugins for Samandarin catalog status

### DIFF
--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -18,6 +18,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Runtime.InteropServices;
+using Microsoft.Win32;
 using Timer = System.Threading.Timer;
 
 namespace OpenSalamander.Samandarin;
@@ -1701,7 +1702,58 @@ internal static class PluginCatalogSources
 
 internal static class InstalledPluginScanner
 {
+    private const string CurrentConfigurationRoot = @"Software\Open Salamander Samandarin\5.0-samandarin-0.11";
+    private const string PluginsKeyName = "Plugins";
+    private const string PluginNameValue = "Name";
+    private const string PluginDllValue = "DLL";
+    private const string PluginVersionValue = "Version";
+
     public static IEnumerable<InstalledPlugin> Scan()
+    {
+        return TryScanConfiguredPlugins(out var configuredPlugins)
+            ? configuredPlugins
+            : ScanPluginDirectory();
+    }
+
+    private static bool TryScanConfiguredPlugins(out IReadOnlyList<InstalledPlugin> plugins)
+    {
+        var configuredPlugins = new List<InstalledPlugin>();
+        using var pluginsKey = Registry.CurrentUser.OpenSubKey(CurrentConfigurationRoot + @"\" + PluginsKeyName);
+        if (pluginsKey is null)
+        {
+            plugins = configuredPlugins;
+            return false;
+        }
+
+        foreach (var subKeyName in pluginsKey.GetSubKeyNames().OrderBy(ParsePluginOrder))
+        {
+            using var pluginKey = pluginsKey.OpenSubKey(subKeyName);
+            if (pluginKey is null)
+            {
+                continue;
+            }
+
+            var dllName = ReadString(pluginKey, PluginDllValue);
+            if (string.IsNullOrWhiteSpace(dllName))
+            {
+                continue;
+            }
+
+            var id = BuildIdFromRegisteredDll(dllName);
+            var displayName = ReadString(pluginKey, PluginNameValue);
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                displayName = id;
+            }
+
+            configuredPlugins.Add(new InstalledPlugin(id, displayName!, ReadString(pluginKey, PluginVersionValue) ?? string.Empty));
+        }
+
+        plugins = configuredPlugins;
+        return true;
+    }
+
+    private static IEnumerable<InstalledPlugin> ScanPluginDirectory()
     {
         var assemblyPath = Assembly.GetExecutingAssembly().Location;
         var pluginDirectory = Directory.GetParent(assemblyPath)?.FullName;
@@ -1730,6 +1782,26 @@ internal static class InstalledPluginScanner
             yield return new InstalledPlugin(id, display, version);
         }
     }
+
+    private static string? ReadString(RegistryKey key, string name) => key.GetValue(name) as string;
+
+    private static int ParsePluginOrder(string subKeyName) => int.TryParse(subKeyName, NumberStyles.Integer, CultureInfo.InvariantCulture, out var order) ? order : int.MaxValue;
+
+    private static string BuildIdFromRegisteredDll(string dllName)
+    {
+        var normalized = dllName.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var fileName = Path.GetFileNameWithoutExtension(normalized);
+        if (Path.IsPathRooted(normalized))
+        {
+            return string.IsNullOrWhiteSpace(fileName) ? normalized : fileName!;
+        }
+
+        var firstSegment = normalized.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        return string.IsNullOrWhiteSpace(firstSegment)
+            ? (string.IsNullOrWhiteSpace(fileName) ? normalized : fileName!)
+            : firstSegment!;
+    }
+
     private static string BuildDisplayName(string id, string file, FileVersionInfo info)
     {
         if (!string.IsNullOrWhiteSpace(info.FileDescription) &&

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -2178,6 +2178,31 @@ internal static class LocalizedText
     }
 }
 
+internal static class PluginVersionComparer
+{
+    public static PluginVersionComparison Compare(string? installed, string? latest, string? scheme)
+    {
+        if (string.IsNullOrWhiteSpace(installed) || string.IsNullOrWhiteSpace(latest))
+        {
+            return PluginVersionComparison.Unknown;
+        }
+
+        if (string.Equals(installed!.Trim(), latest!.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            return PluginVersionComparison.Current;
+        }
+
+        var normalized = (scheme ?? "fileversion").Trim().ToLowerInvariant();
+        if (normalized == "opaque")
+        {
+            return PluginVersionComparison.Different;
+        }
+
+        int comparison = VersionComparer.Compare(latest, installed);
+        return comparison > 0 ? PluginVersionComparison.UpdateAvailable : comparison == 0 ? PluginVersionComparison.Current : PluginVersionComparison.Different;
+    }
+}
+
 internal enum PluginVersionComparison { Unknown, Current, UpdateAvailable, Different }
 internal enum PluginUpdateStatus { Other, UpdateAvailable, NotInCatalog, CatalogError }
 

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -118,6 +118,7 @@ public static class EntryPoint
     private static DialogResult ShowDialog(Form dialog, IntPtr parent)
     {
         IWin32Window? owner = parent != IntPtr.Zero ? new WindowHandleWrapper(parent) : null;
+        ThemeHelper.CenterDialogOverOwner(dialog, owner);
         return owner is null ? dialog.ShowDialog() : dialog.ShowDialog(owner);
     }
 

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -2182,12 +2182,14 @@ internal static class PluginVersionComparer
 {
     public static PluginVersionComparison Compare(string? installed, string? latest, string? scheme)
     {
-        if (string.IsNullOrWhiteSpace(installed) || string.IsNullOrWhiteSpace(latest))
+        var installedVersion = InstalledPluginVersionFormatter.RemovePlatformSuffix(installed);
+        var latestVersion = InstalledPluginVersionFormatter.RemovePlatformSuffix(latest);
+        if (string.IsNullOrWhiteSpace(installedVersion) || string.IsNullOrWhiteSpace(latestVersion))
         {
             return PluginVersionComparison.Unknown;
         }
 
-        if (string.Equals(installed!.Trim(), latest!.Trim(), StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(installedVersion, latestVersion, StringComparison.OrdinalIgnoreCase))
         {
             return PluginVersionComparison.Current;
         }
@@ -2198,7 +2200,7 @@ internal static class PluginVersionComparer
             return PluginVersionComparison.Different;
         }
 
-        int comparison = VersionComparer.Compare(latest, installed);
+        int comparison = VersionComparer.Compare(latestVersion, installedVersion);
         return comparison > 0 ? PluginVersionComparison.UpdateAvailable : comparison == 0 ? PluginVersionComparison.Current : PluginVersionComparison.Different;
     }
 }
@@ -2212,12 +2214,37 @@ internal sealed class InstalledPlugin
     {
         Id = id;
         DisplayName = displayName;
-        VersionText = versionText;
+        VersionText = InstalledPluginVersionFormatter.WithCurrentPlatform(versionText);
     }
 
     public string Id { get; }
     public string DisplayName { get; }
     public string VersionText { get; }
+}
+
+internal static class InstalledPluginVersionFormatter
+{
+    private static readonly Regex PlatformSuffixRegex = new(@"\s\((x86|x64)\)$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    public static string WithCurrentPlatform(string version)
+    {
+        if (string.IsNullOrWhiteSpace(version) || PlatformSuffixRegex.IsMatch(version))
+        {
+            return version;
+        }
+
+        return version.TrimEnd() + (Environment.Is64BitProcess ? " (x64)" : " (x86)");
+    }
+
+    public static string RemovePlatformSuffix(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return string.Empty;
+        }
+
+        return PlatformSuffixRegex.Replace(version!.Trim(), string.Empty);
+    }
 }
 
 internal sealed class PluginUpdateRow

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Web.Script.Serialization;
 using System.Net;
 using System.Net.Http;
@@ -1702,55 +1703,11 @@ internal static class PluginCatalogSources
 
 internal static class InstalledPluginScanner
 {
-    private const string CurrentConfigurationRoot = @"Software\Open Salamander Samandarin\5.0-samandarin-0.11";
-    private const string PluginsKeyName = "Plugins";
-    private const string PluginNameValue = "Name";
-    private const string PluginDllValue = "DLL";
-    private const string PluginVersionValue = "Version";
-
     public static IEnumerable<InstalledPlugin> Scan()
     {
-        return TryScanConfiguredPlugins(out var configuredPlugins)
+        return PluginConfigurationReader.TryReadConfiguredPlugins(out var configuredPlugins)
             ? configuredPlugins
             : ScanPluginDirectory();
-    }
-
-    private static bool TryScanConfiguredPlugins(out IReadOnlyList<InstalledPlugin> plugins)
-    {
-        var configuredPlugins = new List<InstalledPlugin>();
-        using var pluginsKey = Registry.CurrentUser.OpenSubKey(CurrentConfigurationRoot + @"\" + PluginsKeyName);
-        if (pluginsKey is null)
-        {
-            plugins = configuredPlugins;
-            return false;
-        }
-
-        foreach (var subKeyName in pluginsKey.GetSubKeyNames().OrderBy(ParsePluginOrder))
-        {
-            using var pluginKey = pluginsKey.OpenSubKey(subKeyName);
-            if (pluginKey is null)
-            {
-                continue;
-            }
-
-            var dllName = ReadString(pluginKey, PluginDllValue);
-            if (string.IsNullOrWhiteSpace(dllName))
-            {
-                continue;
-            }
-
-            var id = BuildIdFromRegisteredDll(dllName);
-            var displayName = ReadString(pluginKey, PluginNameValue);
-            if (string.IsNullOrWhiteSpace(displayName))
-            {
-                displayName = id;
-            }
-
-            configuredPlugins.Add(new InstalledPlugin(id, displayName!, ReadString(pluginKey, PluginVersionValue) ?? string.Empty));
-        }
-
-        plugins = configuredPlugins;
-        return true;
     }
 
     private static IEnumerable<InstalledPlugin> ScanPluginDirectory()
@@ -1783,25 +1740,6 @@ internal static class InstalledPluginScanner
         }
     }
 
-    private static string? ReadString(RegistryKey key, string name) => key.GetValue(name) as string;
-
-    private static int ParsePluginOrder(string subKeyName) => int.TryParse(subKeyName, NumberStyles.Integer, CultureInfo.InvariantCulture, out var order) ? order : int.MaxValue;
-
-    private static string BuildIdFromRegisteredDll(string dllName)
-    {
-        var normalized = dllName.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var fileName = Path.GetFileNameWithoutExtension(normalized);
-        if (Path.IsPathRooted(normalized))
-        {
-            return string.IsNullOrWhiteSpace(fileName) ? normalized : fileName!;
-        }
-
-        var firstSegment = normalized.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
-        return string.IsNullOrWhiteSpace(firstSegment)
-            ? (string.IsNullOrWhiteSpace(fileName) ? normalized : fileName!)
-            : firstSegment!;
-    }
-
     private static string BuildDisplayName(string id, string file, FileVersionInfo info)
     {
         if (!string.IsNullOrWhiteSpace(info.FileDescription) &&
@@ -1830,28 +1768,322 @@ internal static class InstalledPluginScanner
     }
 }
 
-internal static class PluginVersionComparer
+internal static class PluginConfigurationReader
 {
-    public static PluginVersionComparison Compare(string? installed, string? latest, string? scheme)
+    private const string CurrentConfigurationRoot = @"Software\Open Salamander Samandarin\5.0-samandarin-0.11";
+    private const string PluginsKeyName = "Plugins";
+    private const string PluginNameValue = "Name";
+    private const string PluginDllValue = "DLL";
+    private const string PluginVersionValue = "Version";
+    private const string ConfigurationSection = "Configuration";
+    private const string StorageTypeKey = "StorageType";
+    private const string RegFilePathKey = "RegFilePath";
+    private const string RegFileStorageType = "RegFile";
+    private const string ConfigStorageFileName = "configstorage.ini";
+    private const string DefaultRegFileName = "config.reg";
+
+    private static readonly Regex RegFilePluginSectionRegex = new(
+        @"^HKEY_CURRENT_USER\\" + Regex.Escape(CurrentConfigurationRoot).Replace(@"\\", @"\\") + @"\\" + PluginsKeyName + @"\\([^\\]+)$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    public static bool TryReadConfiguredPlugins(out IReadOnlyList<InstalledPlugin> plugins)
     {
-        if (string.IsNullOrWhiteSpace(installed) || string.IsNullOrWhiteSpace(latest))
+        if (TryGetActiveRegFilePath(out var regFilePath))
         {
-            return PluginVersionComparison.Unknown;
+            return TryReadRegFilePlugins(regFilePath, out plugins);
         }
 
-        if (string.Equals(installed!.Trim(), latest!.Trim(), StringComparison.OrdinalIgnoreCase))
+        return TryReadRegistryPlugins(out plugins);
+    }
+
+    private static bool TryGetActiveRegFilePath(out string regFilePath)
+    {
+        regFilePath = string.Empty;
+        var executableDirectory = GetExecutableDirectory();
+        if (string.IsNullOrWhiteSpace(executableDirectory))
         {
-            return PluginVersionComparison.Current;
+            return false;
         }
 
-        var normalized = (scheme ?? "fileversion").Trim().ToLowerInvariant();
-        if (normalized == "opaque")
+        var bootstrapPath = Path.Combine(executableDirectory!, ConfigStorageFileName);
+        if (File.Exists(bootstrapPath))
         {
-            return PluginVersionComparison.Different;
+            var storageType = ReadIniValue(bootstrapPath, ConfigurationSection, StorageTypeKey);
+            if (string.Equals(storageType, RegFileStorageType, StringComparison.OrdinalIgnoreCase))
+            {
+                regFilePath = ReadIniValue(bootstrapPath, ConfigurationSection, RegFilePathKey) ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(regFilePath))
+                {
+                    regFilePath = Path.Combine(executableDirectory!, DefaultRegFileName);
+                }
+                else if (!Path.IsPathRooted(regFilePath))
+                {
+                    regFilePath = Path.GetFullPath(Path.Combine(executableDirectory!, regFilePath));
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
-        int comparison = VersionComparer.Compare(latest, installed);
-        return comparison > 0 ? PluginVersionComparison.UpdateAvailable : comparison == 0 ? PluginVersionComparison.Current : PluginVersionComparison.Different;
+        var defaultRegFilePath = Path.Combine(executableDirectory!, DefaultRegFileName);
+        if (File.Exists(defaultRegFilePath))
+        {
+            regFilePath = defaultRegFilePath;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadRegistryPlugins(out IReadOnlyList<InstalledPlugin> plugins)
+    {
+        var configuredPlugins = new List<InstalledPlugin>();
+        using var pluginsKey = Registry.CurrentUser.OpenSubKey(CurrentConfigurationRoot + @"\" + PluginsKeyName);
+        if (pluginsKey is null)
+        {
+            plugins = configuredPlugins;
+            return false;
+        }
+
+        foreach (var subKeyName in pluginsKey.GetSubKeyNames().OrderBy(ParsePluginOrder))
+        {
+            using var pluginKey = pluginsKey.OpenSubKey(subKeyName);
+            if (pluginKey is null)
+            {
+                continue;
+            }
+
+            var dllName = ReadString(pluginKey, PluginDllValue);
+            if (string.IsNullOrWhiteSpace(dllName))
+            {
+                continue;
+            }
+
+            configuredPlugins.Add(BuildInstalledPlugin(dllName!, ReadString(pluginKey, PluginNameValue), ReadString(pluginKey, PluginVersionValue)));
+        }
+
+        plugins = configuredPlugins;
+        return true;
+    }
+
+    private static bool TryReadRegFilePlugins(string regFilePath, out IReadOnlyList<InstalledPlugin> plugins)
+    {
+        var configuredPluginsByKey = new Dictionary<string, PluginConfigurationEntry>(StringComparer.OrdinalIgnoreCase);
+        if (!File.Exists(regFilePath))
+        {
+            plugins = Array.Empty<InstalledPlugin>();
+            return true;
+        }
+
+        string? currentPluginKey = null;
+        foreach (var rawLine in File.ReadLines(regFilePath, DetectEncoding(regFilePath)))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith(";", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("[", StringComparison.Ordinal) && line.EndsWith("]", StringComparison.Ordinal))
+            {
+                var section = line.Substring(1, line.Length - 2);
+                var match = RegFilePluginSectionRegex.Match(section);
+                currentPluginKey = match.Success ? match.Groups[1].Value : null;
+                if (currentPluginKey is not null && !configuredPluginsByKey.ContainsKey(currentPluginKey))
+                {
+                    configuredPluginsByKey.Add(currentPluginKey, new PluginConfigurationEntry());
+                }
+
+                continue;
+            }
+
+            if (currentPluginKey is null || !TryParseRegFileStringValue(line, out var valueName, out var valueText))
+            {
+                continue;
+            }
+
+            var entry = configuredPluginsByKey[currentPluginKey];
+            if (string.Equals(valueName, PluginDllValue, StringComparison.OrdinalIgnoreCase))
+            {
+                entry.DllName = valueText;
+            }
+            else if (string.Equals(valueName, PluginNameValue, StringComparison.OrdinalIgnoreCase))
+            {
+                entry.Name = valueText;
+            }
+            else if (string.Equals(valueName, PluginVersionValue, StringComparison.OrdinalIgnoreCase))
+            {
+                entry.Version = valueText;
+            }
+        }
+
+        plugins = configuredPluginsByKey
+            .OrderBy(pair => ParsePluginOrder(pair.Key))
+            .Select(pair => pair.Value)
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.DllName))
+            .Select(entry => BuildInstalledPlugin(entry.DllName!, entry.Name, entry.Version))
+            .ToList();
+        return true;
+    }
+
+    private static InstalledPlugin BuildInstalledPlugin(string dllName, string? displayName, string? version)
+    {
+        var id = BuildIdFromRegisteredDll(dllName);
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = id;
+        }
+
+        return new InstalledPlugin(id, displayName!, version ?? string.Empty);
+    }
+
+    private static string? ReadString(RegistryKey key, string name) => key.GetValue(name) as string;
+
+    private static int ParsePluginOrder(string subKeyName) => int.TryParse(subKeyName, NumberStyles.Integer, CultureInfo.InvariantCulture, out var order) ? order : int.MaxValue;
+
+    private static string BuildIdFromRegisteredDll(string dllName)
+    {
+        var normalized = dllName.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var fileName = Path.GetFileNameWithoutExtension(normalized);
+        if (Path.IsPathRooted(normalized))
+        {
+            return string.IsNullOrWhiteSpace(fileName) ? normalized : fileName!;
+        }
+
+        var firstSegment = normalized.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        return string.IsNullOrWhiteSpace(firstSegment)
+            ? (string.IsNullOrWhiteSpace(fileName) ? normalized : fileName!)
+            : firstSegment!;
+    }
+
+    private static string? ReadIniValue(string filePath, string sectionName, string valueName)
+    {
+        var inSection = false;
+        foreach (var rawLine in File.ReadLines(filePath))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith(";", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("[", StringComparison.Ordinal) && line.EndsWith("]", StringComparison.Ordinal))
+            {
+                inSection = string.Equals(line.Substring(1, line.Length - 2), sectionName, StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inSection)
+            {
+                continue;
+            }
+
+            var equalsIndex = line.IndexOf('=');
+            if (equalsIndex < 0)
+            {
+                continue;
+            }
+
+            var key = line.Substring(0, equalsIndex).Trim();
+            if (string.Equals(key, valueName, StringComparison.OrdinalIgnoreCase))
+            {
+                return line.Substring(equalsIndex + 1).Trim().Trim('"');
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryParseRegFileStringValue(string line, out string valueName, out string valueText)
+    {
+        valueName = string.Empty;
+        valueText = string.Empty;
+        if (!line.StartsWith("\"", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var nameEnd = FindClosingQuote(line, 1);
+        if (nameEnd < 0 || nameEnd + 1 >= line.Length || line[nameEnd + 1] != '=')
+        {
+            return false;
+        }
+
+        var data = line.Substring(nameEnd + 2).TrimStart();
+        if (!data.StartsWith("\"", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var dataEnd = FindClosingQuote(data, 1);
+        if (dataEnd < 0)
+        {
+            return false;
+        }
+
+        valueName = UnescapeRegFileString(line.Substring(1, nameEnd - 1));
+        valueText = UnescapeRegFileString(data.Substring(1, dataEnd - 1));
+        return true;
+    }
+
+    private static int FindClosingQuote(string text, int start)
+    {
+        var backslashCount = 0;
+        for (int i = start; i < text.Length; i++)
+        {
+            if (text[i] == '\\')
+            {
+                backslashCount++;
+                continue;
+            }
+
+            if (text[i] == '"' && backslashCount % 2 == 0)
+            {
+                return i;
+            }
+
+            backslashCount = 0;
+        }
+
+        return -1;
+    }
+
+    private static string UnescapeRegFileString(string text) => text.Replace("\\\\", "\\").Replace("\\\"", "\"");
+
+    private static Encoding DetectEncoding(string filePath)
+    {
+        var bom = new byte[3];
+        using (var stream = File.OpenRead(filePath))
+        {
+            _ = stream.Read(bom, 0, bom.Length);
+        }
+
+        if (bom[0] == 0xFF && bom[1] == 0xFE)
+        {
+            return Encoding.Unicode;
+        }
+
+        if (bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF)
+        {
+            return Encoding.UTF8;
+        }
+
+        return Encoding.Default;
+    }
+
+    private static string? GetExecutableDirectory()
+    {
+        var executablePath = Application.ExecutablePath;
+        return string.IsNullOrWhiteSpace(executablePath) ? null : Path.GetDirectoryName(executablePath);
+    }
+
+    private sealed class PluginConfigurationEntry
+    {
+        public string? Name { get; set; }
+        public string? DllName { get; set; }
+        public string? Version { get; set; }
     }
 }
 

--- a/src/plugins/samandarin/managed/ThemeHelper.cs
+++ b/src/plugins/samandarin/managed/ThemeHelper.cs
@@ -71,6 +71,30 @@ internal static class ThemeHelper
         s_cachedPalette = null;
     }
 
+    public static void CenterDialogOverOwner(Form dialog, IWin32Window? owner)
+    {
+        if (owner is null || owner.Handle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        dialog.StartPosition = FormStartPosition.Manual;
+        dialog.Shown += (_, _) =>
+        {
+            if (!NativeMethods.TryGetWindowRectangle(owner.Handle, out var ownerBounds))
+            {
+                return;
+            }
+
+            var workingArea = Screen.FromHandle(owner.Handle).WorkingArea;
+            int x = ownerBounds.Left + (ownerBounds.Width - dialog.Width) / 2;
+            int y = ownerBounds.Top + (ownerBounds.Height - dialog.Height) / 2;
+            x = Math.Max(workingArea.Left, Math.Min(x, workingArea.Right - dialog.Width));
+            y = Math.Max(workingArea.Top, Math.Min(y, workingArea.Bottom - dialog.Height));
+            dialog.Location = new Point(x, y);
+        };
+    }
+
     public static DialogResult ShowMessageBox(IWin32Window? owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon)
     {
         if (!TryGetPalette(out _))
@@ -81,7 +105,7 @@ internal static class ThemeHelper
         using var dialog = new Form
         {
             Text = caption,
-            StartPosition = owner is null ? FormStartPosition.CenterScreen : FormStartPosition.CenterParent,
+            StartPosition = owner is null ? FormStartPosition.CenterScreen : FormStartPosition.Manual,
             FormBorderStyle = FormBorderStyle.FixedDialog,
             MaximizeBox = false,
             MinimizeBox = false,
@@ -182,6 +206,7 @@ internal static class ThemeHelper
 
         dialog.Controls.Add(layout);
         ApplyTheme(dialog);
+        CenterDialogOverOwner(dialog, owner);
 
         var ownerWindow = owner;
         ownerWindow ??= Form.ActiveForm;
@@ -616,6 +641,23 @@ internal static class ThemeHelper
         private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
         private const int DWMWA_BORDER_COLOR = 34;
 
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RECT
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool IsIconic(IntPtr hwnd);
+
         [DllImport("Samandarin.Spl", CallingConvention = CallingConvention.StdCall)]
         public static extern uint Samandarin_GetCurrentColor(int color);
 
@@ -630,6 +672,18 @@ internal static class ThemeHelper
 
         [DllImport("dwmapi.dll", PreserveSig = true)]
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+
+        public static bool TryGetWindowRectangle(IntPtr handle, out Rectangle bounds)
+        {
+            bounds = Rectangle.Empty;
+            if (handle == IntPtr.Zero || IsIconic(handle) || !GetWindowRect(handle, out var rect))
+            {
+                return false;
+            }
+
+            bounds = Rectangle.FromLTRB(rect.Left, rect.Top, rect.Right, rect.Bottom);
+            return bounds.Width > 0 && bounds.Height > 0;
+        }
 
         public static void SetDarkModeEnabled(bool enabled)
         {

--- a/src/plugins/samandarin/managed_bridge.cpp
+++ b/src/plugins/samandarin/managed_bridge.cpp
@@ -23,6 +23,28 @@ const wchar_t* const kManagedType = L"OpenSalamander.Samandarin.EntryPoint";
 const wchar_t* const kManagedMethod = L"Dispatch";
 const wchar_t* const kPluginCaption = L"Samandarin Update Notifier";
 
+HWND ResolveOwnerWindow(HWND parent)
+{
+    HWND foreground = GetForegroundWindow();
+    if (foreground != nullptr)
+    {
+        HWND root = GetAncestor(foreground, GA_ROOT);
+        if (root != nullptr)
+        {
+            foreground = root;
+        }
+
+        DWORD windowProcessId = 0;
+        GetWindowThreadProcessId(foreground, &windowProcessId);
+        if (windowProcessId == GetCurrentProcessId() && IsWindowVisible(foreground) && !IsIconic(foreground))
+        {
+            return foreground;
+        }
+    }
+
+    return parent;
+}
+
 std::wstring BuildArgument(const wchar_t* command, HWND parent, const wchar_t* payload)
 {
     std::wstring argument = command;
@@ -49,15 +71,16 @@ bool ExecuteCommand(const wchar_t* command, HWND parent, const wchar_t* payload)
         return false;
     }
 
+    HWND owner = ResolveOwnerWindow(parent);
     DWORD returnValue = 0;
-    std::wstring argument = BuildArgument(command, parent, payload);
+    std::wstring argument = BuildArgument(command, owner, payload);
     HRESULT hr = gRuntimeHost->ExecuteInDefaultAppDomain(gAssemblyPath.c_str(), kManagedType, kManagedMethod,
                                                          argument.c_str(), &returnValue);
     if (FAILED(hr))
     {
         wchar_t message[256];
         StringCchPrintfW(message, _countof(message), L"Failed to execute managed command '%s' (0x%08X).", command, hr);
-        MessageBoxW(parent, message, kPluginCaption, MB_ICONERROR | MB_OK);
+        MessageBoxW(owner, message, kPluginCaption, MB_ICONERROR | MB_OK);
         return false;
     }
 
@@ -66,7 +89,7 @@ bool ExecuteCommand(const wchar_t* command, HWND parent, const wchar_t* payload)
 
 void ShowLoadError(HWND parent, const wchar_t* text)
 {
-    MessageBoxW(parent, text, kPluginCaption, MB_ICONERROR | MB_OK);
+    MessageBoxW(ResolveOwnerWindow(parent), text, kPluginCaption, MB_ICONERROR | MB_OK);
 }
 
 std::wstring BuildCurrentVersion()

--- a/translations/chinesesimplified/samandarin.slt
+++ b/translations/chinesesimplified/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\chinesesimplified\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,2052

--- a/translations/czech/samandarin.slt
+++ b/translations/czech/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\czech\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,1029

--- a/translations/dutch/samandarin.slt
+++ b/translations/dutch/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\dutch\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,1043

--- a/translations/french/samandarin.slt
+++ b/translations/french/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\french\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,1036

--- a/translations/german/samandarin.slt
+++ b/translations/german/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\german\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,1031

--- a/translations/hungarian/samandarin.slt
+++ b/translations/hungarian/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\hungarian\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,1038

--- a/translations/romanian/samandarin.slt
+++ b/translations/romanian/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\romanian\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,1048

--- a/translations/russian/samandarin.slt
+++ b/translations/russian/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\russian\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,1049

--- a/translations/slovak/samandarin.slt
+++ b/translations/slovak/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\slovak\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,1051

--- a/translations/spanish/samandarin.slt
+++ b/translations/spanish/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\spanish\samandarin\samandarin.atp"
-TEXTVERSION,"0.4 (x64)"
-VERSION,"0,4,0,193"
+TEXTVERSION,"0.5 (x64)"
+VERSION,"0,5,0,193"
 
 [TRANSLATION]
 LANGID,3082


### PR DESCRIPTION
### Motivation
- The plugin list shown by Samandarin was derived by scanning the plugins folder, which can include unregistered files and miss plugins registered from other locations; the UI must reflect what the plugin manager / configuration actually registers. 

### Description
- Replace folder-only discovery with a registry-backed scan that reads the configured plugin list from the current Open Salamander configuration root and uses that as the authoritative installed-plugins list. 
- Preserve the original recursive `*.spl` directory scan as a fallback when the configuration key is not available. 
- Add helpers to parse plugin registry entries (`ReadString`, `ParsePluginOrder`) and to derive a catalog ID from the registered DLL path (`BuildIdFromRegisteredDll`). 
- Add `using Microsoft.Win32;` and update `InstalledPluginScanner` in `src/plugins/samandarin/managed/EntryPoint.cs` to call `TryScanConfiguredPlugins(...)` before falling back to the directory scan.

### Testing
- Ran `git diff --check` to validate the working tree and whitespace; this check passed. 
- Attempted to run `dotnet build src/plugins/samandarin/managed/Samandarin.Managed.csproj --no-restore` but the environment lacks the `dotnet` SDK so the build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a542fbb769883299915ce599bc0a0d5)