### PR TITLE
Fix tree view first-click folder expansion

### DIFF
--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -1405,6 +1405,14 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SetTreeViewItemChildren(HTreeView, loadData->hParentItem, hasChildren ? 1 : 0);
 
         SendMessage(HTreeView, WM_SETREDRAW, TRUE, 0);
+
+        // The async load is started from TVN_ITEMEXPANDING before the item has
+        // real child nodes.  The common control cannot complete that first
+        // expansion until the children exist, so expand the item now to make
+        // the original click on the +/- button take effect immediately.
+        if (hasChildren)
+            TreeView_Expand(HTreeView, loadData->hParentItem, TVE_EXPAND);
+
         TreeViewDisableNotify = FALSE;
         RedrawWindow(HTreeView, NULL, NULL, RDW_INVALIDATE | RDW_NOERASE);
 


### PR DESCRIPTION
### Motivation
- The tree view started asynchronous child loading from `TVN_ITEMEXPANDING`, which left the control without real child nodes and required a second click on the folder expander; the change makes the original click take effect.

### Description
- Added a programmatic `TreeView_Expand(HTreeView, loadData->hParentItem, TVE_EXPAND)` when `hasChildren` after async load completion and kept `TreeViewDisableNotify` suppressed until after this expansion to avoid re-entrant notification handling (file `src/fileswnb.cpp`).

### Testing
- Ran `git diff --check` which completed without issues; no Windows/Visual Studio build was executed in this environment due to platform constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a573e7e39e08329b7103310fcabdf07)