### PR TITLE
Fix saving and renaming Hot Paths in Configuration

### DIFF
--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -754,8 +754,6 @@ protected:
     BOOL EditMode;
     int EditIndex;
     BOOL LabelEdit; // we are editing a label
-    int PendingLabelIndex;
-    char PendingLabel[MAX_PATH];
 
 public:
     CCfgPageHotPath(BOOL editMode, int editIndex);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3367,8 +3367,6 @@ CCfgPageUserMenu::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 // CCfgPageHotPath
 //
 
-#define WM_USER_HOTPATH_COMMIT_LABEL (WM_APP + 250)
-
 CCfgPageHotPath::CCfgPageHotPath(BOOL editMode, int editIndex)
     : CCommonPropSheetPage(NULL, HLanguage, IDD_CFGPAGE_HOTPATH, IDD_CFGPAGE_HOTPATH, PSP_USETITLE, NULL)
 {
@@ -3378,8 +3376,6 @@ CCfgPageHotPath::CCfgPageHotPath(BOOL editMode, int editIndex)
     DisableNotification = FALSE;
     EditMode = editMode;
     EditIndex = editIndex;
-    PendingLabelIndex = -1;
-    PendingLabel[0] = 0;
     if (editIndex < 0 || editIndex >= HOT_PATHS_COUNT)
     {
         EditMode = FALSE;
@@ -3751,16 +3747,49 @@ CCfgPageHotPath::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
 
             case LVN_ENDLABELEDIT:
+#ifndef _UNICODE
+            case LVN_ENDLABELEDITW:
+#endif // _UNICODE
             {
-                NMLVDISPINFO* nmhd = (NMLVDISPINFO*)nmh;
                 LabelEdit = FALSE;
                 EnableHeader();
+                int index = -1;
+                BOOL hasLabel = FALSE;
+                char name[MAX_PATH];
+                name[0] = 0;
+#ifdef _UNICODE
+                NMLVDISPINFO* nmhd = (NMLVDISPINFO*)nmh;
+                index = nmhd->item.iItem;
                 if (nmhd->item.pszText != NULL)
                 {
-                    char name[MAX_PATH];
                     lstrcpyn(name, nmhd->item.pszText, MAX_PATH);
+                    hasLabel = TRUE;
+                }
+#else  // _UNICODE
+                if (nmh->code == LVN_ENDLABELEDITW)
+                {
+                    NMLVDISPINFOW* nmhd = (NMLVDISPINFOW*)nmh;
+                    index = nmhd->item.iItem;
+                    if (nmhd->item.pszText != NULL)
+                    {
+                        WideCharToMultiByte(CP_ACP, 0, nmhd->item.pszText, -1, name, MAX_PATH, NULL, NULL);
+                        hasLabel = TRUE;
+                    }
+                }
+                else
+                {
+                    NMLVDISPINFOA* nmhd = (NMLVDISPINFOA*)nmh;
+                    index = nmhd->item.iItem;
+                    if (nmhd->item.pszText != NULL)
+                    {
+                        lstrcpyn(name, nmhd->item.pszText, MAX_PATH);
+                        hasLabel = TRUE;
+                    }
+                }
+#endif // _UNICODE
+                if (index != -1 && hasLabel)
+                {
                     Config->CleanName(name);
-                    int index = nmhd->item.iItem;
                     char path[HOTPATHITEM_MAXPATH];
                     path[0] = 0;
                     if (strlen(name) != 0)
@@ -3774,10 +3803,6 @@ CCfgPageHotPath::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     Dirty = TRUE;
                     EnableControls();
 
-                    PendingLabelIndex = index;
-                    lstrcpyn(PendingLabel, name, MAX_PATH);
-                    PostMessage(HWindow, WM_USER_HOTPATH_COMMIT_LABEL, 0, 0);
-
                     // The list view applies the label after this notification
                     // returns.  Report that the edit was accepted without
                     // changing the list control while it is finishing it.
@@ -3789,14 +3814,6 @@ CCfgPageHotPath::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
         }
         break;
-    }
-
-    case WM_USER_HOTPATH_COMMIT_LABEL:
-    {
-        if (PendingLabelIndex >= 0 && PendingLabelIndex < HOT_PATHS_COUNT)
-            ListView_SetItemText(HListView, PendingLabelIndex, 0, PendingLabel);
-        PendingLabelIndex = -1;
-        return TRUE;
     }
 
     case WM_COMMAND:

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -3801,7 +3801,10 @@ CCfgPageHotPath::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     }
                     Config->Set(index, name, path);
                     Dirty = TRUE;
-                    EnableControls();
+                    if (name[0] == 0)
+                        LoadControls(); // discard the removed item's path before it can be reused
+                    else
+                        EnableControls();
 
                     // The list view applies the label after this notification
                     // returns.  Report that the edit was accepted without


### PR DESCRIPTION
### Motivation
- Hot Paths edited directly in the Configuration dialog were not being saved or renamed in ANSI builds because the list-view emits a Unicode `LVN_ENDLABELEDITW` notification that was not handled. 
- The context-menu flow (`Assign to hot path`) previously worked because it prefilled and saved via the dialog path, revealing a mismatch in how label edits were processed.

### Description
- Handle both `LVN_ENDLABELEDIT` and `LVN_ENDLABELEDITW` in `CCfgPageHotPath::DialogProc` so ANSI builds also capture Unicode label notifications. 
- Convert Unicode label text to the ANSI buffer with `WideCharToMultiByte` before cleaning and storing the name, then call `Config->Set(index, name, path)` to persist the edited item. 
- Remove the deferred label-update workaround (`PendingLabel` / `PendingLabelIndex` and `WM_USER_HOTPATH_COMMIT_LABEL`) and related fields from `src/cfgdlg.h` so the list view commits edits normally. 
- Preserve previous logic that saves the current path from the edit control when the edited item is the currently selected row so path and name edits remain consistent.

### Testing
- Ran `git diff --check` and it reported no problems. 
- Executed a structural Python check that verified the handler covers both ANSI and Unicode `LVN_ENDLABELEDIT` notifications and that the edited label is persisted, which succeeded. 
- Committed the changes (`Fix Hot Path label edits from configuration`) and inspected the `git diff` showing the intended updates. 
- A full Windows/MSBuild build was not executed in this environment because the Windows toolchain is not available here (manual or CI build is recommended).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a60f66cd4832981f9e558407ebc7e)