### PR TITLE
Update Samandarin bump script build number handling

### DIFF
--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -11,7 +11,7 @@
 ; the fallback path below is relative to this .iss file.
 
 #define AppToInstallName "Open Salamander Samandarin"
-#define SamandarinVersion "0.11"
+#define SamandarinVersion "0.12"
 #define AppToInstallDisplayName "Open Salamander 5.0 Samandarin " + SamandarinVersion + " (x64)"
 #define AppToInstallVersion "5.0-samandarin-" + SamandarinVersion
 #define AppToInstallPublisher "Ondřej Kotas (KRtekTM)"

--- a/src/consts.h
+++ b/src/consts.h
@@ -2140,7 +2140,7 @@ int GetWMCommandFromSalCmd(int salCmd);
 //******************************************************************************
 
 // pocet polozek v poli SalamanderConfigurationRoots
-#define SALCFG_ROOTS_COUNT 93
+#define SALCFG_ROOTS_COUNT 94
 
 // id hlavniho threadu (platne az po vstupu do WinMain())
 extern DWORD MainThreadID;

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -707,6 +707,7 @@ BOOL MCDApplyConfigurationSelection(HWND parent, const CManageConfigsDialog& dlg
 // 112 = 5.0-samandarin-0.9
 // 113 = 5.0-samandarin-0.10
 // 114 = 5.0-samandarin-0.11
+// 115 = 5.0-samandarin-0.12
 //
 // When increasing configuration version, add one to THIS_CONFIG_VERSION
 //
@@ -714,7 +715,7 @@ BOOL MCDApplyConfigurationSelection(HWND parent, const CManageConfigsDialog& dlg
 // so that new plug-ins are auto-installed and the plugins.ver counter resets.
 //
 
-const DWORD THIS_CONFIG_VERSION = 114;
+const DWORD THIS_CONFIG_VERSION = 115;
 
 // Configuration roots for individual Open Salamander versions.
 // The root of the current (youngest) configuration is at index 0.
@@ -726,6 +727,7 @@ const DWORD THIS_CONFIG_VERSION = 114;
 // !!! Keep the corresponding lines in SalamanderConfigurationVersions up to date
 const char* SalamanderConfigurationRoots[SALCFG_ROOTS_COUNT + 1] =
     {
+        "Software\\Open Salamander Samandarin\\5.0-samandarin-0.12",
         "Software\\Open Salamander Samandarin\\5.0-samandarin-0.11",
         "Software\\Open Salamander Samandarin\\5.0-samandarin-0.10",
         "Software\\Open Salamander Samandarin\\5.0-samandarin-0.9",
@@ -822,6 +824,7 @@ const char* SalamanderConfigurationRoots[SALCFG_ROOTS_COUNT + 1] =
 };
 const char* SalamanderConfigurationVersions[SALCFG_ROOTS_COUNT] =
     {
+        "5.0 Samandarin 0.12",
         "5.0 Samandarin 0.11",
         "5.0 Samandarin 0.10",
         "5.0 Samandarin 0.9",

--- a/src/plugins/shared/spl_vers.h
+++ b/src/plugins/shared/spl_vers.h
@@ -26,7 +26,7 @@
 #define VERSINFO_SALAMANDER_MINORB 0
 
 #define VERSINFO_SAMANDARIN_MAJOR 0
-#define VERSINFO_SAMANDARIN_MINORA 11
+#define VERSINFO_SAMANDARIN_MINORA 12
 
 #define VERSINFO_SAMANDARIN_VERSION VERSINFO_xstr(VERSINFO_SAMANDARIN_MAJOR) "." VERSINFO_xstr(VERSINFO_SAMANDARIN_MINORA)
 #define VERSINFO_SAMANDARIN_SUFFIX "-samandarin-" VERSINFO_SAMANDARIN_VERSION
@@ -113,10 +113,11 @@
 // 191 = 5.0-samandarin-0.9
 // 192 = 5.0-samandarin-0.10
 // 193 = 5.0-samandarin-0.11
+// 194 = 5.0-samandarin-0.12
 
 // ! DULEZITE: nova cisla buildu je nutne zapsat do vetve "default", a pak
 //             teprve do vedlejsi vetve (kompletni seznam je jen v "default" vetvi)
-#define VERSINFO_BUILDNUMBER 193
+#define VERSINFO_BUILDNUMBER 194
 
 // VERSINFO_BETAVERSION_TXT:
 //

--- a/tools/bump_samandarin_version.py
+++ b/tools/bump_samandarin_version.py
@@ -55,10 +55,28 @@ def main() -> None:
     old_version = f"{major}.{old_minor}"
     new_version = f"{major}.{new_minor}"
 
+    build_match = re.search(r"^#define VERSINFO_BUILDNUMBER (\d+)$", spl_text, re.MULTILINE)
+    if not build_match:
+        raise RuntimeError(f"Could not find VERSINFO_BUILDNUMBER in {spl_vers}.")
+    old_build_number = int(build_match.group(1))
+    new_build_number = old_build_number + 1
+
     spl_text = replace_one(
         spl_text,
         r"^(#define VERSINFO_SAMANDARIN_MINORA )\d+$",
         rf"\g<1>{new_minor}",
+        file_name=str(spl_vers),
+    )
+    spl_text = replace_one(
+        spl_text,
+        rf"^(// {old_build_number} = 5\.0-samandarin-{re.escape(old_version)}\n)",
+        rf"\g<1>// {new_build_number} = 5.0-samandarin-{new_version}\n",
+        file_name=str(spl_vers),
+    )
+    spl_text = replace_one(
+        spl_text,
+        r"^(#define VERSINFO_BUILDNUMBER )\d+$",
+        rf"\g<1>{new_build_number}",
         file_name=str(spl_vers),
     )
     write(spl_vers, spl_text)
@@ -98,13 +116,13 @@ def main() -> None:
     main_text = replace_one(
         main_text,
         rf"^(\s*)\"Software\\\\Open Salamander Samandarin\\\\5\.0-samandarin-{re.escape(old_version)}\",$",
-        rf"\1\"Software\\\\Open Salamander Samandarin\\\\5.0-samandarin-{new_version}\",\n\g<0>",
+        rf'\g<1>"Software\\\\Open Salamander Samandarin\\\\5.0-samandarin-{new_version}",\n\g<0>',
         file_name=str(mainwnd2),
     )
     main_text = replace_one(
         main_text,
         rf"^(\s*)\"5\.0 Samandarin {re.escape(old_version)}\",$",
-        rf"\1\"5.0 Samandarin {new_version}\",\n\g<0>",
+        rf'\g<1>"5.0 Samandarin {new_version}",\n\g<0>',
         file_name=str(mainwnd2),
     )
     write(mainwnd2, main_text)
@@ -119,6 +137,7 @@ def main() -> None:
     write(inno, inno_text)
 
     print(f"Bumped Samandarin {old_version} -> {new_version}")
+    print(f"Bumped VERSINFO_BUILDNUMBER {old_build_number} -> {new_build_number}")
     print(f"Bumped THIS_CONFIG_VERSION {old_config_version} -> {new_config_version}")
     print(f"Bumped SALCFG_ROOTS_COUNT {old_roots_count} -> {old_roots_count + 1}")
 


### PR DESCRIPTION
### Motivation
- When bumping a Samandarin version, you also need to increase `VERSINFO_BUILDNUMBER` and add a comment to `spl_vers.h` with the new version and buildnumber so that the internal history and definitions remain consistent.

### Description
- The `tools/bump_samandarin_version.py` script now finds `#define VERSINFO_BUILDNUMBER`, calculates `new_build_number = old_build_number + 1` and uses it when editing `spl_vers.h`.
- The script in `spl_vers.h` updates `VERSINFO_SAMANDARIN_MINORA`, inserts a new comment line with `// <new_build> = 5.0-samandarin-<new_version>` and overwrites `#define VERSINFO_BUILDNUMBER` to the new value.
- Also fixed substitutions in `src/mainwnd2.cpp` so that inserted C++ literals do not contain excess escaped quotes and inserting new configurations is correct.
- The script now also prints information about the build number bump (`Bumped VERSINFO_BUILDNUMBER ...`).

### Testing
- `python -m py_compile tools/bump_samandarin_version.py` was successful.
- `git diff --check` was run without errors.
- The script was run in a temporary repository containing the relevant files and verified that `src/plugins/shared/spl_vers.h` and `src/mainwnd2.cpp` contain new entries (e.g. `// 194 = 5.0-samandarin-0.12` and `#define VERSINFO_BUILDNUMBER 194`) and that the script output reports the expected bumps (Samandarin, VERSINFO_BUILDNUMBER, THIS_CONFIG_VERSION, SALCFG_ROOTS_COUNT).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a559f8db8ac8329ba277182e48ab230)