### PR TITLE
Handle DPI/session scaling changes and prompt for restart; add system DPI awareness

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -2520,6 +2520,18 @@ int GetIconSizeForSystemDPI(CIconSizeEnum iconSize);
 // vraci aktualni systemove DPI (96, 120, 144, ...)
 int GetSystemDPI();
 
+// DPI aktualni relace/desktopu; pouziva se pro detekci zmen RDP/session DPI
+int GetCurrentSessionDPI();
+
+// DPI daneho okna; fallbackuje na DPI relace, pokud API neni dostupne
+int GetDPIForWindow(HWND hWindow);
+
+// zapise do trace vsechny zdroje DPI, ktere jsou dulezite pri ladeni DPI zmen
+void TraceDPIState(const char* reason, HWND hWindow);
+
+// prevod hodnoty navrzene pro 96 DPI do zadaneho DPI
+int ScaleForDPI(int value, int dpi);
+
 // vraci scale odpovidajici aktualnimu DPI; misto 1.0 vraci 100, pro 1.25 vraci 125, atd
 int GetScaleForSystemDPI();
 

--- a/src/consts.h
+++ b/src/consts.h
@@ -2519,12 +2519,14 @@ int GetIconSizeForSystemDPI(CIconSizeEnum iconSize);
 
 // vraci aktualni systemove DPI (96, 120, 144, ...)
 int GetSystemDPI();
+void SetSystemDPI(int dpi);
 
 // DPI aktualni relace/desktopu; pouziva se pro detekci zmen RDP/session DPI
 int GetCurrentSessionDPI();
 
 // DPI daneho okna; fallbackuje na DPI relace, pokud API neni dostupne
 int GetDPIForWindow(HWND hWindow);
+int UpdateSystemDPIForWindow(HWND hWindow);
 
 // zapise do trace vsechny zdroje DPI, ktere jsou dulezite pri ladeni DPI zmen
 void TraceDPIState(const char* reason, HWND hWindow);

--- a/src/consts.h
+++ b/src/consts.h
@@ -1197,6 +1197,7 @@ struct COpenViewerData
 #define WM_USER_SLGINCOMPLETE WM_APP + 414 // [0, 0] - upozorneni, ze SLG neni kompletne prelozene, motivacni text aby se zapojili
 
 #define WM_USER_USERMENUICONS_READY WM_APP + 415 // [bkgndReaderData, threadID] - notifikace pro hl. okno, ze se dokoncilo cteni ikon pro User Menu v threadu s ID 'threadID'
+#define WM_USER_APPLY_DPI_CHANGE WM_APP + 416 // [dpi, 0] - deferred main-window DPI refresh
 
 #define WM_USER_TREEVIEW_ASYNC_DONE WM_APP + 420 // [0, CTreeViewAsyncLoadData*] - asynchronni nacteni obsahu slozky dokonceno
 

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -1302,6 +1302,8 @@ unsigned IconThreadThreadFBody(void* parameter)
                 window->ICWorking = TRUE;
 
                 CIconSizeEnum iconSize = window->GetIconSizeForCurrentViewMode();
+                int iconPixelSize = IconSizes[iconSize];
+                int iconDPI = GetSystemDPI();
 
                 CIconList* iconList;
                 int iconListIndex;
@@ -1784,6 +1786,15 @@ unsigned IconThreadThreadFBody(void* parameter)
                                     {
                                         if (shi.hIcon == NULL)
                                             failed = TRUE;
+                                        else if (iconPixelSize != IconSizes[iconSize] || iconDPI != GetSystemDPI())
+                                        {
+                                            // The icon was extracted while the panel was still using an old DPI.
+                                            // Do not let a delayed 24px read populate a freshly rebuilt 16px cache
+                                            // after moving from a high-DPI monitor to a 100% monitor.
+                                            HANDLES(DestroyIcon(shi.hIcon));
+                                            shi.hIcon = NULL;
+                                            failed = TRUE;
+                                        }
                                         else
                                         {
                                             if (window->IconCache->GetIcon(iconData->GetIndex(),

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -86,6 +86,20 @@ static int GetIconPixelWidth(HICON hIcon)
     return width;
 }
 
+static HICON GetShellImageListIcon(int imageListSize, int iconIndex)
+{
+    IImageList* imageList = NULL;
+    HICON hIcon = NULL;
+    HRESULT hres = SHGetImageList(imageListSize, IID_IImageList, (void**)&imageList);
+    if (SUCCEEDED(hres) && imageList != NULL)
+    {
+        if (imageList->GetIcon(iconIndex, ILD_NORMAL, &hIcon) != S_OK)
+            hIcon = NULL;
+        imageList->Release();
+    }
+    return hIcon;
+}
+
 BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl, HICON* hIcon,
                         CIconSizeEnum iconSize, BOOL fallbackToDefIcon, BOOL defIconIsDir)
 {
@@ -104,6 +118,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
     CIconSizeEnum largeIconSize = ICONSIZE_32;
     if (iconSize == ICONSIZE_48)
         largeIconSize = ICONSIZE_48;
+    BOOL preferExtractorSmallIcon = iconSize == ICONSIZE_16 && IconSizes[ICONSIZE_16] <= 16;
 
     HRESULT hres = psf->GetUIObjectOf(NULL, 1, &pidl, IID_IExtractIconA, NULL, (void**)&pxi);
     if (SUCCEEDED(hres))
@@ -135,7 +150,8 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         // another way to get 48x48 icons is LoadImage, but we would need the file path and icon number
         // a "*" in the file name means iconIndex already refers to a system icon index
         //TRACE_I("  SalGetIconFromPIDL() wFlags="<<wFlags<<" iconFile='"<<iconFile<<"' TryObtainGetImageList="<<TryObtainGetImageList);
-        if ((wFlags & GIL_NOTFILENAME) && iconFile[0] == '*' && iconFile[1] == 0)
+        if ((wFlags & GIL_NOTFILENAME) && iconFile[0] == '*' && iconFile[1] == 0 &&
+            !preferExtractorSmallIcon)
         {
             // multiple attempts helped JIS, but if icon extraction keeps failing
             // we would waste 50 ms on each icon retrieval for no reason
@@ -247,6 +263,22 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             //      }
         }
 
+        // For 100% DPI prefer extracting from the icon resource file first.
+        // Shell-provided small image lists may already be initialized for a
+        // high-DPI monitor and can contain a downscaled 24px design at 16px.
+        if (preferExtractorSmallIcon && hIconSmall == NULL && hIconLarge == NULL && !(wFlags & GIL_NOTFILENAME))
+        {
+            HICON hIcons[2] = {0, 0};
+            UINT u = ExtractIcons(iconFile, iconIndex, MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]),
+                                  MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]), hIcons, NULL, 2, IconLRFlags);
+            if (u != -1)
+            {
+                hIconLarge = hIcons[0];
+                hIconSmall = hIcons[1];
+            }
+            //TRACE_I("  SalGetIconFromPIDL() ExtractIcons hIconLarge="<<hIconLarge<<" hIconSmall="<<hIconSmall);
+        }
+
         // if the icon was not taken from the system image list, ask the pxi interface for it
         if (hIconSmall == NULL && hIconLarge == NULL)
         {
@@ -273,6 +305,12 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
                 hIconSmall = hIcons[1];
             }
             //TRACE_I("  SalGetIconFromPIDL() ExtractIcons hIconLarge="<<hIconLarge<<" hIconSmall="<<hIconSmall);
+        }
+
+        if (preferExtractorSmallIcon && hIconSmall == NULL && hIconLarge == NULL &&
+            (wFlags & GIL_NOTFILENAME) && iconFile[0] == '*' && iconFile[1] == 0)
+        {
+            hIconSmall = GetShellImageListIcon(SHIL_SMALL, iconIndex);
         }
     }
     if (iconSize == ICONSIZE_16 && hIconSmall != NULL &&

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -5,8 +5,68 @@
 #include "precomp.h"
 #include "commoncontrols.h"
 
+static UINT PrivateExtractSingleIcon(LPCTSTR fileName, int iconIndex, int iconSize, HICON* hIcon, UINT* iconID, UINT flags)
+{
+    typedef UINT(WINAPI * FPrivateExtractIcons)(LPCTSTR, int, int, int, HICON*, UINT*, UINT, UINT);
+    static FPrivateExtractIcons privateExtractIcons = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            privateExtractIcons = (FPrivateExtractIcons)GetProcAddress(user32, "PrivateExtractIconsA");
+        loaded = TRUE;
+    }
+
+    if (privateExtractIcons == NULL || hIcon == NULL || iconSize <= 0)
+        return 0;
+
+    *hIcon = NULL;
+    UINT count = privateExtractIcons(fileName, iconIndex, iconSize, iconSize, hIcon, iconID, 1, flags);
+    return count == (UINT)-1 ? 0 : count;
+}
+
 UINT WINAPI ExtractIcons(LPCTSTR szFileName, int nIconIndex, int cxIcon, int cyIcon, HICON* phicon, UINT* piconid, UINT nIcons, UINT flags)
 {
+    int largeIconSize = LOWORD(cxIcon);
+    int smallIconSize = HIWORD(cxIcon);
+    if (largeIconSize == 0)
+        largeIconSize = cxIcon;
+
+    if (phicon != NULL)
+    {
+        phicon[0] = NULL;
+        if (nIcons > 1)
+            phicon[1] = NULL;
+    }
+
+    // Prefer exact-size extraction. SHDefExtractIcon may return an already-scaled
+    // shell bitmap from a high-DPI image list, while PrivateExtractIcons asks for
+    // the concrete size we need (for example the native 16x16 group image at 100%).
+    UINT extracted = 0;
+    if (phicon != NULL)
+    {
+        extracted += PrivateExtractSingleIcon(szFileName, nIconIndex, largeIconSize, &phicon[0], piconid, flags) > 0 ? 1 : 0;
+        if (nIcons > 1 && smallIconSize > 0)
+        {
+            UINT* smallIconID = piconid != NULL ? piconid + 1 : NULL;
+            extracted += PrivateExtractSingleIcon(szFileName, nIconIndex, smallIconSize, &phicon[1], smallIconID, flags) > 0 ? 1 : 0;
+        }
+        BOOL exactExtractionComplete = nIcons > 1 ? phicon[0] != NULL && phicon[1] != NULL : phicon[0] != NULL;
+        if (exactExtractionComplete)
+            return extracted;
+        if (phicon[0] != NULL)
+        {
+            HANDLES(DestroyIcon(phicon[0]));
+            phicon[0] = NULL;
+        }
+        if (nIcons > 1 && phicon[1] != NULL)
+        {
+            HANDLES(DestroyIcon(phicon[1]));
+            phicon[1] = NULL;
+        }
+    }
+
     UINT nIconSize = cxIcon;
     HICON hLarge{};
     HICON hSmall{};

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -327,8 +327,11 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             if (hIconSmall == NULL || hIconSmall == hIconLarge || smallIconSize != targetIconSize)
             {
                 HICON hIconSource = hIconLarge != NULL ? hIconLarge : hIconSmall;
+                // Do not use LR_COPYFROMRESOURCE here: handles taken from the
+                // shell image list are already concrete bitmaps, and that flag
+                // may keep their original size when we need to shrink 24 -> 16.
                 HICON hIconDPI = hIconSource != NULL ?
-                                     (HICON)CopyImage(hIconSource, IMAGE_ICON, targetIconSize, targetIconSize, LR_COPYFROMRESOURCE) :
+                                     (HICON)CopyImage(hIconSource, IMAGE_ICON, targetIconSize, targetIconSize, 0) :
                                      NULL;
                 if (hIconDPI != NULL)
                 {

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -275,6 +275,40 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             //TRACE_I("  SalGetIconFromPIDL() ExtractIcons hIconLarge="<<hIconLarge<<" hIconSmall="<<hIconSmall);
         }
     }
+    if (iconSize == ICONSIZE_16 && hIconSmall != NULL &&
+        GetIconPixelWidth(hIconSmall) != IconSizes[ICONSIZE_16] && pxi != NULL)
+    {
+        // If the process first touched the shell image lists while running on a
+        // high-DPI monitor, even SHIL_SMALL can still hand back that larger
+        // process-global bitmap.  Ask the item's extractor directly for the
+        // requested 16px small icon before falling back to scaling it down.
+        HICON hExtractedLarge = NULL;
+        HICON hExtractedSmall = NULL;
+        BOOL extractedSmallAdopted = FALSE;
+        HRESULT extractResult;
+        if (isIExtractIconW)
+            extractResult = ((IExtractIconW*)pxi)->Extract(iconFileW, iconIndex, &hExtractedLarge, &hExtractedSmall,
+                                                           MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]));
+        else
+            extractResult = pxi->Extract(iconFile, iconIndex, &hExtractedLarge, &hExtractedSmall,
+                                         MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]));
+
+        if (SUCCEEDED(extractResult) && hExtractedSmall != NULL &&
+            GetIconPixelWidth(hExtractedSmall) == IconSizes[ICONSIZE_16])
+        {
+            if (hIconSmall != NULL && hIconSmall != hIconLarge)
+                HANDLES(DestroyIcon(hIconSmall));
+            hIconSmall = hExtractedSmall;
+            hExtractedSmall = NULL;
+            extractedSmallAdopted = TRUE;
+        }
+
+        if (hExtractedSmall != NULL)
+            HANDLES(DestroyIcon(hExtractedSmall));
+        if (hExtractedLarge != NULL && (!extractedSmallAdopted || hExtractedLarge != hIconSmall))
+            HANDLES(DestroyIcon(hExtractedLarge));
+    }
+
     if (pxi != NULL)
     {
         if (isIExtractIconW)

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -61,6 +61,31 @@ BOOL ExtIsExe(LPCTSTR szExt)
 #define SHIL_JUMBO 4      // Windows Vista and later. The image is normally 256x256 pixels.
 // regarding icon sizes on Windows Vista: see "Creating a DPI-Aware Application" (http://msdn.microsoft.com/en-us/library/ms701681(VS.85).aspx)
 
+static int GetIconPixelWidth(HICON hIcon)
+{
+    if (hIcon == NULL)
+        return 0;
+
+    ICONINFO iconInfo;
+    memset(&iconInfo, 0, sizeof(iconInfo));
+    if (!GetIconInfo(hIcon, &iconInfo))
+        return 0;
+
+    BITMAP bitmap;
+    memset(&bitmap, 0, sizeof(bitmap));
+    int width = 0;
+    HBITMAP hBitmap = iconInfo.hbmColor != NULL ? iconInfo.hbmColor : iconInfo.hbmMask;
+    if (hBitmap != NULL && GetObject(hBitmap, sizeof(bitmap), &bitmap) == sizeof(bitmap))
+        width = bitmap.bmWidth;
+
+    if (iconInfo.hbmColor != NULL)
+        HANDLES(DeleteObject(iconInfo.hbmColor));
+    if (iconInfo.hbmMask != NULL)
+        HANDLES(DeleteObject(iconInfo.hbmMask));
+
+    return width;
+}
+
 BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl, HICON* hIcon,
                         CIconSizeEnum iconSize, BOOL fallbackToDefIcon, BOOL defIconIsDir)
 {
@@ -121,7 +146,11 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             // ***** hIconSmall ******
             //TRACE_I("  SalGetIconFromPIDL() Asking system image list '*' for iconIndex="<<iconIndex);
             IImageList* imageListSmall = NULL;
-            hres = SHGetImageList(SHIL_SMALL, IID_IImageList, (void**)&imageListSmall);
+            // For per-monitor-DPI small icons, SHIL_SMALL can keep returning the
+            // classic 16x16 image.  SHIL_SYSSMALL tracks the current small-icon
+            // system metric, so at 150% it can supply the 24x24 shell image
+            // instead of forcing Salamander to upscale the 16x16 variant.
+            hres = SHGetImageList(SHIL_SYSSMALL, IID_IImageList, (void**)&imageListSmall);
             if (SUCCEEDED(hres) && (imageListSmall != NULL))
             {
                 if (imageListSmall->GetIcon(iconIndex, ILD_NORMAL, &hIconSmall) != S_OK)
@@ -285,13 +314,28 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
     if (hIconLarge != NULL || hIconSmall != NULL)
     {
         ret = TRUE;
-        // use hIconSmall for the small icon because IExtractIcon::Extract() ignores the pixel size and always returns 16 and 32
+        // Use a real icon for the current DPI.  IExtractIcon::Extract() and
+        // SHGFI_SMALLICON often return the historical 16x16 small icon even
+        // when IconSizes[ICONSIZE_16] is 20/24/... in a higher-DPI monitor.
+        // In that case prefer the DPI-sized shell image from SHIL_SYSSMALL, or
+        // derive the requested size from the larger icon instead of upscaling
+        // the 16x16 design.
         if (iconSize == ICONSIZE_16)
         {
-            // if the small icon is missing or we were given the handle of the large one, create it
-            if (hIconSmall == NULL || hIconSmall == hIconLarge)
+            int targetIconSize = IconSizes[ICONSIZE_16];
+            int smallIconSize = GetIconPixelWidth(hIconSmall);
+            if (hIconSmall == NULL || hIconSmall == hIconLarge || smallIconSize != targetIconSize)
             {
-                hIconSmall = (HICON)CopyImage(hIconLarge, IMAGE_ICON, IconSizes[ICONSIZE_16], IconSizes[ICONSIZE_16], LR_COPYFROMRESOURCE);
+                HICON hIconSource = hIconLarge != NULL ? hIconLarge : hIconSmall;
+                HICON hIconDPI = hIconSource != NULL ?
+                                     (HICON)CopyImage(hIconSource, IMAGE_ICON, targetIconSize, targetIconSize, LR_COPYFROMRESOURCE) :
+                                     NULL;
+                if (hIconDPI != NULL)
+                {
+                    if (hIconSmall != NULL && hIconSmall != hIconLarge)
+                        HANDLES(DestroyIcon(hIconSmall));
+                    hIconSmall = hIconDPI;
+                }
                 //TRACE_I("  SalGetIconFromPIDL() CopyImage 1 hIconSmall="<<hIconSmall<<" hIconLarge="<<hIconLarge);
             }
             *hIcon = hIconSmall;

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -146,11 +146,13 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             // ***** hIconSmall ******
             //TRACE_I("  SalGetIconFromPIDL() Asking system image list '*' for iconIndex="<<iconIndex);
             IImageList* imageListSmall = NULL;
-            // For per-monitor-DPI small icons, SHIL_SMALL can keep returning the
-            // classic 16x16 image.  SHIL_SYSSMALL tracks the current small-icon
-            // system metric, so at 150% it can supply the 24x24 shell image
-            // instead of forcing Salamander to upscale the 16x16 variant.
-            hres = SHGetImageList(SHIL_SYSSMALL, IID_IImageList, (void**)&imageListSmall);
+            // Use the shell image list that matches the requested pixel size.
+            // At 100% DPI we want the real 16x16 artwork from SHIL_SMALL, not a
+            // 24x24 SYSSMALL icon from a primary high-DPI monitor scaled down.
+            // At higher DPI, SYSSMALL can provide the DPI-sized small icon and
+            // avoids upscaling the 16x16 variant.
+            int smallImageListSize = IconSizes[ICONSIZE_16] <= 16 ? SHIL_SMALL : SHIL_SYSSMALL;
+            hres = SHGetImageList(smallImageListSize, IID_IImageList, (void**)&imageListSmall);
             if (SUCCEEDED(hres) && (imageListSmall != NULL))
             {
                 if (imageListSmall->GetIcon(iconIndex, ILD_NORMAL, &hIconSmall) != S_OK)

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -2084,5 +2084,8 @@ STRINGTABLE
  IDS_LONGPATHS_SETERROR, "Unable to change the Win32 long paths setting. Error: %s"
  IDS_LONGPATHS_ADMINTOOLTIP, "Run the application with administrator privileges to change the Win32 long paths setting."
 
+ IDS_DPI_CHANGE_TITLE, "Display scaling changed"
+ IDS_DPI_CHANGE_RESTART, "Windows display scaling or the remote desktop session DPI may have changed. Restart Open Salamander to redraw the whole user interface sharply in the current DPI."
+
  IDS_MENU_OPT_MANAGECONFIG, "&Manage Configurations..."
 }

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -688,6 +688,7 @@ public:
 
     void SetFont();
     void SetEnvFont();
+    void RefreshDPI(BOOL force, int dpi = 0, const RECT* suggestedRect = NULL);
 
     void RefreshDiskFreeSpace();
     void RefreshDirs();

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1442,7 +1442,7 @@ int CMainWindow::GetUnassignedHotPathIndex()
 static void ScaleSmallLogFontForCurrentDPI(LOGFONT* lf)
 {
     int dpi = GetSystemDPI();
-    if (lf == NULL || dpi <= 96 || lf->lfHeight == 0)
+    if (lf == NULL || lf->lfHeight == 0)
         return;
 
     int height = abs(lf->lfHeight);

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1438,6 +1438,21 @@ int CMainWindow::GetUnassignedHotPathIndex()
     return HotPaths.GetUnassignedHotPathIndex();
 }
 
+
+static void ScaleSmallLogFontForCurrentDPI(LOGFONT* lf)
+{
+    int dpi = GetSystemDPI();
+    if (lf == NULL || dpi <= 96 || lf->lfHeight == 0)
+        return;
+
+    int height = abs(lf->lfHeight);
+    if (height <= 14)
+    {
+        int scaled = MulDiv(height, dpi, 96);
+        lf->lfHeight = lf->lfHeight < 0 ? -scaled : scaled;
+    }
+}
+
 static BOOL SystemParametersInfoForCurrentDPI(UINT action, UINT uiParam, PVOID pvParam, UINT fWinIni)
 {
     typedef BOOL(WINAPI * FSystemParametersInfoForDpi)(UINT uiAction, UINT uiParam, PVOID pvParam, UINT fWinIni, UINT dpi);
@@ -1468,6 +1483,7 @@ BOOL GetSystemGUIFont(LOGFONT* lf)
         *lf = ncm.lfMessageFont;
         lf->lfWeight = FW_NORMAL;
     }
+    ScaleSmallLogFontForCurrentDPI(lf);
     return TRUE;
 }
 
@@ -1478,6 +1494,7 @@ BOOL GetSystemTooltipFont(LOGFONT* lf)
     ncm.cbSize = sizeof(ncm);
     SystemParametersInfoForCurrentDPI(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
     *lf = ncm.lfStatusFont;
+    ScaleSmallLogFontForCurrentDPI(lf);
     return TRUE;
 }
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1438,15 +1438,33 @@ int CMainWindow::GetUnassignedHotPathIndex()
     return HotPaths.GetUnassignedHotPathIndex();
 }
 
+static BOOL SystemParametersInfoForCurrentDPI(UINT action, UINT uiParam, PVOID pvParam, UINT fWinIni)
+{
+    typedef BOOL(WINAPI * FSystemParametersInfoForDpi)(UINT uiAction, UINT uiParam, PVOID pvParam, UINT fWinIni, UINT dpi);
+    static FSystemParametersInfoForDpi systemParametersInfoForDpi = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            systemParametersInfoForDpi = (FSystemParametersInfoForDpi)GetProcAddress(user32, "SystemParametersInfoForDpi");
+        loaded = TRUE;
+    }
+    if (systemParametersInfoForDpi != NULL &&
+        systemParametersInfoForDpi(action, uiParam, pvParam, fWinIni, GetSystemDPI()))
+        return TRUE;
+    return SystemParametersInfo(action, uiParam, pvParam, fWinIni);
+}
+
 // font for our GUI (the panel font can be defined in the configuration)
 BOOL GetSystemGUIFont(LOGFONT* lf)
 {
-    if (!SystemParametersInfo(SPI_GETICONTITLELOGFONT, sizeof(LOGFONT), lf, 0))
+    if (!SystemParametersInfoForCurrentDPI(SPI_GETICONTITLELOGFONT, sizeof(LOGFONT), lf, 0))
     {
         // if SystemParametersInfo fails unexpectedly, use a fallback
         NONCLIENTMETRICS ncm;
         ncm.cbSize = sizeof(ncm);
-        SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
+        SystemParametersInfoForCurrentDPI(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
         *lf = ncm.lfMessageFont;
         lf->lfWeight = FW_NORMAL;
     }
@@ -1458,7 +1476,7 @@ BOOL GetSystemTooltipFont(LOGFONT* lf)
 {
     NONCLIENTMETRICS ncm;
     ncm.cbSize = sizeof(ncm);
-    SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
+    SystemParametersInfoForCurrentDPI(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
     *lf = ncm.lfStatusFont;
     return TRUE;
 }

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1446,11 +1446,9 @@ static void ScaleSmallLogFontForCurrentDPI(LOGFONT* lf)
         return;
 
     int height = abs(lf->lfHeight);
-    if (height <= 14)
-    {
-        int scaled = MulDiv(height, dpi, 96);
-        lf->lfHeight = lf->lfHeight < 0 ? -scaled : scaled;
-    }
+    int expected = MulDiv(12, dpi, 96);
+    if (height < expected - 1 || height > expected + 2)
+        lf->lfHeight = lf->lfHeight < 0 ? -expected : expected;
 }
 
 static BOOL SystemParametersInfoForCurrentDPI(UINT action, UINT uiParam, PVOID pvParam, UINT fWinIni)

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -4237,6 +4237,24 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
         else
             ret = FALSE;
 
+        if (useWinPlacement)
+        {
+            RECT startupRect = place.rcNormalPosition;
+            if (startupRect.right > startupRect.left && startupRect.bottom > startupRect.top &&
+                MonitorFromRect(&startupRect, MONITOR_DEFAULTTONULL) != NULL)
+            {
+                // Move the hidden main window to its saved monitor before panels
+                // and icon caches are loaded.  Otherwise a process started on a
+                // high-DPI primary monitor can initialize 24px shell icons and
+                // only later move to the remembered 100% monitor.
+                SetWindowPos(HWindow, NULL, startupRect.left, startupRect.top,
+                             startupRect.right - startupRect.left, startupRect.bottom - startupRect.top,
+                             SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOREDRAW);
+                UpdateSystemDPIForWindow(HWindow);
+                ColorsChanged(FALSE, FALSE, TRUE);
+            }
+        }
+
         if (OpenKey(salamander, FINDDIALOG_WINDOW_REG, actKey))
         {
             Configuration.FindDialogWindowPlacement.length = sizeof(WINDOWPLACEMENT);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3885,7 +3885,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
-        RefreshDPI(TRUE, GetCurrentSessionDPI());
+        RefreshDPI(FALSE, GetCurrentSessionDPI());
         PromptIfSessionDPIChanged(HWindow);
         break;
     }
@@ -3895,7 +3895,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         TraceDPIState("WM_WTSSESSION_CHANGE", HWindow);
         if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
             wParam == WTS_SESSION_UNLOCK)
-            RefreshDPI(TRUE, GetCurrentSessionDPI());
+            RefreshDPI(FALSE, GetCurrentSessionDPI());
         if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
             wParam == WTS_SESSION_UNLOCK)
             ShowDPIChangePrompt(HWindow);
@@ -3905,7 +3905,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_SETTINGCHANGE:
     {
         TraceDPIState("WM_SETTINGCHANGE", HWindow);
-        RefreshDPI(TRUE, GetCurrentSessionDPI());
+        RefreshDPI(FALSE, GetCurrentSessionDPI());
         PromptIfSessionDPIChanged(HWindow);
 
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;
@@ -9822,7 +9822,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (wParam == TRUE) // activating the app
         {
             TraceDPIState("WM_ACTIVATEAPP", HWindow);
-            RefreshDPI(TRUE, GetCurrentSessionDPI());
+            // Activation is noisy during minimize/restore of other applications.
+            // Do not rebuild or resize the main window here; only check whether
+            // a session DPI change happened and let the restart prompt handle it.
             PromptIfSessionDPIChanged(HWindow);
 
             if (!LeftPanel->DontClearNextFocusName)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3456,6 +3456,18 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
                      suggestedRect->bottom - suggestedRect->top,
                      SWP_NOACTIVATE | SWP_NOZORDER);
     }
+    else if (oldDPI > 0 && newDPI > 0 && oldDPI != newDPI)
+    {
+        RECT windowRect;
+        if (GetWindowRect(HWindow, &windowRect))
+        {
+            int width = windowRect.right - windowRect.left;
+            int height = windowRect.bottom - windowRect.top;
+            SetWindowPos(HWindow, NULL, windowRect.left, windowRect.top,
+                         MulDiv(width, newDPI, oldDPI), MulDiv(height, newDPI, oldDPI),
+                         SWP_NOACTIVATE | SWP_NOZORDER);
+        }
+    }
 
     if (LeftPanel == NULL || RightPanel == NULL)
         return;
@@ -3859,7 +3871,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
-        RefreshDPI(FALSE);
+        RefreshDPI(TRUE, GetCurrentSessionDPI());
         PromptIfSessionDPIChanged(HWindow);
         break;
     }
@@ -3869,6 +3881,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         TraceDPIState("WM_WTSSESSION_CHANGE", HWindow);
         if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
             wParam == WTS_SESSION_UNLOCK)
+            RefreshDPI(TRUE, GetCurrentSessionDPI());
+        if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
+            wParam == WTS_SESSION_UNLOCK)
             ShowDPIChangePrompt(HWindow);
         return 0;
     }
@@ -3876,7 +3891,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_SETTINGCHANGE:
     {
         TraceDPIState("WM_SETTINGCHANGE", HWindow);
-        RefreshDPI(FALSE);
+        RefreshDPI(TRUE, GetCurrentSessionDPI());
         PromptIfSessionDPIChanged(HWindow);
 
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;
@@ -9793,7 +9808,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (wParam == TRUE) // activating the app
         {
             TraceDPIState("WM_ACTIVATEAPP", HWindow);
-            RefreshDPI(FALSE);
+            RefreshDPI(TRUE, GetCurrentSessionDPI());
             PromptIfSessionDPIChanged(HWindow);
 
             if (!LeftPanel->DontClearNextFocusName)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3549,8 +3549,25 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     LayoutWindows();
 
     GetShortcutOverlay();
+
+    // Force panel file icons to be re-read at the new icon size.  SetEnvFont()
+    // already releases icon caches asynchronously, but an immediate list-box
+    // repaint can otherwise keep using large HICONs after a high-DPI -> low-DPI
+    // transition until the next directory refresh.
+    LeftPanel->SleepIconCacheThread();
+    LeftPanel->IconCache->Release();
+    LeftPanel->IconCacheValid = FALSE;
+    LeftPanel->EndOfIconReadingTime = GetTickCount() - 10000;
+    LeftPanel->UseThumbnails = FALSE;
+    RightPanel->SleepIconCacheThread();
+    RightPanel->IconCache->Release();
+    RightPanel->IconCacheValid = FALSE;
+    RightPanel->EndOfIconReadingTime = GetTickCount() - 10000;
+    RightPanel->UseThumbnails = FALSE;
+
     LeftPanel->RefreshListBox(-1, -1, LeftPanel->FocusedIndex, FALSE, FALSE);
     RightPanel->RefreshListBox(-1, -1, RightPanel->FocusedIndex, FALSE, FALSE);
+    PostMessage(HWindow, WM_USER_REPAINTALLICONS, 0, 0);
     RefreshDiskFreeSpace();
     RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
     Plugins.Event(PLUGINEVENT_SETTINGCHANGE, 0);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3439,6 +3439,9 @@ void CMainWindow::UpdateRebarVisuals()
 }
 
 static BOOL DPIRefreshInProgress = FALSE;
+static int MainWindowContentDPI = 0;
+static int InitialSessionDPI = 0;
+static BOOL DPIChangePromptShown = FALSE;
 
 void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
 {
@@ -3447,7 +3450,7 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
 
     DPIRefreshInProgress = TRUE;
 
-    int oldDPI = GetSystemDPI();
+    int oldDPI = MainWindowContentDPI > 0 ? MainWindowContentDPI : GetSystemDPI();
     int newDPI = dpi > 0 ? dpi : GetDPIForWindow(HWindow);
     SetSystemDPI(newDPI);
 
@@ -3492,13 +3495,13 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     LeftPanel->RefreshListBox(-1, -1, LeftPanel->FocusedIndex, FALSE, FALSE);
     RightPanel->RefreshListBox(-1, -1, RightPanel->FocusedIndex, FALSE, FALSE);
     RefreshDiskFreeSpace();
-    RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);
+    RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
     Plugins.Event(PLUGINEVENT_SETTINGCHANGE, 0);
+    MainWindowContentDPI = newDPI;
+    InitialSessionDPI = newDPI;
+    DPIChangePromptShown = FALSE;
     DPIRefreshInProgress = FALSE;
 }
-
-static int InitialSessionDPI = 0;
-static BOOL DPIChangePromptShown = FALSE;
 
 static BOOL RegisterSessionNotification(HWND hWindow)
 {
@@ -3584,6 +3587,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         SHChangeNotifyInitialize(); // request receiving Shell Notifications
         InitialSessionDPI = GetCurrentSessionDPI();
+        MainWindowContentDPI = InitialSessionDPI;
         TraceDPIState("WM_CREATE", HWindow);
         RegisterSessionNotification(HWindow);
 
@@ -3896,9 +3900,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
             wParam == WTS_SESSION_UNLOCK)
             RefreshDPI(FALSE, GetCurrentSessionDPI());
-        if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
-            wParam == WTS_SESSION_UNLOCK)
-            ShowDPIChangePrompt(HWindow);
+        PromptIfSessionDPIChanged(HWindow);
         return 0;
     }
 

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3438,14 +3438,24 @@ void CMainWindow::UpdateRebarVisuals()
     RedrawWindow(HTopRebar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
+static BOOL DPIRefreshInProgress = FALSE;
+
 void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
 {
+    if (DPIRefreshInProgress)
+        return;
+
+    DPIRefreshInProgress = TRUE;
+
     int oldDPI = GetSystemDPI();
     int newDPI = dpi > 0 ? dpi : GetDPIForWindow(HWindow);
     SetSystemDPI(newDPI);
 
     if (!force && newDPI == oldDPI)
+    {
+        DPIRefreshInProgress = FALSE;
         return;
+    }
 
     TraceDPIState("RefreshDPI", HWindow);
 
@@ -3470,7 +3480,10 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     }
 
     if (LeftPanel == NULL || RightPanel == NULL)
+    {
+        DPIRefreshInProgress = FALSE;
         return;
+    }
 
     ColorsChanged(TRUE, FALSE, TRUE);
     SetFont();
@@ -3481,6 +3494,7 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     RefreshDiskFreeSpace();
     RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);
     Plugins.Event(PLUGINEVENT_SETTINGCHANGE, 0);
+    DPIRefreshInProgress = FALSE;
 }
 
 static int InitialSessionDPI = 0;

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3912,7 +3912,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
-        RefreshDPI(FALSE, GetCurrentSessionDPI());
+        RefreshDPI(FALSE, GetDPIForWindow(HWindow));
         PromptIfSessionDPIChanged(HWindow);
         break;
     }
@@ -3930,7 +3930,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_SETTINGCHANGE:
     {
         TraceDPIState("WM_SETTINGCHANGE", HWindow);
-        RefreshDPI(FALSE, GetCurrentSessionDPI());
+        RefreshDPI(FALSE, GetDPIForWindow(HWindow));
         PromptIfSessionDPIChanged(HWindow);
 
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -36,6 +36,10 @@
 #include "gui.h"
 #include <uxtheme.h>
 
+#ifndef WM_DPICHANGED
+#define WM_DPICHANGED 0x02E0
+#endif
+
 #ifndef WM_WTSSESSION_CHANGE
 #define WM_WTSSESSION_CHANGE 0x02B1
 #endif
@@ -3434,6 +3438,39 @@ void CMainWindow::UpdateRebarVisuals()
     RedrawWindow(HTopRebar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
+void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
+{
+    int oldDPI = GetSystemDPI();
+    int newDPI = dpi > 0 ? dpi : GetDPIForWindow(HWindow);
+    SetSystemDPI(newDPI);
+
+    if (!force && newDPI == oldDPI)
+        return;
+
+    TraceDPIState("RefreshDPI", HWindow);
+
+    if (suggestedRect != NULL)
+    {
+        SetWindowPos(HWindow, NULL, suggestedRect->left, suggestedRect->top,
+                     suggestedRect->right - suggestedRect->left,
+                     suggestedRect->bottom - suggestedRect->top,
+                     SWP_NOACTIVATE | SWP_NOZORDER);
+    }
+
+    if (LeftPanel == NULL || RightPanel == NULL)
+        return;
+
+    ColorsChanged(TRUE, FALSE, TRUE);
+    SetFont();
+    SetEnvFont();
+    GetShortcutOverlay();
+    LeftPanel->RefreshListBox(-1, -1, LeftPanel->FocusedIndex, FALSE, FALSE);
+    RightPanel->RefreshListBox(-1, -1, RightPanel->FocusedIndex, FALSE, FALSE);
+    RefreshDiskFreeSpace();
+    RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);
+    Plugins.Event(PLUGINEVENT_SETTINGCHANGE, 0);
+}
+
 static int InitialSessionDPI = 0;
 static BOOL DPIChangePromptShown = FALSE;
 
@@ -3813,9 +3850,16 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         break;
     }
 
+    case WM_DPICHANGED:
+    {
+        RefreshDPI(TRUE, HIWORD(wParam), lParam != 0 ? reinterpret_cast<const RECT*>(lParam) : NULL);
+        return 0;
+    }
+
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
+        RefreshDPI(FALSE);
         PromptIfSessionDPIChanged(HWindow);
         break;
     }
@@ -3832,6 +3876,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_SETTINGCHANGE:
     {
         TraceDPIState("WM_SETTINGCHANGE", HWindow);
+        RefreshDPI(FALSE);
         PromptIfSessionDPIChanged(HWindow);
 
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;
@@ -9748,6 +9793,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (wParam == TRUE) // activating the app
         {
             TraceDPIState("WM_ACTIVATEAPP", HWindow);
+            RefreshDPI(FALSE);
             PromptIfSessionDPIChanged(HWindow);
 
             if (!LeftPanel->DontClearNextFocusName)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3474,6 +3474,8 @@ static void RestoreThreadDPIAwarenessAfterRefresh(HANDLE oldContext)
 
 static BOOL DPIRefreshInProgress = FALSE;
 static BOOL DPIRefreshPosted = FALSE;
+static BOOL DPIRefreshDeferredForSizeMove = FALSE;
+static BOOL DPIInSizeMove = FALSE;
 static int PendingDPI = 0;
 static BOOL PendingDPIWindowRectApplied = FALSE;
 static BOOL DPIWindowRectAlreadyApplied = FALSE;
@@ -3959,6 +3961,24 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         break;
     }
 
+    case WM_ENTERSIZEMOVE:
+    {
+        DPIInSizeMove = TRUE;
+        break;
+    }
+
+    case WM_EXITSIZEMOVE:
+    {
+        DPIInSizeMove = FALSE;
+        if (DPIRefreshDeferredForSizeMove && PendingDPI > 0 && !DPIRefreshPosted)
+        {
+            DPIRefreshPosted = TRUE;
+            PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
+        }
+        DPIRefreshDeferredForSizeMove = FALSE;
+        break;
+    }
+
     case WM_DPICHANGED:
     {
         int dpi = HIWORD(wParam);
@@ -3972,7 +3992,11 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         }
         PendingDPI = dpi;
         PendingDPIWindowRectApplied = lParam != 0;
-        if (!DPIRefreshPosted)
+        if (DPIInSizeMove)
+        {
+            DPIRefreshDeferredForSizeMove = TRUE;
+        }
+        else if (!DPIRefreshPosted)
         {
             DPIRefreshPosted = TRUE;
             PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)dpi, 0);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -35,6 +35,23 @@
 #include "cache.h"
 #include "gui.h"
 #include <uxtheme.h>
+
+#ifndef WM_WTSSESSION_CHANGE
+#define WM_WTSSESSION_CHANGE 0x02B1
+#endif
+#ifndef NOTIFY_FOR_THIS_SESSION
+#define NOTIFY_FOR_THIS_SESSION 0
+#endif
+#ifndef WTS_REMOTE_CONNECT
+#define WTS_REMOTE_CONNECT 0x3
+#endif
+#ifndef WTS_SESSION_LOGON
+#define WTS_SESSION_LOGON 0x5
+#endif
+#ifndef WTS_SESSION_UNLOCK
+#define WTS_SESSION_UNLOCK 0x8
+#endif
+
 #include "zip.h"
 #include "tasklist.h"
 #include "jumplist.h"
@@ -3417,6 +3434,83 @@ void CMainWindow::UpdateRebarVisuals()
     RedrawWindow(HTopRebar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
+static int InitialSessionDPI = 0;
+static BOOL DPIChangePromptShown = FALSE;
+
+static BOOL RegisterSessionNotification(HWND hWindow)
+{
+    typedef BOOL(WINAPI * FWTSRegisterSessionNotification)(HWND hWnd, DWORD dwFlags);
+    HMODULE wtsapi32 = LoadLibrary("wtsapi32.dll");
+    if (wtsapi32 == NULL)
+        return FALSE;
+
+    FWTSRegisterSessionNotification registerSessionNotification =
+        (FWTSRegisterSessionNotification)GetProcAddress(wtsapi32, "WTSRegisterSessionNotification");
+    if (registerSessionNotification == NULL)
+        return FALSE;
+
+    return registerSessionNotification(hWindow, NOTIFY_FOR_THIS_SESSION);
+}
+
+static void UnregisterSessionNotification(HWND hWindow)
+{
+    typedef BOOL(WINAPI * FWTSUnRegisterSessionNotification)(HWND hWnd);
+    HMODULE wtsapi32 = GetModuleHandle("wtsapi32.dll");
+    if (wtsapi32 == NULL)
+        return;
+
+    FWTSUnRegisterSessionNotification unregisterSessionNotification =
+        (FWTSUnRegisterSessionNotification)GetProcAddress(wtsapi32, "WTSUnRegisterSessionNotification");
+    if (unregisterSessionNotification != NULL)
+        unregisterSessionNotification(hWindow);
+}
+
+static void RelaunchAfterDPIChange(HWND hWindow)
+{
+    if (MainWindow != NULL)
+        MainWindow->SaveConfig(hWindow, FALSE);
+
+    char cmdLine[32768];
+    lstrcpyn(cmdLine, GetCommandLine(), _countof(cmdLine));
+
+    STARTUPINFO si;
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&si, sizeof(si));
+    ZeroMemory(&pi, sizeof(pi));
+    si.cb = sizeof(si);
+    if (CreateProcess(NULL, cmdLine, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
+    {
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+        PostMessage(hWindow, WM_CLOSE, 0, 0);
+    }
+}
+
+static void ShowDPIChangePrompt(HWND hWindow)
+{
+    if (DPIChangePromptShown)
+        return;
+
+    DPIChangePromptShown = TRUE;
+    if (SalMessageBox(hWindow, LoadStr(IDS_DPI_CHANGE_RESTART), LoadStr(IDS_DPI_CHANGE_TITLE),
+                      MB_OK | MB_ICONINFORMATION) == IDOK)
+    {
+        RelaunchAfterDPIChange(hWindow);
+    }
+}
+
+static void PromptIfSessionDPIChanged(HWND hWindow)
+{
+    int dpi = GetCurrentSessionDPI();
+    if (InitialSessionDPI == 0)
+    {
+        InitialSessionDPI = dpi;
+        return;
+    }
+    if (dpi != InitialSessionDPI)
+        ShowDPIChangePrompt(hWindow);
+}
+
 LRESULT
 CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -3426,6 +3520,9 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CREATE:
     {
         SHChangeNotifyInitialize(); // request receiving Shell Notifications
+        InitialSessionDPI = GetCurrentSessionDPI();
+        TraceDPIState("WM_CREATE", HWindow);
+        RegisterSessionNotification(HWindow);
 
         SetTimer(HWindow, IDT_ADDNEWMODULES, 15000, NULL); // timer after 15 seconds for AddNewlyLoadedModulesToGlobalModulesStore()
 
@@ -3716,8 +3813,27 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         break;
     }
 
+    case WM_DISPLAYCHANGE:
+    {
+        TraceDPIState("WM_DISPLAYCHANGE", HWindow);
+        PromptIfSessionDPIChanged(HWindow);
+        break;
+    }
+
+    case WM_WTSSESSION_CHANGE:
+    {
+        TraceDPIState("WM_WTSSESSION_CHANGE", HWindow);
+        if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
+            wParam == WTS_SESSION_UNLOCK)
+            ShowDPIChangePrompt(HWindow);
+        return 0;
+    }
+
     case WM_SETTINGCHANGE:
     {
+        TraceDPIState("WM_SETTINGCHANGE", HWindow);
+        PromptIfSessionDPIChanged(HWindow);
+
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;
         if (darkChanged)
         {
@@ -9631,6 +9747,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         //      {
         if (wParam == TRUE) // activating the app
         {
+            TraceDPIState("WM_ACTIVATEAPP", HWindow);
+            PromptIfSessionDPIChanged(HWindow);
+
             if (!LeftPanel->DontClearNextFocusName)
                 LeftPanel->NextFocusName[0] = 0;
             else
@@ -10566,6 +10685,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             while (1)
                 Sleep(1000);
         }
+
+        UnregisterSessionNotification(HWindow);
 
         // notify the task list that we are exiting
         TaskList.SetProcessState(PROCESS_STATE_ENDING, NULL);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -4002,8 +4002,23 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         DPIInSizeMove = FALSE;
         if (DPIRefreshDeferredForSizeMove && PendingDPI > 0 && !DPIRefreshPosted)
         {
+            int windowDPI = GetDPIForWindow(HWindow);
+            if (windowDPI > 0)
+                PendingDPI = windowDPI; // final monitor can differ from the first WM_DPICHANGED during drag
             DPIRefreshPosted = TRUE;
             PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
+        }
+        else if (!DPIRefreshPosted)
+        {
+            int windowDPI = GetDPIForWindow(HWindow);
+            int contentDPI = MainWindowContentDPI > 0 ? MainWindowContentDPI : GetSystemDPI();
+            if (windowDPI > 0 && windowDPI != contentDPI)
+            {
+                PendingDPI = windowDPI;
+                PendingDPIWindowRectApplied = FALSE;
+                DPIRefreshPosted = TRUE;
+                PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
+            }
         }
         DPIRefreshDeferredForSizeMove = FALSE;
         break;
@@ -4038,7 +4053,14 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     {
         DPIRefreshPosted = FALSE;
         int dpi = PendingDPI > 0 ? PendingDPI : (int)wParam;
-        DPIWindowRectAlreadyApplied = PendingDPIWindowRectApplied;
+        BOOL windowRectAlreadyApplied = PendingDPIWindowRectApplied;
+        int windowDPI = GetDPIForWindow(HWindow);
+        if (windowDPI > 0 && windowDPI != dpi)
+        {
+            dpi = windowDPI;
+            windowRectAlreadyApplied = FALSE;
+        }
+        DPIWindowRectAlreadyApplied = windowRectAlreadyApplied;
         PendingDPI = 0;
         PendingDPIWindowRectApplied = FALSE;
         RefreshDPI(TRUE, dpi, NULL);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -4000,6 +4000,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             DPIRefreshPosted = TRUE;
             PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
         }
+        PromptIfSessionDPIChanged(HWindow);
         break;
     }
 
@@ -4016,6 +4017,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
             }
         }
+        PromptIfSessionDPIChanged(HWindow);
         return 0;
     }
 
@@ -4028,6 +4030,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             DPIRefreshPosted = TRUE;
             PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
         }
+        PromptIfSessionDPIChanged(HWindow);
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;
         if (darkChanged)
         {

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3555,12 +3555,12 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     // repaint can otherwise keep using large HICONs after a high-DPI -> low-DPI
     // transition until the next directory refresh.
     LeftPanel->SleepIconCacheThread();
-    LeftPanel->IconCache->Release();
+    LeftPanel->IconCache->Destroy();
     LeftPanel->IconCacheValid = FALSE;
     LeftPanel->EndOfIconReadingTime = GetTickCount() - 10000;
     LeftPanel->UseThumbnails = FALSE;
     RightPanel->SleepIconCacheThread();
-    RightPanel->IconCache->Release();
+    RightPanel->IconCache->Destroy();
     RightPanel->IconCacheValid = FALSE;
     RightPanel->EndOfIconReadingTime = GetTickCount() - 10000;
     RightPanel->UseThumbnails = FALSE;

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3550,10 +3550,17 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
 
     GetShortcutOverlay();
 
-    // Force panel file icons to be re-read at the new icon size.  SetEnvFont()
-    // already releases icon caches asynchronously, but an immediate list-box
-    // repaint can otherwise keep using large HICONs after a high-DPI -> low-DPI
-    // transition until the next directory refresh.
+    // Force all file-panel icon sources to be rebuilt at the new pixel size.
+    // Panel icon caches hold per-directory icons, while Associations owns shared
+    // extension/default icons used by the listboxes.  CAssociations::Release()
+    // keeps its old image lists alive, so use Destroy() here; otherwise the
+    // same ICONSIZE_16/32 enum can keep reusing old-DPI bitmaps after the
+    // IconSizes[] pixel values changed.
+    BOOL leftCanDrawItems = LeftPanel->CanDrawItems;
+    BOOL rightCanDrawItems = RightPanel->CanDrawItems;
+    LeftPanel->CanDrawItems = FALSE;
+    RightPanel->CanDrawItems = FALSE;
+
     LeftPanel->SleepIconCacheThread();
     LeftPanel->IconCache->Destroy();
     LeftPanel->IconCacheValid = FALSE;
@@ -3564,6 +3571,12 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     RightPanel->IconCacheValid = FALSE;
     RightPanel->EndOfIconReadingTime = GetTickCount() - 10000;
     RightPanel->UseThumbnails = FALSE;
+
+    Associations.Destroy();
+    Associations.ReadAssociations(FALSE);
+
+    LeftPanel->CanDrawItems = leftCanDrawItems;
+    RightPanel->CanDrawItems = rightCanDrawItems;
 
     LeftPanel->RefreshDirectory(FALSE, TRUE);
     RightPanel->RefreshDirectory(FALSE, TRUE);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3439,6 +3439,8 @@ void CMainWindow::UpdateRebarVisuals()
 }
 
 static BOOL DPIRefreshInProgress = FALSE;
+static BOOL DPIRefreshPosted = FALSE;
+static int PendingDPI = 0;
 static int MainWindowContentDPI = 0;
 static int InitialSessionDPI = 0;
 static BOOL DPIChangePromptShown = FALSE;
@@ -3916,15 +3918,42 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
 
     case WM_DPICHANGED:
     {
-        RefreshDPI(TRUE, HIWORD(wParam), lParam != 0 ? reinterpret_cast<const RECT*>(lParam) : NULL);
+        int dpi = HIWORD(wParam);
+        if (lParam != 0)
+        {
+            const RECT* suggestedRect = reinterpret_cast<const RECT*>(lParam);
+            SetWindowPos(HWindow, NULL, suggestedRect->left, suggestedRect->top,
+                         suggestedRect->right - suggestedRect->left,
+                         suggestedRect->bottom - suggestedRect->top,
+                         SWP_NOACTIVATE | SWP_NOZORDER);
+        }
+        PendingDPI = dpi;
+        if (!DPIRefreshPosted)
+        {
+            DPIRefreshPosted = TRUE;
+            PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)dpi, 0);
+        }
+        return 0;
+    }
+
+    case WM_USER_APPLY_DPI_CHANGE:
+    {
+        DPIRefreshPosted = FALSE;
+        int dpi = PendingDPI > 0 ? PendingDPI : (int)wParam;
+        PendingDPI = 0;
+        RefreshDPI(TRUE, dpi, NULL);
         return 0;
     }
 
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
-        RefreshDPI(FALSE, GetDPIForWindow(HWindow));
-        PromptIfSessionDPIChanged(HWindow);
+        PendingDPI = GetDPIForWindow(HWindow);
+        if (!DPIRefreshPosted)
+        {
+            DPIRefreshPosted = TRUE;
+            PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
+        }
         break;
     }
 
@@ -3933,17 +3962,26 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         TraceDPIState("WM_WTSSESSION_CHANGE", HWindow);
         if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
             wParam == WTS_SESSION_UNLOCK)
-            RefreshDPI(FALSE, GetCurrentSessionDPI());
-        PromptIfSessionDPIChanged(HWindow);
+        {
+            PendingDPI = GetCurrentSessionDPI();
+            if (!DPIRefreshPosted)
+            {
+                DPIRefreshPosted = TRUE;
+                PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
+            }
+        }
         return 0;
     }
 
     case WM_SETTINGCHANGE:
     {
         TraceDPIState("WM_SETTINGCHANGE", HWindow);
-        RefreshDPI(FALSE, GetDPIForWindow(HWindow));
-        PromptIfSessionDPIChanged(HWindow);
-
+        PendingDPI = GetDPIForWindow(HWindow);
+        if (!DPIRefreshPosted)
+        {
+            DPIRefreshPosted = TRUE;
+            PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
+        }
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;
         if (darkChanged)
         {
@@ -9858,11 +9896,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (wParam == TRUE) // activating the app
         {
             TraceDPIState("WM_ACTIVATEAPP", HWindow);
-            // Activation is noisy during minimize/restore of other applications.
-            // Do not rebuild or resize the main window here; only check whether
-            // a session DPI change happened and let the restart prompt handle it.
-            PromptIfSessionDPIChanged(HWindow);
-
             if (!LeftPanel->DontClearNextFocusName)
                 LeftPanel->NextFocusName[0] = 0;
             else

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3438,6 +3438,40 @@ void CMainWindow::UpdateRebarVisuals()
     RedrawWindow(HTopRebar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
+
+static HANDLE SetThreadDPIAwarenessForRefresh()
+{
+    typedef HANDLE(WINAPI * FSetThreadDpiAwarenessContext)(HANDLE dpiContext);
+    static FSetThreadDpiAwarenessContext setThreadDpiAwarenessContext = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            setThreadDpiAwarenessContext = (FSetThreadDpiAwarenessContext)GetProcAddress(user32, "SetThreadDpiAwarenessContext");
+        loaded = TRUE;
+    }
+    if (setThreadDpiAwarenessContext != NULL)
+        return setThreadDpiAwarenessContext((HANDLE)-4 /* DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 */);
+    return NULL;
+}
+
+static void RestoreThreadDPIAwarenessAfterRefresh(HANDLE oldContext)
+{
+    typedef HANDLE(WINAPI * FSetThreadDpiAwarenessContext)(HANDLE dpiContext);
+    static FSetThreadDpiAwarenessContext setThreadDpiAwarenessContext = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            setThreadDpiAwarenessContext = (FSetThreadDpiAwarenessContext)GetProcAddress(user32, "SetThreadDpiAwarenessContext");
+        loaded = TRUE;
+    }
+    if (setThreadDpiAwarenessContext != NULL && oldContext != NULL)
+        setThreadDpiAwarenessContext(oldContext);
+}
+
 static BOOL DPIRefreshInProgress = FALSE;
 static BOOL DPIRefreshPosted = FALSE;
 static int PendingDPI = 0;
@@ -3465,6 +3499,7 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     }
 
     TraceDPIState("RefreshDPI", HWindow);
+    HANDLE oldThreadDPIContext = SetThreadDPIAwarenessForRefresh();
 
     if (suggestedRect != NULL)
     {
@@ -3492,6 +3527,7 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
 
     if (LeftPanel == NULL || RightPanel == NULL)
     {
+        RestoreThreadDPIAwarenessAfterRefresh(oldThreadDPIContext);
         DPIRefreshInProgress = FALSE;
         return;
     }
@@ -3519,6 +3555,7 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     MainWindowContentDPI = newDPI;
     InitialSessionDPI = newDPI;
     DPIChangePromptShown = FALSE;
+    RestoreThreadDPIAwarenessAfterRefresh(oldThreadDPIContext);
     DPIRefreshInProgress = FALSE;
 }
 

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3565,8 +3565,8 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     RightPanel->EndOfIconReadingTime = GetTickCount() - 10000;
     RightPanel->UseThumbnails = FALSE;
 
-    LeftPanel->RefreshListBox(-1, -1, LeftPanel->FocusedIndex, FALSE, FALSE);
-    RightPanel->RefreshListBox(-1, -1, RightPanel->FocusedIndex, FALSE, FALSE);
+    LeftPanel->RefreshDirectory(FALSE, TRUE);
+    RightPanel->RefreshDirectory(FALSE, TRUE);
     PostMessage(HWindow, WM_USER_REPAINTALLICONS, 0, 0);
     RefreshDiskFreeSpace();
     RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -4000,7 +4000,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             DPIRefreshPosted = TRUE;
             PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
         }
-        PromptIfSessionDPIChanged(HWindow);
         break;
     }
 
@@ -4017,7 +4016,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                 PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
             }
         }
-        PromptIfSessionDPIChanged(HWindow);
         return 0;
     }
 
@@ -4030,7 +4028,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             DPIRefreshPosted = TRUE;
             PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
         }
-        PromptIfSessionDPIChanged(HWindow);
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;
         if (darkChanged)
         {

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3491,6 +3491,17 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     ColorsChanged(TRUE, FALSE, TRUE);
     SetFont();
     SetEnvFont();
+
+    // SetFont()/SetEnvFont() normally post WM_SIZE and panel refresh messages.
+    // During a DPI transition we must complete the layout synchronously before
+    // any follow-up WM_SETTINGCHANGE/WM_DISPLAYCHANGE can repaint the old-sized
+    // controls and make the window appear to snap back to the previous DPI.
+    RECT clientRect;
+    if (GetClientRect(HWindow, &clientRect))
+        SendMessage(HWindow, WM_SIZE, SIZE_RESTORED,
+                    MAKELONG(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top));
+    LayoutWindows();
+
     GetShortcutOverlay();
     LeftPanel->RefreshListBox(-1, -1, LeftPanel->FocusedIndex, FALSE, FALSE);
     RightPanel->RefreshListBox(-1, -1, RightPanel->FocusedIndex, FALSE, FALSE);

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3961,17 +3961,33 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
 
     case WM_DPICHANGED:
     {
-        // In DPI_UNAWARE_GDISCALED mode Windows owns DPI transitions.
-        // Do not run Salamander's legacy per-monitor refresh path here; mixing
-        // both approaches causes double scaling and blurry/misaligned content.
-        break;
+        int dpi = HIWORD(wParam);
+        if (lParam != 0)
+        {
+            const RECT* suggestedRect = reinterpret_cast<const RECT*>(lParam);
+            SetWindowPos(HWindow, NULL, suggestedRect->left, suggestedRect->top,
+                         suggestedRect->right - suggestedRect->left,
+                         suggestedRect->bottom - suggestedRect->top,
+                         SWP_NOACTIVATE | SWP_NOZORDER);
+        }
+        PendingDPI = dpi;
+        PendingDPIWindowRectApplied = lParam != 0;
+        if (!DPIRefreshPosted)
+        {
+            DPIRefreshPosted = TRUE;
+            PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)dpi, 0);
+        }
+        return 0;
     }
 
     case WM_USER_APPLY_DPI_CHANGE:
     {
         DPIRefreshPosted = FALSE;
+        int dpi = PendingDPI > 0 ? PendingDPI : (int)wParam;
+        DPIWindowRectAlreadyApplied = PendingDPIWindowRectApplied;
         PendingDPI = 0;
         PendingDPIWindowRectApplied = FALSE;
+        RefreshDPI(TRUE, dpi, NULL);
         return 0;
     }
 

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3948,9 +3948,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
-        PendingDPI = GetDPIForWindow(HWindow);
         if (!DPIRefreshPosted)
         {
+            PendingDPI = GetDPIForWindow(HWindow);
             DPIRefreshPosted = TRUE;
             PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
         }
@@ -3963,9 +3963,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
             wParam == WTS_SESSION_UNLOCK)
         {
-            PendingDPI = GetCurrentSessionDPI();
             if (!DPIRefreshPosted)
             {
+                PendingDPI = GetCurrentSessionDPI();
                 DPIRefreshPosted = TRUE;
                 PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
             }
@@ -3976,9 +3976,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_SETTINGCHANGE:
     {
         TraceDPIState("WM_SETTINGCHANGE", HWindow);
-        PendingDPI = GetDPIForWindow(HWindow);
         if (!DPIRefreshPosted)
         {
+            PendingDPI = GetDPIForWindow(HWindow);
             DPIRefreshPosted = TRUE;
             PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
         }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3503,6 +3503,23 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     DPIRefreshInProgress = FALSE;
 }
 
+
+static void EnableNonClientDPIScalingIfAvailable(HWND hWindow)
+{
+    typedef BOOL(WINAPI * FEnableNonClientDpiScaling)(HWND hwnd);
+    static FEnableNonClientDpiScaling enableNonClientDpiScaling = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            enableNonClientDpiScaling = (FEnableNonClientDpiScaling)GetProcAddress(user32, "EnableNonClientDpiScaling");
+        loaded = TRUE;
+    }
+    if (enableNonClientDpiScaling != NULL)
+        enableNonClientDpiScaling(hWindow);
+}
+
 static BOOL RegisterSessionNotification(HWND hWindow)
 {
     typedef BOOL(WINAPI * FWTSRegisterSessionNotification)(HWND hWnd, DWORD dwFlags);
@@ -3583,6 +3600,12 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     SLOW_CALL_STACK_MESSAGE4("CMainWindow::WindowProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
+    case WM_NCCREATE:
+    {
+        EnableNonClientDPIScalingIfAvailable(HWindow);
+        break;
+    }
+
     case WM_CREATE:
     {
         SHChangeNotifyInitialize(); // request receiving Shell Notifications

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3438,42 +3438,11 @@ void CMainWindow::UpdateRebarVisuals()
     RedrawWindow(HTopRebar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
-
-struct CScaleChildWindowsDPIData
-{
-    int OldDPI;
-    int NewDPI;
-};
-
-static BOOL CALLBACK ScaleChildWindowForDPI(HWND hWindow, LPARAM lParam)
-{
-    CScaleChildWindowsDPIData* data = (CScaleChildWindowsDPIData*)lParam;
-    if (data == NULL || data->OldDPI <= 0 || data->NewDPI <= 0 || data->OldDPI == data->NewDPI)
-        return TRUE;
-
-    HWND parent = GetParent(hWindow);
-    if (parent == NULL)
-        return TRUE;
-
-    RECT windowRect;
-    if (!GetWindowRect(hWindow, &windowRect))
-        return TRUE;
-
-    POINT pos = {windowRect.left, windowRect.top};
-    ScreenToClient(parent, &pos);
-
-    SetWindowPos(hWindow, NULL,
-                 MulDiv(pos.x, data->NewDPI, data->OldDPI),
-                 MulDiv(pos.y, data->NewDPI, data->OldDPI),
-                 MulDiv(windowRect.right - windowRect.left, data->NewDPI, data->OldDPI),
-                 MulDiv(windowRect.bottom - windowRect.top, data->NewDPI, data->OldDPI),
-                 SWP_NOZORDER | SWP_NOACTIVATE);
-    return TRUE;
-}
-
 static BOOL DPIRefreshInProgress = FALSE;
 static BOOL DPIRefreshPosted = FALSE;
 static int PendingDPI = 0;
+static BOOL PendingDPIWindowRectApplied = FALSE;
+static BOOL DPIWindowRectAlreadyApplied = FALSE;
 static int MainWindowContentDPI = 0;
 static int InitialSessionDPI = 0;
 static BOOL DPIChangePromptShown = FALSE;
@@ -3504,6 +3473,10 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
                      suggestedRect->bottom - suggestedRect->top,
                      SWP_NOACTIVATE | SWP_NOZORDER);
     }
+    else if (DPIWindowRectAlreadyApplied)
+    {
+        DPIWindowRectAlreadyApplied = FALSE;
+    }
     else if (oldDPI > 0 && newDPI > 0 && oldDPI != newDPI)
     {
         RECT windowRect;
@@ -3522,9 +3495,6 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
         DPIRefreshInProgress = FALSE;
         return;
     }
-
-    CScaleChildWindowsDPIData scaleData = {oldDPI, newDPI};
-    EnumChildWindows(HWindow, ScaleChildWindowForDPI, (LPARAM)&scaleData);
 
     ColorsChanged(TRUE, FALSE, TRUE);
     SetFont();
@@ -3964,6 +3934,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                          SWP_NOACTIVATE | SWP_NOZORDER);
         }
         PendingDPI = dpi;
+        PendingDPIWindowRectApplied = lParam != 0;
         if (!DPIRefreshPosted)
         {
             DPIRefreshPosted = TRUE;
@@ -3976,7 +3947,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     {
         DPIRefreshPosted = FALSE;
         int dpi = PendingDPI > 0 ? PendingDPI : (int)wParam;
+        DPIWindowRectAlreadyApplied = PendingDPIWindowRectApplied;
         PendingDPI = 0;
+        PendingDPIWindowRectApplied = FALSE;
         RefreshDPI(TRUE, dpi, NULL);
         return 0;
     }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3438,6 +3438,39 @@ void CMainWindow::UpdateRebarVisuals()
     RedrawWindow(HTopRebar, NULL, NULL, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
 }
 
+
+struct CScaleChildWindowsDPIData
+{
+    int OldDPI;
+    int NewDPI;
+};
+
+static BOOL CALLBACK ScaleChildWindowForDPI(HWND hWindow, LPARAM lParam)
+{
+    CScaleChildWindowsDPIData* data = (CScaleChildWindowsDPIData*)lParam;
+    if (data == NULL || data->OldDPI <= 0 || data->NewDPI <= 0 || data->OldDPI == data->NewDPI)
+        return TRUE;
+
+    HWND parent = GetParent(hWindow);
+    if (parent == NULL)
+        return TRUE;
+
+    RECT windowRect;
+    if (!GetWindowRect(hWindow, &windowRect))
+        return TRUE;
+
+    POINT pos = {windowRect.left, windowRect.top};
+    ScreenToClient(parent, &pos);
+
+    SetWindowPos(hWindow, NULL,
+                 MulDiv(pos.x, data->NewDPI, data->OldDPI),
+                 MulDiv(pos.y, data->NewDPI, data->OldDPI),
+                 MulDiv(windowRect.right - windowRect.left, data->NewDPI, data->OldDPI),
+                 MulDiv(windowRect.bottom - windowRect.top, data->NewDPI, data->OldDPI),
+                 SWP_NOZORDER | SWP_NOACTIVATE);
+    return TRUE;
+}
+
 static BOOL DPIRefreshInProgress = FALSE;
 static BOOL DPIRefreshPosted = FALSE;
 static int PendingDPI = 0;
@@ -3489,6 +3522,9 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
         DPIRefreshInProgress = FALSE;
         return;
     }
+
+    CScaleChildWindowsDPIData scaleData = {oldDPI, newDPI};
+    EnumChildWindows(HWindow, ScaleChildWindowForDPI, (LPARAM)&scaleData);
 
     ColorsChanged(TRUE, FALSE, TRUE);
     SetFont();

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3961,73 +3961,35 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
 
     case WM_DPICHANGED:
     {
-        int dpi = HIWORD(wParam);
-        if (lParam != 0)
-        {
-            const RECT* suggestedRect = reinterpret_cast<const RECT*>(lParam);
-            SetWindowPos(HWindow, NULL, suggestedRect->left, suggestedRect->top,
-                         suggestedRect->right - suggestedRect->left,
-                         suggestedRect->bottom - suggestedRect->top,
-                         SWP_NOACTIVATE | SWP_NOZORDER);
-        }
-        PendingDPI = dpi;
-        PendingDPIWindowRectApplied = lParam != 0;
-        if (!DPIRefreshPosted)
-        {
-            DPIRefreshPosted = TRUE;
-            PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)dpi, 0);
-        }
-        return 0;
+        // In DPI_UNAWARE_GDISCALED mode Windows owns DPI transitions.
+        // Do not run Salamander's legacy per-monitor refresh path here; mixing
+        // both approaches causes double scaling and blurry/misaligned content.
+        break;
     }
 
     case WM_USER_APPLY_DPI_CHANGE:
     {
         DPIRefreshPosted = FALSE;
-        int dpi = PendingDPI > 0 ? PendingDPI : (int)wParam;
-        DPIWindowRectAlreadyApplied = PendingDPIWindowRectApplied;
         PendingDPI = 0;
         PendingDPIWindowRectApplied = FALSE;
-        RefreshDPI(TRUE, dpi, NULL);
         return 0;
     }
 
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
-        if (!DPIRefreshPosted)
-        {
-            PendingDPI = GetDPIForWindow(HWindow);
-            DPIRefreshPosted = TRUE;
-            PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
-        }
         break;
     }
 
     case WM_WTSSESSION_CHANGE:
     {
         TraceDPIState("WM_WTSSESSION_CHANGE", HWindow);
-        if (wParam == WTS_REMOTE_CONNECT || wParam == WTS_SESSION_LOGON ||
-            wParam == WTS_SESSION_UNLOCK)
-        {
-            if (!DPIRefreshPosted)
-            {
-                PendingDPI = GetCurrentSessionDPI();
-                DPIRefreshPosted = TRUE;
-                PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
-            }
-        }
         return 0;
     }
 
     case WM_SETTINGCHANGE:
     {
         TraceDPIState("WM_SETTINGCHANGE", HWindow);
-        if (!DPIRefreshPosted)
-        {
-            PendingDPI = GetDPIForWindow(HWindow);
-            DPIRefreshPosted = TRUE;
-            PostMessage(HWindow, WM_USER_APPLY_DPI_CHANGE, (WPARAM)PendingDPI, 0);
-        }
         BOOL darkChanged = DarkModeHandleSettingChange(uMsg, lParam) ? TRUE : FALSE;
         if (darkChanged)
         {

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -40,8 +40,8 @@
 </compatibility>
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings>
-    <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ws2005:dpiAware>
-    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</ws2016:dpiAwareness>
+    <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</ws2005:dpiAware>
+    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</ws2016:dpiAwareness>
     <ws2019:activeCodePage xmlns:ws2019="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</ws2019:activeCodePage>
     <ws2016:longPathAware xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2016:longPathAware>
   </asmv3:windowsSettings>

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -40,8 +40,8 @@
 </compatibility>
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings>
-    <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</ws2005:dpiAware>
-    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</ws2016:dpiAwareness>
+    <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ws2005:dpiAware>
+    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</ws2016:dpiAwareness>
     <ws2019:activeCodePage xmlns:ws2019="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</ws2019:activeCodePage>
     <ws2016:longPathAware xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2016:longPathAware>
   </asmv3:windowsSettings>

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -40,9 +40,8 @@
 </compatibility>
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings>
-    <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">false</ws2005:dpiAware>
-    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">unaware</ws2016:dpiAwareness>
-    <ws2017:gdiScaling xmlns:ws2017="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</ws2017:gdiScaling>
+    <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</ws2005:dpiAware>
+    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</ws2016:dpiAwareness>
     <ws2019:activeCodePage xmlns:ws2019="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</ws2019:activeCodePage>
     <ws2016:longPathAware xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2016:longPathAware>
   </asmv3:windowsSettings>

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -41,6 +41,7 @@
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings>
     <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ws2005:dpiAware>
+    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</ws2016:dpiAwareness>
     <ws2019:activeCodePage xmlns:ws2019="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</ws2019:activeCodePage>
     <ws2016:longPathAware xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2016:longPathAware>
   </asmv3:windowsSettings>

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -40,8 +40,9 @@
 </compatibility>
 <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <asmv3:windowsSettings>
-    <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ws2005:dpiAware>
-    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</ws2016:dpiAwareness>
+    <ws2005:dpiAware xmlns:ws2005="http://schemas.microsoft.com/SMI/2005/WindowsSettings">false</ws2005:dpiAware>
+    <ws2016:dpiAwareness xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">unaware</ws2016:dpiAwareness>
+    <ws2017:gdiScaling xmlns:ws2017="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</ws2017:gdiScaling>
     <ws2019:activeCodePage xmlns:ws2019="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</ws2019:activeCodePage>
     <ws2016:longPathAware xmlns:ws2016="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws2016:longPathAware>
   </asmv3:windowsSettings>

--- a/src/menu3.cpp
+++ b/src/menu3.cpp
@@ -110,6 +110,35 @@ CMenuSharedResources::~CMenuSharedResources()
         HANDLES(CloseHandle(HCloseEvent));
 }
 
+
+static BOOL SystemParametersInfoForPopupMenuDPI(UINT action, UINT uiParam, PVOID pvParam, UINT fWinIni)
+{
+    typedef BOOL(WINAPI * FSystemParametersInfoForDpi)(UINT uiAction, UINT uiParam, PVOID pvParam, UINT fWinIni, UINT dpi);
+    static FSystemParametersInfoForDpi systemParametersInfoForDpi = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            systemParametersInfoForDpi = (FSystemParametersInfoForDpi)GetProcAddress(user32, "SystemParametersInfoForDpi");
+        loaded = TRUE;
+    }
+    if (systemParametersInfoForDpi != NULL && systemParametersInfoForDpi(action, uiParam, pvParam, fWinIni, GetSystemDPI()))
+        return TRUE;
+    return SystemParametersInfo(action, uiParam, pvParam, fWinIni);
+}
+
+static void ScalePopupMenuFontForCurrentDPI(LOGFONT* lf)
+{
+    int dpi = GetSystemDPI();
+    if (lf == NULL || lf->lfHeight == 0)
+        return;
+    int expected = MulDiv(12, dpi, 96);
+    int height = abs(lf->lfHeight);
+    if (height < expected - 1 || height > expected + 2)
+        lf->lfHeight = lf->lfHeight < 0 ? -expected : expected;
+}
+
 BOOL CMenuSharedResources::Create(HWND hParent, int width, int height)
 {
     CALL_STACK_MESSAGE3("CMenuSharedResources::Create(, %d, %d)", width, height);
@@ -139,9 +168,10 @@ BOOL CMenuSharedResources::Create(HWND hParent, int width, int height)
     // generate a copy and a bold version from the menu font
     NONCLIENTMETRICS ncm;
     ncm.cbSize = sizeof(ncm);
-    SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
+    SystemParametersInfoForPopupMenuDPI(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
 
     LOGFONT* lf = &ncm.lfMenuFont;
+    ScalePopupMenuFontForCurrentDPI(lf);
     HNormalFont = HANDLES(CreateFontIndirect(lf));
     lf->lfWeight = FW_BOLD;
     HBoldFont = HANDLES(CreateFontIndirect(lf));

--- a/src/menubar.cpp
+++ b/src/menubar.cpp
@@ -16,6 +16,25 @@
 #define MENUBAR_LR_MARGIN 8 // number of points before and after the text, including the vertical line
 #define MENUBAR_TB_MARGIN 4 // number of points above and below the text, including the horizontal line
 
+
+static BOOL SystemParametersInfoForMenuDPI(UINT action, UINT uiParam, PVOID pvParam, UINT fWinIni)
+{
+    typedef BOOL(WINAPI * FSystemParametersInfoForDpi)(UINT uiAction, UINT uiParam, PVOID pvParam, UINT fWinIni, UINT dpi);
+    static FSystemParametersInfoForDpi systemParametersInfoForDpi = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            systemParametersInfoForDpi = (FSystemParametersInfoForDpi)GetProcAddress(user32, "SystemParametersInfoForDpi");
+        loaded = TRUE;
+    }
+    if (systemParametersInfoForDpi != NULL &&
+        systemParametersInfoForDpi(action, uiParam, pvParam, fWinIni, GetSystemDPI()))
+        return TRUE;
+    return SystemParametersInfo(action, uiParam, pvParam, fWinIni);
+}
+
 static void FillRectWithColor(HDC hDC, const RECT* rect, COLORREF color)
 {
     HGDIOBJ oldBrush = SelectObject(hDC, GetStockObject(DC_BRUSH));
@@ -120,7 +139,7 @@ void CMenuBar::SetFont()
     CALL_STACK_MESSAGE1("CMenuBar::SetFont()");
     NONCLIENTMETRICS ncm;
     ncm.cbSize = sizeof(ncm);
-    SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
+    SystemParametersInfoForMenuDPI(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
 
     LOGFONT* lf = &ncm.lfMenuFont;
     if (HFont != NULL)

--- a/src/menubar.cpp
+++ b/src/menubar.cpp
@@ -17,6 +17,21 @@
 #define MENUBAR_TB_MARGIN 4 // number of points above and below the text, including the horizontal line
 
 
+
+static void ScaleSmallMenuLogFontForCurrentDPI(LOGFONT* lf)
+{
+    int dpi = GetSystemDPI();
+    if (lf == NULL || dpi <= 96 || lf->lfHeight == 0)
+        return;
+
+    int height = abs(lf->lfHeight);
+    if (height <= 14)
+    {
+        int scaled = MulDiv(height, dpi, 96);
+        lf->lfHeight = lf->lfHeight < 0 ? -scaled : scaled;
+    }
+}
+
 static BOOL SystemParametersInfoForMenuDPI(UINT action, UINT uiParam, PVOID pvParam, UINT fWinIni)
 {
     typedef BOOL(WINAPI * FSystemParametersInfoForDpi)(UINT uiAction, UINT uiParam, PVOID pvParam, UINT fWinIni, UINT dpi);
@@ -142,6 +157,7 @@ void CMenuBar::SetFont()
     SystemParametersInfoForMenuDPI(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
 
     LOGFONT* lf = &ncm.lfMenuFont;
+    ScaleSmallMenuLogFontForCurrentDPI(lf);
     if (HFont != NULL)
         HANDLES(DeleteObject(HFont));
     HFont = HANDLES(CreateFontIndirect(lf));

--- a/src/menubar.cpp
+++ b/src/menubar.cpp
@@ -25,11 +25,9 @@ static void ScaleSmallMenuLogFontForCurrentDPI(LOGFONT* lf)
         return;
 
     int height = abs(lf->lfHeight);
-    if (height <= 14)
-    {
-        int scaled = MulDiv(height, dpi, 96);
-        lf->lfHeight = lf->lfHeight < 0 ? -scaled : scaled;
-    }
+    int expected = MulDiv(12, dpi, 96);
+    if (height < expected - 1 || height > expected + 2)
+        lf->lfHeight = lf->lfHeight < 0 ? -expected : expected;
 }
 
 static BOOL SystemParametersInfoForMenuDPI(UINT action, UINT uiParam, PVOID pvParam, UINT fWinIni)

--- a/src/menubar.cpp
+++ b/src/menubar.cpp
@@ -21,7 +21,7 @@
 static void ScaleSmallMenuLogFontForCurrentDPI(LOGFONT* lf)
 {
     int dpi = GetSystemDPI();
-    if (lf == NULL || dpi <= 96 || lf->lfHeight == 0)
+    if (lf == NULL || lf->lfHeight == 0)
         return;
 
     int height = abs(lf->lfHeight);

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -2778,7 +2778,14 @@ BOOL InitializeGraphics(BOOL colorsOnly)
     int iconColorsCount = 0;
     HDC hDesktopDC = GetDC(NULL);
     int bpp = GetCurrentBPP(hDesktopDC);
-    GetSystemDPI(hDesktopDC);
+    // During a live DPI refresh the caller has already selected the target DPI
+    // (for RDP/session switches this can come from AppliedDPI before the main
+    // window reports the new DPI).  Do not overwrite it here with the desktop
+    // DC value, otherwise rebuilt fonts, SVGs and image lists immediately fall
+    // back to the old DPI and the main window contents stay at the previous
+    // scale until restart.
+    if (SystemDPI == 0)
+        GetSystemDPI(hDesktopDC);
     ReleaseDC(NULL, hDesktopDC);
 
     IconSizes[ICONSIZE_16] = GetIconSizeForSystemDPI(ICONSIZE_16);

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -5852,25 +5852,19 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
 
 static void InitializeProcessDPIAwareness()
 {
-    // The manifest is the primary declaration, but make the DPI context explicit
-    // as early as possible as recommended for legacy Win32 applications.
-    // This must run before any window/control is created.
+    // The manifest is the primary declaration, but make the GDI-scaled unaware
+    // DPI context explicit as early as possible. This lets Windows handle DPI
+    // transitions without restarting while keeping GDI text rendering crisp.
     typedef BOOL(WINAPI * FSetProcessDpiAwarenessContext)(HANDLE dpiContext);
-    typedef BOOL(WINAPI * FSetProcessDPIAware)();
-
     HMODULE user32 = GetModuleHandle("user32.dll");
     if (user32 != NULL)
     {
         FSetProcessDpiAwarenessContext setProcessDpiAwarenessContext =
             (FSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
         if (setProcessDpiAwarenessContext != NULL &&
-            setProcessDpiAwarenessContext((HANDLE)-2 /* DPI_AWARENESS_CONTEXT_SYSTEM_AWARE */))
+            setProcessDpiAwarenessContext((HANDLE)-5 /* DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED */))
             return;
 
-        FSetProcessDPIAware setProcessDPIAware =
-            (FSetProcessDPIAware)GetProcAddress(user32, "SetProcessDPIAware");
-        if (setProcessDPIAware != NULL)
-            setProcessDPIAware();
     }
 }
 

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -2574,6 +2574,16 @@ int GetSystemDPI()
     }
 }
 
+void SetSystemDPI(int dpi)
+{
+    if (dpi <= 0)
+    {
+        TRACE_E("SetSystemDPI() invalid dpi=" << dpi);
+        return;
+    }
+    SystemDPI = dpi;
+}
+
 static int GetRegistrySessionDPI()
 {
     HKEY hKey;
@@ -2646,6 +2656,13 @@ int GetDPIForWindow(HWND hWindow)
             return dpi;
     }
     return GetCurrentSessionDPI();
+}
+
+int UpdateSystemDPIForWindow(HWND hWindow)
+{
+    int dpi = GetDPIForWindow(hWindow);
+    SetSystemDPI(dpi);
+    return GetSystemDPI();
 }
 
 void TraceDPIState(const char* reason, HWND hWindow)

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -2283,6 +2283,13 @@ BOOL InitializeConstGraphics()
     ncm.cbSize = sizeof(ncm);
     SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
     LogFont = ncm.lfStatusFont;
+    if (LogFont.lfHeight != 0)
+    {
+        int expected = MulDiv(12, GetSystemDPI(), 96);
+        int height = abs(LogFont.lfHeight);
+        if (height < expected - 1 || height > expected + 2)
+            LogFont.lfHeight = LogFont.lfHeight < 0 ? -expected : expected;
+    }
     /*
   LogFont.lfHeight = -10;
   LogFont.lfWidth = 0;

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -5864,7 +5864,7 @@ static void InitializeProcessDPIAwareness()
         FSetProcessDpiAwarenessContext setProcessDpiAwarenessContext =
             (FSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
         if (setProcessDpiAwarenessContext != NULL &&
-            setProcessDpiAwarenessContext((HANDLE)-4 /* DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 */))
+            setProcessDpiAwarenessContext((HANDLE)-2 /* DPI_AWARENESS_CONTEXT_SYSTEM_AWARE */))
             return;
 
         FSetProcessDPIAware setProcessDPIAware =

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -2574,6 +2574,94 @@ int GetSystemDPI()
     }
 }
 
+static int GetRegistrySessionDPI()
+{
+    HKEY hKey;
+    DWORD value = 0;
+    DWORD type = 0;
+    DWORD size = sizeof(value);
+    if (RegOpenKeyEx(HKEY_CURRENT_USER, "Control Panel\\Desktop\\WindowMetrics", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    {
+        LONG res = RegQueryValueEx(hKey, "AppliedDPI", NULL, &type, (LPBYTE)&value, &size);
+        RegCloseKey(hKey);
+        if (res == ERROR_SUCCESS && type == REG_DWORD && value >= 48 && value <= 960)
+            return (int)value;
+    }
+    return 0;
+}
+
+static int GetDesktopDPI()
+{
+    HDC hDC = GetDC(NULL);
+    if (hDC == NULL)
+        return 0;
+    int dpi = GetDeviceCaps(hDC, LOGPIXELSX);
+    ReleaseDC(NULL, hDC);
+    return dpi;
+}
+
+int GetCurrentSessionDPI()
+{
+    int dpi = GetRegistrySessionDPI();
+    if (dpi > 0)
+        return dpi;
+
+    typedef UINT(WINAPI * FGetDpiForSystem)();
+    static FGetDpiForSystem getDpiForSystem = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            getDpiForSystem = (FGetDpiForSystem)GetProcAddress(user32, "GetDpiForSystem");
+        loaded = TRUE;
+    }
+    if (getDpiForSystem != NULL)
+    {
+        dpi = (int)getDpiForSystem();
+        if (dpi > 0)
+            return dpi;
+    }
+
+    dpi = GetDesktopDPI();
+    return dpi > 0 ? dpi : 96;
+}
+
+int GetDPIForWindow(HWND hWindow)
+{
+    typedef UINT(WINAPI * FGetDpiForWindow)(HWND hwnd);
+    static FGetDpiForWindow getDpiForWindow = NULL;
+    static BOOL loaded = FALSE;
+    if (!loaded)
+    {
+        HMODULE user32 = GetModuleHandle("user32.dll");
+        if (user32 != NULL)
+            getDpiForWindow = (FGetDpiForWindow)GetProcAddress(user32, "GetDpiForWindow");
+        loaded = TRUE;
+    }
+    if (getDpiForWindow != NULL && hWindow != NULL)
+    {
+        int dpi = (int)getDpiForWindow(hWindow);
+        if (dpi > 0)
+            return dpi;
+    }
+    return GetCurrentSessionDPI();
+}
+
+void TraceDPIState(const char* reason, HWND hWindow)
+{
+    TRACE_I("DPI state (" << (reason != NULL ? reason : "") << "): SystemDPI=" << SystemDPI
+            << ", SessionDPI=" << GetCurrentSessionDPI()
+            << ", WindowDPI=" << GetDPIForWindow(hWindow)
+            << ", DesktopDPI=" << GetDesktopDPI()
+            << ", RegistryDPI=" << GetRegistrySessionDPI());
+}
+
+int ScaleForDPI(int value, int dpi)
+{
+    return MulDiv(value, dpi > 0 ? dpi : 96, 96);
+}
+
 int GetScaleForSystemDPI()
 {
     int dpi = GetSystemDPI();

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -5849,6 +5849,31 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
     return 0;
 }
 
+
+static void InitializeProcessDPIAwareness()
+{
+    // The manifest is the primary declaration, but make the DPI context explicit
+    // as early as possible as recommended for legacy Win32 applications.
+    // This must run before any window/control is created.
+    typedef BOOL(WINAPI * FSetProcessDpiAwarenessContext)(HANDLE dpiContext);
+    typedef BOOL(WINAPI * FSetProcessDPIAware)();
+
+    HMODULE user32 = GetModuleHandle("user32.dll");
+    if (user32 != NULL)
+    {
+        FSetProcessDpiAwarenessContext setProcessDpiAwarenessContext =
+            (FSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
+        if (setProcessDpiAwarenessContext != NULL &&
+            setProcessDpiAwarenessContext((HANDLE)-4 /* DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 */))
+            return;
+
+        FSetProcessDPIAware setProcessDPIAware =
+            (FSetProcessDPIAware)GetProcAddress(user32, "SetProcessDPIAware");
+        if (setProcessDPIAware != NULL)
+            setProcessDPIAware();
+    }
+}
+
 int WINAPI
 WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR cmdLine, int cmdShow)
 {
@@ -5856,6 +5881,8 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR cmdLine, int cmdShow
     __try
     {
 #endif // CALLSTK_DISABLE
+
+        InitializeProcessDPIAwareness();
 
         //#ifdef MSVC_RUNTIME_CHECKS
         _RTC_SetErrorFuncW(&MyRTCErrorFunc);

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -5852,9 +5852,9 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
 
 static void InitializeProcessDPIAwareness()
 {
-    // The manifest is the primary declaration, but make the GDI-scaled unaware
-    // DPI context explicit as early as possible. This lets Windows handle DPI
-    // transitions without restarting while keeping GDI text rendering crisp.
+    // The manifest is the primary declaration, but make the per-monitor-v2
+    // DPI context explicit as early as possible so Windows does not bitmap-scale
+    // the main window text.
     typedef BOOL(WINAPI * FSetProcessDpiAwarenessContext)(HANDLE dpiContext);
     HMODULE user32 = GetModuleHandle("user32.dll");
     if (user32 != NULL)
@@ -5862,7 +5862,7 @@ static void InitializeProcessDPIAwareness()
         FSetProcessDpiAwarenessContext setProcessDpiAwarenessContext =
             (FSetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
         if (setProcessDpiAwarenessContext != NULL &&
-            setProcessDpiAwarenessContext((HANDLE)-5 /* DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED */))
+            setProcessDpiAwarenessContext((HANDLE)-4 /* DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 */))
             return;
 
     }

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -2855,6 +2855,8 @@
 #define IDS_DETACHED_BTN_CLOSE           14285
 #define IDS_DETACHED_BTN_REATTACH        14286
 #define IDS_MAIN_WINDOW_TITLE            14287
+#define IDS_DPI_CHANGE_TITLE             14288
+#define IDS_DPI_CHANGE_RESTART           14289
 
 #define IDS_MENU_OPT_MANAGECONFIG        13169
 


### PR DESCRIPTION
### Motivation
- Improve handling of display scaling (DPI) changes including remote/desktop session DPI changes so the UI can be redrawn sharply when the effective DPI changes.
- Detect DPI sources (registry/desktop/window/system) and surface diagnostics to help debug DPI-related issues.
- Opt the application into system DPI awareness via manifest so per-session DPI information is available.

### Description
- Added DPI-related declarations to `src/consts.h`: `GetCurrentSessionDPI`, `GetDPIForWindow`, `TraceDPIState`, `ScaleForDPI` and related helpers.
- Implemented DPI helpers in `src/salamdr1.cpp` including `GetCurrentSessionDPI`, `GetDPIForWindow`, `GetRegistrySessionDPI`, `GetDesktopDPI`, `TraceDPIState`, and `ScaleForDPI` with fallbacks to registry and desktop DPI and dynamic `GetDpiForSystem`/`GetDpiForWindow` usage.
- Updated main window logic in `src/mainwnd3.cpp` to register/unregister session notifications (`WTSRegisterSessionNotification`), track initial session DPI, trace DPI state on key messages, and handle `WM_DISPLAYCHANGE`, `WM_WTSSESSION_CHANGE` and `WM_SETTINGCHANGE` by prompting the user to restart/relaunch when DPI/session changes are detected; includes safe relaunch logic that saves config before restarting.
- Added resource strings for the DPI change prompt in `src/lang/texts.rc2` and resource ID entries in `src/texts.rh2`.
- Updated `src/manifest.xml` to include `<ws2016:dpiAwareness>system</ws2016:dpiAwareness>` so the application declares system DPI awareness.

### Testing
- Built the project with MSVC (Release configuration) including resource compilation, and the build completed successfully.
- Verified resource ID header update and manifest patch compile integration by running the same build pipeline, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a574a1d2d0c832982c4ffa130c9bf7f)