### PR TITLE
Fix command-line history navigation and detached tree repaint

### DIFF
--- a/src/editwnd.cpp
+++ b/src/editwnd.cpp
@@ -527,6 +527,7 @@ CEditLine::CEditLine()
 #endif // _UNICODE
     SkipCharacter = FALSE;
     SelChangeDisabled = FALSE;
+    EditWindow = NULL;
 }
 
 void CEditLine::InsertText(char* s)
@@ -546,7 +547,8 @@ CEditLine::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (MainWindow->HasLockedUI())
             return 0;
-        if (MainWindow->EditWindow->Dropped())
+        CEditWindow* editWindow = EditWindow != NULL ? EditWindow : MainWindow->EditWindow;
+        if (editWindow != NULL && editWindow->Dropped())
             break;
 
         if (SkipCharacter)
@@ -836,7 +838,8 @@ CEditLine::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (MainWindow->HasLockedUI())
             return 0;
-        if (MainWindow->EditWindow->Dropped())
+        CEditWindow* editWindow = EditWindow != NULL ? EditWindow : MainWindow->EditWindow;
+        if (editWindow != NULL && editWindow->Dropped())
             break;
         SkipCharacter = FALSE;
         break;
@@ -846,7 +849,8 @@ CEditLine::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (MainWindow->HasLockedUI())
             return 0;
-        if (MainWindow->EditWindow->Dropped())
+        CEditWindow* editWindow = EditWindow != NULL ? EditWindow : MainWindow->EditWindow;
+        if (editWindow != NULL && editWindow->Dropped())
             break;
         if (SkipCharacter)
             return 0;
@@ -889,7 +893,8 @@ CEditLine::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             panel->SelectItems = !panel->GetSel(panel->FocusedIndex);
         }
 
-        if (MainWindow->EditWindow->Dropped())
+        CEditWindow* editWindow = EditWindow != NULL ? EditWindow : MainWindow->EditWindow;
+        if (editWindow != NULL && editWindow->Dropped())
             break;
         else
         {
@@ -901,6 +906,12 @@ CEditLine::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 // Control - scroll without popping up the listbox
                 if (controlPressed && !altPressed && !shiftPressed)
                     break;
+                if (!controlPressed && !altPressed && !shiftPressed &&
+                    editWindow != NULL && editWindow->NavigateHistory(wParam == VK_UP))
+                {
+                    SkipCharacter = TRUE;
+                    return 0;
+                }
             }
         }
 
@@ -1857,6 +1868,8 @@ CEditWindow::CEditWindow()
     SetUnicodeWindow(TRUE);
 #endif // _UNICODE
     EditLine = new CEditLine();
+    if (EditLine != NULL)
+        EditLine->SetEditWindow(this);
     Text = new CInnerText(this);
     LastText = NULL;
     Enabled = TRUE;
@@ -1939,6 +1952,47 @@ void CEditWindow::FillHistory()
             if (Configuration.EditHistory[i] != NULL)
                 SendMessage(HWindow, CB_ADDSTRING, 0, (LPARAM)Configuration.EditHistory[i]);
     }
+}
+
+BOOL CEditWindow::NavigateHistory(BOOL older)
+{
+    if (HWindow == NULL || !Configuration.EnableCmdLineHistory)
+        return FALSE;
+
+    int count = (int)SendMessage(HWindow, CB_GETCOUNT, 0, 0);
+    if (count <= 0)
+        return FALSE;
+
+    int index = (int)SendMessage(HWindow, CB_GETCURSEL, 0, 0);
+    if (older)
+    {
+        if (index == CB_ERR)
+            index = 0;
+        else if (index < count - 1)
+            index++;
+        else
+            return TRUE;
+    }
+    else
+    {
+        if (index == CB_ERR)
+            return TRUE;
+        if (index > 0)
+            index--;
+        else
+            return TRUE;
+    }
+
+    if (SendMessage(HWindow, CB_SETCURSEL, index, 0) != CB_ERR)
+    {
+        if (EditLine != NULL && EditLine->HWindow != NULL)
+        {
+            int len = GetWindowTextLength(EditLine->HWindow);
+            SendMessage(EditLine->HWindow, EM_SETSEL, len, len);
+        }
+        return TRUE;
+    }
+    return FALSE;
 }
 
 BOOL CEditWindow::Dropped()

--- a/src/editwnd.cpp
+++ b/src/editwnd.cpp
@@ -1868,8 +1868,7 @@ CEditWindow::CEditWindow()
     SetUnicodeWindow(TRUE);
 #endif // _UNICODE
     EditLine = new CEditLine();
-    if (EditLine != NULL)
-        EditLine->SetEditWindow(this);
+    EditLine->SetEditWindow(this);
     Text = new CInnerText(this);
     LastText = NULL;
     Enabled = TRUE;

--- a/src/editwnd.h
+++ b/src/editwnd.h
@@ -15,6 +15,8 @@ struct CCommandLineLaunchInfo
 
 void BuildCommandShellLine(CCommandLineLaunchInfo* launchInfo);
 
+class CEditWindow;
+
 //
 // ****************************************************************************
 
@@ -23,9 +25,11 @@ class CEditLine : public CWindow
 protected:
     BOOL SkipCharacter;
     BOOL SelChangeDisabled;
+    CEditWindow* EditWindow;
 
 public:
     CEditLine();
+    void SetEditWindow(CEditWindow* editWindow) { EditWindow = editWindow; }
 
     void InsertText(char* s);
 
@@ -92,6 +96,7 @@ public:
     int GetNeededHeight();
     void SetFont();
     void FillHistory();
+    BOOL NavigateHistory(BOOL older);
     BOOL Dropped(); // listbox is dropped down
     void Enable(BOOL enable);
     BOOL IsEnabled() { return Enabled; }

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -203,7 +203,11 @@ static LRESULT CALLBACK TreeViewSubclassProc(HWND hwnd, UINT message, WPARAM wPa
     case WM_SIZE:
     {
         LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
-        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW);
+        RedrawWindow(hwnd, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_UPDATENOW);
+
+        HWND parent = GetParent(hwnd);
+        if (parent != NULL && MainWindow != NULL && parent == MainWindow->GetDetachedPanelWindow(cpsRight))
+            RedrawWindow(parent, NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_UPDATENOW);
         return result;
     }
 


### PR DESCRIPTION
### Motivation
- Restore Up/Down navigation through the command-line history when a command-line combo is focused while preserving existing Alt+/Ctrl+Up/Down behavior. 
- Ensure detached command-line bars use their own combo/dropdown state instead of accidentally sharing the main window state. 
- Eliminate visual artifacts left in detached tree-view hosts after scrolling/resizing by forcing a proper repaint of the detached host. 

### Description
- Add an `EditWindow` pointer to `CEditLine` and a `SetEditWindow` helper so each edit control knows its owning `CEditWindow`, and set that link when creating the edit window (`src/editwnd.h`, `src/editwnd.cpp`). 
- Implement `CEditWindow::NavigateHistory(BOOL older)` to move the combo selection and restore caret position, and call it from `CEditLine::WindowProc` when handling bare `VK_UP`/`VK_DOWN` so arrow-history navigation works when focused (while keeping Alt+Up/Down dropdown and Ctrl+Up/Down behavior intact) (`src/editwnd.cpp`). 
- Update `CEditLine` handling to consult its owning `CEditWindow` (or fallback to `MainWindow->EditWindow`) for dropdown state checks so detached edit boxes behave correctly (`src/editwnd.cpp`). 
- Force a fuller redraw of the tree-view after scroll/resize and also trigger a redraw of the detached panel host to clear selection-frame fragments in detached windows (`src/fileswn2.cpp`). 

### Testing
- Ran `git diff --check` to validate no trivial whitespace/patch issues, which passed. 
- Verified repository status and local diffs with `git status --short` and manual inspection of the modified regions, both OK. 
- Full Visual Studio / Windows build could not be executed in the current container because no MSBuild/Windows toolchain is available, so an in-OS build/test was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56d3414f5c832988ae9188620d26bc)