### PR TITLE
Fix dark scrollbar tracking and palette

### DIFF
--- a/src/third_party/darkmodelib/src/DmlibHook.cpp
+++ b/src/third_party/darkmodelib/src/DmlibHook.cpp
@@ -228,7 +228,11 @@ static HTHEME WINAPI MyOpenNcThemeData(HWND hWnd, LPCWSTR pszClassList)
 		if (isWindowOrParentUsingDarkScrollBar(hWnd))
 #endif
 		{
-			hWnd = nullptr;
+			// Keep the real owner window.  Passing nullptr forces UxTheme to
+			// use its generic Explorer palette, which has a light (32,32,32)
+			// scrollbar track even when the owner opted into dark mode.  The
+			// owner is needed to select its dark policy and the corresponding
+			// RGB(23,23,23) track palette for both client and non-client bars.
 			pszClassList = L"Explorer::ScrollBar";
 		}
 	}

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1094,11 +1094,6 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             LayoutStatusBar();
         }
         Paint(ps.hdc);
-        if (DarkModeShouldUseDarkColors())
-        {
-            PostMessage(HScrollBar, kScrollBarTrackRepaint, 0, 0);
-            PostMessage(VScrollBar, kScrollBarTrackRepaint, 0, 0);
-        }
         RECT corner = {Width, Height,
                        Width + GetSystemMetrics(SM_CXVSCROLL),
                        Height + GetSystemMetrics(SM_CYHSCROLL)};

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -105,12 +105,11 @@ LRESULT CALLBACK ViewerZoomControlSubclass(HWND hwnd, UINT message, WPARAM wPara
     return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
-// The native themed SCROLLBAR can issue a second paint after thumb tracking.
-// Queue the track overlay after every native paint, so RGB(23,23,23) wins over
-// that delayed themed repaint without replacing the native arrows or thumb.
+// Keep the native arrows and thumb, but paint its track with Salamander's dark
+// palette.  This must happen in the same paint cycle: posting a second paint
+// visibly exposes the system's lighter track between the two operations.
 static const UINT_PTR kHScrollBarSubclassId = 2;
 static const UINT_PTR kVScrollBarSubclassId = 3;
-static const UINT kScrollBarTrackRepaint = WM_APP + 203;
 
 static void PaintScrollBarTrack(HWND hwnd)
 {
@@ -126,7 +125,7 @@ static void PaintScrollBarTrack(HWND hwnd)
     HBRUSH brush = HANDLES(CreateSolidBrush(RGB(23, 23, 23)));
     if (hdc != NULL && brush != NULL)
     {
-            const int arrowSize = sbi.dxyLineButton;
+        const int arrowSize = sbi.dxyLineButton;
         const bool vertical = (GetWindowLong(hwnd, GWL_STYLE) & SBS_VERT) != 0;
         if (vertical)
         {
@@ -166,16 +165,10 @@ static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wPara
 {
     if (message == WM_NCDESTROY)
         RemoveWindowSubclass(hwnd, HScrollBarSubclass, subclassId);
-    if (message == kScrollBarTrackRepaint)
-    {
-        if (DarkModeShouldUseDarkColors())
-            PaintScrollBarTrack(hwnd);
-        return 0;
-    }
     if ((message == WM_PAINT || message == WM_NCPAINT) && DarkModeShouldUseDarkColors())
     {
         LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
-        PostMessage(hwnd, kScrollBarTrackRepaint, 0, 0);
+        PaintScrollBarTrack(hwnd);
         return result;
     }
     return DefSubclassProc(hwnd, message, wParam, lParam);
@@ -1332,12 +1325,19 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
             case SB_THUMBTRACK:
             {
-                // A child SCROLLBAR already tracks its native thumb smoothly.
-                // Handle each track notification directly, but keep
-                // EnableSetScroll false so Paint() cannot reset its metrics
-                // or snap the thumb back to an older position.
+                // Do not load and repaint the document in the scrollbar's
+                // tracking message.  A slow file or a large fullscreen paint
+                // otherwise blocks the control's mouse loop, making its thumb
+                // lag behind the pointer or jump when the queued messages are
+                // eventually handled.  The native child control continues to
+                // track immediately; coalesce document updates on a timer.
+                EnableSetScroll = FALSE;
+                if (VScrollWParam == -1)
+                {
+                    VScrollWParamOld = -1;
+                    SetTimer(HWindow, IDT_THUMBSCROLL, 20, NULL);
+                }
                 VScrollWParam = wParam;
-                OnVScroll();
                 break;
             }
             }


### PR DESCRIPTION
### Motivation
- Fix internal viewer vertical thumb dragging lag/jumping by ensuring document updates do not block the native scrollbar tracking loop.
- Eliminate dark-mode scrollbar track flicker by forcing the viewer to render the correct dark track color (`RGB(23,23,23)`) instead of allowing a lighter themed repaint to show through.
- Restore correct dark scrollbar palette selection for main-window and child scrollbars by letting UxTheme use the real owner HWND when requesting the `Explorer::ScrollBar` theme.

### Description
- Coalesce thumb-track updates in the internal viewer by avoiding immediate document load/repaint during `SB_THUMBTRACK` and using a timer (`IDT_THUMBSCROLL`) to drive `OnVScroll` processing later, preserving responsive native thumb tracking (`src/viewer3.cpp`).
- Paint the scrollbar track with Salamander's dark track color inside the scrollbar subclass paint path so the dark track (`RGB(23,23,23)`) is applied in the same paint cycle and no queued secondary repaint can expose the lighter system track (`src/viewer3.cpp`).
- Remove the queued/posted secondary repaint for the scrollbar track and call `PaintScrollBarTrack` synchronously after native paint to avoid visible flashing (`src/viewer3.cpp`).
- Update the vendored darkmodelib hook to preserve the real owner `HWND` when requesting `Explorer::ScrollBar`, ensuring UxTheme resolves the window’s dark scrollbar palette (including the dark track) instead of falling back to the generic Explorer palette (`src/third_party/darkmodelib/src/DmlibHook.cpp`).

### Testing
- Ran a `python3` static regression check that asserts the expected timer-based coalescing code paths exist and that the delayed `PostMessage` repaint was removed, and the checks passed.
- Ran `git diff --check` to ensure no whitespace/patch issues and the repository diff checks passed; Windows runtime / UI integration tests were not run because a Windows build/runtime was unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59ed21f6488329a63887cbf33c87d3)