### PR TITLE
Upravit bump skript: navýšit VERSINFO_BUILDNUMBER a aktualizovat spl_vers.h

### DIFF
--- a/tools/bump_samandarin_version.py
+++ b/tools/bump_samandarin_version.py
@@ -55,10 +55,28 @@ def main() -> None:
     old_version = f"{major}.{old_minor}"
     new_version = f"{major}.{new_minor}"
 
+    build_match = re.search(r"^#define VERSINFO_BUILDNUMBER (\d+)$", spl_text, re.MULTILINE)
+    if not build_match:
+        raise RuntimeError(f"Could not find VERSINFO_BUILDNUMBER in {spl_vers}.")
+    old_build_number = int(build_match.group(1))
+    new_build_number = old_build_number + 1
+
     spl_text = replace_one(
         spl_text,
         r"^(#define VERSINFO_SAMANDARIN_MINORA )\d+$",
         rf"\g<1>{new_minor}",
+        file_name=str(spl_vers),
+    )
+    spl_text = replace_one(
+        spl_text,
+        rf"^(// {old_build_number} = 5\.0-samandarin-{re.escape(old_version)}\n)",
+        rf"\g<1>// {new_build_number} = 5.0-samandarin-{new_version}\n",
+        file_name=str(spl_vers),
+    )
+    spl_text = replace_one(
+        spl_text,
+        r"^(#define VERSINFO_BUILDNUMBER )\d+$",
+        rf"\g<1>{new_build_number}",
         file_name=str(spl_vers),
     )
     write(spl_vers, spl_text)
@@ -98,13 +116,13 @@ def main() -> None:
     main_text = replace_one(
         main_text,
         rf"^(\s*)\"Software\\\\Open Salamander Samandarin\\\\5\.0-samandarin-{re.escape(old_version)}\",$",
-        rf"\1\"Software\\\\Open Salamander Samandarin\\\\5.0-samandarin-{new_version}\",\n\g<0>",
+        rf'\g<1>"Software\\\\Open Salamander Samandarin\\\\5.0-samandarin-{new_version}",\n\g<0>',
         file_name=str(mainwnd2),
     )
     main_text = replace_one(
         main_text,
         rf"^(\s*)\"5\.0 Samandarin {re.escape(old_version)}\",$",
-        rf"\1\"5.0 Samandarin {new_version}\",\n\g<0>",
+        rf'\g<1>"5.0 Samandarin {new_version}",\n\g<0>',
         file_name=str(mainwnd2),
     )
     write(mainwnd2, main_text)
@@ -119,6 +137,7 @@ def main() -> None:
     write(inno, inno_text)
 
     print(f"Bumped Samandarin {old_version} -> {new_version}")
+    print(f"Bumped VERSINFO_BUILDNUMBER {old_build_number} -> {new_build_number}")
     print(f"Bumped THIS_CONFIG_VERSION {old_config_version} -> {new_config_version}")
     print(f"Bumped SALCFG_ROOTS_COUNT {old_roots_count} -> {old_roots_count + 1}")
 


### PR DESCRIPTION
### Motivation
- Při bumpu Samandarin verze je potřeba zároveň zvýšit `VERSINFO_BUILDNUMBER` a doplnit do `spl_vers.h` komentář s novou verzí a buildnumber tak, aby interní historie a definice zůstaly konzistentní.

### Description
- Skript `tools/bump_samandarin_version.py` nyní najde `#define VERSINFO_BUILDNUMBER`, spočítá `new_build_number = old_build_number + 1` a použije ho při úpravě `spl_vers.h`.
- Skript v `spl_vers.h` aktualizuje `VERSINFO_SAMANDARIN_MINORA`, vloží nový řádek komentáře se zápisem `// <new_build> = 5.0-samandarin-<new_version>` a přepíše `#define VERSINFO_BUILDNUMBER` na novou hodnotu.
- Opraveny jsou také náhrady v `src/mainwnd2.cpp` tak, aby vkládané C++ literály neobsahovaly přebytečné escapované uvozovky a vložení nových konfigurací bylo korektní.
- Skript nyní vypisuje i informaci o bumpu build numberu (`Bumped VERSINFO_BUILDNUMBER ...`).

### Testing
- `python -m py_compile tools/bump_samandarin_version.py` proběhl úspěšně.
- Spuštěno `git diff --check` bez chyb.
- Skript byl spuštěn v dočasném repozitáři obsahujícím relevantní soubory a ověřeno, že `src/plugins/shared/spl_vers.h` a `src/mainwnd2.cpp` obsahují nové záznamy (např. `// 194 = 5.0-samandarin-0.12` a `#define VERSINFO_BUILDNUMBER 194`) a že výstup skriptu hlásí očekávané bumpy (Samandarin, VERSINFO_BUILDNUMBER, THIS_CONFIG_VERSION, SALCFG_ROOTS_COUNT).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a559f8db8ac8329ba277182e48ab230)