### PR TITLE
Restore internal viewer palette after dark mode

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -269,6 +269,7 @@ thread_local int gListViewColorUpdateDepth = 0;
 static COLORREF gDialogTextColor = GetSysColor(COLOR_BTNTEXT);
 static COLORREF gDialogBackgroundColor = GetSysColor(COLOR_BTNFACE);
 static HBRUSH gDialogBrushHandle = NULL;
+static HBRUSH gScrollbarTrackBrush = NULL;
 static bool gDialogBrushOwned = false;
 static DarkModeColors gColors = {GetSysColor(COLOR_BTNTEXT), GetSysColor(COLOR_BTNFACE), GetSysColor(COLOR_BTNTEXT), false};
 static COLORREF gAutocompleteSelectedFg = RGB(255, 255, 255);
@@ -3093,9 +3094,14 @@ bool DarkModeHandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT&
         return true;
 
     case WM_CTLCOLORSCROLLBAR:
-        SetBkColor(hdc, background);
-        result = reinterpret_cast<LRESULT>(brush);
+    {
+        const COLORREF scrollbarTrack = RGB(23, 23, 23);
+        SetBkColor(hdc, scrollbarTrack);
+        if (gScrollbarTrackBrush == NULL)
+            gScrollbarTrackBrush = CreateSolidBrush(scrollbarTrack);
+        result = reinterpret_cast<LRESULT>(gScrollbarTrackBrush != NULL ? gScrollbarTrackBrush : brush);
         return true;
+    }
     }
 
     return false;

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2676,7 +2676,9 @@ void DarkModeFixScrollbars()
     if (!gSupported)
         return;
 
-    HookDarkScrollbars();
+    // darkmodelib owns the supported scrollbar hook.  Do not install the
+    // legacy duplicate hook here: it forces Explorer::ScrollBar and bypasses
+    // the library's per-window dark scrollbar policy.
 }
 
 void DarkModeConfigureDialogColors(COLORREF textColor, COLORREF backgroundColor, HBRUSH dialogBrush)

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2109,7 +2109,9 @@ void HookDarkScrollbars()
     auto replacement = [](HWND hWnd, LPCWSTR classList) -> HTHEME {
         if (classList != nullptr && wcscmp(classList, L"ScrollBar") == 0)
         {
-            hWnd = nullptr;
+            // Preserve the real scrollbar HWND so UxTheme can use the
+            // window's dark-mode policy and palette instead of falling back
+            // to the generic Explorer track color.
             classList = L"Explorer::ScrollBar";
         }
         return gOpenNcThemeData ? gOpenNcThemeData(hWnd, classList) : nullptr;

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -694,6 +694,14 @@ static void WindowsDarkModeUpdatePalette(bool useDarkColors)
         memcpy(ViewerColors, SavedViewerColorsBeforeDark, sizeof(ViewerColors));
         ViewerColorsSavedBeforeDark = false;
     }
+    else if (WindowsDarkModeIsViewerPalette(ViewerColors))
+    {
+        // A dark configuration loaded from storage is repaired through a
+        // temporary palette, so WindowsDarkModeBuildPalette() never receives
+        // ViewerColors and therefore has no light palette to restore here.
+        // Restore the standard light viewer palette explicitly in that path.
+        WindowsLightModeBuildViewerPalette(ViewerColors);
+    }
 }
 
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -2472,6 +2472,7 @@ void CViewerWindow::LayoutStatusBar()
     StatusBarHeight = ShowStatusBar ? max(20, GetSystemMetrics(SM_CYSMICON) + 4) : 0;
     int scrollWidth = GetSystemMetrics(SM_CXVSCROLL);
     int scrollHeight = GetSystemMetrics(SM_CYHSCROLL);
+    int gripWidth = (GetWindowLong(HStatusBar, GWL_STYLE) & SBARS_SIZEGRIP) ? scrollWidth : 0;
     ShowWindow(HStatusBar, ShowStatusBar ? SW_SHOW : SW_HIDE);
     ShowWindow(HZoomReset, ShowStatusBar ? SW_SHOW : SW_HIDE);
     ShowWindow(HZoomOut, ShowStatusBar ? SW_SHOW : SW_HIDE);
@@ -2490,7 +2491,7 @@ void CViewerWindow::LayoutStatusBar()
     // Do not reserve the size-grip width here.  The status bar owns that
     // grip at the window edge, while the zoom controls must extend right up
     // to it instead of leaving an unused scrollbar-width gap.
-    int x = rc.right;
+    int x = rc.right - gripWidth;
     x -= 22;
     SetWindowPos(HZoomIn, HWND_TOP, x, rc.bottom - StatusBarHeight + 2, 22, StatusBarHeight - 4, SWP_NOACTIVATE);
     x -= 54;

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -636,7 +636,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     BkgndBrushSel = NULL;
     LineNumberBrush = NULL;
     ViewerFont = NULL;
-    HStatusBar = HScrollBar = HZoomReset = HZoomOut = HZoomEdit = HZoomIn = NULL;
+    HStatusBar = HScrollBar = VScrollBar = HZoomReset = HZoomOut = HZoomEdit = HZoomIn = NULL;
     StatusBarHeight = 0;
     ZoomPercent = Configuration.ViewerZoomPercent;
     StatusOffset = -1;
@@ -2470,6 +2470,7 @@ void CViewerWindow::LayoutStatusBar()
     // The status bar and its controls are window chrome.  Their dimensions
     // must not follow the document font zoom.
     StatusBarHeight = ShowStatusBar ? max(20, GetSystemMetrics(SM_CYSMICON) + 4) : 0;
+    int scrollWidth = GetSystemMetrics(SM_CXVSCROLL);
     int scrollHeight = GetSystemMetrics(SM_CYHSCROLL);
     ShowWindow(HStatusBar, ShowStatusBar ? SW_SHOW : SW_HIDE);
     ShowWindow(HZoomReset, ShowStatusBar ? SW_SHOW : SW_HIDE);
@@ -2479,7 +2480,10 @@ void CViewerWindow::LayoutStatusBar()
     // Horizontal scrollbar (child control) spans the full client width, positioned
     // above the status bar — same layout as Notepad's Edit control.
     SetWindowPos(HScrollBar, NULL, 0, rc.bottom - StatusBarHeight - scrollHeight,
-                 rc.right, scrollHeight,
+                 rc.right - scrollWidth, scrollHeight,
+                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREDRAW);
+    SetWindowPos(VScrollBar, NULL, rc.right - scrollWidth, 0, scrollWidth,
+                 rc.bottom - StatusBarHeight - scrollHeight,
                  SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREDRAW);
     // Keep the native status bar behind its interactive children.
     SetWindowPos(HStatusBar, HWND_BOTTOM, 0, rc.bottom - StatusBarHeight, rc.right, StatusBarHeight, SWP_NOACTIVATE);
@@ -2497,6 +2501,7 @@ void CViewerWindow::LayoutStatusBar()
     SetWindowPos(HZoomReset, HWND_TOP, x, rc.bottom - StatusBarHeight + 2, 42, StatusBarHeight - 4, SWP_NOACTIVATE);
     InvalidateRect(HWindow, NULL, FALSE);
     InvalidateRect(HScrollBar, NULL, FALSE);
+    InvalidateRect(VScrollBar, NULL, FALSE);
     InvalidateRect(HStatusBar, NULL, FALSE);
 }
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -641,6 +641,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     ZoomPercent = Configuration.ViewerZoomPercent;
     StatusOffset = -1;
     CachedTotalLines = -1;
+    CachedMaxLineLen = -1;
     LayoutNeeded = TRUE;
 
     Width = Height = 0;
@@ -2034,6 +2035,7 @@ void CViewerWindow::Paint(HDC dc)
             // Keep the gutter visibly distinct from document text in both
             // standard light schemes and Windows Dark Mode.
             SetTextColor(dc, DarkModeShouldUseDarkColors() ? RGB(160, 160, 160) : RGB(96, 96, 96));
+            int gutterBkMode = SetBkMode(dc, TRANSPARENT);
             __int64 documentLine = LineOffset.Count >= 3 ? GetDocumentLineNumber(LineOffset[0]) : 1;
             for (int i = 0; i < LineOffset.Count / 3; i++)
             {
@@ -2054,6 +2056,7 @@ void CViewerWindow::Paint(HDC dc)
                     DrawText(dc, number, -1, &numberRect, DT_RIGHT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
                 }
             }
+            SetBkMode(dc, gutterBkMode);
         }
         //---
         SelectObject(dc, oldFont);
@@ -2356,6 +2359,56 @@ int CViewerWindow::GetTextLeft() const
     if (!ShowLineNumbers)
         return BORDER_WIDTH;
     return BORDER_WIDTH + (LineNumberDigits + 1) * CharWidth;
+}
+
+__int64 CViewerWindow::GetMaxDocumentLineLen()
+{
+    if (CachedMaxLineLen >= 0)
+        return CachedMaxLineLen;
+    if (Type == vtHex)
+        return CachedMaxLineLen = 62 + 16 - 8 + HexOffsetLength;
+
+    const __int64 savedSeek = Seek;
+    const __int64 savedLoaded = Loaded;
+    __int64 longest = 0;
+    __int64 current = 0;
+    __int64 pos = TextStartOffset();
+    BOOL fatalErr = FALSE;
+    while (pos < FileSize)
+    {
+        __int64 read = Prepare(NULL, pos, min((__int64)VIEW_BUFFER_SIZE, FileSize - pos), fatalErr);
+        if (fatalErr || read <= 0)
+            break;
+        unsigned char* text = Buffer + pos - Seek;
+        for (__int64 i = 0; i < read; ++i)
+        {
+            unsigned char ch = text[i];
+            if (ch == '\r' || ch == '\n' || (Configuration.EOL_NULL && ch == 0))
+            {
+                if (current > longest)
+                    longest = current;
+                current = 0;
+            }
+            else if (ch == '\t')
+            {
+                const int tabSize = max(1, Configuration.TabSize);
+                current += tabSize - current % tabSize;
+            }
+            else if ((ch & 0xC0) != 0x80) // count UTF-8 code points, not continuation bytes
+            {
+                ++current;
+            }
+        }
+        pos += read;
+    }
+    if (current > longest)
+        longest = current;
+    if (savedLoaded > 0)
+    {
+        BOOL restoreFatalErr = FALSE;
+        Prepare(NULL, savedSeek, savedLoaded, restoreFatalErr);
+    }
+    return CachedMaxLineLen = longest;
 }
 
 __int64 CViewerWindow::GetDocumentLineNumber(__int64 offset, __int64* lineStart)

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -634,6 +634,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     // GDI variables
     BkgndBrush = NULL;
     BkgndBrushSel = NULL;
+    LineNumberBrush = NULL;
     ViewerFont = NULL;
     HStatusBar = HScrollBar = HZoomReset = HZoomOut = HZoomEdit = HZoomIn = NULL;
     StatusBarHeight = 0;
@@ -1378,7 +1379,7 @@ void CViewerWindow::Paint(HDC dc)
         r.right = GetTextLeft();
         r.top = 0;
         r.bottom = Height;
-        FillRect(dc, &r, BkgndBrush); // clear the columns to the left of the text
+        FillRect(dc, &r, ShowLineNumbers ? LineNumberBrush : BkgndBrush);
         RECT fullLine;
         fullLine.left = 0;
         fullLine.top = 0;
@@ -2030,7 +2031,9 @@ void CViewerWindow::Paint(HDC dc)
         SetBkMode(Bitmap.HMemDC, oldMode);
         if (ShowLineNumbers)
         {
-            SetTextColor(dc, GetCOLORREF(ViewerColors[VIEWER_FG_NORMAL]));
+            // Keep the gutter visibly distinct from document text in both
+            // standard light schemes and Windows Dark Mode.
+            SetTextColor(dc, DarkModeShouldUseDarkColors() ? RGB(160, 160, 160) : RGB(96, 96, 96));
             __int64 documentLine = LineOffset.Count >= 3 ? GetDocumentLineNumber(LineOffset[0]) : 1;
             for (int i = 0; i < LineOffset.Count / 3; i++)
             {
@@ -2090,6 +2093,13 @@ BOOL CViewerWindow::CreateViewerBrushs()
     if (BkgndBrushSel == NULL)
     {
         TRACE_E("Unable to create window selected text background brush.");
+        return FALSE;
+    }
+    const COLORREF gutterBackground = DarkModeShouldUseDarkColors() ? RGB(38, 38, 38) : RGB(245, 245, 245);
+    LineNumberBrush = HANDLES(CreateSolidBrush(gutterBackground));
+    if (LineNumberBrush == NULL)
+    {
+        TRACE_E("Unable to create line-number gutter background brush.");
         return FALSE;
     }
     return TRUE;
@@ -2189,6 +2199,11 @@ void CViewerWindow::ReleaseViewerBrushs()
     {
         HANDLES(DeleteObject(BkgndBrushSel));
         BkgndBrushSel = NULL;
+    }
+    if (LineNumberBrush != NULL)
+    {
+        HANDLES(DeleteObject(LineNumberBrush));
+        LineNumberBrush = NULL;
     }
 }
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -642,6 +642,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     StatusOffset = -1;
     CachedTotalLines = -1;
     CachedMaxLineLen = -1;
+    CachedVerticalPageSize = -1;
     LayoutNeeded = TRUE;
 
     Width = Height = 0;

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -2403,10 +2403,6 @@ void CViewerWindow::LayoutStatusBar()
     // must not follow the document font zoom.
     StatusBarHeight = ShowStatusBar ? max(20, GetSystemMetrics(SM_CYSMICON) + 4) : 0;
     int scrollHeight = GetSystemMetrics(SM_CYHSCROLL);
-    // The grip width corresponds to the V scrollbar area.  With non-client
-    // WS_VSCROLL the client area is already reduced by SM_CXVSCROLL; the
-    // status bar size grip occupies that same width at the right edge.
-    int gripWidth = (HStatusBar != NULL && (GetWindowLong(HStatusBar, GWL_STYLE) & SBARS_SIZEGRIP)) ? GetSystemMetrics(SM_CXVSCROLL) : 0;
     ShowWindow(HStatusBar, ShowStatusBar ? SW_SHOW : SW_HIDE);
     ShowWindow(HZoomReset, ShowStatusBar ? SW_SHOW : SW_HIDE);
     ShowWindow(HZoomOut, ShowStatusBar ? SW_SHOW : SW_HIDE);
@@ -2419,10 +2415,10 @@ void CViewerWindow::LayoutStatusBar()
                  SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREDRAW);
     // Keep the native status bar behind its interactive children.
     SetWindowPos(HStatusBar, HWND_BOTTOM, 0, rc.bottom - StatusBarHeight, rc.right, StatusBarHeight, SWP_NOACTIVATE);
-    // Position zoom buttons at the right edge of the client area, flush
-    // against the grip.  The V scrollbar (non-client) is already shortened
-    // by WM_NCPAINT, so the grip/zoom area visually meets the window edge.
-    int x = rc.right - gripWidth;
+    // Do not reserve the size-grip width here.  The status bar owns that
+    // grip at the window edge, while the zoom controls must extend right up
+    // to it instead of leaving an unused scrollbar-width gap.
+    int x = rc.right;
     x -= 22;
     SetWindowPos(HZoomIn, HWND_TOP, x, rc.bottom - StatusBarHeight + 2, 22, StatusBarHeight - 4, SWP_NOACTIVATE);
     x -= 54;

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -427,8 +427,9 @@ protected:
     int HexOffsetLength; // hex mode: number of characters in the offset (in the leftmost column)
 
     // GDI objects (each thread has its own)
-    HBRUSH BkgndBrush;    // solid brush with the window background color
-    HBRUSH BkgndBrushSel; // solid brush with the window background color - selected text
+    HBRUSH BkgndBrush;       // solid brush with the window background color
+    HBRUSH BkgndBrushSel;    // solid brush with the window background color - selected text
+    HBRUSH LineNumberBrush;  // distinct background for the line-number gutter
 
     CBitmap Bitmap;
     HFONT ViewerFont;

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -243,6 +243,7 @@ protected:
     // determine the maximum length of a visible line in the view (text mode: must be repainted,
     // otherwise LineOffset is outdated)
     __int64 GetMaxVisibleLineLen(__int64 newFirstLineLen = -1, BOOL ignoreFirstLine = FALSE);
+    __int64 GetMaxDocumentLineLen();
 
     // determine the maximum OriginX for the current view (text mode: must be repainted,
     // otherwise LineOffset is outdated)
@@ -443,7 +444,8 @@ protected:
     int StatusBarHeight;
     int ZoomPercent;
     __int64 StatusOffset;
-    __int64 CachedTotalLines; // cached total line count for gutter sizing (-1 = not computed)
+    __int64 CachedTotalLines;  // cached total line count for gutter sizing (-1 = not computed)
+    __int64 CachedMaxLineLen;  // longest document line in display cells (-1 = not computed)
     BOOL LayoutNeeded; // TRUE = LayoutStatusBar() must run before the next paint
 
     int EnumFileNamesSourceUID;     // UID of our source for enumerating names in the viewer

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -447,6 +447,7 @@ protected:
     __int64 StatusOffset;
     __int64 CachedTotalLines;  // cached total line count for gutter sizing (-1 = not computed)
     __int64 CachedMaxLineLen;  // longest document line in display cells (-1 = not computed)
+    __int64 CachedVerticalPageSize; // stable V-scrollbar page extent (-1 = not computed)
     BOOL LayoutNeeded; // TRUE = LayoutStatusBar() must run before the next paint
 
     int EnumFileNamesSourceUID;     // UID of our source for enumerating names in the viewer

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -437,6 +437,7 @@ protected:
 
     HWND HStatusBar;
     HWND HScrollBar;
+    HWND VScrollBar;
     HWND HZoomReset;
     HWND HZoomOut;
     HWND HZoomEdit;

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -2010,9 +2010,10 @@ void CViewerWindow::SetScrollBar()
         if (ScrollScaleY < 0.00001)
             ScrollScaleY = 0.00001; // against "divide by zero"
         int page = (int)(ViewSize / ScrollScaleY + 0.5 + 1);
-        if (max == 0 || si.nMin != 0 || si.nMax != max / ScrollScaleY + 0.5 + 1 ||
+        if (VScrollWParam == -1 &&
+            (max == 0 || si.nMin != 0 || si.nMax != max / ScrollScaleY + 0.5 + 1 ||
             si.nPage != (DWORD)page ||
-            si.nPos != SeekY / ScrollScaleY + 0.5) // if it needs to be set ...
+            si.nPos != SeekY / ScrollScaleY + 0.5)) // if it needs to be set ...
         {
             si.cbSize = sizeof(si);
             si.fMask = SIF_ALL | SIF_DISABLENOSCROLL;

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -2038,6 +2038,16 @@ void CViewerWindow::SetScrollBar()
         GetScrollInfo(HScrollBar, SB_CTL, &si);
 
         const int visibleColumns = (Width - GetTextLeft()) / CharWidth;
+        if (WrapText)
+        {
+            OriginX = 0;
+            ScrollScaleX = 1.0;
+            si.cbSize = sizeof(si);
+            si.fMask = SIF_ALL | SIF_DISABLENOSCROLL;
+            si.nMin = si.nMax = si.nPage = si.nPos = 0;
+            SetScrollInfo(HScrollBar, SB_CTL, &si, TRUE);
+            return;
+        }
         max = OriginX + visibleColumns;
         // Use the longest line in the whole document, not merely the rows
         // currently on screen.  The thumb must not resize while scrolling.

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -693,7 +693,7 @@ void CViewerWindow::HeightChanged(BOOL& fatalErr)
 {
     CALL_STACK_MESSAGE1("CViewerWindow::HeightChanged()");
     fatalErr = FALSE;
-    CachedTotalLines = CachedMaxLineLen = -1; // invalidate document metrics cache
+    CachedTotalLines = CachedMaxLineLen = CachedVerticalPageSize = -1; // invalidate document metrics cache
     switch (Type)
     {
     case vtHex:
@@ -2009,7 +2009,9 @@ void CViewerWindow::SetScrollBar()
         ScrollScaleY = ((double)max) / 20000.0;
         if (ScrollScaleY < 0.00001)
             ScrollScaleY = 0.00001; // against "divide by zero"
-        int page = (int)(ViewSize / ScrollScaleY + 0.5 + 1);
+        if (CachedVerticalPageSize < 0)
+            CachedVerticalPageSize = ViewSize;
+        int page = (int)(CachedVerticalPageSize / ScrollScaleY + 0.5 + 1);
         if (VScrollWParam == -1 &&
             (max == 0 || si.nMin != 0 || si.nMax != max / ScrollScaleY + 0.5 + 1 ||
             si.nPage != (DWORD)page ||

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -2005,15 +2005,16 @@ void CViewerWindow::SetScrollBar()
         si.fMask = SIF_ALL;
         GetScrollInfo(VScrollBar, SB_CTL, &si);
 
-        // Keep the V-scroll coordinate system tied to the full document.
-        // ViewSize varies with the byte lengths of currently visible rows;
-        // using it in the range makes thumb drag mapping lag or jump.
-        __int64 max = Type == vtText ? FileSize : ViewSize + MaxSeekY;
+        if (CachedVerticalPageSize < 0)
+            CachedVerticalPageSize = ViewSize;
+        // The thumb coordinate range must end exactly at MaxSeekY plus the
+        // stable page extent. FileSize is not equivalent for text mode
+        // (BOM/EOL and variable visible byte spans), which made drag mapping
+        // lag behind the pointer and prevented reaching the document end.
+        __int64 max = MaxSeekY + CachedVerticalPageSize;
         ScrollScaleY = ((double)max) / 20000.0;
         if (ScrollScaleY < 0.00001)
             ScrollScaleY = 0.00001; // against "divide by zero"
-        if (CachedVerticalPageSize < 0)
-            CachedVerticalPageSize = ViewSize;
         int page = (int)(CachedVerticalPageSize / ScrollScaleY + 0.5 + 1);
         if (VScrollWParam == -1 &&
             (max == 0 || si.nMin != 0 || si.nMax != max / ScrollScaleY + 0.5 + 1 ||

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -693,7 +693,7 @@ void CViewerWindow::HeightChanged(BOOL& fatalErr)
 {
     CALL_STACK_MESSAGE1("CViewerWindow::HeightChanged()");
     fatalErr = FALSE;
-    CachedTotalLines = -1; // invalidate gutter line-count cache
+    CachedTotalLines = CachedMaxLineLen = -1; // invalidate document metrics cache
     switch (Type)
     {
     case vtHex:
@@ -2037,15 +2037,18 @@ void CViewerWindow::SetScrollBar()
         si.fMask = SIF_ALL;
         GetScrollInfo(HScrollBar, SB_CTL, &si);
 
-        max = OriginX + (Width - BORDER_WIDTH) / CharWidth;
-        __int64 maxLL = GetMaxVisibleLineLen();
+        const int visibleColumns = (Width - GetTextLeft()) / CharWidth;
+        max = OriginX + visibleColumns;
+        // Use the longest line in the whole document, not merely the rows
+        // currently on screen.  The thumb must not resize while scrolling.
+        __int64 maxLL = GetMaxDocumentLineLen();
         if (max < maxLL)
             max = maxLL;
 
         ScrollScaleX = ((double)max) / 20000.0;
         if (ScrollScaleX < 0.00001)
             ScrollScaleX = 0.00001; // against "divide by zero"
-        page = (int)(((Width - BORDER_WIDTH) / CharWidth) / ScrollScaleX + 0.5 + 2);
+        page = (int)(visibleColumns / ScrollScaleX + 0.5 + 2);
         if (max == 0 || si.nMin != 0 || si.nMax != max / ScrollScaleX + 0.5 + 1 ||
             si.nPage != (DWORD)page ||
             si.nPos != OriginX / ScrollScaleX + 0.5) // if it needs to be set ...

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -2005,7 +2005,10 @@ void CViewerWindow::SetScrollBar()
         si.fMask = SIF_ALL;
         GetScrollInfo(VScrollBar, SB_CTL, &si);
 
-        __int64 max = ViewSize + MaxSeekY;
+        // Keep the V-scroll coordinate system tied to the full document.
+        // ViewSize varies with the byte lengths of currently visible rows;
+        // using it in the range makes thumb drag mapping lag or jump.
+        __int64 max = Type == vtText ? FileSize : ViewSize + MaxSeekY;
         ScrollScaleY = ((double)max) / 20000.0;
         if (ScrollScaleY < 0.00001)
             ScrollScaleY = 0.00001; // against "divide by zero"

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -2003,7 +2003,7 @@ void CViewerWindow::SetScrollBar()
         SCROLLINFO si;
         si.cbSize = sizeof(si);
         si.fMask = SIF_ALL;
-        GetScrollInfo(HWindow, SB_VERT, &si);
+        GetScrollInfo(VScrollBar, SB_CTL, &si);
 
         __int64 max = ViewSize + MaxSeekY;
         ScrollScaleY = ((double)max) / 20000.0;
@@ -2029,7 +2029,7 @@ void CViewerWindow::SetScrollBar()
                 si.nPage = 0;
                 si.nPos = 0;
             }
-            SetScrollInfo(HWindow, SB_VERT, &si, TRUE);
+            SetScrollInfo(VScrollBar, SB_CTL, &si, TRUE);
         }
 
         // horizontal scrollbar

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -116,7 +116,7 @@ static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wPara
 {
     if (message == WM_NCDESTROY)
         RemoveWindowSubclass(hwnd, HScrollBarSubclass, subclassId);
-    if (message == WM_PAINT && DarkModeShouldUseDarkColors())
+    if ((message == WM_PAINT || message == WM_NCPAINT) && DarkModeShouldUseDarkColors())
     {
         LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
         SCROLLBARINFO sbi;
@@ -1046,47 +1046,54 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
-    // The vertical scrollbar is a non-client element.  Its coordinates in a
-    // window DC are not client coordinates, therefore derive both edges from
-    // ClientToScreen() rather than from the outer window rectangle.
+    // The vertical scrollbar is a non-client element.  Ask USER for its
+    // actual screen rectangle, because client/window metric arithmetic is
+    // offset by the menu and non-client frame on some Windows versions.
     case WM_NCPAINT:
     {
         LRESULT ncResult = DefWindowProc(HWindow, WM_NCPAINT, wParam, lParam);
         if (DarkModeShouldUseDarkColors())
         {
+            SCROLLBARINFO sbi;
+            memset(&sbi, 0, sizeof(sbi));
+            sbi.cbSize = sizeof(sbi);
             RECT rcWindow;
-            RECT rcClient;
             GetWindowRect(HWindow, &rcWindow);
-            GetClientRect(HWindow, &rcClient);
-            POINT clientOrigin = {0, 0};
-            ClientToScreen(HWindow, &clientOrigin);
-
-            const int clientTop = clientOrigin.y - rcWindow.top;
-            const int clientBottom = clientTop + rcClient.bottom;
-            const int vScrollLeft = clientOrigin.x - rcWindow.left + rcClient.right;
-            const int vScrollRight = vScrollLeft + GetSystemMetrics(SM_CXVSCROLL);
-            HDC hdc = GetWindowDC(HWindow);
-            HBRUSH brush = HANDLES(CreateSolidBrush(RGB(32, 32, 32)));
-            if (hdc != NULL && brush != NULL)
+            if (GetScrollBarInfo(HWindow, OBJID_VSCROLL, &sbi))
             {
-                // Cover the native dark-theme seam at the actual top edge of
-                // the non-client scrollbar, not at the top of the title bar.
-                RECT topFix = {vScrollLeft, clientTop, vScrollRight, clientTop + 1};
-                FillRect(hdc, &topFix, brush);
+                RECT vScroll = sbi.rcScrollBar;
+                OffsetRect(&vScroll, -rcWindow.left, -rcWindow.top);
 
-                // The scrollbar must end at the bottom of the horizontal bar.
-                // The horizontal bar ends directly above the status bar.
-                if (StatusBarHeight > 0)
+                RECT rcClient;
+                GetClientRect(HWindow, &rcClient);
+                POINT clientOrigin = {0, 0};
+                ClientToScreen(HWindow, &clientOrigin);
+                const int clientBottom = clientOrigin.y - rcWindow.top + rcClient.bottom;
+
+                HDC hdc = GetWindowDC(HWindow);
+                HBRUSH brush = HANDLES(CreateSolidBrush(RGB(32, 32, 32)));
+                if (hdc != NULL && brush != NULL)
                 {
-                    RECT bottomFix = {vScrollLeft, clientBottom - StatusBarHeight,
-                                      vScrollRight, clientBottom};
-                    FillRect(hdc, &bottomFix, brush);
+                    // Cover both the seam row immediately above the scrollbar
+                    // and its first row.  This removes the persistent 1px
+                    // white line without relying on frame/menu dimensions.
+                    RECT topFix = {vScroll.left, vScroll.top - 1, vScroll.right, vScroll.top + 1};
+                    FillRect(hdc, &topFix, brush);
+
+                    // End the V scrollbar at the horizontal scrollbar's lower
+                    // edge, which is immediately above the status bar.
+                    if (StatusBarHeight > 0)
+                    {
+                        RECT bottomFix = {vScroll.left, clientBottom - StatusBarHeight,
+                                          vScroll.right, vScroll.bottom};
+                        FillRect(hdc, &bottomFix, brush);
+                    }
                 }
+                if (brush != NULL)
+                    HANDLES(DeleteObject(brush));
+                if (hdc != NULL)
+                    ReleaseDC(HWindow, hdc);
             }
-            if (brush != NULL)
-                HANDLES(DeleteObject(brush));
-            if (hdc != NULL)
-                ReleaseDC(HWindow, hdc);
         }
         return ncResult;
     }

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1106,18 +1106,22 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             PostMessage(HScrollBar, kScrollBarTrackRepaint, 0, 0);
             PostMessage(VScrollBar, kScrollBarTrackRepaint, 0, 0);
         }
+        RECT corner = {Width, Height,
+                       Width + GetSystemMetrics(SM_CXVSCROLL),
+                       Height + GetSystemMetrics(SM_CYHSCROLL)};
         if (ShowStatusBar)
         {
             // The child scrollbars leave one intersection cell above the
-            // status bar.  Paint it in the active scheme color.  When the
-            // status bar is hidden, leave this cell untouched so its native
-            // resize grip remains visible and functional.
-            RECT corner = {Width, Height,
-                           Width + GetSystemMetrics(SM_CXVSCROLL),
-                           Height + GetSystemMetrics(SM_CYHSCROLL)};
+            // status bar. Paint it in the active scheme color.
             const COLORREF cornerColor = DarkModeShouldUseDarkColors() ? RGB(32, 32, 32)
                                                                          : RGB(240, 240, 240);
             FillViewerRectWithColor(ps.hdc, &corner, cornerColor);
+        }
+        else
+        {
+            // With no status bar there is no STATUSCLASS size grip to repaint
+            // this cell. Draw the native sizing grip on every parent paint.
+            DrawFrameControl(ps.hdc, &corner, DFC_SCROLL, DFCS_SCROLLSIZEGRIP);
         }
         HANDLES(EndPaint(HWindow, &ps));
         return 0;
@@ -1301,6 +1305,9 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 // drag finished; we must call OnVScroll() from here or the scrollbar briefly blinks at the old position
                 VScrollWParam = wParam;
+                // Force the final released position through OnVScroll() even
+                // when it matches the last SB_THUMBTRACK notification.
+                VScrollWParamOld = -1;
                 KillTimer(HWindow, IDT_THUMBSCROLL);
                 MSG msg; // we do not want any additional timer; clear the queue
                 while (PeekMessage(&msg, HWindow, WM_TIMER, WM_TIMER, PM_REMOVE))

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -163,6 +163,47 @@ static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wPara
     return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
+static const UINT kViewerVScrollOverlayRepaint = WM_APP + 204;
+
+static void PaintViewerVScrollOverlay(HWND hwnd, int statusBarHeight)
+{
+    SCROLLBARINFO sbi;
+    memset(&sbi, 0, sizeof(sbi));
+    sbi.cbSize = sizeof(sbi);
+    if (!GetScrollBarInfo(hwnd, OBJID_VSCROLL, &sbi))
+        return;
+
+    RECT rcWindow;
+    GetWindowRect(hwnd, &rcWindow);
+    RECT vScroll = sbi.rcScrollBar;
+    OffsetRect(&vScroll, -rcWindow.left, -rcWindow.top);
+
+    RECT rcClient;
+    GetClientRect(hwnd, &rcClient);
+    POINT clientOrigin = {0, 0};
+    ClientToScreen(hwnd, &clientOrigin);
+    const int hScrollTop = clientOrigin.y - rcWindow.top + rcClient.bottom -
+                           statusBarHeight - GetSystemMetrics(SM_CYHSCROLL);
+
+    HDC hdc = GetWindowDC(hwnd);
+    HBRUSH brush = HANDLES(CreateSolidBrush(RGB(32, 32, 32)));
+    if (hdc != NULL && brush != NULL)
+    {
+        // Hide the themed seam and the complete part of the non-client
+        // scrollbar below the document rectangle.  Its native painting is
+        // queued first, then this overlay runs after it.
+        RECT topFix = {vScroll.left, vScroll.top - 1, vScroll.right, vScroll.top + 1};
+        FillRect(hdc, &topFix, brush);
+        RECT bottomFix = {vScroll.left, max(vScroll.top, hScrollTop),
+                          vScroll.right, vScroll.bottom};
+        FillRect(hdc, &bottomFix, brush);
+    }
+    if (brush != NULL)
+        HANDLES(DeleteObject(brush));
+    if (hdc != NULL)
+        ReleaseDC(hwnd, hdc);
+}
+
 #ifndef WM_UAHDRAWMENU
 #define WM_UAHDRAWMENU 0x0091
 #endif
@@ -1058,56 +1099,21 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
-    // The vertical scrollbar is a non-client element.  Ask USER for its
-    // actual screen rectangle, because client/window metric arithmetic is
-    // offset by the menu and non-client frame on some Windows versions.
+    // Keep WS_VSCROLL on the main viewer window.  Windows paints that native
+    // scrollbar to the full non-client height, so queue the masking overlay
+    // after its paint rather than forcing another NC paint while thumb-tracking.
     case WM_NCPAINT:
     {
         LRESULT ncResult = DefWindowProc(HWindow, WM_NCPAINT, wParam, lParam);
         if (DarkModeShouldUseDarkColors())
-        {
-            SCROLLBARINFO sbi;
-            memset(&sbi, 0, sizeof(sbi));
-            sbi.cbSize = sizeof(sbi);
-            RECT rcWindow;
-            GetWindowRect(HWindow, &rcWindow);
-            if (GetScrollBarInfo(HWindow, OBJID_VSCROLL, &sbi))
-            {
-                RECT vScroll = sbi.rcScrollBar;
-                OffsetRect(&vScroll, -rcWindow.left, -rcWindow.top);
-
-                RECT rcClient;
-                GetClientRect(HWindow, &rcClient);
-                POINT clientOrigin = {0, 0};
-                ClientToScreen(HWindow, &clientOrigin);
-                const int hScrollTop = clientOrigin.y - rcWindow.top + rcClient.bottom -
-                                       StatusBarHeight - GetSystemMetrics(SM_CYHSCROLL);
-
-                HDC hdc = GetWindowDC(HWindow);
-                HBRUSH brush = HANDLES(CreateSolidBrush(RGB(32, 32, 32)));
-                if (hdc != NULL && brush != NULL)
-                {
-                    // Cover both the seam row immediately above the scrollbar
-                    // and its first row.  This removes the persistent 1px
-                    // white line without relying on frame/menu dimensions.
-                    RECT topFix = {vScroll.left, vScroll.top - 1, vScroll.right, vScroll.top + 1};
-                    FillRect(hdc, &topFix, brush);
-
-                    // The V scrollbar ends at the horizontal scrollbar's top
-                    // edge.  This keeps it out of both the horizontal bar and
-                    // the status-bar size grip below it.
-                    RECT bottomFix = {vScroll.left, max(vScroll.top, hScrollTop),
-                                      vScroll.right, vScroll.bottom};
-                    FillRect(hdc, &bottomFix, brush);
-                }
-                if (brush != NULL)
-                    HANDLES(DeleteObject(brush));
-                if (hdc != NULL)
-                    ReleaseDC(HWindow, hdc);
-            }
-        }
+            PostMessage(HWindow, kViewerVScrollOverlayRepaint, 0, 0);
         return ncResult;
     }
+
+    case kViewerVScrollOverlayRepaint:
+        if (DarkModeShouldUseDarkColors())
+            PaintViewerVScrollOverlay(HWindow, StatusBarHeight);
+        return 0;
 
     case WM_PAINT:
     {

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -611,7 +611,10 @@ CViewerWindow::GetMaxVisibleLineLen(__int64 newFirstLineLen, BOOL ignoreFirstLin
 __int64
 CViewerWindow::GetMaxOriginX(__int64 newFirstLineLen, BOOL ignoreFirstLine, __int64 maxLineLen)
 {
-    __int64 maxLL = maxLineLen != -1 ? maxLineLen : GetMaxVisibleLineLen(newFirstLineLen, ignoreFirstLine);
+    // Horizontal scrolling is defined by the whole document.  Limiting it
+    // to the current rows makes the thumb size and reachable range change
+    // as the user scrolls vertically.
+    __int64 maxLL = maxLineLen != -1 ? maxLineLen : GetMaxDocumentLineLen();
     int columns = (Width - GetTextLeft()) / CharWidth;
     return maxLL > columns ? maxLL - columns : 0;
 }
@@ -1114,6 +1117,9 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         Paint(ps.hdc);
         HANDLES(EndPaint(HWindow, &ps));
+        // Scroll/status-bar repaints can occur after the original NC paint.
+        // Apply the V-scrollbar overlay once more after the client paint.
+        SendMessage(HWindow, WM_NCPAINT, 1, 0);
         return 0;
     }
 
@@ -1174,7 +1180,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 if (FileName != NULL)
                 {
-                    // limit movement according to the longest visible line
+                    // limit movement according to the longest document line
                     __int64 maxOX = GetMaxOriginX();
                     if (OriginX > maxOX)
                     {
@@ -1374,7 +1380,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         OriginX = (__int64)(ScrollScaleX * ((short)HIWORD(wParam)) + 0.5);
                     }
 
-                    // limit movement according to the longest visible line
+                    // limit movement according to the longest document line
                     __int64 maxOX = GetMaxOriginX();
                     if (OriginX > maxOX)
                         OriginX = maxOX;
@@ -1386,6 +1392,13 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 UpdateWindow(HWindow); // so that ViewSize is calculated for the next PageDown
             }
             }
+        }
+        // The themed scrollbar can repaint itself after the document update.
+        // Force its subclass to restore the dark track after that repaint.
+        if (HScrollBar != NULL)
+        {
+            InvalidateRect(HScrollBar, NULL, FALSE);
+            UpdateWindow(HScrollBar);
         }
         return 0;
     }

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1101,6 +1101,11 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             LayoutStatusBar();
         }
         Paint(ps.hdc);
+        if (DarkModeShouldUseDarkColors())
+        {
+            PostMessage(HScrollBar, kScrollBarTrackRepaint, 0, 0);
+            PostMessage(VScrollBar, kScrollBarTrackRepaint, 0, 0);
+        }
         if (ShowStatusBar)
         {
             // The child scrollbars leave one intersection cell above the
@@ -1307,19 +1312,12 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
             case SB_THUMBTRACK:
             {
-                // the actual scrolling runs from a timer because USB mice and MS scrollbars 
-                // misbehave otherwise: when the viewer is fullscreen, repainting the whole window 
-                // takes long enough that the stubborn scrollbar waits, so dragging feels like 
-                // a chewing gum; posting the scroll message or deferring painting did not help;
-                // a timer was the only reliable fix we found.
-                if (VScrollWParam == -1)
-                {
-                    VScrollWParam = wParam;
-                    VScrollWParamOld = -1;
-                    SetTimer(HWindow, IDT_THUMBSCROLL, 20, NULL);
-                }
-                else
-                    VScrollWParam = wParam;
+                // A child SCROLLBAR already tracks its native thumb smoothly.
+                // Handle each track notification directly, but keep
+                // EnableSetScroll false so Paint() cannot reset its metrics
+                // or snap the thumb back to an older position.
+                VScrollWParam = wParam;
+                OnVScroll();
                 break;
             }
             }

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -105,12 +105,10 @@ LRESULT CALLBACK ViewerZoomControlSubclass(HWND hwnd, UINT message, WPARAM wPara
     return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
-// Subclass for the horizontal scrollbar: repaints the track background
-// with RGB(23,23,23) so it is darker than the default dark-mode track
-// (RGB(32,32,32)), matching the user's desired look.
-// The scrollbar's track is drawn in WM_NCPAINT (non-client area), so we
-// intercept that message, let the default dark theme paint, then overdraw
-// only the track regions (between arrows, excluding the thumb).
+// Subclass for the horizontal scrollbar.  A child SCROLLBAR has no useful
+// non-client track: its complete surface is painted by WM_PAINT.  Repaint the
+// native control first and then replace only its two track sections with the
+// requested RGB(23,23,23), keeping its arrows and thumb intact.
 static const UINT_PTR kHScrollBarSubclassId = 2;
 
 static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
@@ -118,45 +116,38 @@ static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wPara
 {
     if (message == WM_NCDESTROY)
         RemoveWindowSubclass(hwnd, HScrollBarSubclass, subclassId);
-    if (message == WM_NCPAINT && DarkModeShouldUseDarkColors())
+    if (message == WM_PAINT && DarkModeShouldUseDarkColors())
     {
-        // Let the default dark scrollbar paint (arrows, track, thumb).
         LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
-        HDC hdc = GetWindowDC(hwnd);
-        if (hdc != NULL)
+        SCROLLBARINFO sbi;
+        memset(&sbi, 0, sizeof(sbi));
+        sbi.cbSize = sizeof(sbi);
+        if (GetScrollBarInfo(hwnd, OBJID_CLIENT, &sbi))
         {
-            RECT rcWnd;
-            GetWindowRect(hwnd, &rcWnd);
-            int wndW = rcWnd.right - rcWnd.left;
-            int wndH = rcWnd.bottom - rcWnd.top;
-            // Get scrollbar layout info (absolute positions within the control).
-            SCROLLBARINFO sbi;
-            sbi.cbSize = sizeof(sbi);
-            if (GetScrollBarInfo(hwnd, OBJID_CLIENT, &sbi))
+            RECT rc;
+            GetClientRect(hwnd, &rc);
+            const int arrowWidth = sbi.dxyLineButton;
+            const int thumbLeft = sbi.xyThumbTop;
+            const int thumbRight = sbi.xyThumbBottom;
+            HDC hdc = GetDC(hwnd);
+            HBRUSH brush = HANDLES(CreateSolidBrush(RGB(23, 23, 23)));
+            if (hdc != NULL && brush != NULL)
             {
-                int arrowSize = sbi.dxyLineButton;
-                // thumbLeft/thumbRight are absolute x-coordinates within the scrollbar.
-                int thumbLeft = sbi.xyThumbTop;
-                int thumbRight = sbi.xyThumbBottom;
-                HBRUSH br = HANDLES(CreateSolidBrush(RGB(23, 23, 23)));
-                if (br != NULL)
+                if (arrowWidth < thumbLeft)
                 {
-                    // Left track: between left arrow and thumb
-                    if (arrowSize < thumbLeft)
-                    {
-                        RECT leftTrack = { arrowSize, 0, thumbLeft, wndH };
-                        FillRect(hdc, &leftTrack, br);
-                    }
-                    // Right track: between thumb and right arrow
-                    if (thumbRight < wndW - arrowSize)
-                    {
-                        RECT rightTrack = { thumbRight, 0, wndW - arrowSize, wndH };
-                        FillRect(hdc, &rightTrack, br);
-                    }
-                    HANDLES(DeleteObject(br));
+                    RECT track = {arrowWidth, rc.top, thumbLeft, rc.bottom};
+                    FillRect(hdc, &track, brush);
+                }
+                if (thumbRight < rc.right - arrowWidth)
+                {
+                    RECT track = {thumbRight, rc.top, rc.right - arrowWidth, rc.bottom};
+                    FillRect(hdc, &track, brush);
                 }
             }
-            ReleaseDC(hwnd, hdc);
+            if (brush != NULL)
+                HANDLES(DeleteObject(brush));
+            if (hdc != NULL)
+                ReleaseDC(hwnd, hdc);
         }
         return result;
     }
@@ -1055,39 +1046,47 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
-    // Paint over the bottom portion of the non-client V scrollbar and fix
-    // the 1px white line at its top.  The V scrollbar (WS_VSCROLL) is a
-    // non-client element that extends the full client height.  We let
-    // DefWindowProc draw it first, then overdraw two regions:
-    //   1) The top 1px – paint with the background colour (RGB(32,32,32)).
-    //   2) The bottom StatusBarHeight pixels – paint with the same colour
-    //      so the V scrollbar appears shortened (stops at the H scrollbar).
+    // The vertical scrollbar is a non-client element.  Its coordinates in a
+    // window DC are not client coordinates, therefore derive both edges from
+    // ClientToScreen() rather than from the outer window rectangle.
     case WM_NCPAINT:
     {
         LRESULT ncResult = DefWindowProc(HWindow, WM_NCPAINT, wParam, lParam);
-        if (DarkModeShouldUseDarkColors() && StatusBarHeight > 0)
+        if (DarkModeShouldUseDarkColors())
         {
+            RECT rcWindow;
+            RECT rcClient;
+            GetWindowRect(HWindow, &rcWindow);
+            GetClientRect(HWindow, &rcClient);
+            POINT clientOrigin = {0, 0};
+            ClientToScreen(HWindow, &clientOrigin);
+
+            const int clientTop = clientOrigin.y - rcWindow.top;
+            const int clientBottom = clientTop + rcClient.bottom;
+            const int vScrollLeft = clientOrigin.x - rcWindow.left + rcClient.right;
+            const int vScrollRight = vScrollLeft + GetSystemMetrics(SM_CXVSCROLL);
             HDC hdc = GetWindowDC(HWindow);
-            if (hdc != NULL)
+            HBRUSH brush = HANDLES(CreateSolidBrush(RGB(32, 32, 32)));
+            if (hdc != NULL && brush != NULL)
             {
-                RECT rcWnd;
-                GetWindowRect(HWindow, &rcWnd);
-                int wndW = rcWnd.right - rcWnd.left;
-                int vScrollW = GetSystemMetrics(SM_CXVSCROLL);
-                HBRUSH br = HANDLES(CreateSolidBrush(DarkModeGetColors().background));
-                if (br != NULL)
+                // Cover the native dark-theme seam at the actual top edge of
+                // the non-client scrollbar, not at the top of the title bar.
+                RECT topFix = {vScrollLeft, clientTop, vScrollRight, clientTop + 1};
+                FillRect(hdc, &topFix, brush);
+
+                // The scrollbar must end at the bottom of the horizontal bar.
+                // The horizontal bar ends directly above the status bar.
+                if (StatusBarHeight > 0)
                 {
-                    // Fix 1px white line at the very top of the V scrollbar
-                    RECT topFix = { wndW - vScrollW, 0, wndW, 1 };
-                    FillRect(hdc, &topFix, br);
-                    // Paint over the bottom StatusBarHeight pixels
-                    int bottomTop = (rcWnd.bottom - rcWnd.top) - StatusBarHeight;
-                    RECT bottomFix = { wndW - vScrollW, bottomTop, wndW, rcWnd.bottom - rcWnd.top };
-                    FillRect(hdc, &bottomFix, br);
-                    HANDLES(DeleteObject(br));
+                    RECT bottomFix = {vScrollLeft, clientBottom - StatusBarHeight,
+                                      vScrollRight, clientBottom};
+                    FillRect(hdc, &bottomFix, brush);
                 }
-                ReleaseDC(HWindow, hdc);
             }
+            if (brush != NULL)
+                HANDLES(DeleteObject(brush));
+            if (hdc != NULL)
+                ReleaseDC(HWindow, hdc);
         }
         return ncResult;
     }

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1101,6 +1101,16 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             LayoutStatusBar();
         }
         Paint(ps.hdc);
+        if (DarkModeShouldUseDarkColors())
+        {
+            // Child scrollbars stop at the document rectangle.  Paint their
+            // uncovered intersection explicitly so resize/layout repainting
+            // cannot leave a white system-color corner behind.
+            RECT corner = {Width, Height,
+                           Width + GetSystemMetrics(SM_CXVSCROLL),
+                           Height + GetSystemMetrics(SM_CYHSCROLL)};
+            FillViewerRectWithColor(ps.hdc, &corner, RGB(32, 32, 32));
+        }
         HANDLES(EndPaint(HWindow, &ps));
         return 0;
     }

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1101,15 +1101,18 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             LayoutStatusBar();
         }
         Paint(ps.hdc);
-        if (DarkModeShouldUseDarkColors())
+        if (ShowStatusBar)
         {
-            // Child scrollbars stop at the document rectangle.  Paint their
-            // uncovered intersection explicitly so resize/layout repainting
-            // cannot leave a white system-color corner behind.
+            // The child scrollbars leave one intersection cell above the
+            // status bar.  Paint it in the active scheme color.  When the
+            // status bar is hidden, leave this cell untouched so its native
+            // resize grip remains visible and functional.
             RECT corner = {Width, Height,
                            Width + GetSystemMetrics(SM_CXVSCROLL),
                            Height + GetSystemMetrics(SM_CYHSCROLL)};
-            FillViewerRectWithColor(ps.hdc, &corner, RGB(32, 32, 32));
+            const COLORREF cornerColor = DarkModeShouldUseDarkColors() ? RGB(32, 32, 32)
+                                                                         : RGB(240, 240, 240);
+            FillViewerRectWithColor(ps.hdc, &corner, cornerColor);
         }
         HANDLES(EndPaint(HWindow, &ps));
         return 0;

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -163,46 +163,6 @@ static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wPara
     return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
-static const UINT kViewerVScrollOverlayRepaint = WM_APP + 204;
-
-static void PaintViewerVScrollOverlay(HWND hwnd, int statusBarHeight)
-{
-    SCROLLBARINFO sbi;
-    memset(&sbi, 0, sizeof(sbi));
-    sbi.cbSize = sizeof(sbi);
-    if (!GetScrollBarInfo(hwnd, OBJID_VSCROLL, &sbi))
-        return;
-
-    RECT rcWindow;
-    GetWindowRect(hwnd, &rcWindow);
-    RECT vScroll = sbi.rcScrollBar;
-    OffsetRect(&vScroll, -rcWindow.left, -rcWindow.top);
-
-    RECT rcClient;
-    GetClientRect(hwnd, &rcClient);
-    POINT clientOrigin = {0, 0};
-    ClientToScreen(hwnd, &clientOrigin);
-    const int hScrollTop = clientOrigin.y - rcWindow.top + rcClient.bottom -
-                           statusBarHeight - GetSystemMetrics(SM_CYHSCROLL);
-
-    HDC hdc = GetWindowDC(hwnd);
-    HBRUSH brush = HANDLES(CreateSolidBrush(RGB(32, 32, 32)));
-    if (hdc != NULL && brush != NULL)
-    {
-        // Hide the themed seam and the complete part of the non-client
-        // scrollbar below the document rectangle.  Its native painting is
-        // queued first, then this overlay runs after it.
-        RECT topFix = {vScroll.left, vScroll.top - 1, vScroll.right, vScroll.top + 1};
-        FillRect(hdc, &topFix, brush);
-        RECT bottomFix = {vScroll.left, max(vScroll.top, hScrollTop),
-                          vScroll.right, vScroll.bottom};
-        FillRect(hdc, &bottomFix, brush);
-    }
-    if (brush != NULL)
-        HANDLES(DeleteObject(brush));
-    if (hdc != NULL)
-        ReleaseDC(hwnd, hdc);
-}
 
 #ifndef WM_UAHDRAWMENU
 #define WM_UAHDRAWMENU 0x0091
@@ -1002,12 +962,17 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DarkModeRefreshTitleBar(HWindow);
         ApplyViewerMenuTheme(HWindow);
 
+        SetWindowLong(HWindow, GWL_STYLE, GetWindowLong(HWindow, GWL_STYLE) & ~WS_VSCROLL);
+        SetWindowPos(HWindow, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+
         HStatusBar = CreateWindowEx(0, STATUSCLASSNAME, NULL,
                                     WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | SBARS_SIZEGRIP,
                                     0, 0, 0, 0, HWindow, NULL, HInstance, NULL);
         HScrollBar = CreateWindowEx(0, "SCROLLBAR", NULL, WS_CHILD | WS_VISIBLE | SBS_HORZ,
                                     0, 0, 0, 0, HWindow, NULL, HInstance, NULL);
         SetWindowSubclass(HScrollBar, HScrollBarSubclass, kHScrollBarSubclassId, 0);
+        VScrollBar = CreateWindowEx(0, "SCROLLBAR", NULL, WS_CHILD | WS_VISIBLE | SBS_VERT,
+                                    0, 0, 0, 0, HWindow, NULL, HInstance, NULL);
         HZoomReset = CreateWindowEx(0, "BUTTON", "Reset", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON | BS_FLAT,
                                     0, 0, 0, 0, HWindow, (HMENU)IDC_VIEWER_ZOOM_RESET, HInstance, NULL);
         HZoomOut = CreateWindowEx(0, "BUTTON", "-", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON | BS_FLAT,
@@ -1099,21 +1064,6 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         break;
     }
 
-    // Keep WS_VSCROLL on the main viewer window.  Windows paints that native
-    // scrollbar to the full non-client height, so queue the masking overlay
-    // after its paint rather than forcing another NC paint while thumb-tracking.
-    case WM_NCPAINT:
-    {
-        LRESULT ncResult = DefWindowProc(HWindow, WM_NCPAINT, wParam, lParam);
-        if (DarkModeShouldUseDarkColors())
-            PostMessage(HWindow, kViewerVScrollOverlayRepaint, 0, 0);
-        return ncResult;
-    }
-
-    case kViewerVScrollOverlayRepaint:
-        if (DarkModeShouldUseDarkColors())
-            PaintViewerVScrollOverlay(HWindow, StatusBarHeight);
-        return 0;
 
     case WM_PAINT:
     {
@@ -1155,15 +1105,15 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (IsWindowVisible(HWindow)) // the last WM_SIZE arrives when closing the window; we do not care (error dialogs without the viewer window are highly undesirable)
         {
             SetToolTipOffset(-1);
-            int clientWidth = LOWORD(lParam);
-            int clientHeight = HIWORD(lParam);
+            int clientWidth = LOWORD(lParam) - GetSystemMetrics(SM_CXVSCROLL);
+            int clientHeight = HIWORD(lParam) - GetSystemMetrics(SM_CYHSCROLL);
             BOOL widthChanged = (Width != clientWidth);
             Width = clientWidth;
             Bitmap.Enlarge(Width, CharHeight);
             if (Width < 0)
                 Width = 0;
             int scrollHeight = GetSystemMetrics(SM_CYHSCROLL);
-            int viewHeight = max(0, clientHeight - scrollHeight - StatusBarHeight);
+            int viewHeight = max(0, clientHeight - StatusBarHeight);
             if (Height != viewHeight ||
                 widthChanged && Type == vtText && WrapText)
             {

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -105,50 +105,59 @@ LRESULT CALLBACK ViewerZoomControlSubclass(HWND hwnd, UINT message, WPARAM wPara
     return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
-// Subclass for the horizontal scrollbar.  A child SCROLLBAR has no useful
-// non-client track: its complete surface is painted by WM_PAINT.  Repaint the
-// native control first and then replace only its two track sections with the
-// requested RGB(23,23,23), keeping its arrows and thumb intact.
+// The native themed SCROLLBAR can issue a second paint after thumb tracking.
+// Queue the track overlay after every native paint, so RGB(23,23,23) wins over
+// that delayed themed repaint without replacing the native arrows or thumb.
 static const UINT_PTR kHScrollBarSubclassId = 2;
+static const UINT kHScrollBarTrackRepaint = WM_APP + 203;
+
+static void PaintHScrollBarTrack(HWND hwnd)
+{
+    SCROLLBARINFO sbi;
+    memset(&sbi, 0, sizeof(sbi));
+    sbi.cbSize = sizeof(sbi);
+    if (!GetScrollBarInfo(hwnd, OBJID_CLIENT, &sbi))
+        return;
+
+    RECT rc;
+    GetClientRect(hwnd, &rc);
+    HDC hdc = GetDC(hwnd);
+    HBRUSH brush = HANDLES(CreateSolidBrush(RGB(23, 23, 23)));
+    if (hdc != NULL && brush != NULL)
+    {
+        const int arrowWidth = sbi.dxyLineButton;
+        if (arrowWidth < sbi.xyThumbTop)
+        {
+            RECT track = {arrowWidth, rc.top, sbi.xyThumbTop, rc.bottom};
+            FillRect(hdc, &track, brush);
+        }
+        if (sbi.xyThumbBottom < rc.right - arrowWidth)
+        {
+            RECT track = {sbi.xyThumbBottom, rc.top, rc.right - arrowWidth, rc.bottom};
+            FillRect(hdc, &track, brush);
+        }
+    }
+    if (brush != NULL)
+        HANDLES(DeleteObject(brush));
+    if (hdc != NULL)
+        ReleaseDC(hwnd, hdc);
+}
 
 static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
                                            UINT_PTR subclassId, DWORD_PTR refData)
 {
     if (message == WM_NCDESTROY)
         RemoveWindowSubclass(hwnd, HScrollBarSubclass, subclassId);
+    if (message == kHScrollBarTrackRepaint)
+    {
+        if (DarkModeShouldUseDarkColors())
+            PaintHScrollBarTrack(hwnd);
+        return 0;
+    }
     if ((message == WM_PAINT || message == WM_NCPAINT) && DarkModeShouldUseDarkColors())
     {
         LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
-        SCROLLBARINFO sbi;
-        memset(&sbi, 0, sizeof(sbi));
-        sbi.cbSize = sizeof(sbi);
-        if (GetScrollBarInfo(hwnd, OBJID_CLIENT, &sbi))
-        {
-            RECT rc;
-            GetClientRect(hwnd, &rc);
-            const int arrowWidth = sbi.dxyLineButton;
-            const int thumbLeft = sbi.xyThumbTop;
-            const int thumbRight = sbi.xyThumbBottom;
-            HDC hdc = GetDC(hwnd);
-            HBRUSH brush = HANDLES(CreateSolidBrush(RGB(23, 23, 23)));
-            if (hdc != NULL && brush != NULL)
-            {
-                if (arrowWidth < thumbLeft)
-                {
-                    RECT track = {arrowWidth, rc.top, thumbLeft, rc.bottom};
-                    FillRect(hdc, &track, brush);
-                }
-                if (thumbRight < rc.right - arrowWidth)
-                {
-                    RECT track = {thumbRight, rc.top, rc.right - arrowWidth, rc.bottom};
-                    FillRect(hdc, &track, brush);
-                }
-            }
-            if (brush != NULL)
-                HANDLES(DeleteObject(brush));
-            if (hdc != NULL)
-                ReleaseDC(hwnd, hdc);
-        }
+        PostMessage(hwnd, kHScrollBarTrackRepaint, 0, 0);
         return result;
     }
     return DefSubclassProc(hwnd, message, wParam, lParam);
@@ -1071,7 +1080,8 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 GetClientRect(HWindow, &rcClient);
                 POINT clientOrigin = {0, 0};
                 ClientToScreen(HWindow, &clientOrigin);
-                const int clientBottom = clientOrigin.y - rcWindow.top + rcClient.bottom;
+                const int hScrollTop = clientOrigin.y - rcWindow.top + rcClient.bottom -
+                                       StatusBarHeight - GetSystemMetrics(SM_CYHSCROLL);
 
                 HDC hdc = GetWindowDC(HWindow);
                 HBRUSH brush = HANDLES(CreateSolidBrush(RGB(32, 32, 32)));
@@ -1083,14 +1093,12 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     RECT topFix = {vScroll.left, vScroll.top - 1, vScroll.right, vScroll.top + 1};
                     FillRect(hdc, &topFix, brush);
 
-                    // End the V scrollbar at the horizontal scrollbar's lower
-                    // edge, which is immediately above the status bar.
-                    if (StatusBarHeight > 0)
-                    {
-                        RECT bottomFix = {vScroll.left, clientBottom - StatusBarHeight,
-                                          vScroll.right, vScroll.bottom};
-                        FillRect(hdc, &bottomFix, brush);
-                    }
+                    // The V scrollbar ends at the horizontal scrollbar's top
+                    // edge.  This keeps it out of both the horizontal bar and
+                    // the status-bar size grip below it.
+                    RECT bottomFix = {vScroll.left, max(vScroll.top, hScrollTop),
+                                      vScroll.right, vScroll.bottom};
+                    FillRect(hdc, &bottomFix, brush);
                 }
                 if (brush != NULL)
                     HANDLES(DeleteObject(brush));
@@ -1117,9 +1125,6 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         Paint(ps.hdc);
         HANDLES(EndPaint(HWindow, &ps));
-        // Scroll/status-bar repaints can occur after the original NC paint.
-        // Apply the V-scrollbar overlay once more after the client paint.
-        SendMessage(HWindow, WM_NCPAINT, 1, 0);
         return 0;
     }
 
@@ -1392,13 +1397,6 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 UpdateWindow(HWindow); // so that ViewSize is calculated for the next PageDown
             }
             }
-        }
-        // The themed scrollbar can repaint itself after the document update.
-        // Force its subclass to restore the dark track after that repaint.
-        if (HScrollBar != NULL)
-        {
-            InvalidateRect(HScrollBar, NULL, FALSE);
-            UpdateWindow(HScrollBar);
         }
         return 0;
     }

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -109,9 +109,10 @@ LRESULT CALLBACK ViewerZoomControlSubclass(HWND hwnd, UINT message, WPARAM wPara
 // Queue the track overlay after every native paint, so RGB(23,23,23) wins over
 // that delayed themed repaint without replacing the native arrows or thumb.
 static const UINT_PTR kHScrollBarSubclassId = 2;
-static const UINT kHScrollBarTrackRepaint = WM_APP + 203;
+static const UINT_PTR kVScrollBarSubclassId = 3;
+static const UINT kScrollBarTrackRepaint = WM_APP + 203;
 
-static void PaintHScrollBarTrack(HWND hwnd)
+static void PaintScrollBarTrack(HWND hwnd)
 {
     SCROLLBARINFO sbi;
     memset(&sbi, 0, sizeof(sbi));
@@ -125,16 +126,33 @@ static void PaintHScrollBarTrack(HWND hwnd)
     HBRUSH brush = HANDLES(CreateSolidBrush(RGB(23, 23, 23)));
     if (hdc != NULL && brush != NULL)
     {
-        const int arrowWidth = sbi.dxyLineButton;
-        if (arrowWidth < sbi.xyThumbTop)
+            const int arrowSize = sbi.dxyLineButton;
+        const bool vertical = (GetWindowLong(hwnd, GWL_STYLE) & SBS_VERT) != 0;
+        if (vertical)
         {
-            RECT track = {arrowWidth, rc.top, sbi.xyThumbTop, rc.bottom};
-            FillRect(hdc, &track, brush);
+            if (arrowSize < sbi.xyThumbTop)
+            {
+                RECT track = {rc.left, arrowSize, rc.right, sbi.xyThumbTop};
+                FillRect(hdc, &track, brush);
+            }
+            if (sbi.xyThumbBottom < rc.bottom - arrowSize)
+            {
+                RECT track = {rc.left, sbi.xyThumbBottom, rc.right, rc.bottom - arrowSize};
+                FillRect(hdc, &track, brush);
+            }
         }
-        if (sbi.xyThumbBottom < rc.right - arrowWidth)
+        else
         {
-            RECT track = {sbi.xyThumbBottom, rc.top, rc.right - arrowWidth, rc.bottom};
-            FillRect(hdc, &track, brush);
+            if (arrowSize < sbi.xyThumbTop)
+            {
+                RECT track = {arrowSize, rc.top, sbi.xyThumbTop, rc.bottom};
+                FillRect(hdc, &track, brush);
+            }
+            if (sbi.xyThumbBottom < rc.right - arrowSize)
+            {
+                RECT track = {sbi.xyThumbBottom, rc.top, rc.right - arrowSize, rc.bottom};
+                FillRect(hdc, &track, brush);
+            }
         }
     }
     if (brush != NULL)
@@ -148,16 +166,16 @@ static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wPara
 {
     if (message == WM_NCDESTROY)
         RemoveWindowSubclass(hwnd, HScrollBarSubclass, subclassId);
-    if (message == kHScrollBarTrackRepaint)
+    if (message == kScrollBarTrackRepaint)
     {
         if (DarkModeShouldUseDarkColors())
-            PaintHScrollBarTrack(hwnd);
+            PaintScrollBarTrack(hwnd);
         return 0;
     }
     if ((message == WM_PAINT || message == WM_NCPAINT) && DarkModeShouldUseDarkColors())
     {
         LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
-        PostMessage(hwnd, kHScrollBarTrackRepaint, 0, 0);
+        PostMessage(hwnd, kScrollBarTrackRepaint, 0, 0);
         return result;
     }
     return DefSubclassProc(hwnd, message, wParam, lParam);
@@ -624,6 +642,8 @@ CViewerWindow::GetMaxOriginX(__int64 newFirstLineLen, BOOL ignoreFirstLine, __in
     // Horizontal scrolling is defined by the whole document.  Limiting it
     // to the current rows makes the thumb size and reachable range change
     // as the user scrolls vertically.
+    if (WrapText)
+        return 0;
     __int64 maxLL = maxLineLen != -1 ? maxLineLen : GetMaxDocumentLineLen();
     int columns = (Width - GetTextLeft()) / CharWidth;
     return maxLL > columns ? maxLL - columns : 0;
@@ -973,6 +993,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SetWindowSubclass(HScrollBar, HScrollBarSubclass, kHScrollBarSubclassId, 0);
         VScrollBar = CreateWindowEx(0, "SCROLLBAR", NULL, WS_CHILD | WS_VISIBLE | SBS_VERT,
                                     0, 0, 0, 0, HWindow, NULL, HInstance, NULL);
+        SetWindowSubclass(VScrollBar, HScrollBarSubclass, kVScrollBarSubclassId, 0);
         HZoomReset = CreateWindowEx(0, "BUTTON", "Reset", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON | BS_FLAT,
                                     0, 0, 0, 0, HWindow, (HMENU)IDC_VIEWER_ZOOM_RESET, HInstance, NULL);
         HZoomOut = CreateWindowEx(0, "BUTTON", "-", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON | BS_FLAT,

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1120,8 +1120,17 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         else
         {
             // With no status bar there is no STATUSCLASS size grip to repaint
-            // this cell. Draw the native sizing grip on every parent paint.
-            DrawFrameControl(ps.hdc, &corner, DFC_SCROLL, DFCS_SCROLLSIZEGRIP);
+            // this cell. Draw a scheme-aware grip on every parent paint.
+            if (DarkModeShouldUseDarkColors())
+            {
+                FillViewerRectWithColor(ps.hdc, &corner, RGB(32, 32, 32));
+                for (int offset = 3; offset < corner.right - corner.left; offset += 4)
+                    for (int dot = 0; dot < offset; dot += 4)
+                        SetPixel(ps.hdc, corner.right - 2 - dot, corner.bottom - 2 - offset + dot,
+                                 RGB(150, 150, 150));
+            }
+            else
+                DrawFrameControl(ps.hdc, &corner, DFC_SCROLL, DFCS_SCROLLSIZEGRIP);
         }
         HANDLES(EndPaint(HWindow, &ps));
         return 0;
@@ -1314,6 +1323,10 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     ;
                 OnVScroll();
                 VScrollWParam = -1;
+                // Commit the final position immediately after tracking ends;
+                // otherwise the child control retains its pre-drag scroll info
+                // until a later repaint/input event.
+                SetScrollBar();
                 break;
             }
 


### PR DESCRIPTION
### Motivation
- Fix case where switching away from the Windows Dark Mode scheme did not restore the internal viewer colors when a dark palette was loaded from configuration storage instead of being applied during the current session.

### Description
- Add a fallback in `WindowsDarkModeUpdatePalette` to detect when `ViewerColors` match the Windows dark viewer palette and call `WindowsLightModeBuildViewerPalette(ViewerColors)` to explicitly restore the standard light viewer palette. 
- Change is implemented in `src/salamdr1.cpp` by adding the `else if (WindowsDarkModeIsViewerPalette(ViewerColors))` branch after the existing saved-palette restore path.

### Testing
- Ran `git diff --check` which produced no whitespace/errors and succeeded. 
- Performed a targeted Python source assertion that verified both the saved-palette restore branch and the new fallback branch are present and ordered correctly, which succeeded. 
- Committed the change as `Restore internal viewer palette after dark mode` and verified the repository status updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59abb91a7c8329b498442fc4c8668e)