### PR TITLE
TreeView: improve redraw on scroll/resize and convert auto-hide/width to per-panel state

### DIFF
--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -411,6 +411,8 @@ struct CConfiguration
     int DriveBarWidth;
     int TreeViewWidth;
     BOOL TreeViewAutoHide;
+    int DetachedTreeViewWidth;
+    BOOL DetachedTreeViewAutoHide;
     int GripsVisible;
 
     BOOL DetachedPanels;                    // TRUE = restore right side in a detached top-level window

--- a/src/common/sheets.cpp
+++ b/src/common/sheets.cpp
@@ -29,6 +29,8 @@ extern CWinLibHelp* WinLibHelp;
 
 namespace
 {
+const UINT_PTR TREE_PROP_TREE_REDRAW_SUBCLASS_ID = 1;
+
 COLORREF LightenColorSimple(COLORREF color, int amount)
 {
     int r = GetRValue(color) + amount;
@@ -78,13 +80,37 @@ void ApplyTreeViewColors(HWND treeView)
             SetWindowTheme(treeView, L"explorer", NULL);
     }
 
-    RedrawWindow(treeView, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE);
+    RedrawWindow(treeView, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
 }
 
 void RepaintWindowTree(HWND hwnd)
 {
     if (hwnd != NULL)
-        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE | RDW_ALLCHILDREN);
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_UPDATENOW);
+}
+
+LRESULT CALLBACK TreeViewRedrawSubclassProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
+                                            UINT_PTR subclassId, DWORD_PTR referenceData)
+{
+    (void)referenceData;
+
+    switch (message)
+    {
+    case WM_HSCROLL:
+    case WM_VSCROLL:
+    case WM_SIZE:
+    {
+        LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
+        return result;
+    }
+
+    case WM_NCDESTROY:
+        RemoveWindowSubclass(hwnd, TreeViewRedrawSubclassProc, subclassId);
+        break;
+    }
+
+    return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
 bool IsChoiceButton(HWND hwnd)
@@ -1259,6 +1285,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         ChildDialogRect.bottom = p.y + h;
         DestroyWindow(hwnd);
         HTreeView = GetDlgItem(HWindow, _TPD_IDC_TREE);
+        SetWindowSubclass(HTreeView, TreeViewRedrawSubclassProc, TREE_PROP_TREE_REDRAW_SUBCLASS_ID, 0);
         BOOL appIsThemed = IsAppThemed();
         ApplyTreeViewColors(HTreeView);
         if (WinLib_DarkMode_ShouldApplyDialogTree(HWindow))
@@ -1515,6 +1542,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (WindowWidth != NULL)
             *WindowWidth = r.right - r.left;
         LayoutControls();
+        RepaintWindowTree(HWindow);
         break;
     }
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -744,6 +744,8 @@ CConfiguration::CConfiguration()
     DriveBarWidth = 1; // dummy
     TreeViewWidth = 200;
     TreeViewAutoHide = FALSE;
+    DetachedTreeViewWidth = TreeViewWidth;
+    DetachedTreeViewAutoHide = TreeViewAutoHide;
 
     GripsVisible = TRUE;
     DetachedPanels = FALSE;

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -2224,6 +2224,9 @@ CFilesWindow::CFilesWindow(CMainWindow* parent, CPanelSide side)
     HTreeHeaderToolTip = NULL;
     HTreeSplit = NULL;
     TreeViewAutoHideExpanded = FALSE;
+    TreeViewAutoHideCollapseStart = 0;
+    TreeViewWidth = Configuration.TreeViewWidth;
+    TreeViewAutoHide = Configuration.TreeViewAutoHide;
     TreeViewAsyncLoadThread = NULL;
     TreeViewAsyncTerminateEvent = HANDLES(CreateEvent(NULL, TRUE, FALSE, NULL)); // manual reset
     TreeViewAsyncLoadData = NULL;

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -3268,6 +3268,8 @@ BOOL CFilesWindow::CommonRefresh(HWND parent, int suggestedTopIndex, const char*
         {
             Parent->EditWindowSetDirectory();
         }
+        if (Parent->DetachedPanels && IsRightPanel())
+            Parent->UpdateDetachedCommandLine();
     }
 
     //TRACE_I("read directory: begin");

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -698,6 +698,8 @@ void CFilesWindow::SetTreeViewWidth(int width)
     TreeViewWidth = width;
     if (MainWindow == NULL || !MainWindow->DetachedPanels || MainWindow->LeftPanel == this)
         Configuration.TreeViewWidth = width;
+    else if (MainWindow->RightPanel == this)
+        Configuration.DetachedTreeViewWidth = width;
 
     if (MainWindow != NULL)
         MainWindow->LayoutWindows();
@@ -711,6 +713,8 @@ void CFilesWindow::ToggleTreeViewAutoHide()
     TreeViewAutoHide = !TreeViewAutoHide;
     if (MainWindow == NULL || !MainWindow->DetachedPanels || MainWindow->LeftPanel == this)
         Configuration.TreeViewAutoHide = TreeViewAutoHide;
+    else if (MainWindow->RightPanel == this)
+        Configuration.DetachedTreeViewAutoHide = TreeViewAutoHide;
     TreeViewAutoHideExpanded = FALSE;
     TreeViewAutoHideCollapseStart = 0;
     if (HTreeHeader != NULL)

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -502,7 +502,12 @@ static LRESULT CALLBACK TreeViewSplitSubclassProc(HWND hwnd, UINT message, WPARA
         {
             POINT pt;
             GetCursorPos(&pt);
-            ScreenToClient(MainWindow->HWindow, &pt);
+            HWND hostWindow = MainWindow != NULL ? MainWindow->GetDetachedPanelWindow(panel->PanelSide) : NULL;
+            if (hostWindow == NULL && MainWindow != NULL)
+                hostWindow = MainWindow->HWindow;
+            if (hostWindow == NULL)
+                hostWindow = GetParent(hwnd);
+            ScreenToClient(hostWindow, &pt);
             panel->SetTreeViewWidth(pt.x - panel->TreeViewSplitOffset);
             return 0;
         }

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -38,6 +38,7 @@ enum
 static const char* TREEVIEW_SPLIT_SUBCLASSPROC = "SAL_TREEVIEW_SPLIT_SUBCLASSPROC";
 static const char* TREEVIEW_SPLIT_OWNER = "SAL_TREEVIEW_SPLIT_OWNER";
 static const UINT_PTR TREEVIEW_HEADER_SUBCLASS_ID = 1;
+static const UINT_PTR TREEVIEW_SUBCLASS_ID = 2;
 
 static void DrawTreeViewHeaderIcon(HDC hdc, int left, int top, int size, COLORREF color)
 {
@@ -122,17 +123,17 @@ static void UpdateTreeViewHeaderToolTip(CFilesWindow* panel)
     ti.cbSize = sizeof(ti);
     ti.hwnd = panel->HTreeHeader;
     ti.uId = 1;
-    if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
+    if (panel->TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
         SetRectEmpty(&ti.rect);
     else
         ti.rect = GetTreeViewHeaderCloseRect(panel->HTreeHeader);
     SendMessage(panel->HTreeHeaderToolTip, TTM_NEWTOOLRECT, 0, (LPARAM)&ti);
     ti.uId = 2;
-    if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
+    if (panel->TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
         SetRectEmpty(&ti.rect);
     else
         ti.rect = GetTreeViewHeaderPinRect(panel->HTreeHeader);
-    ti.lpszText = LoadStr(Configuration.TreeViewAutoHide ? IDS_TREEVIEW_PANEL_PIN : IDS_TREEVIEW_PANEL_AUTO_HIDE);
+    ti.lpszText = LoadStr(panel->TreeViewAutoHide ? IDS_TREEVIEW_PANEL_PIN : IDS_TREEVIEW_PANEL_AUTO_HIDE);
     SendMessage(panel->HTreeHeaderToolTip, TTM_UPDATETIPTEXT, 0, (LPARAM)&ti);
     SendMessage(panel->HTreeHeaderToolTip, TTM_NEWTOOLRECT, 0, (LPARAM)&ti);
 }
@@ -190,6 +191,30 @@ static BOOL IsPointInWindow(HWND hwnd, POINT pt)
     return hwnd != NULL && IsWindowVisible(hwnd) && GetWindowRect(hwnd, &r) && PtInRect(&r, pt);
 }
 
+static LRESULT CALLBACK TreeViewSubclassProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
+                                             UINT_PTR subclassId, DWORD_PTR referenceData)
+{
+    (void)referenceData;
+
+    switch (message)
+    {
+    case WM_HSCROLL:
+    case WM_VSCROLL:
+    case WM_SIZE:
+    {
+        LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
+        return result;
+    }
+
+    case WM_NCDESTROY:
+        RemoveWindowSubclass(hwnd, TreeViewSubclassProc, subclassId);
+        break;
+    }
+
+    return DefSubclassProc(hwnd, message, wParam, lParam);
+}
+
 static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
                                                    UINT_PTR subclassId, DWORD_PTR referenceData)
 {
@@ -222,7 +247,7 @@ static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPAR
 
     case WM_MOUSEMOVE:
     {
-        if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
+        if (panel->TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
         {
             LONG_PTR state = GetWindowLongPtr(hwnd, GWLP_USERDATA);
             if ((state & TREEVIEW_HEADER_AUTOHIDE_EXPAND_TIMER_SET) == 0)
@@ -264,7 +289,7 @@ static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPAR
         break;
 
     case WM_LBUTTONDOWN:
-        if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
+        if (panel->TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
         {
             KillTimer(hwnd, TREEVIEW_AUTOHIDE_EXPAND_TIMER);
             SetWindowLongPtr(hwnd, GWLP_USERDATA, 0);
@@ -275,7 +300,7 @@ static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPAR
 
     case WM_LBUTTONUP:
     {
-        if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
+        if (panel->TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
         {
             KillTimer(hwnd, TREEVIEW_AUTOHIDE_EXPAND_TIMER);
             SetWindowLongPtr(hwnd, GWLP_USERDATA, 0);
@@ -310,7 +335,7 @@ static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPAR
         FillRect(hdc, &r, background);
         COLORREF textColor = dark ? DarkModeGetDialogTextColor() : GetSysColor(COLOR_BTNTEXT);
 
-        if (Configuration.TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
+        if (panel->TreeViewAutoHide && !panel->TreeViewAutoHideExpanded)
         {
             int oldGraphicsMode = SetGraphicsMode(hdc, GM_ADVANCED);
             XFORM transform = {0, 1, -1, 0, (FLOAT)r.right, 0};
@@ -360,7 +385,7 @@ static LRESULT CALLBACK TreeViewHeaderSubclassProc(HWND hwnd, UINT message, WPAR
             SelectObject(hdc, oldPen);
             DeleteObject(closePen);
         }
-        DrawTreeViewHeaderPin(hdc, &pinRect, Configuration.TreeViewAutoHide,
+        DrawTreeViewHeaderPin(hdc, &pinRect, panel->TreeViewAutoHide,
                               (hot & TREEVIEW_HEADER_HOT_PIN) != 0 ? GetSysColor(COLOR_HIGHLIGHTTEXT) : textColor);
 
         int iconSize = min(16, max(0, r.bottom - r.top - 4));
@@ -555,14 +580,14 @@ CFilesWindow* CFilesWindow::GetTreeViewSourcePanel()
 
 int CFilesWindow::GetTreeViewWidth(int clientWidth)
 {
-    return ClampTreeViewWidth(clientWidth, Configuration.TreeViewWidth);
+    return ClampTreeViewWidth(clientWidth, TreeViewWidth);
 }
 
 int CFilesWindow::GetTreeViewReservedWidth(int clientWidth)
 {
     if (!IsTreeViewHost() || !TreeViewActive)
         return 0;
-    if (Configuration.TreeViewAutoHide)
+    if (TreeViewAutoHide)
         return GetTreeViewHeaderHeight();
     return GetTreeViewWidth(clientWidth) + TREEVIEW_SPLITTER_WIDTH;
 }
@@ -656,13 +681,18 @@ void CFilesWindow::UpdateTreeViewColors()
 
 void CFilesWindow::SetTreeViewWidth(int width)
 {
-    if (MainWindow != NULL && MainWindow->HWindow != NULL)
+    HWND hostWindow = MainWindow != NULL ? MainWindow->GetDetachedPanelWindow(PanelSide) : NULL;
+    if (hostWindow == NULL && MainWindow != NULL)
+        hostWindow = MainWindow->HWindow;
+    if (hostWindow != NULL)
     {
         RECT r;
-        GetClientRect(MainWindow->HWindow, &r);
+        GetClientRect(hostWindow, &r);
         width = ClampTreeViewWidth(r.right - r.left, width);
     }
-    Configuration.TreeViewWidth = width;
+    TreeViewWidth = width;
+    if (MainWindow == NULL || !MainWindow->DetachedPanels || MainWindow->LeftPanel == this)
+        Configuration.TreeViewWidth = width;
 
     if (MainWindow != NULL)
         MainWindow->LayoutWindows();
@@ -670,29 +700,36 @@ void CFilesWindow::SetTreeViewWidth(int width)
 
 void CFilesWindow::ToggleTreeViewAutoHide()
 {
-    double visibleLeftRatio = MainWindow != NULL ? MainWindow->GetVisibleLeftPanelRatio() : 0.5;
+    BOOL detachedRightTree = MainWindow != NULL && MainWindow->DetachedPanels && MainWindow->RightPanel == this;
+    double visibleLeftRatio = MainWindow != NULL && !detachedRightTree ? MainWindow->GetVisibleLeftPanelRatio() : 0.5;
 
-    Configuration.TreeViewAutoHide = !Configuration.TreeViewAutoHide;
+    TreeViewAutoHide = !TreeViewAutoHide;
+    if (MainWindow == NULL || !MainWindow->DetachedPanels || MainWindow->LeftPanel == this)
+        Configuration.TreeViewAutoHide = TreeViewAutoHide;
     TreeViewAutoHideExpanded = FALSE;
+    TreeViewAutoHideCollapseStart = 0;
     if (HTreeHeader != NULL)
     {
         SetWindowLongPtr(HTreeHeader, GWLP_USERDATA, 0);
-        if (Configuration.TreeViewAutoHide)
+        if (TreeViewAutoHide)
             SetTimer(HTreeHeader, TREEVIEW_AUTOHIDE_TIMER, 50, NULL);
         else
             KillTimer(HTreeHeader, TREEVIEW_AUTOHIDE_TIMER);
         UpdateTreeViewHeaderToolTip(this);
         InvalidateRect(HTreeHeader, NULL, TRUE);
     }
-    if (MainWindow != NULL)
+    if (MainWindow != NULL && detachedRightTree)
+        MainWindow->LayoutWindows();
+    else if (MainWindow != NULL)
         MainWindow->RestoreVisiblePanelRatio(visibleLeftRatio);
 }
 
 void CFilesWindow::ExpandTreeViewAutoHide()
 {
-    if (!Configuration.TreeViewAutoHide || TreeViewAutoHideExpanded)
+    if (!TreeViewAutoHide || TreeViewAutoHideExpanded)
         return;
     TreeViewAutoHideExpanded = TRUE;
+    TreeViewAutoHideCollapseStart = 0;
     if (HTreeHeader != NULL)
         InvalidateRect(HTreeHeader, NULL, TRUE);
     if (MainWindow != NULL)
@@ -701,18 +738,34 @@ void CFilesWindow::ExpandTreeViewAutoHide()
 
 void CFilesWindow::CollapseTreeViewAutoHideIfNeeded()
 {
-    if (!Configuration.TreeViewAutoHide || !TreeViewAutoHideExpanded)
+    if (!TreeViewAutoHide || !TreeViewAutoHideExpanded)
         return;
 
     if (GetCapture() == HTreeSplit)
+    {
+        TreeViewAutoHideCollapseStart = 0;
         return;
+    }
 
     POINT pt;
     GetCursorPos(&pt);
     if (IsPointInWindow(HTreeHeader, pt) || IsPointInWindow(HTreeView, pt) || IsPointInWindow(HTreeSplit, pt))
+    {
+        TreeViewAutoHideCollapseStart = 0;
+        return;
+    }
+
+    DWORD now = GetTickCount();
+    if (TreeViewAutoHideCollapseStart == 0)
+    {
+        TreeViewAutoHideCollapseStart = now;
+        return;
+    }
+    if (now - TreeViewAutoHideCollapseStart < TREEVIEW_AUTOHIDE_EXPAND_DELAY)
         return;
 
     TreeViewAutoHideExpanded = FALSE;
+    TreeViewAutoHideCollapseStart = 0;
     SetWindowLongPtr(HTreeHeader, GWLP_USERDATA, 0);
     InvalidateRect(HTreeHeader, NULL, TRUE);
     if (MainWindow != NULL)
@@ -2094,6 +2147,7 @@ void CFilesWindow::CreateTreeView()
             TRACE_E("Unable to create tree-view.");
             return;
         }
+        SetWindowSubclass(HTreeView, TreeViewSubclassProc, TREEVIEW_SUBCLASS_ID, (DWORD_PTR)this);
         if (appIsThemed)
             SetWindowTheme(HTreeView, (L" "), (L" "));
         DarkModeApplyWindow(HTreeView);
@@ -2150,12 +2204,12 @@ void CFilesWindow::CreateTreeView()
             SendMessage(HTreeHeaderToolTip, TTM_ADDTOOL, 0, (LPARAM)&ti);
             ti.uId = 2;
             ti.rect = GetTreeViewHeaderPinRect(HTreeHeader);
-            ti.lpszText = LoadStr(Configuration.TreeViewAutoHide ? IDS_TREEVIEW_PANEL_PIN : IDS_TREEVIEW_PANEL_AUTO_HIDE);
+            ti.lpszText = LoadStr(TreeViewAutoHide ? IDS_TREEVIEW_PANEL_PIN : IDS_TREEVIEW_PANEL_AUTO_HIDE);
             SendMessage(HTreeHeaderToolTip, TTM_ADDTOOL, 0, (LPARAM)&ti);
         }
     }
 
-    if (Configuration.TreeViewAutoHide && HTreeHeader != NULL)
+    if (TreeViewAutoHide && HTreeHeader != NULL)
         SetTimer(HTreeHeader, TREEVIEW_AUTOHIDE_TIMER, 50, NULL);
 
     if (HTreeSplit == NULL)
@@ -2230,7 +2284,10 @@ void CFilesWindow::DestroyTreeView()
         HTreeSplit = NULL;
     }
     if (!TreeViewActive)
+    {
         TreeViewAutoHideExpanded = FALSE;
+        TreeViewAutoHideCollapseStart = 0;
+    }
 
     if (HTreeView != NULL)
     {
@@ -2259,14 +2316,14 @@ void CFilesWindow::UpdateTreeView(BOOL active)
 
     if (HTreeView != NULL)
     {
-        ShowWindow(HTreeView, TreeViewActive && (!Configuration.TreeViewAutoHide || TreeViewAutoHideExpanded) ? SW_SHOW : SW_HIDE);
+        ShowWindow(HTreeView, TreeViewActive && (!TreeViewAutoHide || TreeViewAutoHideExpanded) ? SW_SHOW : SW_HIDE);
         if (TreeViewActive)
             RefreshTreeView();
     }
     if (HTreeHeader != NULL)
         ShowWindow(HTreeHeader, TreeViewActive ? SW_SHOW : SW_HIDE);
     if (HTreeSplit != NULL)
-        ShowWindow(HTreeSplit, TreeViewActive && (!Configuration.TreeViewAutoHide || TreeViewAutoHideExpanded) ? SW_SHOW : SW_HIDE);
+        ShowWindow(HTreeSplit, TreeViewActive && (!TreeViewAutoHide || TreeViewAutoHideExpanded) ? SW_SHOW : SW_HIDE);
 
     if (MainWindow != NULL)
         MainWindow->LayoutWindows();

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -817,6 +817,9 @@ public:
     HWND HTreeHeaderToolTip;
     HWND HTreeSplit;
     BOOL TreeViewAutoHideExpanded;
+    DWORD TreeViewAutoHideCollapseStart;
+    int TreeViewWidth;
+    BOOL TreeViewAutoHide;
 
     CPanelSide PanelSide;
     bool CustomTabColorValid;

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <shlwapi.h>
-#include <uxtheme.h>
 #undef PathIsPrefix
 
 #include "tooltip.h"
@@ -1847,54 +1846,6 @@ static BOOL InsertDetachedBand(HWND rebar, HWND child, int bandID, int index, in
     return SendMessage(rebar, RB_INSERTBAND, (WPARAM)index, (LPARAM)&rbbi) != 0;
 }
 
-static void ApplyDetachedRebarVisuals(HWND rebar)
-{
-    if (rebar == NULL)
-        return;
-
-    if (DarkModeShouldUseDarkColors())
-    {
-        SetWindowTheme(rebar, nullptr, nullptr);
-        SetWindowTheme(rebar, L"DarkMode_Explorer", nullptr);
-        SendMessage(rebar, RB_SETBKCOLOR, 0, (LPARAM)DarkModeGetColors().background);
-        SendMessage(rebar, RB_SETTEXTCOLOR, 0, (LPARAM)DarkModeGetColors().readableText);
-
-        COLORSCHEME colorScheme = {sizeof(COLORSCHEME)};
-        colorScheme.clrBtnHighlight = RGB(0x38, 0x38, 0x38);
-        colorScheme.clrBtnShadow = RGB(0x38, 0x38, 0x38);
-        SendMessage(rebar, RB_SETCOLORSCHEME, 0, (LPARAM)&colorScheme);
-    }
-    else
-    {
-        SetWindowTheme(rebar, (L" "), (L" "));
-        SendMessage(rebar, RB_SETBKCOLOR, 0, (LPARAM)CLR_DEFAULT);
-        SendMessage(rebar, RB_SETTEXTCOLOR, 0, (LPARAM)CLR_DEFAULT);
-
-        COLORSCHEME colorScheme = {sizeof(COLORSCHEME)};
-        colorScheme.clrBtnHighlight = GetSysColor(COLOR_BTNHILIGHT);
-        colorScheme.clrBtnShadow = GetSysColor(COLOR_BTNSHADOW);
-        SendMessage(rebar, RB_SETCOLORSCHEME, 0, (LPARAM)&colorScheme);
-    }
-
-    DarkModeApplyWindow(rebar);
-    DarkModeApplyRebarSeparators(rebar);
-
-    const int bandCount = (int)SendMessage(rebar, RB_GETBANDCOUNT, 0, 0);
-    for (int i = 0; i < bandCount; ++i)
-    {
-        REBARBANDINFO rbi = {0};
-        rbi.cbSize = sizeof(REBARBANDINFO);
-        rbi.fMask = RBBIM_CHILD;
-        if (SendMessage(rebar, RB_GETBANDINFO, i, (LPARAM)&rbi) != 0 && rbi.hwndChild != NULL)
-        {
-            DarkModeApplyWindow(rbi.hwndChild);
-            RedrawWindow(rbi.hwndChild, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
-        }
-    }
-
-    RedrawWindow(rebar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
-}
-
 BOOL CMainWindow::EnsureDetachedChrome()
 {
     CALL_STACK_MESSAGE1("CMainWindow::EnsureDetachedChrome()");
@@ -1921,7 +1872,8 @@ BOOL CMainWindow::EnsureDetachedChrome()
                                            HRightDetachedWindow, (HMENU)0, HInstance, NULL);
         if (HDetachedTopRebar == NULL)
             DETACHED_CHROME_FAIL();
-        ApplyDetachedRebarVisuals(HDetachedTopRebar);
+        DarkModeApplyWindow(HDetachedTopRebar);
+        DarkModeApplyRebarSeparators(HDetachedTopRebar);
     }
 
     if (DetachedMenuBar == NULL)
@@ -2097,8 +2049,6 @@ BOOL CMainWindow::EnsureDetachedChrome()
         }
         UpdateDetachedCommandLine();
     }
-
-    ApplyDetachedRebarVisuals(HDetachedTopRebar);
 
     CreatingDetachedChrome = FALSE;
 #undef DETACHED_CHROME_FAIL
@@ -2648,13 +2598,11 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
         RightPanel->UpdateTreeView(TRUE);
         SetWindowPos(HRightDetachedWindow, NULL, mainRect.left + leftOuterWidth + 16, mainRect.top,
                      rightOuterWidth, mainOuterHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+        ShowWindow(HRightDetachedWindow, SW_SHOW);
         SetWindowPos(HWindow, NULL, mainRect.left, mainRect.top, leftOuterWidth, mainOuterHeight,
                      SWP_NOZORDER | SWP_NOACTIVATE);
         LayoutWindows();
         LayoutDetachedPanels();
-        ShowWindow(HRightDetachedWindow, SW_SHOW);
-        RedrawWindow(HRightDetachedWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
-        UpdateWindow(HRightDetachedWindow);
         SetWindowTitle();
         CreatingDetachedChrome = FALSE;
     }
@@ -2898,9 +2846,7 @@ LRESULT CALLBACK CMainWindow::DetachedPanelWindowProc(HWND hWnd, UINT uMsg, WPAR
         {
             RECT r;
             GetClientRect(hWnd, &r);
-            HBRUSH brush = DarkModeShouldUseDarkColors() ? DarkModeGetPanelFrameBrush() :
-                                                            (HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
-            FillRect((HDC)wParam, &r, brush);
+            FillRect((HDC)wParam, &r, HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
             return 1;
         }
 
@@ -5249,7 +5195,8 @@ void CMainWindow::OnColorsChanged(BOOL reloadUMIcons)
     }
     if (HDetachedTopRebar != NULL)
     {
-        ApplyDetachedRebarVisuals(HDetachedTopRebar);
+        DarkModeApplyWindow(HDetachedTopRebar);
+        DarkModeApplyRebarSeparators(HDetachedTopRebar);
     }
     LayoutWindows();
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2848,7 +2848,9 @@ LRESULT CALLBACK CMainWindow::DetachedPanelWindowProc(HWND hWnd, UINT uMsg, WPAR
         {
             RECT r;
             GetClientRect(hWnd, &r);
-            FillRect((HDC)wParam, &r, HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
+            HBRUSH brush = DarkModeShouldUseDarkColors() ? DarkModeGetPanelFrameBrush() :
+                                                            (HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
+            FillRect((HDC)wParam, &r, brush);
             return 1;
         }
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <shlwapi.h>
+#include <uxtheme.h>
 #undef PathIsPrefix
 
 #include "tooltip.h"
@@ -1853,13 +1854,14 @@ static void ApplyDetachedRebarVisuals(HWND rebar)
 
     if (DarkModeShouldUseDarkColors())
     {
+        SetWindowTheme(rebar, nullptr, nullptr);
         SetWindowTheme(rebar, L"DarkMode_Explorer", nullptr);
         SendMessage(rebar, RB_SETBKCOLOR, 0, (LPARAM)DarkModeGetColors().background);
         SendMessage(rebar, RB_SETTEXTCOLOR, 0, (LPARAM)DarkModeGetColors().readableText);
 
         COLORSCHEME colorScheme = {sizeof(COLORSCHEME)};
-        colorScheme.clrBtnHighlight = DarkModeGetColors().highlightFrame;
-        colorScheme.clrBtnShadow = DarkModeGetColors().lighterBackground;
+        colorScheme.clrBtnHighlight = RGB(0x38, 0x38, 0x38);
+        colorScheme.clrBtnShadow = RGB(0x38, 0x38, 0x38);
         SendMessage(rebar, RB_SETCOLORSCHEME, 0, (LPARAM)&colorScheme);
     }
     else

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2193,12 +2193,12 @@ void CMainWindow::LayoutDetachedPanelWindow(CPanelSide side, int width, int heig
     {
         if (treeHeaderHeight == 0)
             treeHeaderHeight = panel->GetTreeViewHeaderHeight();
-        if (Configuration.TreeViewAutoHide)
+        if (panel->TreeViewAutoHide)
             treeDisplayWidth = panel->GetTreeViewWidth(width);
         else
             treeDisplayWidth = panel->GetTreeViewWidth(width);
-        treeAutoHideExpanded = Configuration.TreeViewAutoHide && panel->TreeViewAutoHideExpanded;
-        if (Configuration.TreeViewAutoHide)
+        treeAutoHideExpanded = panel->TreeViewAutoHide && panel->TreeViewAutoHideExpanded;
+        if (panel->TreeViewAutoHide)
             treeWidth = treeHeaderHeight;
         else
         {
@@ -2247,8 +2247,8 @@ void CMainWindow::LayoutDetachedPanelWindow(CPanelSide side, int width, int heig
         }
         if (panel->HTreeHeader != NULL && panel->TreeViewActive)
         {
-            BOOL collapsed = Configuration.TreeViewAutoHide && !treeAutoHideExpanded;
-            int headerWidth = collapsed ? treeWidth + 1 : treeDisplayWidth + (Configuration.TreeViewAutoHide ? 1 : 0);
+            BOOL collapsed = panel->TreeViewAutoHide && !treeAutoHideExpanded;
+            int headerWidth = collapsed ? treeWidth + 1 : treeDisplayWidth + (panel->TreeViewAutoHide ? 1 : 0);
             int headerHeight = collapsed ? contentHeight : treeHeaderHeight;
             hdwp = HANDLES(DeferWindowPos(hdwp, panel->HTreeHeader, HWND_TOP,
                                           0, detachedTopRebarHeight, headerWidth, headerHeight,
@@ -2259,14 +2259,14 @@ void CMainWindow::LayoutDetachedPanelWindow(CPanelSide side, int width, int heig
             int treeViewHeight = contentHeight - treeHeaderHeight;
             if (treeViewHeight < 0)
                 treeViewHeight = 0;
-            BOOL show = !Configuration.TreeViewAutoHide || treeAutoHideExpanded;
+            BOOL show = !panel->TreeViewAutoHide || treeAutoHideExpanded;
             hdwp = HANDLES(DeferWindowPos(hdwp, panel->HTreeView, HWND_TOP,
-                                          0, detachedTopRebarHeight + treeHeaderHeight, treeDisplayWidth + (Configuration.TreeViewAutoHide ? 1 : 0), treeViewHeight,
+                                          0, detachedTopRebarHeight + treeHeaderHeight, treeDisplayWidth + (panel->TreeViewAutoHide ? 1 : 0), treeViewHeight,
                                           SWP_NOACTIVATE | (show ? SWP_SHOWWINDOW : SWP_HIDEWINDOW)));
         }
         if (panel->HTreeSplit != NULL && panel->TreeViewActive)
         {
-            BOOL show = !Configuration.TreeViewAutoHide || treeAutoHideExpanded;
+            BOOL show = !panel->TreeViewAutoHide || treeAutoHideExpanded;
             int displaySplitWidth = show ? 4 : 0;
             hdwp = HANDLES(DeferWindowPos(hdwp, panel->HTreeSplit, HWND_TOP,
                                           treeDisplayWidth, detachedTopRebarHeight, displaySplitWidth, contentHeight,
@@ -2355,12 +2355,12 @@ void CMainWindow::LayoutMainWindowDetachedPanel(int width, int height)
     if (LeftPanel->HTreeView != NULL && LeftPanel->TreeViewActive)
     {
         treeHeaderHeight = LeftPanel->GetTreeViewHeaderHeight();
-        if (Configuration.TreeViewAutoHide)
+        if (LeftPanel->TreeViewAutoHide)
             treeDisplayWidth = LeftPanel->GetTreeViewWidth(width);
         else
             treeDisplayWidth = LeftPanel->GetTreeViewWidth(width);
-        treeAutoHideExpanded = Configuration.TreeViewAutoHide && LeftPanel->TreeViewAutoHideExpanded;
-        if (Configuration.TreeViewAutoHide)
+        treeAutoHideExpanded = LeftPanel->TreeViewAutoHide && LeftPanel->TreeViewAutoHideExpanded;
+        if (LeftPanel->TreeViewAutoHide)
             treeWidth = treeHeaderHeight;
         else
         {
@@ -2407,8 +2407,8 @@ void CMainWindow::LayoutMainWindowDetachedPanel(int width, int height)
 
         if (LeftPanel->HTreeHeader != NULL && LeftPanel->TreeViewActive)
         {
-            BOOL collapsed = Configuration.TreeViewAutoHide && !treeAutoHideExpanded;
-            int headerWidth = collapsed ? treeWidth + 1 : treeDisplayWidth + (Configuration.TreeViewAutoHide ? 1 : 0);
+            BOOL collapsed = LeftPanel->TreeViewAutoHide && !treeAutoHideExpanded;
+            int headerWidth = collapsed ? treeWidth + 1 : treeDisplayWidth + (LeftPanel->TreeViewAutoHide ? 1 : 0);
             int headerHeight = collapsed ? PanelsHeight : treeHeaderHeight;
             hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeHeader, HWND_TOP,
                                           0, TopRebarHeight, headerWidth, headerHeight,
@@ -2419,14 +2419,14 @@ void CMainWindow::LayoutMainWindowDetachedPanel(int width, int height)
             int treeViewHeight = PanelsHeight - treeHeaderHeight;
             if (treeViewHeight < 0)
                 treeViewHeight = 0;
-            BOOL show = !Configuration.TreeViewAutoHide || treeAutoHideExpanded;
+            BOOL show = !LeftPanel->TreeViewAutoHide || treeAutoHideExpanded;
             hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeView, HWND_TOP,
-                                          0, TopRebarHeight + treeHeaderHeight, treeDisplayWidth + (Configuration.TreeViewAutoHide ? 1 : 0), treeViewHeight,
+                                          0, TopRebarHeight + treeHeaderHeight, treeDisplayWidth + (LeftPanel->TreeViewAutoHide ? 1 : 0), treeViewHeight,
                                           SWP_NOACTIVATE | (show ? SWP_SHOWWINDOW : SWP_HIDEWINDOW)));
         }
         if (LeftPanel->HTreeSplit != NULL && LeftPanel->TreeViewActive)
         {
-            BOOL show = !Configuration.TreeViewAutoHide || treeAutoHideExpanded;
+            BOOL show = !LeftPanel->TreeViewAutoHide || treeAutoHideExpanded;
             int displaySplitWidth = show ? 4 : 0;
             hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeSplit, HWND_TOP,
                                           treeDisplayWidth, TopRebarHeight, displaySplitWidth, PanelsHeight,
@@ -2548,6 +2548,28 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
 
     if (detached)
     {
+        RECT mainRect;
+        RECT mainClientRect;
+        GetWindowRect(HWindow, &mainRect);
+        GetClientRect(HWindow, &mainClientRect);
+        int mainOuterWidth = mainRect.right - mainRect.left;
+        int mainOuterHeight = mainRect.bottom - mainRect.top;
+        int mainClientWidth = mainClientRect.right - mainClientRect.left;
+        int nonClientWidth = mainOuterWidth - mainClientWidth;
+        int leftClientWidth = SplitPositionPix > 0 ? SplitPositionPix : mainClientWidth / 2;
+        if (leftClientWidth < MIN_WIN_WIDTH)
+            leftClientWidth = MIN_WIN_WIDTH;
+        int leftOuterWidth = leftClientWidth + nonClientWidth;
+        if (leftOuterWidth < 320)
+            leftOuterWidth = 320;
+        int splitWidth = GetSplitBarWidth();
+        int rightClientWidth = mainClientWidth - leftClientWidth - splitWidth;
+        if (rightClientWidth < MIN_WIN_WIDTH)
+            rightClientWidth = MIN_WIN_WIDTH;
+        int rightOuterWidth = rightClientWidth + nonClientWidth;
+        if (rightOuterWidth < 320)
+            rightOuterWidth = 320;
+
         if (HRightDetachedWindow == NULL)
             HRightDetachedWindow = CreateDetachedPanelWindow(this, cpsRight);
         if (HRightDetachedWindow == NULL)
@@ -2570,7 +2592,11 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
             return FALSE;
         CreatingDetachedChrome = TRUE;
         RightPanel->UpdateTreeView(TRUE);
+        SetWindowPos(HRightDetachedWindow, NULL, mainRect.left + leftOuterWidth + 16, mainRect.top,
+                     rightOuterWidth, mainOuterHeight, SWP_NOZORDER | SWP_NOACTIVATE);
         ShowWindow(HRightDetachedWindow, SW_SHOW);
+        SetWindowPos(HWindow, NULL, mainRect.left, mainRect.top, leftOuterWidth, mainOuterHeight,
+                     SWP_NOZORDER | SWP_NOACTIVATE);
         LayoutWindows();
         LayoutDetachedPanels();
         SetWindowTitle();
@@ -2636,7 +2662,7 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
             int treeHeaderHeight = LeftPanel->GetTreeViewHeaderHeight();
             if (LeftTabWindow != NULL)
                 treeHeaderHeight = LeftTabWindow->GetNeededHeight();
-            if (Configuration.TreeViewAutoHide)
+            if (LeftPanel->TreeViewAutoHide)
                 treeWidth = treeHeaderHeight;
             else
             {

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2591,6 +2591,10 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
         if (!EnsureDetachedChrome())
             return FALSE;
         CreatingDetachedChrome = TRUE;
+        RightPanel->TreeViewWidth = Configuration.DetachedTreeViewWidth;
+        RightPanel->TreeViewAutoHide = Configuration.DetachedTreeViewAutoHide;
+        RightPanel->TreeViewAutoHideExpanded = FALSE;
+        RightPanel->TreeViewAutoHideCollapseStart = 0;
         RightPanel->UpdateTreeView(TRUE);
         SetWindowPos(HRightDetachedWindow, NULL, mainRect.left + leftOuterWidth + 16, mainRect.top,
                      rightOuterWidth, mainOuterHeight, SWP_NOZORDER | SWP_NOACTIVATE);

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2598,11 +2598,13 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
         RightPanel->UpdateTreeView(TRUE);
         SetWindowPos(HRightDetachedWindow, NULL, mainRect.left + leftOuterWidth + 16, mainRect.top,
                      rightOuterWidth, mainOuterHeight, SWP_NOZORDER | SWP_NOACTIVATE);
-        ShowWindow(HRightDetachedWindow, SW_SHOW);
         SetWindowPos(HWindow, NULL, mainRect.left, mainRect.top, leftOuterWidth, mainOuterHeight,
                      SWP_NOZORDER | SWP_NOACTIVATE);
         LayoutWindows();
         LayoutDetachedPanels();
+        ShowWindow(HRightDetachedWindow, SW_SHOW);
+        RedrawWindow(HRightDetachedWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+        UpdateWindow(HRightDetachedWindow);
         SetWindowTitle();
         CreatingDetachedChrome = FALSE;
     }

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -2604,6 +2604,20 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
     }
     else
     {
+        RECT mainRectBeforeReattach;
+        RECT mainClientBeforeReattach;
+        RECT detachedRectBeforeReattach;
+        RECT detachedClientBeforeReattach;
+        GetWindowRect(HWindow, &mainRectBeforeReattach);
+        GetClientRect(HWindow, &mainClientBeforeReattach);
+        SetRectEmpty(&detachedRectBeforeReattach);
+        SetRectEmpty(&detachedClientBeforeReattach);
+        if (HRightDetachedWindow != NULL)
+        {
+            GetWindowRect(HRightDetachedWindow, &detachedRectBeforeReattach);
+            GetClientRect(HRightDetachedWindow, &detachedClientBeforeReattach);
+        }
+
         if (RightTabWindow != NULL && RightTabWindow->HWindow != NULL)
             SetParent(RightTabWindow->HWindow, HWindow);
         for (int i = 0; i < RightPanelTabs.Count; ++i)
@@ -2638,6 +2652,24 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
         RebuildPanelTabs(cpsLeft);
         RebuildPanelTabs(cpsRight);
         RefreshPanelTabLayout();
+        int mainClientWidthBeforeReattach = mainClientBeforeReattach.right - mainClientBeforeReattach.left;
+        int detachedClientWidthBeforeReattach = detachedClientBeforeReattach.right - detachedClientBeforeReattach.left;
+        if (detachedClientWidthBeforeReattach > 0)
+        {
+            int mainOuterWidthBeforeReattach = mainRectBeforeReattach.right - mainRectBeforeReattach.left;
+            int mainOuterHeightBeforeReattach = mainRectBeforeReattach.bottom - mainRectBeforeReattach.top;
+            int mainClientHeightBeforeReattach = mainClientBeforeReattach.bottom - mainClientBeforeReattach.top;
+            int detachedOuterHeightBeforeReattach = detachedRectBeforeReattach.bottom - detachedRectBeforeReattach.top;
+            int detachedClientHeightBeforeReattach = detachedClientBeforeReattach.bottom - detachedClientBeforeReattach.top;
+            int nonClientWidth = mainOuterWidthBeforeReattach - mainClientWidthBeforeReattach;
+            int nonClientHeight = mainOuterHeightBeforeReattach - mainClientHeightBeforeReattach;
+            int combinedClientWidth = mainClientWidthBeforeReattach + detachedClientWidthBeforeReattach + GetSplitBarWidth();
+            int combinedClientHeight = max(mainClientHeightBeforeReattach, detachedClientHeightBeforeReattach);
+            int combinedOuterWidth = combinedClientWidth + nonClientWidth;
+            int combinedOuterHeight = max(combinedClientHeight + nonClientHeight, detachedOuterHeightBeforeReattach);
+            SetWindowPos(HWindow, NULL, mainRectBeforeReattach.left, mainRectBeforeReattach.top,
+                         combinedOuterWidth, combinedOuterHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+        }
         RECT mainClientRect;
         GetClientRect(HWindow, &mainClientRect);
         WindowWidth = mainClientRect.right - mainClientRect.left;

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1846,6 +1846,53 @@ static BOOL InsertDetachedBand(HWND rebar, HWND child, int bandID, int index, in
     return SendMessage(rebar, RB_INSERTBAND, (WPARAM)index, (LPARAM)&rbbi) != 0;
 }
 
+static void ApplyDetachedRebarVisuals(HWND rebar)
+{
+    if (rebar == NULL)
+        return;
+
+    if (DarkModeShouldUseDarkColors())
+    {
+        SetWindowTheme(rebar, L"DarkMode_Explorer", nullptr);
+        SendMessage(rebar, RB_SETBKCOLOR, 0, (LPARAM)DarkModeGetColors().background);
+        SendMessage(rebar, RB_SETTEXTCOLOR, 0, (LPARAM)DarkModeGetColors().readableText);
+
+        COLORSCHEME colorScheme = {sizeof(COLORSCHEME)};
+        colorScheme.clrBtnHighlight = DarkModeGetColors().highlightFrame;
+        colorScheme.clrBtnShadow = DarkModeGetColors().lighterBackground;
+        SendMessage(rebar, RB_SETCOLORSCHEME, 0, (LPARAM)&colorScheme);
+    }
+    else
+    {
+        SetWindowTheme(rebar, (L" "), (L" "));
+        SendMessage(rebar, RB_SETBKCOLOR, 0, (LPARAM)CLR_DEFAULT);
+        SendMessage(rebar, RB_SETTEXTCOLOR, 0, (LPARAM)CLR_DEFAULT);
+
+        COLORSCHEME colorScheme = {sizeof(COLORSCHEME)};
+        colorScheme.clrBtnHighlight = GetSysColor(COLOR_BTNHILIGHT);
+        colorScheme.clrBtnShadow = GetSysColor(COLOR_BTNSHADOW);
+        SendMessage(rebar, RB_SETCOLORSCHEME, 0, (LPARAM)&colorScheme);
+    }
+
+    DarkModeApplyWindow(rebar);
+    DarkModeApplyRebarSeparators(rebar);
+
+    const int bandCount = (int)SendMessage(rebar, RB_GETBANDCOUNT, 0, 0);
+    for (int i = 0; i < bandCount; ++i)
+    {
+        REBARBANDINFO rbi = {0};
+        rbi.cbSize = sizeof(REBARBANDINFO);
+        rbi.fMask = RBBIM_CHILD;
+        if (SendMessage(rebar, RB_GETBANDINFO, i, (LPARAM)&rbi) != 0 && rbi.hwndChild != NULL)
+        {
+            DarkModeApplyWindow(rbi.hwndChild);
+            RedrawWindow(rbi.hwndChild, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+        }
+    }
+
+    RedrawWindow(rebar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+}
+
 BOOL CMainWindow::EnsureDetachedChrome()
 {
     CALL_STACK_MESSAGE1("CMainWindow::EnsureDetachedChrome()");
@@ -1872,8 +1919,7 @@ BOOL CMainWindow::EnsureDetachedChrome()
                                            HRightDetachedWindow, (HMENU)0, HInstance, NULL);
         if (HDetachedTopRebar == NULL)
             DETACHED_CHROME_FAIL();
-        DarkModeApplyWindow(HDetachedTopRebar);
-        DarkModeApplyRebarSeparators(HDetachedTopRebar);
+        ApplyDetachedRebarVisuals(HDetachedTopRebar);
     }
 
     if (DetachedMenuBar == NULL)
@@ -2049,6 +2095,8 @@ BOOL CMainWindow::EnsureDetachedChrome()
         }
         UpdateDetachedCommandLine();
     }
+
+    ApplyDetachedRebarVisuals(HDetachedTopRebar);
 
     CreatingDetachedChrome = FALSE;
 #undef DETACHED_CHROME_FAIL
@@ -5199,8 +5247,7 @@ void CMainWindow::OnColorsChanged(BOOL reloadUMIcons)
     }
     if (HDetachedTopRebar != NULL)
     {
-        DarkModeApplyWindow(HDetachedTopRebar);
-        DarkModeApplyRebarSeparators(HDetachedTopRebar);
+        ApplyDetachedRebarVisuals(HDetachedTopRebar);
     }
     LayoutWindows();
 

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -4692,6 +4692,20 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                      &Configuration.TreeViewWidth, sizeof(DWORD));
             GetValue(actKey, CONFIG_TREEVIEWAUTOHIDE_REG, REG_DWORD,
                      &Configuration.TreeViewAutoHide, sizeof(DWORD));
+            if (LeftPanel != NULL)
+            {
+                LeftPanel->TreeViewWidth = Configuration.TreeViewWidth;
+                LeftPanel->TreeViewAutoHide = Configuration.TreeViewAutoHide;
+                LeftPanel->TreeViewAutoHideExpanded = FALSE;
+                LeftPanel->TreeViewAutoHideCollapseStart = 0;
+            }
+            if (RightPanel != NULL)
+            {
+                RightPanel->TreeViewWidth = Configuration.TreeViewWidth;
+                RightPanel->TreeViewAutoHide = Configuration.TreeViewAutoHide;
+                RightPanel->TreeViewAutoHideExpanded = FALSE;
+                RightPanel->TreeViewAutoHideCollapseStart = 0;
+            }
             GetValue(actKey, CONFIG_GRIPSVISIBLE_REG, REG_DWORD,
                      &Configuration.GripsVisible, sizeof(DWORD));
             //---  top rebar end

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -1166,6 +1166,8 @@ const char* CONFIG_DRIVEBARBREAK_REG = "Drive Bar Break";
 const char* CONFIG_DRIVEBARWIDTH_REG = "Drive Bar Width";
 const char* CONFIG_TREEVIEWWIDTH_REG = "Tree View Width";
 const char* CONFIG_TREEVIEWAUTOHIDE_REG = "Tree View Auto Hide";
+const char* CONFIG_DETACHEDTREEVIEWWIDTH_REG = "Detached Tree View Width";
+const char* CONFIG_DETACHEDTREEVIEWAUTOHIDE_REG = "Detached Tree View Auto Hide";
 const char* CONFIG_GRIPSVISIBLE_REG = "Grips Visible";
 
 const char* SALAMANDER_CONFIRMATION_REG = "Confirmation";
@@ -2871,10 +2873,24 @@ void CMainWindow::SaveConfig(HWND parent, BOOL showConfigFileSaveError)
                          &Configuration.DriveBarBreak, sizeof(DWORD));
                 SetValue(actKey, CONFIG_DRIVEBARWIDTH_REG, REG_DWORD,
                          &Configuration.DriveBarWidth, sizeof(DWORD));
+                if (LeftPanel != NULL)
+                {
+                    Configuration.TreeViewWidth = LeftPanel->TreeViewWidth;
+                    Configuration.TreeViewAutoHide = LeftPanel->TreeViewAutoHide;
+                }
+                if (RightPanel != NULL && DetachedPanels)
+                {
+                    Configuration.DetachedTreeViewWidth = RightPanel->TreeViewWidth;
+                    Configuration.DetachedTreeViewAutoHide = RightPanel->TreeViewAutoHide;
+                }
                 SetValue(actKey, CONFIG_TREEVIEWWIDTH_REG, REG_DWORD,
                          &Configuration.TreeViewWidth, sizeof(DWORD));
                 SetValue(actKey, CONFIG_TREEVIEWAUTOHIDE_REG, REG_DWORD,
                          &Configuration.TreeViewAutoHide, sizeof(DWORD));
+                SetValue(actKey, CONFIG_DETACHEDTREEVIEWWIDTH_REG, REG_DWORD,
+                         &Configuration.DetachedTreeViewWidth, sizeof(DWORD));
+                SetValue(actKey, CONFIG_DETACHEDTREEVIEWAUTOHIDE_REG, REG_DWORD,
+                         &Configuration.DetachedTreeViewAutoHide, sizeof(DWORD));
                 SetValue(actKey, CONFIG_GRIPSVISIBLE_REG, REG_DWORD,
                          &Configuration.GripsVisible, sizeof(DWORD));
 
@@ -4692,6 +4708,12 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                      &Configuration.TreeViewWidth, sizeof(DWORD));
             GetValue(actKey, CONFIG_TREEVIEWAUTOHIDE_REG, REG_DWORD,
                      &Configuration.TreeViewAutoHide, sizeof(DWORD));
+            Configuration.DetachedTreeViewWidth = Configuration.TreeViewWidth;
+            Configuration.DetachedTreeViewAutoHide = Configuration.TreeViewAutoHide;
+            GetValue(actKey, CONFIG_DETACHEDTREEVIEWWIDTH_REG, REG_DWORD,
+                     &Configuration.DetachedTreeViewWidth, sizeof(DWORD));
+            GetValue(actKey, CONFIG_DETACHEDTREEVIEWAUTOHIDE_REG, REG_DWORD,
+                     &Configuration.DetachedTreeViewAutoHide, sizeof(DWORD));
             if (LeftPanel != NULL)
             {
                 LeftPanel->TreeViewWidth = Configuration.TreeViewWidth;
@@ -4701,8 +4723,8 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
             }
             if (RightPanel != NULL)
             {
-                RightPanel->TreeViewWidth = Configuration.TreeViewWidth;
-                RightPanel->TreeViewAutoHide = Configuration.TreeViewAutoHide;
+                RightPanel->TreeViewWidth = Configuration.DetachedPanels ? Configuration.DetachedTreeViewWidth : Configuration.TreeViewWidth;
+                RightPanel->TreeViewAutoHide = Configuration.DetachedPanels ? Configuration.DetachedTreeViewAutoHide : Configuration.TreeViewAutoHide;
                 RightPanel->TreeViewAutoHideExpanded = FALSE;
                 RightPanel->TreeViewAutoHideCollapseStart = 0;
             }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -2995,7 +2995,7 @@ BOOL CMainWindow::IsPanelZoomed(BOOL leftPanel)
                 if (LeftTabWindow != NULL)
                     treeHeaderH = LeftTabWindow->GetNeededHeight();
                 int treeLeftWidth = 0;
-                if (Configuration.TreeViewAutoHide)
+                if (LeftPanel->TreeViewAutoHide)
                     treeLeftWidth = treeHeaderH;
                 else
                     treeLeftWidth = LeftPanel->GetTreeViewWidth(totalPanelsWidth) + 4;
@@ -7562,7 +7562,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                     int treeHeaderH = LeftPanel->GetTreeViewHeaderHeight();
                     if (LeftTabWindow != NULL)
                         treeHeaderH = LeftTabWindow->GetNeededHeight();
-                    if (Configuration.TreeViewAutoHide)
+                    if (LeftPanel->TreeViewAutoHide)
                         treeLeftWidth = treeHeaderH;
                     else
                         treeLeftWidth = LeftPanel->GetTreeViewWidth(totalPanelsWidth) + 4; // +TREEVIEW_SPLITTER_WIDTH
@@ -8402,7 +8402,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             int treeReservedWidth = 0;
             if (LeftPanel != NULL && LeftPanel->HTreeView != NULL && LeftPanel->TreeViewActive)
             {
-                if (Configuration.TreeViewAutoHide)
+                if (LeftPanel->TreeViewAutoHide)
                 {
                     treeReservedWidth = LeftPanel->GetTreeViewHeaderHeight();
                     if (LeftTabWindow != NULL)
@@ -8894,13 +8894,13 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             if (LeftTabWindow != NULL)
                 treeHeaderHeight = LeftTabWindow->GetNeededHeight();
 
-            if (Configuration.TreeViewAutoHide)
+            if (LeftPanel->TreeViewAutoHide)
                 treeDisplayWidth = LeftPanel->GetTreeViewWidth(WindowWidth);
             else
                 treeDisplayWidth = LeftPanel->GetTreeViewWidth(totalPanelsWidth);
-            treeAutoHideExpanded = Configuration.TreeViewAutoHide && LeftPanel->TreeViewAutoHideExpanded;
+            treeAutoHideExpanded = LeftPanel->TreeViewAutoHide && LeftPanel->TreeViewAutoHideExpanded;
 
-            if (Configuration.TreeViewAutoHide)
+            if (LeftPanel->TreeViewAutoHide)
                 treeWidth = treeHeaderHeight;
             else
             {
@@ -9029,12 +9029,12 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             // When the right panel is zoomed, keep Tree View above it as well;
             // the right panel starts at the left tab/panel edge, so this does not
             // overlap Tree View but preserves its visibility.
-            BOOL treeOnTop = Configuration.TreeViewAutoHide || rightZoomed;
-            int treeX = Configuration.TreeViewAutoHide ? 0 : 1;
-            int treeWindowWidth = treeDisplayWidth + (Configuration.TreeViewAutoHide ? 1 : 0);
+            BOOL treeOnTop = LeftPanel->TreeViewAutoHide || rightZoomed;
+            int treeX = LeftPanel->TreeViewAutoHide ? 0 : 1;
+            int treeWindowWidth = treeDisplayWidth + (LeftPanel->TreeViewAutoHide ? 1 : 0);
             if (LeftPanel != NULL && LeftPanel->HTreeHeader != NULL && LeftPanel->TreeViewActive)
             {
-                BOOL collapsed = Configuration.TreeViewAutoHide && !treeAutoHideExpanded;
+                BOOL collapsed = LeftPanel->TreeViewAutoHide && !treeAutoHideExpanded;
                 int headerWidth = collapsed ? treeWidth + 1 : treeWindowWidth;
                 int headerHeight = collapsed ? PanelsHeight : treeHeaderHeight;
                 hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeHeader,
@@ -9047,7 +9047,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 int treeViewHeight = PanelsHeight - treeHeaderHeight;
                 if (treeViewHeight < 0)
                     treeViewHeight = 0;
-                BOOL show = !Configuration.TreeViewAutoHide || treeAutoHideExpanded;
+                BOOL show = !LeftPanel->TreeViewAutoHide || treeAutoHideExpanded;
                 hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeView,
                                               treeOnTop ? HWND_TOP : NULL,
                                               treeX, TopRebarHeight + treeHeaderHeight, treeWindowWidth, treeViewHeight,
@@ -9056,7 +9056,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             }
             if (LeftPanel != NULL && LeftPanel->HTreeSplit != NULL && LeftPanel->TreeViewActive)
             {
-                BOOL show = !Configuration.TreeViewAutoHide || treeAutoHideExpanded;
+                BOOL show = !LeftPanel->TreeViewAutoHide || treeAutoHideExpanded;
                 int displaySplitWidth = show ? 4 : 0;
                 hdwp = HANDLES(DeferWindowPos(hdwp, LeftPanel->HTreeSplit,
                                               treeOnTop ? HWND_TOP : NULL,

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -8324,7 +8324,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                     BeginStopStatusbarRepaint(); // skip throbber repaints when dragging the XOR split bar
 
                 DragMode = TRUE;
-                DragAnchorX = p.x - r.left;
+                DragAnchorX = p.x - SplitPositionPix;
                 SetCapture(HWindow);
 
                 HWND toolTip = CreateWindowEx(0,
@@ -8356,7 +8356,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 POINT mp;
                 GetCursorPos(&mp);
                 POINT p2;
-                p2.x = r.left;
+                p2.x = SplitPositionPix;
                 p2.y = 0;
                 ClientToScreen(HWindow, &p2);
                 mp.x = p2.x;

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -8324,7 +8324,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                     BeginStopStatusbarRepaint(); // skip throbber repaints when dragging the XOR split bar
 
                 DragMode = TRUE;
-                DragAnchorX = p.x - SplitPositionPix;
+                DragAnchorX = p.x - r.left;
                 SetCapture(HWindow);
 
                 HWND toolTip = CreateWindowEx(0,
@@ -8356,7 +8356,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 POINT mp;
                 GetCursorPos(&mp);
                 POINT p2;
-                p2.x = SplitPositionPix;
+                p2.x = r.left;
                 p2.y = 0;
                 ClientToScreen(HWindow, &p2);
                 mp.x = p2.x;

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -297,13 +297,10 @@ void CMainWindow::DirHistoryRemoveActualPath(CFilesWindow* panel)
 
 void CMainWindow::GetSplitRect(RECT& r)
 {
-    const int splitHitPadding = 4;
     r.left = SplitPositionPix;
     r.top = TopRebarHeight;
     r.right = SplitPositionPix + MainWindow->GetSplitBarWidth();
     r.bottom = WindowHeight - EditHeight - BottomToolBarHeight;
-    r.left -= splitHitPadding;
-    r.right += splitHitPadding;
 }
 
 void CMainWindow::GetWindowSplitRect(RECT& r)

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -297,10 +297,13 @@ void CMainWindow::DirHistoryRemoveActualPath(CFilesWindow* panel)
 
 void CMainWindow::GetSplitRect(RECT& r)
 {
+    const int splitHitPadding = 4;
     r.left = SplitPositionPix;
     r.top = TopRebarHeight;
     r.right = SplitPositionPix + MainWindow->GetSplitBarWidth();
     r.bottom = WindowHeight - EditHeight - BottomToolBarHeight;
+    r.left -= splitHitPadding;
+    r.right += splitHitPadding;
 }
 
 void CMainWindow::GetWindowSplitRect(RECT& r)

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -1457,7 +1457,7 @@ void CMainWindow::ChangePanel(BOOL force)
                     int treeHeaderH = LeftPanel->GetTreeViewHeaderHeight();
                     if (LeftTabWindow != NULL)
                         treeHeaderH = LeftTabWindow->GetNeededHeight();
-                    if (Configuration.TreeViewAutoHide)
+                    if (LeftPanel->TreeViewAutoHide)
                         treeLeftWidth = treeHeaderH;
                     else
                         treeLeftWidth = LeftPanel->GetTreeViewWidth(totalPanelsWidth) + 4;


### PR DESCRIPTION
### Motivation
- Fix visual glitches where tree views were not immediately repainted after theme/dark-mode changes, scrolling or resizing, and make tree view auto-hide/width behavior per-panel so detached/secondary panels behave independently.
- Ensure immediate erasing and update when forcing redraws to avoid artifacts on theme switches and window operations.

### Description
- Change redraw flags to include `RDW_ERASE | RDW_UPDATENOW` in `ApplyTreeViewColors`, `RepaintWindowTree`, and in subclass handlers to force immediate, clean repaints.
- Add `TreeViewRedrawSubclassProc`/`TreeViewSubclassProc` to subclass tree views and trigger a redraw on `WM_HSCROLL`, `WM_VSCROLL`, and `WM_SIZE` while removing the subclass on `WM_NCDESTROY`.
- Convert global `Configuration.TreeViewAutoHide` and `Configuration.TreeViewWidth` usage into per-panel members `TreeViewAutoHide`, `TreeViewWidth`, and `TreeViewAutoHideCollapseStart`, and only persist changes back to `Configuration` for the primary/left panel (or when appropriate) to keep detached/right panels independent.
- Update multiple layout and painting code paths (`fileswn1.cpp`, `fileswn2.cpp`, `fileswnd.h`, `mainwnd*.cpp`, `sheets.cpp`) to use the per-panel flags and width, to update header/tooltip text, timers, show/hide logic, and layout calculations accordingly.
- Improve auto-hide collapse timing by tracking `TreeViewAutoHideCollapseStart` and deferring collapse until the configured delay has elapsed, and reset the timer/marker when user interaction occurs.

### Testing
- Performed automated CI build for Windows (MSVC) in Debug and Release configurations and the build completed without errors.
- Executed existing automated unit/integration tests in CI and they completed with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5562a38894832997c3cd4c6a9b12f3)