### PR TITLE
Fix Salmon minidump exception pointer handling

### DIFF
--- a/src/salmon/minidump.cpp
+++ b/src/salmon/minidump.cpp
@@ -51,7 +51,14 @@ BOOL GenerateMiniDump(CMinidumpParams* minidumpParams, CSalmonSharedMemory* mem,
                 ePtrs.ExceptionRecord = &mem->ExceptionRecord;
                 expParam.ThreadId = mem->ThreadId;
                 expParam.ExceptionPointers = &ePtrs;
-                expParam.ClientPointers = FALSE;
+                // Salmon writes the dump from a helper process.  The exception
+                // records above are copies stored in Salmon's address space, not
+                // pointers inside the crashed Salamander process, so DbgHelp must
+                // treat them as client-side pointers.  Passing FALSE makes newer
+                // DbgHelp versions validate those addresses in the target process
+                // and MiniDumpWriteDump can fail with HRESULT_FROM_WIN32(
+                // ERROR_INVALID_USER_BUFFER), shown in the UI as -2147023112.
+                expParam.ClientPointers = TRUE;
 
                 // great explanation of the flags (better than on MSDN): http://www.debuginfo.com/articles/effminidumps.html#minidumptypes
                 static MINIDUMP_TYPE dumpType;


### PR DESCRIPTION
### Motivation
- Out-of-process minidump generation in Salmon was failing with `-2147023112` (HRESULT_FROM_WIN32(ERROR_INVALID_USER_BUFFER)) because DbgHelp validated exception pointers against the target process when they were actually copies in Salmon's address space.
- The intent is to make minidump generation robust when Salmon writes dumps from a helper process using copied `EXCEPTION_RECORD`/`CONTEXT` data.

### Description
- In `src/salmon/minidump.cpp` set `MINIDUMP_EXCEPTION_INFORMATION::ClientPointers` to `TRUE` when passing copied exception structures to `MiniDumpWriteDump`.
- Add a comment explaining that the copied exception records live in Salmon's address space and therefore DbgHelp must be told they are client-side pointers to avoid `ERROR_INVALID_USER_BUFFER`.

### Testing
- Ran a small Python check that verifies `-2147023112` maps to `0x800706F8` / Win32 `ERROR_INVALID_USER_BUFFER`, which succeeded.
- Ran `git diff --check` to ensure no whitespace/errors introduced, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55d69aea8083298449708bb077d77b)