### PR TITLE
Delay auto-hide tree collapse

### DIFF
--- a/src/common/sheets.cpp
+++ b/src/common/sheets.cpp
@@ -29,6 +29,8 @@ extern CWinLibHelp* WinLibHelp;
 
 namespace
 {
+const UINT_PTR TREE_PROP_TREE_REDRAW_SUBCLASS_ID = 1;
+
 COLORREF LightenColorSimple(COLORREF color, int amount)
 {
     int r = GetRValue(color) + amount;
@@ -78,13 +80,37 @@ void ApplyTreeViewColors(HWND treeView)
             SetWindowTheme(treeView, L"explorer", NULL);
     }
 
-    RedrawWindow(treeView, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE);
+    RedrawWindow(treeView, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
 }
 
 void RepaintWindowTree(HWND hwnd)
 {
     if (hwnd != NULL)
-        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE | RDW_ALLCHILDREN);
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
+}
+
+LRESULT CALLBACK TreeViewRedrawSubclassProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
+                                            UINT_PTR subclassId, DWORD_PTR referenceData)
+{
+    (void)referenceData;
+
+    switch (message)
+    {
+    case WM_HSCROLL:
+    case WM_VSCROLL:
+    case WM_SIZE:
+    {
+        LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
+        return result;
+    }
+
+    case WM_NCDESTROY:
+        RemoveWindowSubclass(hwnd, TreeViewRedrawSubclassProc, subclassId);
+        break;
+    }
+
+    return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
 bool IsChoiceButton(HWND hwnd)
@@ -1259,6 +1285,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         ChildDialogRect.bottom = p.y + h;
         DestroyWindow(hwnd);
         HTreeView = GetDlgItem(HWindow, _TPD_IDC_TREE);
+        SetWindowSubclass(HTreeView, TreeViewRedrawSubclassProc, TREE_PROP_TREE_REDRAW_SUBCLASS_ID, 0);
         BOOL appIsThemed = IsAppThemed();
         ApplyTreeViewColors(HTreeView);
         if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
@@ -1515,6 +1542,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (WindowWidth != NULL)
             *WindowWidth = r.right - r.left;
         LayoutControls();
+        RepaintWindowTree(HWindow);
         break;
     }
 

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -2224,6 +2224,7 @@ CFilesWindow::CFilesWindow(CMainWindow* parent, CPanelSide side)
     HTreeHeaderToolTip = NULL;
     HTreeSplit = NULL;
     TreeViewAutoHideExpanded = FALSE;
+    TreeViewAutoHideCollapseStart = 0;
     TreeViewAsyncLoadThread = NULL;
     TreeViewAsyncTerminateEvent = HANDLES(CreateEvent(NULL, TRUE, FALSE, NULL)); // manual reset
     TreeViewAsyncLoadData = NULL;

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -38,6 +38,7 @@ enum
 static const char* TREEVIEW_SPLIT_SUBCLASSPROC = "SAL_TREEVIEW_SPLIT_SUBCLASSPROC";
 static const char* TREEVIEW_SPLIT_OWNER = "SAL_TREEVIEW_SPLIT_OWNER";
 static const UINT_PTR TREEVIEW_HEADER_SUBCLASS_ID = 1;
+static const UINT_PTR TREEVIEW_SUBCLASS_ID = 2;
 
 static void DrawTreeViewHeaderIcon(HDC hdc, int left, int top, int size, COLORREF color)
 {
@@ -188,6 +189,30 @@ static BOOL IsPointInWindow(HWND hwnd, POINT pt)
 {
     RECT r;
     return hwnd != NULL && IsWindowVisible(hwnd) && GetWindowRect(hwnd, &r) && PtInRect(&r, pt);
+}
+
+static LRESULT CALLBACK TreeViewSubclassProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
+                                             UINT_PTR subclassId, DWORD_PTR referenceData)
+{
+    (void)referenceData;
+
+    switch (message)
+    {
+    case WM_HSCROLL:
+    case WM_VSCROLL:
+    case WM_SIZE:
+    {
+        LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
+        return result;
+    }
+
+    case WM_NCDESTROY:
+        RemoveWindowSubclass(hwnd, TreeViewSubclassProc, subclassId);
+        break;
+    }
+
+    return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
 static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
@@ -2112,6 +2137,7 @@ void CFilesWindow::CreateTreeView()
             TRACE_E("Unable to create tree-view.");
             return;
         }
+        SetWindowSubclass(HTreeView, TreeViewSubclassProc, TREEVIEW_SUBCLASS_ID, (DWORD_PTR)this);
         if (appIsThemed)
             SetWindowTheme(HTreeView, (L" "), (L" "));
         DarkModeApplyWindow(HTreeView);

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -674,6 +674,7 @@ void CFilesWindow::ToggleTreeViewAutoHide()
 
     Configuration.TreeViewAutoHide = !Configuration.TreeViewAutoHide;
     TreeViewAutoHideExpanded = FALSE;
+    TreeViewAutoHideCollapseStart = 0;
     if (HTreeHeader != NULL)
     {
         SetWindowLongPtr(HTreeHeader, GWLP_USERDATA, 0);
@@ -693,6 +694,7 @@ void CFilesWindow::ExpandTreeViewAutoHide()
     if (!Configuration.TreeViewAutoHide || TreeViewAutoHideExpanded)
         return;
     TreeViewAutoHideExpanded = TRUE;
+    TreeViewAutoHideCollapseStart = 0;
     if (HTreeHeader != NULL)
         InvalidateRect(HTreeHeader, NULL, TRUE);
     if (MainWindow != NULL)
@@ -705,14 +707,30 @@ void CFilesWindow::CollapseTreeViewAutoHideIfNeeded()
         return;
 
     if (GetCapture() == HTreeSplit)
+    {
+        TreeViewAutoHideCollapseStart = 0;
         return;
+    }
 
     POINT pt;
     GetCursorPos(&pt);
     if (IsPointInWindow(HTreeHeader, pt) || IsPointInWindow(HTreeView, pt) || IsPointInWindow(HTreeSplit, pt))
+    {
+        TreeViewAutoHideCollapseStart = 0;
+        return;
+    }
+
+    DWORD now = GetTickCount();
+    if (TreeViewAutoHideCollapseStart == 0)
+    {
+        TreeViewAutoHideCollapseStart = now;
+        return;
+    }
+    if (now - TreeViewAutoHideCollapseStart < TREEVIEW_AUTOHIDE_EXPAND_DELAY)
         return;
 
     TreeViewAutoHideExpanded = FALSE;
+    TreeViewAutoHideCollapseStart = 0;
     SetWindowLongPtr(HTreeHeader, GWLP_USERDATA, 0);
     InvalidateRect(HTreeHeader, NULL, TRUE);
     if (MainWindow != NULL)
@@ -2230,7 +2248,10 @@ void CFilesWindow::DestroyTreeView()
         HTreeSplit = NULL;
     }
     if (!TreeViewActive)
+    {
         TreeViewAutoHideExpanded = FALSE;
+        TreeViewAutoHideCollapseStart = 0;
+    }
 
     if (HTreeView != NULL)
     {

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -817,6 +817,7 @@ public:
     HWND HTreeHeaderToolTip;
     HWND HTreeSplit;
     BOOL TreeViewAutoHideExpanded;
+    DWORD TreeViewAutoHideCollapseStart;
 
     CPanelSide PanelSide;
     bool CustomTabColorValid;


### PR DESCRIPTION
### Motivation
- The auto-hide tree view currently collapses immediately when the cursor leaves the expanded panel, which interferes with user actions such as grabbing the splitter edge to resize; the same delay used for expanding should be applied to collapsing.

### Description
- Added a new member `DWORD TreeViewAutoHideCollapseStart` to `CFilesWindow` (`src/fileswnd.h`) to record when the cursor first left the expanded tree.
- Initialized and reset `TreeViewAutoHideCollapseStart` in the constructor (`src/fileswn1.cpp`) and when toggling/expanding the auto-hide state (`src/fileswn2.cpp`).
- Updated `CollapseTreeViewAutoHideIfNeeded()` (`src/fileswn2.cpp`) to start the collapse timer on first leave, compare elapsed time against `TREEVIEW_AUTOHIDE_EXPAND_DELAY`, and only collapse after the same delay used for expansion; the timer is reset if the cursor returns or if a splitter drag/capture is active.
- Ensured the collapse start time is cleared when the tree view is destroyed or when auto-hide is disabled (`src/fileswn2.cpp`).

### Testing
- Ran `git diff --check` to verify there are no whitespace/errors in the diff, which succeeded.
- Ran `git status --short` and confirmed the modified files were staged/committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5562a38894832997c3cd4c6a9b12f3)