### PR TITLE
Allow Change Case to perform case-only renames

### DIFF
--- a/src/fileswn6.cpp
+++ b/src/fileswn6.cpp
@@ -1425,7 +1425,7 @@ BOOL CFilesWindow::BuildScriptMain(COperations* script, CActionType type,
                     if (type == atChangeCase)
                     {
                         COperation op;
-                        op.OpFlags = 0; // case change = rename = report invalid names (not just tolerance of existing ones)
+                        op.OpFlags = OPFL_ALLOW_CASE_ONLY_RENAME; // case change = rename = report invalid names (not just tolerance of existing ones)
                         op.Opcode = ocMoveDir;
                         op.Size = MOVE_DIR_SIZE;
                         op.Attr = oneFile->Attr;
@@ -2345,7 +2345,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
     if (type == atChangeCase)
     {
         op.Opcode = ocMoveDir;
-        op.OpFlags = 0; // case change = rename; we'll report invalid names (not just tolerate existing ones)
+        op.OpFlags = OPFL_ALLOW_CASE_ONLY_RENAME; // case change = rename; we'll report invalid names (not just tolerate existing ones)
         op.Size = MOVE_DIR_SIZE;
         op.Attr = sourceDirAttr;
         BOOL skip;
@@ -3086,7 +3086,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
     {
         op.Opcode = ocMoveFile;
         op.FileSize = fileSizeLoc;
-        op.OpFlags = 0;
+        op.OpFlags = OPFL_ALLOW_CASE_ONLY_RENAME;
         op.Size = MOVE_FILE_SIZE;
         op.Attr = sourceFileAttr;
         BOOL skip;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -5637,7 +5637,8 @@ BOOL DoMoveFile(COperation* op, HWND hProgressDlg, void* buffer,
                 {
                     std::wstring sourceCmpW = SalPathRemoveExtendedPrefixW(sourceNameMvDirW.c_str());
                     std::wstring targetCmpW = SalPathRemoveExtendedPrefixW(targetNameMvDirW.c_str());
-                    if (CompareStringW(LOCALE_USER_DEFAULT, NORM_IGNORECASE, sourceCmpW.c_str(), -1, targetCmpW.c_str(), -1) == CSTR_EQUAL)
+                    if ((op->OpFlags & OPFL_ALLOW_CASE_ONLY_RENAME) == 0 &&
+                        CompareStringW(LOCALE_USER_DEFAULT, NORM_IGNORECASE, sourceCmpW.c_str(), -1, targetCmpW.c_str(), -1) == CSTR_EQUAL)
                         SetLastError(ERROR_ALREADY_EXISTS);
                     else
                     {

--- a/src/worker.h
+++ b/src/worker.h
@@ -214,6 +214,7 @@ enum COperationCode
 #define OPFL_TGTPATH_IS_NET 0x00000020       // the target path is a network path
 #define OPFL_TGTPATH_IS_FAST 0x00000040      // the target path is a disk, USB disk, flash drive, flash-card reader, CD, DVD, or RAM disk (not a network or floppy)
 #define OPFL_IGNORE_INVALID_NAME 0x00000080  // skip the name validity test (for directories: unchanged name = do not flag as invalid)
+#define OPFL_ALLOW_CASE_ONLY_RENAME 0x00000100 // allow renames where source and target differ only by letter case
 
 struct COperation
 {


### PR DESCRIPTION
### Motivation
- Change Case operations that should only change letter case failed because the move worker treated source and target as identical (case-insensitive) and returned `ERROR_ALREADY_EXISTS` instead of performing the rename.
- The intent is to let Change Case use the real rename path for case-only differences while keeping existing duplicate-name protections for ordinary moves.

### Description
- Added a new operation flag `OPFL_ALLOW_CASE_ONLY_RENAME` in `src/worker.h` to indicate ops that may rename only by changing letter case.
- Marked Change Case operations (files and directories, including post-recursion directory renames and non-recursive selected directories) to set `OpFlags = OPFL_ALLOW_CASE_ONLY_RENAME` in `src/fileswn6.cpp`.
- Updated `DoMoveFile` in `src/worker.cpp` to skip the case-insensitive `CompareStringW` existence check when the new flag is set, allowing the underlying `MoveFileW` call to perform case-only renames.
- Preserved the original case-insensitive duplicate-name guard for normal move operations by conditioning the check on the new flag.

### Testing
- Ran `git diff --check` which produced no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56e66201cc8329a4841804ea51a283)