### PR TITLE
Document startup parameters and add -welcome switch

### DIFF
--- a/doc/command-line-parameters.md
+++ b/doc/command-line-parameters.md
@@ -1,0 +1,60 @@
+# Command-line parameters
+
+This document describes every command-line form accepted by the two executable
+programs shipped with Open Salamander. Parameter names are case-insensitive.
+Quote an argument that contains spaces. `salamand.exe` accepts only the
+hyphen-prefixed forms listed below, except where another form is explicitly
+shown.
+
+## `salamand.exe`
+
+### Panel paths and activation
+
+| Parameter | Argument | Description |
+| --- | --- | --- |
+| `-l <path>` | Required path | Opens `<path>` in the left panel. Environment variables in the path are expanded. |
+| `-r <path>` | Required path | Opens `<path>` in the right panel. Environment variables in the path are expanded. |
+| `-a <path>` | Required path | Opens `<path>` in the active panel. Environment variables in the path are expanded. |
+| `-p <0\|1\|2>` | Required panel number | Selects the active panel: `0` leaves the selection unchanged, `1` selects the left panel, and `2` selects the right panel. |
+| `-aj <path>` | Required path | Opens `<path>` in the active panel using the Jump List *hot path* syntax. This is an internal parameter used by Jump List shortcuts. |
+
+Paths which are not plugin file-system paths are made absolute relative to the
+current directory. For example:
+
+```bat
+salamand.exe -l "C:\\Source Code" -r "%USERPROFILE%\\Downloads" -p 2
+```
+
+### Configuration and appearance
+
+| Parameter | Argument | Description |
+| --- | --- | --- |
+| `-c <file>` | Required configuration-file name or path | Uses the specified configuration file instead of the default `config.reg`. A relative name is looked up beside `salamand.exe`, then in the user's Roaming AppData directory. |
+| `-i <index>` | Required icon index | Forces the main-window icon to the specified zero-based index. Valid indices range from `0` up to the number of built-in main-window icons minus one. |
+| `-t <text>` | Required title prefix | Forces the main-window title prefix. |
+| `-o` | None | Forces single-instance behaviour: if another compatible Salamander instance is running, the new invocation activates it instead of opening another instance. |
+| `-language <name>` or `/language <name>` | Required language name | Selects `<name>.slg` from the `lang` directory. The name must not contain a path separator, colon, or dot. |
+
+### Welcome dialog and installer integration
+
+| Parameter | Argument | Description |
+| --- | --- | --- |
+| `-welcome` | None | Forces the configuration Welcome dialog to open during startup, even when Salamander already has a usable configuration. The installer uses this after installation. |
+| `-run_notepad <file>` | Required file path | Requests opening `<file>` in Notepad after Salamander has started. This is an internal installer/SFX integration parameter. |
+
+Unrecognised parameters, missing required arguments, and slash-prefixed forms
+other than `/language` cause Salamander to show an invalid-command-line error.
+
+## `utils\\salmon.exe`
+
+`salmon.exe` is Open Salamander's crash-report helper. It is normally launched
+by Salamander and is not intended to be run directly by end users.
+
+| Parameter form | Description |
+| --- | --- |
+| `salmon.exe --test` | Creates a test bug-report package in the temporary directory and verifies its compression workflow. `/test` is an equivalent spelling. No other arguments may follow. |
+| `salmon.exe "<file-mapping-name>" "<language-file>"` | Normal internal invocation. `<file-mapping-name>` is the shared-memory mapping created by Salamander; `<language-file>` is the `.slg` file name used for report UI strings. Both arguments must be quoted. |
+
+For the normal internal form, the first two arguments must be quoted as shown
+above. The helper reads those two arguments and ignores any remaining text.
+Invalid direct invocations show the crash helper's command-line error.

--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -1559,7 +1559,7 @@ Name: "{autodesktop}\Open Salamander Samandarin (x64)"; Filename: "{app}\{#AppTo
 Name: "{group}\Open Salamander Samandarin (x64)"; Filename: "{app}\{#AppToInstallExeName}"; WorkingDir: "{app}"; Tasks: startmenuicon; Check: not IsPortableInstall
 
 [Run]
-Filename: "{app}\{#AppToInstallExeName}"; Parameters: "-language ""{language}"""; Description: "{cm:LaunchProgram}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\{#AppToInstallExeName}"; Parameters: "-welcome -language ""{language}"""; Description: "{cm:LaunchProgram}"; Flags: nowait postinstall skipifsilent
 
 
 [UninstallRun]

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -4968,11 +4968,11 @@ FIND_NEW_SLG_FILE:
     // nactena (NULL -> zadna; pouziji se default hodnoty)
     if (autoImportConfig)
         SALAMANDER_ROOT_REG = autoImportConfigFromKey; // pri UPGRADE nema hledani konfigurace smysl
-    else if (storageTypeFromBootstrap && bootstrapStorageUsable)
+    else if (storageTypeFromBootstrap && bootstrapStorageUsable && !ForceWelcomeDialog)
         // configstorage.ini is the authoritative storage selection with existing configuration.  Do not open
         // the Welcome dialog again just because importable configurations exist;
-        // the dialog is only for first-time/unselected storage or explicit Manage
-        // Configurations from the menu.
+        // the dialog is only for first-time/unselected storage, an explicit -welcome
+        // request, or Manage Configurations from the menu.
         SALAMANDER_ROOT_REG = SalamanderConfigurationRoots[0];
     else
     {

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -372,6 +372,7 @@ char CurrentHelpDir[SAL_MAX_PATH] = ""; // po prvnim pouziti helpu je zde cesta 
 WORD LanguageID = 0;                // language-id .SPL souboru
 
 char OpenReadmeInNotepad[MAX_PATH]; // pouziva se jen pri spusteni z instalaku: jmeno souboru, ktere mame v IDLE otevrit v notepadu (spustit notepad)
+BOOL ForceWelcomeDialog = FALSE;    // command-line request to show the Welcome dialog
 
 BOOL UseCustomPanelFont = FALSE;
 HFONT Font = NULL;
@@ -4236,6 +4237,7 @@ BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams
         ConfigurationNameIgnoreIfNotExists = FALSE;
     }
     OpenReadmeInNotepad[0] = 0;
+    ForceWelcomeDialog = FALSE;
     if (GetCmdLine(buf, _countof(buf), argv, p, cmdLine))
     {
         int i;
@@ -4372,6 +4374,12 @@ BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams
             { // Vista+: after installation: installer (SFX7ZIP) executes Salamander and asks for execution of notepad with readme file
                 lstrcpyn(OpenReadmeInNotepad, argv[i + 1], MAX_PATH);
                 i++;
+                continue;
+            }
+
+            if (StrICmp(argv[i], "-welcome") == 0)
+            { // show the configuration Welcome dialog even when a configuration already exists
+                ForceWelcomeDialog = TRUE;
                 continue;
             }
 
@@ -4926,8 +4934,8 @@ FIND_NEW_SLG_FILE:
             bootstrapStorageUsable = currentRegistryConfigExistsAtStartup;
     }
 
-    BOOL forceWelcomeDialog = !autoImportConfig && (!storageTypeFromBootstrap || !bootstrapStorageUsable) &&
-                              !portableConfigExists && !currentRegistryConfigExistsAtStartup;
+    BOOL forceWelcomeDialog = ForceWelcomeDialog || (!autoImportConfig && (!storageTypeFromBootstrap || !bootstrapStorageUsable) &&
+                                                     !portableConfigExists && !currentRegistryConfigExistsAtStartup);
 
     // pokud soubor existuje, bude importovan do registry; v portable file rezimu
     // je config.reg aktivni storage backend, ne legacy auto-import do HKCU


### PR DESCRIPTION
### Motivation

- Provide a single English reference that documents all command-line parameters accepted by both `salamand.exe` and `utils\salmon.exe` so users and integrators can reliably invoke the apps.
- Add a mechanism to force the first-run Welcome/configuration dialog for integration scenarios (installer post-install run) where the dialog must be shown even if a configuration exists.

### Description

- Add `doc/command-line-parameters.md` describing every parsed `salamand.exe` option (panel paths, config/language/options, installer integration) and `utils\salmon.exe` usage. 
- Implement a new command-line switch `-welcome` by introducing `ForceWelcomeDialog` and wiring it into `ParseCommandLineParameters` and the startup `forceWelcomeDialog` logic in `src/salamdr1.cpp` so the Welcome dialog is shown when requested.
- Update the Inno Setup installer post-install run in `doc/runbook-setup/inno_setup_salamander_x64.iss` to launch the installed application with `-welcome` while preserving the chosen installer `-language` parameter.
- Small documentation clarification in the `salmon` section to clarify how the helper treats its quoted arguments.

### Testing

- Ran a Python static coverage check that verifies every parsed option in `src/salamdr1.cpp` and `src/salmon/salmon.cpp` is present in `doc/command-line-parameters.md`, and that the `-welcome` installer parameter is present in the installer script; the check passed.
- Ran `git diff --check` and whitespace checks which reported no problems.
- Attempted to run native build/run tools but Windows toolchain (`msbuild`/`devenv`) is not available in this environment, so no native application runtime test was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d02f13ac8329ab0f9d33c463c855)