### PR TITLE
Use configured panel font in Find results

### DIFF
--- a/src/finddlg1.cpp
+++ b/src/finddlg1.cpp
@@ -92,6 +92,25 @@ void FillFindRect(HDC hdc, const RECT* rect, COLORREF color)
         FillRect(hdc, rect, brush);
 }
 
+
+void ApplyFindResultsFontAndColors(HWND listView)
+{
+    if (listView == NULL)
+        return;
+
+    SendMessage(listView, WM_SETFONT, (WPARAM)Font, MAKELPARAM(TRUE, 0));
+
+    if (DarkModeShouldUseDarkColors())
+    {
+        DarkModeUpdateListViewColors(listView);
+        return;
+    }
+
+    COLORREF windowColor = GetSysColor(COLOR_WINDOW);
+    ListView_SetBkColor(listView, windowColor);
+    ListView_SetTextBkColor(listView, windowColor);
+}
+
 void UpdateFindDarkChrome(HWND dialog, HWND statusBar, HWND listView, CFindTBHeader* tbHeader)
 {
     if (WinLib_DarkMode_ShouldApplyDialogTree(dialog))
@@ -103,7 +122,7 @@ void UpdateFindDarkChrome(HWND dialog, HWND statusBar, HWND listView, CFindTBHea
     }
 
     if (listView != NULL)
-        DarkModeUpdateListViewColors(listView);
+        ApplyFindResultsFontAndColors(listView);
 
     if (statusBar != NULL)
     {
@@ -403,7 +422,7 @@ CFoundFilesListView::CFoundFilesListView(HWND dlg, int ctrlID, CFindDialog* find
     // add this panel to the array of sources for enumerating files in viewers
     EnumFileNamesAddSourceUID(HWindow, &EnumFileNamesSourceUID);
 
-    DarkModeUpdateListViewColors(HWindow);
+    ApplyFindResultsFontAndColors(HWindow);
 }
 
 CFoundFilesListView::~CFoundFilesListView()
@@ -4654,6 +4673,8 @@ MENU_TEMPLATE_ITEM FindLookInBrowseMenu[] =
     case WM_USER_CFGCHANGED:
     {
         TBHeader->SetFont();
+        if (FoundFilesListView != NULL)
+            ApplyFindResultsFontAndColors(FoundFilesListView->HWindow);
         return 0;
     }
 


### PR DESCRIPTION
### Motivation
- The Find results list used a different font/metrics than main panels, causing mismatched row heights compared to panels controlled by Configuration.
- In light color schemes some ListView subcolumns had a gray background while others stayed white, producing inconsistent column backgrounds.
- Font changes in Configuration were not always applied to existing Find windows, so changes needed to be reapplied when config updates occur.

### Description
- Added `ApplyFindResultsFontAndColors(HWND)` in `src/finddlg1.cpp` which sets the results list to the configured panel font with `SendMessage(..., WM_SETFONT, Font, ...)` and applies background colors; it delegates to `DarkModeUpdateListViewColors` when dark mode is active and forces `GetSysColor(COLOR_WINDOW)` for `ListView_SetBkColor`/`ListView_SetTextBkColor` in light mode.
- Replaced direct `DarkModeUpdateListViewColors` calls with `ApplyFindResultsFontAndColors` in `UpdateFindDarkChrome` and used the helper when constructing `CFoundFilesListView` so the correct font/colors are applied at creation (`FoundFilesListView->HWindow`).
- Reapplied font/colors in response to configuration changes by invoking `ApplyFindResultsFontAndColors` from the `WM_USER_CFGCHANGED` handler so panel font changes propagate to open Find windows.

### Testing
- Ran `git diff --check` to validate changes and formatting, which succeeded.
- Changes were committed on the branch with message `Use panel font and light background in Find results`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5acb9d10f08329969f845d1c6e30a8)