### PR TITLE
Keep icon reader alive after shell icon handler faults

### DIFF
--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -1226,8 +1226,15 @@ void IconThreadThreadFBodyAux(const char* path, SHFILEINFO& shi, CIconSizeEnum i
         //SHGetFileInfo(path, 0, &shi, sizeof(shi),
         //              SHGFI_ICON | SHGFI_SMALLICON | SHGFI_SHELLICONSIZE);
     }
-    __except (CCallStack::HandleException(GetExceptionInformation(), 4))
+    __except (EXCEPTION_EXECUTE_HANDLER)
     {
+        // Shell icon handlers run in-process and some third-party handlers are
+        // known to throw SEH exceptions while extracting icons.  This icon
+        // reader already has a safe fallback path (simple/default icons), so do
+        // not route these exceptions through CCallStack::HandleException(): that
+        // handler intentionally terminates the process after writing a bug
+        // report.  Keep Salamander alive and mark this icon as unavailable.
+        TRACE_E("Shell icon handler failed while getting an icon for: " << path);
         FGIExceptionHasOccured++;
         shi.hIcon = NULL;
     }


### PR DESCRIPTION
### Motivation
- Third-party shell icon handlers can raise SEH exceptions while extracting icons and previously those were routed through `CCallStack::HandleException(...)`, which writes a bug report and terminates the process, so we need to avoid crashing the whole application for a single faulty handler.

### Description
- Replace the `__except (CCallStack::HandleException(GetExceptionInformation(), 4))` handler in `IconThreadThreadFBodyAux()` with a local `__except (EXCEPTION_EXECUTE_HANDLER)` in `src/fileswn1.cpp`, log the failing path, increment `FGIExceptionHasOccured`, and set `shi.hIcon = NULL` so the existing fallback to simple/default icons is used instead of invoking the fatal bug-report flow.

### Testing
- Ran `git diff --check` to ensure no whitespace or trailing errors and it succeeded. 
- Verified the old fatal handler pattern is gone using `rg -n "__except \(CCallStack::HandleException\(GetExceptionInformation\(\), 4\)" src/fileswn1.cpp` and the search returned no results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55b84652dc832987b5e34da4be68fa)