### PR TITLE
Fix scoped dark scrollbar track rendering

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2664,6 +2664,18 @@ void DarkModeAllowDarkScrollbars(HWND hwnd)
 #endif
 }
 
+void DarkModeDisallowDarkScrollbars(HWND hwnd)
+{
+    if (hwnd == NULL)
+        return;
+
+#if USE_DARKMODELIB && defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 1)
+    dmlib::disableDarkScrollBarForWindowAndChildren(hwnd);
+#else
+    (void)hwnd;
+#endif
+}
+
 void DarkModeConfigureDialogColors(COLORREF textColor, COLORREF backgroundColor, HBRUSH dialogBrush)
 {
     if (gDialogBrushOwned && gDialogBrushHandle != NULL && gDialogBrushHandle != dialogBrush)

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2652,7 +2652,7 @@ void DarkModeFixScrollbars()
 #endif
 }
 
-void DarkModeAllowDarkScrollbars(HWND hwnd)
+static void AllowDarkScrollbarsInHost(HWND hwnd)
 {
     if (hwnd == NULL)
         return;
@@ -2667,6 +2667,36 @@ void DarkModeAllowDarkScrollbars(HWND hwnd)
 #else
     (void)hwnd;
 #endif
+}
+
+extern "C" __declspec(dllexport) void WINAPI SalamanderAllowDarkScrollbars(HWND hwnd)
+{
+    AllowDarkScrollbarsInHost(hwnd);
+}
+
+void DarkModeAllowDarkScrollbars(HWND hwnd)
+{
+    if (hwnd == NULL)
+        return;
+
+    // Plugins link their own copy of darkmode.cpp, whereas the IAT callback
+    // and its scoped-window set belong to salamand.exe.  Route plugin calls
+    // to the exported host entry point instead of updating their inert local
+    // DarkModeLib instance.
+    HMODULE callerModule = NULL;
+    GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                       reinterpret_cast<LPCWSTR>(&DarkModeAllowDarkScrollbars), &callerModule);
+    if (callerModule != GetModuleHandleW(NULL))
+    {
+        typedef void(WINAPI* HostAllowDarkScrollbarsFn)(HWND);
+        HostAllowDarkScrollbarsFn hostAllow = reinterpret_cast<HostAllowDarkScrollbarsFn>(
+            GetProcAddress(GetModuleHandleW(NULL), "SalamanderAllowDarkScrollbars"));
+        if (hostAllow != NULL)
+            hostAllow(hwnd);
+        return;
+    }
+
+    AllowDarkScrollbarsInHost(hwnd);
 }
 
 void DarkModeDisallowDarkScrollbars(HWND hwnd)

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2663,7 +2663,15 @@ static void AllowDarkScrollbarsInHost(HWND hwnd)
     // non-client scrollbars have already obtained a theme handle.  Reapply
     // the Explorer theme to make those existing scrollbars reopen their
     // theme through the now-enabled scoped hook.
-    dmlib::setDarkScrollBar(hwnd);
+    static const wchar_t kScrollBarThemeAppliedProp[] = L"Salamander.DarkScrollBarThemeApplied";
+    if (GetPropW(hwnd, kScrollBarThemeAppliedProp) == NULL)
+    {
+        // SetWindowTheme can synchronously deliver WM_THEMECHANGED.  Mark the
+        // window first so its handler's dark-mode refresh does not recursively
+        // attempt to reapply the same theme until the stack overflows.
+        SetPropW(hwnd, kScrollBarThemeAppliedProp, reinterpret_cast<HANDLE>(1));
+        dmlib::setDarkScrollBar(hwnd);
+    }
 #else
     (void)hwnd;
 #endif

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2659,6 +2659,11 @@ void DarkModeAllowDarkScrollbars(HWND hwnd)
 
 #if USE_DARKMODELIB && defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 1)
     dmlib::enableDarkScrollBarForWindowAndChildren(hwnd);
+    // Plugin windows normally opt in from WM_CREATE, after their WS_*SCROLL
+    // non-client scrollbars have already obtained a theme handle.  Reapply
+    // the Explorer theme to make those existing scrollbars reopen their
+    // theme through the now-enabled scoped hook.
+    dmlib::setDarkScrollBar(hwnd);
 #else
     (void)hwnd;
 #endif

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -57,6 +57,9 @@ void DarkModeFixScrollbars();
 // Allows the limited dark scrollbar hook to affect this window subtree.
 void DarkModeAllowDarkScrollbars(HWND hwnd);
 
+// Removes a window subtree from the limited dark scrollbar hook.
+void DarkModeDisallowDarkScrollbars(HWND hwnd);
+
 // Supplies dialog foreground/background colors and brush for WM_CTLCOLOR helpers.
 void DarkModeConfigureDialogColors(COLORREF textColor, COLORREF backgroundColor, HBRUSH dialogBrush);
 void DarkModeSetConfiguredColors(COLORREF schemeTextColor, COLORREF schemeBackgroundColor,

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -273,11 +273,7 @@ bool HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT& result,
 {
 #if USE_DARKMODELIB
     if (message == WM_CTLCOLORSTATIC || message == WM_CTLCOLORBTN || message == WM_CTLCOLOREDIT ||
-        message == WM_CTLCOLORLISTBOX || message == WM_CTLCOLORDLG || message == WM_CTLCOLORMSGBOX ||
-        // Some plugin-owned standard controls do not reopen their native
-        // scrollbar theme after creation.  Supplying the dark parent brush
-        // keeps those tracks out of the system-light fallback path.
-        message == WM_CTLCOLORSCROLLBAR)
+        message == WM_CTLCOLORLISTBOX || message == WM_CTLCOLORDLG || message == WM_CTLCOLORMSGBOX)
     {
         HDC hdc = reinterpret_cast<HDC>(wParam);
         if (hdc != NULL)

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -273,8 +273,7 @@ bool HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT& result,
 {
 #if USE_DARKMODELIB
     if (message == WM_CTLCOLORSTATIC || message == WM_CTLCOLORBTN || message == WM_CTLCOLOREDIT ||
-        message == WM_CTLCOLORLISTBOX || message == WM_CTLCOLORDLG || message == WM_CTLCOLORMSGBOX ||
-        message == WM_CTLCOLORSCROLLBAR)
+        message == WM_CTLCOLORLISTBOX || message == WM_CTLCOLORDLG || message == WM_CTLCOLORMSGBOX)
     {
         HDC hdc = reinterpret_cast<HDC>(wParam);
         if (hdc != NULL)

--- a/src/darkmode_backend_darkmodelib.cpp
+++ b/src/darkmode_backend_darkmodelib.cpp
@@ -273,7 +273,11 @@ bool HandleCtlColor(UINT message, WPARAM wParam, LPARAM lParam, LRESULT& result,
 {
 #if USE_DARKMODELIB
     if (message == WM_CTLCOLORSTATIC || message == WM_CTLCOLORBTN || message == WM_CTLCOLOREDIT ||
-        message == WM_CTLCOLORLISTBOX || message == WM_CTLCOLORDLG || message == WM_CTLCOLORMSGBOX)
+        message == WM_CTLCOLORLISTBOX || message == WM_CTLCOLORDLG || message == WM_CTLCOLORMSGBOX ||
+        // Some plugin-owned standard controls do not reopen their native
+        // scrollbar theme after creation.  Supplying the dark parent brush
+        // keeps those tracks out of the system-light fallback path.
+        message == WM_CTLCOLORSCROLLBAR)
     {
         HDC hdc = reinterpret_cast<HDC>(wParam);
         if (hdc != NULL)

--- a/src/plugins/filecomp/filecomp.cpp
+++ b/src/plugins/filecomp/filecomp.cpp
@@ -178,6 +178,7 @@ void ApplyFileCompDarkMode(HWND hwnd)
     {
         DarkModeApplyWindow(hwnd);
         DarkModeRefreshTitleBar(hwnd);
+        DarkModeAllowDarkScrollbars(hwnd);
         DarkModeApplyTree(hwnd);
     }
 }

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -319,6 +319,12 @@ BOOL CMainWindow::Init()
         return FALSE;
     }
 
+    // These custom windows own WS_VSCROLL/WS_HSCROLL themselves.  Reapply
+    // the scoped Explorer scrollbar theme to the actual scrollbar owners,
+    // not just to the File Comparator frame created earlier.
+    DarkModeAllowDarkScrollbars(LeftFileViewHWnd);
+    DarkModeAllowDarkScrollbars(RightFileViewHWnd);
+
     // disable the scrollbars
     EnableScrollBar(LeftFileViewHWnd, SB_BOTH, ESB_DISABLE_BOTH);
     EnableScrollBar(RightFileViewHWnd, SB_BOTH, ESB_DISABLE_BOTH);

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -257,7 +257,7 @@ BOOL CMainWindow::Init()
     LeftHeader = new CFileHeaderWindow("");
     if (!LeftHeader)
         return Error(HWND(NULL), IDS_LOWMEM);
-    if (!LeftHeader->CreateEx(WS_EX_STATICEDGE,
+    if (!LeftHeader->CreateEx(0,
                               CWINDOW_CLASSNAME,
                               "",
                               WS_VISIBLE | WS_CHILD,
@@ -274,7 +274,7 @@ BOOL CMainWindow::Init()
     RightHeader = new CFileHeaderWindow("");
     if (!RightHeader)
         return Error(HWND(NULL), IDS_LOWMEM);
-    if (!RightHeader->CreateEx(WS_EX_STATICEDGE,
+    if (!RightHeader->CreateEx(0,
                                CWINDOW_CLASSNAME,
                                "",
                                WS_VISIBLE | WS_CHILD,
@@ -289,7 +289,7 @@ BOOL CMainWindow::Init()
     }
 
     // create the file view windows
-    LeftFileViewHWnd = CreateWindowEx(WS_EX_STATICEDGE,
+    LeftFileViewHWnd = CreateWindowEx(0,
                                       FILEVIEWWINDOW_CLASSNAME,
                                       "",
                                       WS_VISIBLE | WS_CHILD | WS_VSCROLL | WS_HSCROLL,
@@ -304,7 +304,7 @@ BOOL CMainWindow::Init()
         return FALSE;
     }
 
-    RightFileViewHWnd = CreateWindowEx(WS_EX_STATICEDGE,
+    RightFileViewHWnd = CreateWindowEx(0,
                                        FILEVIEWWINDOW_CLASSNAME,
                                        "",
                                        WS_VISIBLE | WS_CHILD | WS_VSCROLL | WS_HSCROLL,

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -250,7 +250,7 @@ BOOL CMainWindow::Init()
 
     RestoreRebarLayout();
 
-    RebarHeight = LONG(SendMessage(Rebar->HWindow, RB_GETBARHEIGHT, 0, 0)) + 4 + REBAR_BORDER;
+    RebarHeight = LONG(SendMessage(Rebar->HWindow, RB_GETBARHEIGHT, 0, 0)) + REBAR_BORDER;
     ApplyFileCompMainWindowChrome(HWindow, HToolbar, Rebar->HWindow);
 
     // create the window caption
@@ -1701,7 +1701,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
             case RBN_HEIGHTCHANGE:
             {
-                RebarHeight = LONG(SendMessage(Rebar->HWindow, RB_GETBARHEIGHT, 0, 0)) + 4 + REBAR_BORDER;
+                RebarHeight = LONG(SendMessage(Rebar->HWindow, RB_GETBARHEIGHT, 0, 0)) + REBAR_BORDER;
                 ApplyFileCompMainWindowChrome(HWindow, HToolbar, Rebar->HWindow);
                 if (Initialized)
                     LayoutChilds();

--- a/src/plugins/filecomp/mainwnd.h
+++ b/src/plugins/filecomp/mainwnd.h
@@ -25,7 +25,7 @@
 #define BI_NEXTDIFF 4
 #define BI_LASTDIFF 5
 
-#define REBAR_BORDER 2 // height of the gap below the rebar
+#define REBAR_BORDER 0 // no legacy gap below the rebar in dark mode
 
 // flags for CMainWindow::UpdateToolbarButtons()
 #define UTB_DIFFSSELECTION 0x01

--- a/src/plugins/jsonviewer/managed/ThemeHelper.cs
+++ b/src/plugins/jsonviewer/managed/ThemeHelper.cs
@@ -893,7 +893,12 @@ namespace EPocalipse.Json.Viewer
 
                 try
                 {
-                    SetWindowTheme(handle, "DarkMode_Explorer", null);
+                    // The scrollbar-specific class list is required for
+                    // WinForms controls that own native scrollbars.  The
+                    // generic DarkMode_Explorer theme leaves those tracks on
+                    // the light system rendering path on several Windows 11
+                    // builds.
+                    SetWindowTheme(handle, "Explorer::ScrollBar", null);
                 }
                 catch (DllNotFoundException)
                 {

--- a/src/plugins/jsonviewer/managed/ThemeHelper.cs
+++ b/src/plugins/jsonviewer/managed/ThemeHelper.cs
@@ -248,7 +248,7 @@ namespace EPocalipse.Json.Viewer
         // the dark Explorer theme after its handle exists.
         private static void ApplyNativeScrollbarTheme(Control control, ThemePalette palette)
         {
-            if (!palette.IsDark || !control.IsHandleCreated)
+            if (!palette.IsDark)
             {
                 return;
             }
@@ -257,9 +257,12 @@ namespace EPocalipse.Json.Viewer
                 control is TextBoxBase || control is ComboBox || control is DataGridView ||
                 control is ScrollableControl)
             {
-                NativeMethods.ApplyDarkScrollbarTheme(control.Handle);
                 control.HandleCreated -= ControlOnHandleCreatedApplyScrollbarTheme;
                 control.HandleCreated += ControlOnHandleCreatedApplyScrollbarTheme;
+                if (control.IsHandleCreated)
+                {
+                    NativeMethods.ApplyDarkScrollbarTheme(control.Handle);
+                }
             }
         }
 

--- a/src/plugins/jsonviewer/managed/ThemeHelper.cs
+++ b/src/plugins/jsonviewer/managed/ThemeHelper.cs
@@ -231,12 +231,43 @@ namespace EPocalipse.Json.Viewer
                 ThemeRenderer.Attach(contextual, palette);
             }
 
+            ApplyNativeScrollbarTheme(control, palette);
+
             control.ControlAdded -= ControlOnControlAdded;
             control.ControlAdded += ControlOnControlAdded;
 
             foreach (Control child in control.Controls)
             {
                 ApplyToControl(child, palette);
+            }
+        }
+
+        // WinForms owns the native scrollbar HWNDs for TreeView, PropertyGrid,
+        // ListView and the embedded editors.  Their scrollbars are not painted
+        // by the managed BackColor properties, so opt the control itself into
+        // the dark Explorer theme after its handle exists.
+        private static void ApplyNativeScrollbarTheme(Control control, ThemePalette palette)
+        {
+            if (!palette.IsDark || !control.IsHandleCreated)
+            {
+                return;
+            }
+
+            if (control is TreeView || control is ListView || control is PropertyGrid ||
+                control is TextBoxBase || control is ComboBox || control is DataGridView ||
+                control is ScrollableControl)
+            {
+                NativeMethods.ApplyDarkScrollbarTheme(control.Handle);
+                control.HandleCreated -= ControlOnHandleCreatedApplyScrollbarTheme;
+                control.HandleCreated += ControlOnHandleCreatedApplyScrollbarTheme;
+            }
+        }
+
+        private static void ControlOnHandleCreatedApplyScrollbarTheme(object? sender, EventArgs e)
+        {
+            if (sender is Control control && GetPalette() is ThemePalette palette)
+            {
+                ApplyNativeScrollbarTheme(control, palette);
             }
         }
 
@@ -844,6 +875,25 @@ namespace EPocalipse.Json.Viewer
                 try
                 {
                     SetWindowTheme(handle, string.Empty, string.Empty);
+                }
+                catch (DllNotFoundException)
+                {
+                }
+                catch (EntryPointNotFoundException)
+                {
+                }
+            }
+
+            public static void ApplyDarkScrollbarTheme(IntPtr handle)
+            {
+                if (handle == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                try
+                {
+                    SetWindowTheme(handle, "DarkMode_Explorer", null);
                 }
                 catch (DllNotFoundException)
                 {

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -3597,6 +3597,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         ConfigurePictViewDarkModeFromHost();
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
+        DarkModeAllowDarkScrollbars(HWindow);
         DarkModeApplyTree(HWindow);
         UpdateRendererFrameForTheme();
 

--- a/src/plugins/renamer/renamer.cpp
+++ b/src/plugins/renamer/renamer.cpp
@@ -150,6 +150,7 @@ void ApplyRenamerDarkMode(HWND hwnd)
     {
         DarkModeApplyWindow(hwnd);
         DarkModeRefreshTitleBar(hwnd);
+        DarkModeAllowDarkScrollbars(hwnd);
         DarkModeApplyTree(hwnd);
     }
 }

--- a/src/plugins/samandarin/managed_bridge.cpp
+++ b/src/plugins/samandarin/managed_bridge.cpp
@@ -269,11 +269,13 @@ extern "C" __declspec(dllexport) void __stdcall Samandarin_SetDarkModeState(BOOL
 
 extern "C" __declspec(dllexport) void __stdcall Samandarin_ApplyDarkModeTree(HWND hwnd)
 {
+    DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
 }
 
 extern "C" __declspec(dllexport) void __stdcall Samandarin_UpdateListViewDarkMode(HWND hwnd)
 {
+    DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
     DarkModeUpdateListViewColors(hwnd, RGB(0xFF, 0xFF, 0xFF), RGB(56, 56, 56), true);
 }

--- a/src/plugins/shared/winliblt.cpp
+++ b/src/plugins/shared/winliblt.cpp
@@ -134,6 +134,10 @@ void ApplyWinLibDarkMode(HWND hwnd)
     {
         DarkModeApplyWindow(hwnd);
         DarkModeRefreshTitleBar(hwnd);
+        // Plugin top-level windows are intentionally part of the scoped
+        // scrollbar hook.  Without this opt-in, their native list/viewer
+        // scrollbars retain the system light theme in dark mode.
+        DarkModeAllowDarkScrollbars(hwnd);
         DarkModeApplyTree(hwnd);
     }
 }

--- a/src/plugins/textviewer/managed_bridge.cpp
+++ b/src/plugins/textviewer/managed_bridge.cpp
@@ -371,5 +371,6 @@ extern "C" __declspec(dllexport) void __stdcall TextViewer_SetDarkModeState(BOOL
 
 extern "C" __declspec(dllexport) void __stdcall TextViewer_ApplyDarkModeTree(HWND hwnd)
 {
+    DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
 }

--- a/src/plugins/webview2renderviewer/managed_bridge.cpp
+++ b/src/plugins/webview2renderviewer/managed_bridge.cpp
@@ -371,5 +371,6 @@ extern "C" __declspec(dllexport) void __stdcall RenderViewer_SetDarkModeState(BO
 
 extern "C" __declspec(dllexport) void __stdcall RenderViewer_ApplyDarkModeTree(HWND hwnd)
 {
+    DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
 }

--- a/src/third_party/darkmodelib/include/Darkmodelib.h
+++ b/src/third_party/darkmodelib/include/Darkmodelib.h
@@ -299,6 +299,8 @@ namespace dmlib
 
 	/// Makes scroll bars on the specified window and all its children consistent.
 	DMLIB_API void enableDarkScrollBarForWindowAndChildren(HWND hWnd);
+	/// Removes a window from the limited dark scrollbar scope.
+	DMLIB_API void disableDarkScrollBarForWindowAndChildren(HWND hWnd);
 
 	// ========================================================================
 	// Colors

--- a/src/third_party/darkmodelib/src/Darkmodelib.cpp
+++ b/src/third_party/darkmodelib/src/Darkmodelib.cpp
@@ -1020,6 +1020,13 @@ void dmlib::enableDarkScrollBarForWindowAndChildren([[maybe_unused]] HWND hWnd)
 #endif
 }
 
+void dmlib::disableDarkScrollBarForWindowAndChildren([[maybe_unused]] HWND hWnd)
+{
+#if defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 1)
+	dmlib_hook::disableDarkScrollBarForWindowAndChildren(hWnd);
+#endif
+}
+
 /**
  * @brief Checks if current mode is dark type.
  */

--- a/src/third_party/darkmodelib/src/DmlibHook.cpp
+++ b/src/third_party/darkmodelib/src/DmlibHook.cpp
@@ -168,6 +168,7 @@ static void UnhookFunction(HookData<T>& hookData) noexcept
 #if defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 0)
 using fnOpenNcThemeData = auto (WINAPI*)(HWND hWnd, LPCWSTR pszClassList) -> HTHEME; // ordinal 49
 static fnOpenNcThemeData pfOpenNcThemeData = nullptr;
+static bool g_scrollBarThemeColorHooked = false;
 
 bool dmlib_hook::loadOpenNcThemeData(const HMODULE& hUxtheme) noexcept
 {
@@ -249,6 +250,7 @@ static HTHEME WINAPI MyOpenNcThemeData(HWND hWnd, LPCWSTR pszClassList)
 		if (isWindowOrParentUsingDarkScrollBar(hWnd))
 		{
 			useDarkScrollBar = true;
+			hWnd = nullptr;
 			pszClassList = L"Explorer::ScrollBar";
 		}
 #else
@@ -275,7 +277,11 @@ void dmlib_hook::fixDarkScrollBar()
 		if (addr != nullptr) // && pfOpenNcThemeData != nullptr) // checked in InitDarkMode
 		{
 			ReplaceFunction<fnOpenNcThemeData>(addr, MyOpenNcThemeData);
-			dmlib_hook::hookThemeColor();
+			// This hook remains installed for the process lifetime.  Do not add a
+			// reference on every color refresh, otherwise the refcount can grow
+			// indefinitely while switching the application theme.
+			if (!g_scrollBarThemeColorHooked)
+				g_scrollBarThemeColorHooked = dmlib_hook::hookThemeColor();
 		}
 	}
 }

--- a/src/third_party/darkmodelib/src/DmlibHook.cpp
+++ b/src/third_party/darkmodelib/src/DmlibHook.cpp
@@ -26,6 +26,7 @@
 #if defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 0)
 #include <mutex>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #endif
 
@@ -178,7 +179,8 @@ bool dmlib_hook::loadOpenNcThemeData(const HMODULE& hUxtheme) noexcept
 #if defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 1)
 // limit dark scroll bar to specific windows and their children
 static std::unordered_set<HWND> g_darkScrollBarWindows;
-static std::unordered_set<HTHEME> g_darkScrollBarThemes;
+static std::unordered_map<HWND, std::unordered_set<HTHEME>> g_darkScrollBarThemesByWindow;
+static std::unordered_map<HTHEME, size_t> g_darkScrollBarThemeRefs;
 static std::mutex g_darkScrollBarMutex;
 
 /**
@@ -197,6 +199,24 @@ void dmlib_hook::enableDarkScrollBarForWindowAndChildren(HWND hWnd)
 {
 	const std::lock_guard<std::mutex> lock(g_darkScrollBarMutex);
 	g_darkScrollBarWindows.insert(hWnd);
+}
+
+void dmlib_hook::disableDarkScrollBarForWindowAndChildren(HWND hWnd)
+{
+	const std::lock_guard<std::mutex> lock(g_darkScrollBarMutex);
+	g_darkScrollBarWindows.erase(hWnd);
+
+	const auto themesIt = g_darkScrollBarThemesByWindow.find(hWnd);
+	if (themesIt == g_darkScrollBarThemesByWindow.end())
+		return;
+
+	for (HTHEME hTheme : themesIt->second)
+	{
+		const auto refIt = g_darkScrollBarThemeRefs.find(hTheme);
+		if (refIt != g_darkScrollBarThemeRefs.end() && --refIt->second == 0)
+			g_darkScrollBarThemeRefs.erase(refIt);
+	}
+	g_darkScrollBarThemesByWindow.erase(themesIt);
 }
 
 static bool isWindowOrParentUsingDarkScrollBar(HWND hWnd)
@@ -220,12 +240,13 @@ static bool isWindowOrParentUsingDarkScrollBar(HWND hWnd)
 	return (hWnd != hRoot && hasElement(g_darkScrollBarWindows, hRoot));
 }
 
-static void rememberDarkScrollBarTheme(HTHEME hTheme)
+static void rememberDarkScrollBarTheme(HTHEME hTheme, HWND hWnd)
 {
 	if (hTheme != nullptr)
 	{
 		const std::lock_guard<std::mutex> lock(g_darkScrollBarMutex);
-		g_darkScrollBarThemes.insert(hTheme);
+		if (g_darkScrollBarThemesByWindow[hWnd].insert(hTheme).second)
+			++g_darkScrollBarThemeRefs[hTheme];
 	}
 }
 
@@ -233,9 +254,9 @@ static bool isDarkScrollBarTheme(HTHEME hTheme)
 {
 	const std::lock_guard<std::mutex> lock(g_darkScrollBarMutex);
 #if (defined(_MSC_VER) && (_MSVC_LANG >= 202002L)) || (__cplusplus >= 202002L)
-	return g_darkScrollBarThemes.contains(hTheme);
+	return g_darkScrollBarThemeRefs.contains(hTheme);
 #else
-	return g_darkScrollBarThemes.count(hTheme) != 0;
+	return g_darkScrollBarThemeRefs.count(hTheme) != 0;
 #endif
 }
 #endif // defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 1)
@@ -244,12 +265,14 @@ static HTHEME WINAPI MyOpenNcThemeData(HWND hWnd, LPCWSTR pszClassList)
 {
 	static constexpr std::wstring_view scrollBarClassName = WC_SCROLLBAR;
 	bool useDarkScrollBar = false;
+	HWND darkScrollBarRoot = nullptr;
 	if (scrollBarClassName == pszClassList)
 	{
 #if defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 1)
 		if (isWindowOrParentUsingDarkScrollBar(hWnd))
 		{
 			useDarkScrollBar = true;
+			darkScrollBarRoot = ::GetAncestor(hWnd, GA_ROOT);
 			hWnd = nullptr;
 			pszClassList = L"Explorer::ScrollBar";
 		}
@@ -262,7 +285,7 @@ static HTHEME WINAPI MyOpenNcThemeData(HWND hWnd, LPCWSTR pszClassList)
 #if defined(_DARKMODELIB_USE_SCROLLBAR_FIX) && (_DARKMODELIB_USE_SCROLLBAR_FIX > 1)
 	if (useDarkScrollBar)
 	{
-		rememberDarkScrollBarTheme(hTheme);
+		rememberDarkScrollBarTheme(hTheme, darkScrollBarRoot);
 	}
 #endif
 	return hTheme;

--- a/src/third_party/darkmodelib/src/DmlibHook.cpp
+++ b/src/third_party/darkmodelib/src/DmlibHook.cpp
@@ -16,6 +16,8 @@
 
 #include <windows.h>
 
+#include <commctrl.h>
+
 #include <uxtheme.h>
 #include <vsstyle.h>
 #include <vssym32.h>
@@ -182,6 +184,10 @@ static std::unordered_set<HWND> g_darkScrollBarWindows;
 static std::unordered_map<HWND, std::unordered_set<HTHEME>> g_darkScrollBarThemesByWindow;
 static std::unordered_map<HTHEME, size_t> g_darkScrollBarThemeRefs;
 static std::mutex g_darkScrollBarMutex;
+static constexpr UINT_PTR kDarkScrollBarScopeSubclassId = 1;
+
+static LRESULT CALLBACK DarkScrollBarScopeSubclass(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam,
+                                                   UINT_PTR subclassId, DWORD_PTR refData);
 
 /**
  * @brief Makes scroll bars on the specified window and all its children consistent.
@@ -199,6 +205,7 @@ void dmlib_hook::enableDarkScrollBarForWindowAndChildren(HWND hWnd)
 {
 	const std::lock_guard<std::mutex> lock(g_darkScrollBarMutex);
 	g_darkScrollBarWindows.insert(hWnd);
+	::SetWindowSubclass(hWnd, DarkScrollBarScopeSubclass, kDarkScrollBarScopeSubclassId, 0);
 }
 
 void dmlib_hook::disableDarkScrollBarForWindowAndChildren(HWND hWnd)
@@ -217,6 +224,17 @@ void dmlib_hook::disableDarkScrollBarForWindowAndChildren(HWND hWnd)
 			g_darkScrollBarThemeRefs.erase(refIt);
 	}
 	g_darkScrollBarThemesByWindow.erase(themesIt);
+}
+
+static LRESULT CALLBACK DarkScrollBarScopeSubclass(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam,
+                                                   UINT_PTR subclassId, [[maybe_unused]] DWORD_PTR refData)
+{
+	if (message == WM_NCDESTROY)
+	{
+		dmlib_hook::disableDarkScrollBarForWindowAndChildren(hWnd);
+		::RemoveWindowSubclass(hWnd, DarkScrollBarScopeSubclass, subclassId);
+	}
+	return ::DefSubclassProc(hWnd, message, wParam, lParam);
 }
 
 static bool isWindowOrParentUsingDarkScrollBar(HWND hWnd)

--- a/src/third_party/darkmodelib/src/DmlibHook.cpp
+++ b/src/third_party/darkmodelib/src/DmlibHook.cpp
@@ -661,21 +661,26 @@ void dmlib_hook::unhookThemeColor() noexcept
 		g_hDarkTheme = nullptr;
 	}
 
-	if (g_hBrushBg != nullptr)
+	// The scrollbar hook keeps the theme drawing hook alive for the process.
+	// A temporary TaskDialog must not delete brushes still used by that hook.
+	if (g_hookDataGetThemeColor.m_ref == 0)
 	{
-		::DeleteObject(g_hBrushBg);
-		g_hBrushBg = nullptr;
-	}
+		if (g_hBrushBg != nullptr)
+		{
+			::DeleteObject(g_hBrushBg);
+			g_hBrushBg = nullptr;
+		}
 
-	if (g_hBrushBgFooter != nullptr)
-	{
-		::DeleteObject(g_hBrushBgFooter);
-		g_hBrushBgFooter = nullptr;
-	}
+		if (g_hBrushBgFooter != nullptr)
+		{
+			::DeleteObject(g_hBrushBgFooter);
+			g_hBrushBgFooter = nullptr;
+		}
 
-	if (g_hBrushScrollBarTrack != nullptr)
-	{
-		::DeleteObject(g_hBrushScrollBarTrack);
-		g_hBrushScrollBarTrack = nullptr;
+		if (g_hBrushScrollBarTrack != nullptr)
+		{
+			::DeleteObject(g_hBrushScrollBarTrack);
+			g_hBrushScrollBarTrack = nullptr;
+		}
 	}
 }

--- a/src/third_party/darkmodelib/src/DmlibHook.h
+++ b/src/third_party/darkmodelib/src/DmlibHook.h
@@ -20,6 +20,8 @@ namespace dmlib_hook
 	bool loadOpenNcThemeData(const HMODULE& hUxtheme) noexcept;
 	/// Makes scroll bars on the specified window and all its children consistent.
 	void enableDarkScrollBarForWindowAndChildren(HWND hWnd);
+	/// Removes a window from the limited dark scrollbar scope.
+	void disableDarkScrollBarForWindowAndChildren(HWND hWnd);
 	void fixDarkScrollBar();
 #endif
 

--- a/src/third_party/darkmodelib/src/dmlib.def
+++ b/src/third_party/darkmodelib/src/dmlib.def
@@ -23,6 +23,7 @@ EXPORTS
 	isDarkModeReg
 	setSysColor
 	enableDarkScrollBarForWindowAndChildren
+	disableDarkScrollBarForWindowAndChildren
 	setColorTone
 	getColorTone
 	setBackgroundColor

--- a/src/tserver/darkmode_stub.cpp
+++ b/src/tserver/darkmode_stub.cpp
@@ -21,6 +21,8 @@ bool DarkModeHandleSettingChange(UINT message, LPARAM lParam)
     return false;
 }
 void DarkModeFixScrollbars() {}
+void DarkModeAllowDarkScrollbars(HWND hwnd) { UNREFERENCED_PARAMETER(hwnd); }
+void DarkModeDisallowDarkScrollbars(HWND hwnd) { UNREFERENCED_PARAMETER(hwnd); }
 void DarkModeConfigureDialogColors(COLORREF textColor, COLORREF backgroundColor, HBRUSH dialogBrush)
 {
     UNREFERENCED_PARAMETER(textColor);

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -105,91 +105,6 @@ LRESULT CALLBACK ViewerZoomControlSubclass(HWND hwnd, UINT message, WPARAM wPara
     return DefSubclassProc(hwnd, message, wParam, lParam);
 }
 
-// The native themed SCROLLBAR can issue a second paint after thumb tracking.
-// We override the track background to RGB(23,23,23) after every native paint.
-static const UINT_PTR kHScrollBarSubclassId = 2;
-static const UINT_PTR kVScrollBarSubclassId = 3;
-
-static void PaintScrollBarTrack(HDC hdc, HWND hwnd)
-{
-    SCROLLBARINFO sbi;
-    memset(&sbi, 0, sizeof(sbi));
-    sbi.cbSize = sizeof(sbi);
-    if (!GetScrollBarInfo(hwnd, OBJID_CLIENT, &sbi))
-        return;
-
-    RECT rc;
-    GetClientRect(hwnd, &rc);
-
-    HBRUSH brush = HANDLES(CreateSolidBrush(RGB(23, 23, 23)));
-    if (brush == NULL)
-        return;
-
-    const int arrowSize = sbi.dxyLineButton;
-    const bool vertical = (GetWindowLong(hwnd, GWL_STYLE) & SBS_VERT) != 0;
-    if (vertical)
-    {
-        if (arrowSize < sbi.xyThumbTop)
-        {
-            RECT track = {rc.left, arrowSize, rc.right, sbi.xyThumbTop};
-            FillRect(hdc, &track, brush);
-        }
-        if (sbi.xyThumbBottom < rc.bottom - arrowSize)
-        {
-            RECT track = {rc.left, sbi.xyThumbBottom, rc.right, rc.bottom - arrowSize};
-            FillRect(hdc, &track, brush);
-        }
-    }
-    else
-    {
-        if (arrowSize < sbi.xyThumbTop)
-        {
-            RECT track = {arrowSize, rc.top, sbi.xyThumbTop, rc.bottom};
-            FillRect(hdc, &track, brush);
-        }
-        if (sbi.xyThumbBottom < rc.right - arrowSize)
-        {
-            RECT track = {sbi.xyThumbBottom, rc.top, rc.right - arrowSize, rc.bottom};
-            FillRect(hdc, &track, brush);
-        }
-    }
-    HANDLES(DeleteObject(brush));
-}
-
-static LRESULT CALLBACK HScrollBarSubclass(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam,
-                                           UINT_PTR subclassId, DWORD_PTR refData)
-{
-    if (message == WM_NCDESTROY)
-        RemoveWindowSubclass(hwnd, HScrollBarSubclass, subclassId);
-
-    if (message == WM_ERASEBKGND && DarkModeShouldUseDarkColors())
-    {
-        RECT rc;
-        GetClientRect(hwnd, &rc);
-        HBRUSH brush = HANDLES(CreateSolidBrush(RGB(23, 23, 23)));
-        if (brush != NULL)
-        {
-            FillRect((HDC)wParam, &rc, brush);
-            HANDLES(DeleteObject(brush));
-        }
-        return 1;
-    }
-
-    if ((message == WM_PAINT || message == WM_NCPAINT) && DarkModeShouldUseDarkColors())
-    {
-        LRESULT result = DefSubclassProc(hwnd, message, wParam, lParam);
-        HDC hdc = GetDC(hwnd);
-        if (hdc != NULL)
-        {
-            PaintScrollBarTrack(hdc, hwnd);
-            ReleaseDC(hwnd, hdc);
-        }
-        return result;
-    }
-    return DefSubclassProc(hwnd, message, wParam, lParam);
-}
-
-
 #ifndef WM_UAHDRAWMENU
 #define WM_UAHDRAWMENU 0x0091
 #endif
@@ -991,6 +906,10 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         DarkModeApplyWindow(HWindow);
         DarkModeRefreshTitleBar(HWindow);
         ApplyViewerMenuTheme(HWindow);
+        // The scrollbar hook is intentionally opt-in.  Register this top-level
+        // viewer before its child SCROLLBAR controls are created, so only this
+        // viewer (not unrelated dialogs) receives the Explorer scrollbar theme.
+        DarkModeAllowDarkScrollbars(HWindow);
 
         SetWindowLong(HWindow, GWL_STYLE, GetWindowLong(HWindow, GWL_STYLE) & ~WS_VSCROLL);
         SetWindowPos(HWindow, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
@@ -1000,10 +919,8 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                     0, 0, 0, 0, HWindow, NULL, HInstance, NULL);
         HScrollBar = CreateWindowEx(0, "SCROLLBAR", NULL, WS_CHILD | WS_VISIBLE | SBS_HORZ,
                                     0, 0, 0, 0, HWindow, NULL, HInstance, NULL);
-        SetWindowSubclass(HScrollBar, HScrollBarSubclass, kHScrollBarSubclassId, 0);
         VScrollBar = CreateWindowEx(0, "SCROLLBAR", NULL, WS_CHILD | WS_VISIBLE | SBS_VERT,
                                     0, 0, 0, 0, HWindow, NULL, HInstance, NULL);
-        SetWindowSubclass(VScrollBar, HScrollBarSubclass, kVScrollBarSubclassId, 0);
         HZoomReset = CreateWindowEx(0, "BUTTON", LoadStr(IDS_VIEWER_ZOOM_RESET), WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON | BS_FLAT,
                                     0, 0, 0, 0, HWindow, (HMENU)IDC_VIEWER_ZOOM_RESET, HInstance, NULL);
         HZoomOut = CreateWindowEx(0, "BUTTON", "-", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON | BS_FLAT,

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -4133,6 +4133,9 @@ MENU_TEMPLATE_ITEM ViewerCodingMenu[] =
 
     case WM_DESTROY:
     {
+        // The scrollbar hook stores HWNDs.  Remove this entry before Windows
+        // can recycle the handle for an unrelated top-level dialog.
+        DarkModeDisallowDarkScrollbars(HWindow);
         DragAcceptFiles(HWindow, FALSE);
         if (HToolTip != NULL)
         {

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -87,7 +87,13 @@ LRESULT CALLBACK ViewerZoomControlSubclass(HWND hwnd, UINT message, WPARAM wPara
                            : hot     ? RGB(0x40, 0x40, 0x40)
                            :           colors.background;
                 FillViewerRectWithColor(hdc, &rc, bg);
-                DrawEdge(hdc, &rc, BDR_SUNKENOUTER, BF_RECT);
+                // DrawEdge obtains its highlight/shadow colors from the
+                // system palette, which leaves a bright legacy frame around
+                // these otherwise dark status-bar controls.  Use the same
+                // dark panel frame as the rest of the application instead.
+                HBRUSH frameBrush = DarkModeGetPanelFrameBrush();
+                if (frameBrush != NULL)
+                    FrameRect(hdc, &rc, frameBrush);
                 SetBkMode(hdc, TRANSPARENT);
                 SetTextColor(hdc, colors.readableText);
                 HFONT font = (HFONT)SendMessage(hwnd, WM_GETFONT, 0, 0);


### PR DESCRIPTION
### Motivation
- Restore dark-mode scrollbar track appearance to RGB(23,23,23) for the main window and internal viewer while avoiding forcing that style globally and causing legacy theme fallbacks in other dialogs.
- Eliminate the per-scrollbar paint subclass in the internal viewer that caused severe thumb-drag lag.

### Description
- Stop overriding `WM_CTLCOLORSCROLLBAR` in `darkmode_backend_darkmodelib.cpp` so dialogs no longer receive a forced dark-surface brush and legacy scrollbar fallbacks are avoided.
- In `DmlibHook.cpp` make `OpenNcThemeData` return the `Explorer::ScrollBar` theme with `hWnd = nullptr` for scoped windows and remember the resulting `HTHEME`, allowing the hook to supply the dark track color only for registered windows.
- Add a process-lifetime guard `g_scrollBarThemeColorHooked` to avoid repeatedly calling `hookThemeColor()` on every color refresh and thereby growing hook refcounts indefinitely.
- In `viewer3.cpp` register the viewer with the scoped scrollbar hook (`DarkModeAllowDarkScrollbars(HWindow)`) before child scrollbars are created and remove the paint-subclass that manually repainted the track to eliminate the vertical-thumb drag lag.

### Testing
- Ran repository checks including `git diff --check` which reported no problems.
- Verified changed files via local `git status` and `git diff` to confirm intended edits were applied.
- No Windows/MSVC build or runtime verification was performed in this Linux environment, so visual behaviour on Windows was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5aa1719a6c832990eeaf17319c0d7f)