### PR TITLE
Fix JSON viewer dark scrollbar theming

### DIFF
--- a/src/plugins/jsonviewer/managed/JsonViewer.ThemeAdapter.cs
+++ b/src/plugins/jsonviewer/managed/JsonViewer.ThemeAdapter.cs
@@ -50,6 +50,8 @@ namespace EPocalipse.Json.Viewer
             pnlVisualizer.ForeColor = palette.Foreground;
             ThemeHelper.ApplyNativeDarkMode(pnlVisualizer);
             ThemeHelper.RecreateHandleForInitialDarkTheme(cbVisualizers);
+            ThemeHelper.ApplyNativeDarkMode(cbVisualizers);
+            ReapplyNativeThemeAfterFirstLayout();
 
             pnlFind.BackColor = palette.ControlBackground;
             pnlFind.ForeColor = palette.Foreground;
@@ -63,6 +65,25 @@ namespace EPocalipse.Json.Viewer
             lblError.LinkColor = palette.Accent;
             lblError.ActiveLinkColor = palette.HighlightForeground;
             lblError.VisitedLinkColor = palette.Accent;
+        }
+
+        private void ReapplyNativeThemeAfterFirstLayout()
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            BeginInvoke(new Action(() =>
+            {
+                ThemeHelper.ApplyNativeDarkMode(pnlVisualizer);
+                ThemeHelper.ApplyNativeDarkMode(cbVisualizers);
+                foreach (Control visualizer in pnlVisualizer.Controls)
+                {
+                    ThemeHelper.ApplyTheme(visualizer);
+                    ThemeHelper.ApplyNativeDarkMode(visualizer);
+                }
+            }));
         }
 
         private void StyleTabControl(ThemeHelper.ThemePalette palette)

--- a/src/plugins/jsonviewer/managed/JsonViewer.ThemeAdapter.cs
+++ b/src/plugins/jsonviewer/managed/JsonViewer.ThemeAdapter.cs
@@ -49,9 +49,7 @@ namespace EPocalipse.Json.Viewer
             pnlVisualizer.BackColor = palette.Background;
             pnlVisualizer.ForeColor = palette.Foreground;
             ThemeHelper.ApplyNativeDarkMode(pnlVisualizer);
-            ThemeHelper.RecreateHandleForInitialDarkTheme(cbVisualizers);
             ThemeHelper.ApplyNativeDarkMode(cbVisualizers);
-            ReapplyNativeThemeAfterFirstLayout();
 
             pnlFind.BackColor = palette.ControlBackground;
             pnlFind.ForeColor = palette.Foreground;
@@ -65,25 +63,6 @@ namespace EPocalipse.Json.Viewer
             lblError.LinkColor = palette.Accent;
             lblError.ActiveLinkColor = palette.HighlightForeground;
             lblError.VisitedLinkColor = palette.Accent;
-        }
-
-        private void ReapplyNativeThemeAfterFirstLayout()
-        {
-            if (!IsHandleCreated)
-            {
-                return;
-            }
-
-            BeginInvoke(new Action(() =>
-            {
-                ThemeHelper.ApplyNativeDarkMode(pnlVisualizer);
-                ThemeHelper.ApplyNativeDarkMode(cbVisualizers);
-                foreach (Control visualizer in pnlVisualizer.Controls)
-                {
-                    ThemeHelper.ApplyTheme(visualizer);
-                    ThemeHelper.ApplyNativeDarkMode(visualizer);
-                }
-            }));
         }
 
         private void StyleTabControl(ThemeHelper.ThemePalette palette)

--- a/src/plugins/jsonviewer/managed/JsonViewer.ThemeAdapter.cs
+++ b/src/plugins/jsonviewer/managed/JsonViewer.ThemeAdapter.cs
@@ -48,6 +48,8 @@ namespace EPocalipse.Json.Viewer
 
             pnlVisualizer.BackColor = palette.Background;
             pnlVisualizer.ForeColor = palette.Foreground;
+            pnlVisualizer.SizeChanged -= PnlVisualizerOnSizeChanged;
+            pnlVisualizer.SizeChanged += PnlVisualizerOnSizeChanged;
             ThemeHelper.ApplyNativeDarkMode(pnlVisualizer);
             ThemeHelper.ApplyNativeDarkMode(cbVisualizers);
 
@@ -63,6 +65,29 @@ namespace EPocalipse.Json.Viewer
             lblError.LinkColor = palette.Accent;
             lblError.ActiveLinkColor = palette.HighlightForeground;
             lblError.VisitedLinkColor = palette.Accent;
+        }
+
+        private void PnlVisualizerOnSizeChanged(object sender, EventArgs e)
+        {
+            if (!IsHandleCreated || IsDisposed)
+            {
+                return;
+            }
+
+            BeginInvoke(new Action(() =>
+            {
+                if (IsDisposed || !pnlVisualizer.IsHandleCreated)
+                {
+                    return;
+                }
+
+                ThemeHelper.ApplyNativeDarkMode(pnlVisualizer);
+                foreach (Control visualizer in pnlVisualizer.Controls)
+                {
+                    ThemeHelper.ApplyNativeDarkMode(visualizer);
+                    NativeThemeRefreshScheduler.ScheduleNativeDarkModeRefresh(visualizer);
+                }
+            }));
         }
 
         private void StyleTabControl(ThemeHelper.ThemePalette palette)

--- a/src/plugins/jsonviewer/managed/JsonVisualizers.ThemeAdapter.cs
+++ b/src/plugins/jsonviewer/managed/JsonVisualizers.ThemeAdapter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Windows.Forms;
 
 namespace EPocalipse.Json.Viewer
@@ -86,6 +87,8 @@ namespace EPocalipse.Json.Viewer
 
     internal static class NativeThemeRefreshScheduler
     {
+        private static readonly ConditionalWeakTable<Control, RefreshState> s_refreshes = new ConditionalWeakTable<Control, RefreshState>();
+
         public static void ScheduleNativeDarkModeRefresh(Control control)
         {
             if (!control.IsHandleCreated || control.IsDisposed)
@@ -93,26 +96,42 @@ namespace EPocalipse.Json.Viewer
                 return;
             }
 
-            int remainingPasses = 4;
-            var timer = new Timer { Interval = 50 };
-            timer.Tick += (_, _) =>
+            if (!s_refreshes.TryGetValue(control, out var state))
             {
-                if (control.IsDisposed || !control.IsHandleCreated || --remainingPasses <= 0)
+                state = new RefreshState();
+                s_refreshes.Add(control, state);
+                control.Disposed += (_, _) =>
                 {
-                    timer.Stop();
-                    timer.Dispose();
-                    return;
-                }
+                    StopRefresh(state);
+                    s_refreshes.Remove(control);
+                };
+            }
 
-                ThemeHelper.ApplyNativeDarkMode(control);
-                control.Invalidate(true);
-            };
-            control.Disposed += (_, _) =>
+            state.Timer?.Stop();
+            state.Timer?.Dispose();
+
+            state.Timer = new Timer { Interval = 25 };
+            state.Timer.Tick += (_, _) =>
             {
-                timer.Stop();
-                timer.Dispose();
+                StopRefresh(state);
+                if (!control.IsDisposed && control.IsHandleCreated)
+                {
+                    ThemeHelper.ApplyNativeDarkMode(control);
+                }
             };
-            timer.Start();
+            state.Timer.Start();
+        }
+
+        private static void StopRefresh(RefreshState state)
+        {
+            state.Timer?.Stop();
+            state.Timer?.Dispose();
+            state.Timer = null;
+        }
+
+        private sealed class RefreshState
+        {
+            public Timer Timer { get; set; }
         }
     }
 }

--- a/src/plugins/jsonviewer/managed/JsonVisualizers.ThemeAdapter.cs
+++ b/src/plugins/jsonviewer/managed/JsonVisualizers.ThemeAdapter.cs
@@ -36,17 +36,7 @@ namespace EPocalipse.Json.Viewer
             ThemeHelper.RecreateHandleForInitialDarkTheme(pgJsonObject);
             ThemeHelper.ApplyNativeDarkMode(pgJsonObject);
 
-            if (pgJsonObject.IsHandleCreated)
-            {
-                pgJsonObject.BeginInvoke(new Action(() =>
-                {
-                    if (pgJsonObject.IsHandleCreated)
-                    {
-                        ThemeHelper.ApplyNativeDarkMode(pgJsonObject);
-                        pgJsonObject.Invalidate(true);
-                    }
-                }));
-            }
+            NativeThemeRefreshScheduler.ScheduleNativeDarkModeRefresh(pgJsonObject);
         }
     }
 
@@ -72,6 +62,39 @@ namespace EPocalipse.Json.Viewer
             ThemeHelper.ApplyTheme(this);
             ThemeHelper.RecreateHandleForInitialDarkTheme(lvGrid);
             ThemeHelper.ApplyNativeDarkMode(lvGrid);
+            NativeThemeRefreshScheduler.ScheduleNativeDarkModeRefresh(lvGrid);
+        }
+    }
+
+    internal static class NativeThemeRefreshScheduler
+    {
+        public static void ScheduleNativeDarkModeRefresh(Control control)
+        {
+            if (!control.IsHandleCreated || control.IsDisposed)
+            {
+                return;
+            }
+
+            int remainingPasses = 4;
+            var timer = new Timer { Interval = 50 };
+            timer.Tick += (_, _) =>
+            {
+                if (control.IsDisposed || !control.IsHandleCreated || --remainingPasses <= 0)
+                {
+                    timer.Stop();
+                    timer.Dispose();
+                    return;
+                }
+
+                ThemeHelper.ApplyNativeDarkMode(control);
+                control.Invalidate(true);
+            };
+            control.Disposed += (_, _) =>
+            {
+                timer.Stop();
+                timer.Dispose();
+            };
+            timer.Start();
         }
     }
 }

--- a/src/plugins/jsonviewer/managed/JsonVisualizers.ThemeAdapter.cs
+++ b/src/plugins/jsonviewer/managed/JsonVisualizers.ThemeAdapter.cs
@@ -25,6 +25,15 @@ namespace EPocalipse.Json.Viewer
             }
         }
 
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            base.OnSizeChanged(e);
+            if (pgJsonObject is not null)
+            {
+                NativeThemeRefreshScheduler.ScheduleNativeDarkModeRefresh(pgJsonObject);
+            }
+        }
+
         private void PgJsonObjectOnSelectedObjectsChanged(object sender, EventArgs e)
         {
             ApplyPropertyGridTheme();
@@ -54,6 +63,15 @@ namespace EPocalipse.Json.Viewer
             if (Visible)
             {
                 ApplyGridTheme();
+            }
+        }
+
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            base.OnSizeChanged(e);
+            if (lvGrid is not null)
+            {
+                NativeThemeRefreshScheduler.ScheduleNativeDarkModeRefresh(lvGrid);
             }
         }
 

--- a/src/plugins/jsonviewer/managed/ThemeHelper.cs
+++ b/src/plugins/jsonviewer/managed/ThemeHelper.cs
@@ -199,10 +199,7 @@ namespace EPocalipse.Json.Viewer
                 case ComboBox comboBox:
                     comboBox.BackColor = palette.InputBackground;
                     comboBox.ForeColor = palette.InputForeground;
-                    if (palette.IsDark)
-                    {
-                        comboBox.FlatStyle = FlatStyle.Flat;
-                    }
+                    comboBox.FlatStyle = FlatStyle.Standard;
                     comboBox.DrawMode = DrawMode.OwnerDrawFixed;
                     comboBox.DrawItem -= ComboBoxOnDrawItem;
                     comboBox.DrawItem += ComboBoxOnDrawItem;

--- a/src/plugins/jsonviewer/managed/ThemeHelper.cs
+++ b/src/plugins/jsonviewer/managed/ThemeHelper.cs
@@ -298,9 +298,7 @@ namespace EPocalipse.Json.Viewer
                 return;
             }
 
-            if (control is TreeView || control is ListView || control is PropertyGrid ||
-                control is TextBoxBase || control is ComboBox || control is DataGridView ||
-                control is ScrollableControl)
+            if (ControlNeedsNativeScrollbarTheme(control))
             {
                 control.HandleCreated -= ControlOnHandleCreatedApplyScrollbarTheme;
                 control.HandleCreated += ControlOnHandleCreatedApplyScrollbarTheme;
@@ -329,6 +327,19 @@ namespace EPocalipse.Json.Viewer
             {
                 NativeMethods.ApplyDarkModeTree(control.Handle);
             }
+
+            if (ControlNeedsNativeScrollbarTheme(control))
+            {
+                NativeMethods.ApplyDarkScrollbarTheme(control.Handle);
+                NativeMethods.RedrawNonClientArea(control.Handle);
+            }
+        }
+
+        private static bool ControlNeedsNativeScrollbarTheme(Control control)
+        {
+            return control is TreeView || control is ListView || control is PropertyGrid ||
+                control is TextBoxBase || control is ComboBox || control is DataGridView ||
+                control is ScrollableControl;
         }
 
         private static void ApplyFormChrome(Form form, ThemePalette palette)
@@ -885,8 +896,17 @@ namespace EPocalipse.Json.Viewer
             [DllImport("dwmapi.dll", PreserveSig = true)]
             private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
 
+            private const uint RDW_INVALIDATE = 0x0001;
+            private const uint RDW_ERASE = 0x0004;
+            private const uint RDW_FRAME = 0x0400;
+            private const uint RDW_ALLCHILDREN = 0x0080;
+            private const uint RDW_UPDATENOW = 0x0100;
+
             [DllImport("uxtheme.dll", CharSet = CharSet.Unicode, SetLastError = true)]
             private static extern int SetWindowTheme(IntPtr hwnd, string? appName, string? idList);
+
+            [DllImport("user32.dll", SetLastError = true)]
+            private static extern bool RedrawWindow(IntPtr hwnd, IntPtr lprcUpdate, IntPtr hrgnUpdate, uint flags);
 
             public static uint GetCurrentColor(int color)
             {
@@ -1016,12 +1036,32 @@ namespace EPocalipse.Json.Viewer
 
                 try
                 {
-                    // The scrollbar-specific class list is required for
-                    // WinForms controls that own native scrollbars.  The
-                    // generic DarkMode_Explorer theme leaves those tracks on
-                    // the light system rendering path on several Windows 11
-                    // builds.
-                    SetWindowTheme(handle, "Explorer::ScrollBar", null);
+                    // The scrollbar-specific id list must be applied to the
+                    // control after the native dark-scrollbar hook is enabled.
+                    // Passing it as the sub-app name does not reliably reopen
+                    // the scrollbar theme on first show, leaving WinForms
+                    // scrollbars light until a later repaint.
+                    SetWindowTheme(handle, null, "DarkMode_Explorer::ScrollBar");
+                }
+                catch (DllNotFoundException)
+                {
+                }
+                catch (EntryPointNotFoundException)
+                {
+                }
+            }
+
+            public static void RedrawNonClientArea(IntPtr handle)
+            {
+                if (handle == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                try
+                {
+                    RedrawWindow(handle, IntPtr.Zero, IntPtr.Zero,
+                        RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
                 }
                 catch (DllNotFoundException)
                 {

--- a/src/plugins/jsonviewer/managed/ThemeHelper.cs
+++ b/src/plugins/jsonviewer/managed/ThemeHelper.cs
@@ -298,7 +298,9 @@ namespace EPocalipse.Json.Viewer
                 return;
             }
 
-            if (ControlNeedsNativeScrollbarTheme(control))
+            if (control is TreeView || control is ListView || control is PropertyGrid ||
+                control is TextBoxBase || control is ComboBox || control is DataGridView ||
+                control is ScrollableControl)
             {
                 control.HandleCreated -= ControlOnHandleCreatedApplyScrollbarTheme;
                 control.HandleCreated += ControlOnHandleCreatedApplyScrollbarTheme;
@@ -327,19 +329,6 @@ namespace EPocalipse.Json.Viewer
             {
                 NativeMethods.ApplyDarkModeTree(control.Handle);
             }
-
-            if (ControlNeedsNativeScrollbarTheme(control))
-            {
-                NativeMethods.ApplyDarkScrollbarTheme(control.Handle);
-                NativeMethods.RedrawNonClientArea(control.Handle);
-            }
-        }
-
-        private static bool ControlNeedsNativeScrollbarTheme(Control control)
-        {
-            return control is TreeView || control is ListView || control is PropertyGrid ||
-                control is TextBoxBase || control is ComboBox || control is DataGridView ||
-                control is ScrollableControl;
         }
 
         private static void ApplyFormChrome(Form form, ThemePalette palette)
@@ -896,17 +885,8 @@ namespace EPocalipse.Json.Viewer
             [DllImport("dwmapi.dll", PreserveSig = true)]
             private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
 
-            private const uint RDW_INVALIDATE = 0x0001;
-            private const uint RDW_ERASE = 0x0004;
-            private const uint RDW_FRAME = 0x0400;
-            private const uint RDW_ALLCHILDREN = 0x0080;
-            private const uint RDW_UPDATENOW = 0x0100;
-
             [DllImport("uxtheme.dll", CharSet = CharSet.Unicode, SetLastError = true)]
             private static extern int SetWindowTheme(IntPtr hwnd, string? appName, string? idList);
-
-            [DllImport("user32.dll", SetLastError = true)]
-            private static extern bool RedrawWindow(IntPtr hwnd, IntPtr lprcUpdate, IntPtr hrgnUpdate, uint flags);
 
             public static uint GetCurrentColor(int color)
             {
@@ -1036,32 +1016,12 @@ namespace EPocalipse.Json.Viewer
 
                 try
                 {
-                    // The scrollbar-specific id list must be applied to the
-                    // control after the native dark-scrollbar hook is enabled.
-                    // Passing it as the sub-app name does not reliably reopen
-                    // the scrollbar theme on first show, leaving WinForms
-                    // scrollbars light until a later repaint.
-                    SetWindowTheme(handle, null, "DarkMode_Explorer::ScrollBar");
-                }
-                catch (DllNotFoundException)
-                {
-                }
-                catch (EntryPointNotFoundException)
-                {
-                }
-            }
-
-            public static void RedrawNonClientArea(IntPtr handle)
-            {
-                if (handle == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                try
-                {
-                    RedrawWindow(handle, IntPtr.Zero, IntPtr.Zero,
-                        RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+                    // The scrollbar-specific class list is required for
+                    // WinForms controls that own native scrollbars.  The
+                    // generic DarkMode_Explorer theme leaves those tracks on
+                    // the light system rendering path on several Windows 11
+                    // builds.
+                    SetWindowTheme(handle, "Explorer::ScrollBar", null);
                 }
                 catch (DllNotFoundException)
                 {

--- a/src/plugins/jsonviewer/managed/ThemeHelper.cs
+++ b/src/plugins/jsonviewer/managed/ThemeHelper.cs
@@ -764,7 +764,10 @@ namespace EPocalipse.Json.Viewer
             {
                 _comboBox = comboBox;
                 _palette = palette;
-                AssignHandle(comboBox.Handle);
+                if (comboBox.IsHandleCreated)
+                {
+                    AssignHandle(comboBox.Handle);
+                }
                 comboBox.HandleCreated += ComboBoxOnHandleCreated;
                 comboBox.HandleDestroyed += ComboBoxOnHandleDestroyed;
                 comboBox.Disposed += ComboBoxOnDisposed;
@@ -793,9 +796,10 @@ namespace EPocalipse.Json.Viewer
                     return;
                 }
 
+                var painter = new ComboBoxDarkModePainter(comboBox, palette);
+                s_painters.Add(comboBox, painter);
                 if (comboBox.IsHandleCreated)
                 {
-                    s_painters.Add(comboBox, new ComboBoxDarkModePainter(comboBox, palette));
                     comboBox.Invalidate();
                 }
             }

--- a/src/plugins/jsonviewer/managed/ThemeHelper.cs
+++ b/src/plugins/jsonviewer/managed/ThemeHelper.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
@@ -199,8 +200,9 @@ namespace EPocalipse.Json.Viewer
                 case ComboBox comboBox:
                     comboBox.BackColor = palette.InputBackground;
                     comboBox.ForeColor = palette.InputForeground;
-                    comboBox.FlatStyle = FlatStyle.Standard;
+                    comboBox.FlatStyle = FlatStyle.Flat;
                     comboBox.DrawMode = DrawMode.OwnerDrawFixed;
+                    ComboBoxDarkModePainter.Attach(comboBox, palette);
                     comboBox.DrawItem -= ComboBoxOnDrawItem;
                     comboBox.DrawItem += ComboBoxOnDrawItem;
                     backgroundSet = true;
@@ -746,6 +748,137 @@ namespace EPocalipse.Json.Viewer
             public Color TabBorder { get; }
         }
 
+
+        private sealed class ComboBoxDarkModePainter : NativeWindow
+        {
+            private const int WM_PAINT = 0x000F;
+            private const int WM_NCPAINT = 0x0085;
+            private const int WM_PRINTCLIENT = 0x0318;
+
+            private static readonly ConditionalWeakTable<ComboBox, ComboBoxDarkModePainter> s_painters = new ConditionalWeakTable<ComboBox, ComboBoxDarkModePainter>();
+
+            private ComboBox _comboBox;
+            private ThemePalette _palette;
+
+            private ComboBoxDarkModePainter(ComboBox comboBox, ThemePalette palette)
+            {
+                _comboBox = comboBox;
+                _palette = palette;
+                AssignHandle(comboBox.Handle);
+                comboBox.HandleCreated += ComboBoxOnHandleCreated;
+                comboBox.HandleDestroyed += ComboBoxOnHandleDestroyed;
+                comboBox.Disposed += ComboBoxOnDisposed;
+            }
+
+            public static void Attach(ComboBox comboBox, ThemePalette palette)
+            {
+                if (!palette.IsDark)
+                {
+                    if (s_painters.TryGetValue(comboBox, out var existingLight))
+                    {
+                        existingLight.Detach();
+                        s_painters.Remove(comboBox);
+                    }
+                    return;
+                }
+
+                if (s_painters.TryGetValue(comboBox, out var existing))
+                {
+                    existing._palette = palette;
+                    if (comboBox.IsHandleCreated && existing.Handle != comboBox.Handle)
+                    {
+                        existing.AssignHandle(comboBox.Handle);
+                    }
+                    comboBox.Invalidate();
+                    return;
+                }
+
+                if (comboBox.IsHandleCreated)
+                {
+                    s_painters.Add(comboBox, new ComboBoxDarkModePainter(comboBox, palette));
+                    comboBox.Invalidate();
+                }
+            }
+
+            protected override void WndProc(ref Message m)
+            {
+                base.WndProc(ref m);
+
+                if (m.Msg == WM_PAINT || m.Msg == WM_NCPAINT || m.Msg == WM_PRINTCLIENT)
+                {
+                    PaintDropDownButton();
+                }
+            }
+
+            private void ComboBoxOnHandleCreated(object? sender, EventArgs e)
+            {
+                if (_comboBox.IsHandleCreated)
+                {
+                    AssignHandle(_comboBox.Handle);
+                    _comboBox.Invalidate();
+                }
+            }
+
+            private void ComboBoxOnHandleDestroyed(object? sender, EventArgs e)
+            {
+                ReleaseHandle();
+            }
+
+            private void ComboBoxOnDisposed(object? sender, EventArgs e)
+            {
+                Detach();
+                s_painters.Remove(_comboBox);
+            }
+
+            private void Detach()
+            {
+                _comboBox.HandleCreated -= ComboBoxOnHandleCreated;
+                _comboBox.HandleDestroyed -= ComboBoxOnHandleDestroyed;
+                _comboBox.Disposed -= ComboBoxOnDisposed;
+                ReleaseHandle();
+            }
+
+            private void PaintDropDownButton()
+            {
+                if (!_comboBox.IsHandleCreated || _comboBox.ClientSize.Width <= 0 || _comboBox.ClientSize.Height <= 0)
+                {
+                    return;
+                }
+
+                using var graphics = Graphics.FromHwnd(_comboBox.Handle);
+                var client = _comboBox.ClientRectangle;
+                int buttonWidth = Math.Max(SystemInformation.HorizontalScrollBarArrowWidth, _comboBox.Height);
+                var buttonBounds = new Rectangle(Math.Max(client.Left, client.Right - buttonWidth), client.Top, Math.Min(buttonWidth, client.Width), client.Height);
+
+                using (var background = new SolidBrush(_palette.InputBackground))
+                {
+                    graphics.FillRectangle(background, buttonBounds);
+                }
+
+                using (var border = new Pen(_palette.ControlBorder))
+                {
+                    var borderBounds = client;
+                    borderBounds.Width -= 1;
+                    borderBounds.Height -= 1;
+                    graphics.DrawRectangle(border, borderBounds);
+                    graphics.DrawLine(border, buttonBounds.Left, buttonBounds.Top, buttonBounds.Left, buttonBounds.Bottom - 1);
+                }
+
+                int arrowWidth = Math.Max(6, _comboBox.DeviceDpi / 16);
+                int arrowHeight = Math.Max(4, _comboBox.DeviceDpi / 24);
+                int centerX = buttonBounds.Left + buttonBounds.Width / 2;
+                int centerY = buttonBounds.Top + buttonBounds.Height / 2;
+                Point[] arrow =
+                {
+                    new Point(centerX - arrowWidth / 2, centerY - arrowHeight / 2),
+                    new Point(centerX + arrowWidth / 2, centerY - arrowHeight / 2),
+                    new Point(centerX, centerY + arrowHeight / 2)
+                };
+
+                using var arrowBrush = new SolidBrush(_palette.InputForeground);
+                graphics.FillPolygon(arrowBrush, arrow);
+            }
+        }
         private static class ThemeRenderer
         {
             public static void Attach(ToolStrip toolStrip, ThemePalette palette)

--- a/src/plugins/jsonviewer/managed/ViewerHost.cs
+++ b/src/plugins/jsonviewer/managed/ViewerHost.cs
@@ -682,9 +682,21 @@ internal static class ViewerHost
 
             ShowInTaskbar = true;
             Show();
+            ApplyThemeAfterFirstShow();
             Activate();
             NativeMethods.SetForegroundWindow(Handle);
             return true;
+        }
+
+        private void ApplyThemeAfterFirstShow()
+        {
+            ThemeHelper.ApplyTheme(this);
+            ThemeHelper.ApplyTheme(_viewer);
+            _viewer.ApplyCurrentTheme();
+            ThemeHelper.ApplyNativeDarkMode(this);
+            ThemeHelper.ApplyNativeDarkMode(_viewer);
+            Update();
+            _viewer.Update();
         }
 
         public void AllowClose()

--- a/src/plugins/jsonviewer/managed/ViewerHost.cs
+++ b/src/plugins/jsonviewer/managed/ViewerHost.cs
@@ -682,21 +682,26 @@ internal static class ViewerHost
 
             ShowInTaskbar = true;
             Show();
-            ApplyThemeAfterFirstShow();
             Activate();
             NativeMethods.SetForegroundWindow(Handle);
+            BeginInvoke(new Action(ApplyThemeAfterFirstShow));
             return true;
         }
 
         private void ApplyThemeAfterFirstShow()
         {
+            if (IsDisposed || !IsHandleCreated)
+            {
+                return;
+            }
+
             ThemeHelper.ApplyTheme(this);
             ThemeHelper.ApplyTheme(_viewer);
             _viewer.ApplyCurrentTheme();
             ThemeHelper.ApplyNativeDarkMode(this);
             ThemeHelper.ApplyNativeDarkMode(_viewer);
-            Update();
-            _viewer.Update();
+            Invalidate(true);
+            _viewer.Invalidate(true);
         }
 
         public void AllowClose()

--- a/src/plugins/jsonviewer/managed/ViewerHost.cs
+++ b/src/plugins/jsonviewer/managed/ViewerHost.cs
@@ -695,13 +695,8 @@ internal static class ViewerHost
                 return;
             }
 
-            ThemeHelper.ApplyTheme(this);
-            ThemeHelper.ApplyTheme(_viewer);
-            _viewer.ApplyCurrentTheme();
             ThemeHelper.ApplyNativeDarkMode(this);
             ThemeHelper.ApplyNativeDarkMode(_viewer);
-            Invalidate(true);
-            _viewer.Invalidate(true);
         }
 
         public void AllowClose()

--- a/src/plugins/jsonviewer/managed_bridge.cpp
+++ b/src/plugins/jsonviewer/managed_bridge.cpp
@@ -15,6 +15,8 @@
 
 namespace
 {
+constexpr UINT kDarkModeRedrawFlags = RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW;
+
 ICLRRuntimeHost* gRuntimeHost = nullptr;
 std::wstring gAssemblyPath;
 const wchar_t* const kManagedType = L"OpenSalamander.JsonViewer.EntryPoint";
@@ -221,6 +223,7 @@ BOOL CALLBACK ApplyJsonViewerDarkModeChild(HWND hwnd, LPARAM)
 {
     DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
+    RedrawWindow(hwnd, nullptr, nullptr, kDarkModeRedrawFlags);
     return TRUE;
 }
 
@@ -380,6 +383,7 @@ extern "C" __declspec(dllexport) void __stdcall JsonViewer_ApplyDarkModeTree(HWN
     DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
     EnumChildWindows(hwnd, ApplyJsonViewerDarkModeChild, 0);
+    RedrawWindow(hwnd, nullptr, nullptr, kDarkModeRedrawFlags);
 }
 
 extern "C" __declspec(dllexport) void __stdcall JsonViewer_UpdateListViewDarkMode(HWND hwnd)
@@ -387,5 +391,6 @@ extern "C" __declspec(dllexport) void __stdcall JsonViewer_UpdateListViewDarkMod
     DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
     EnumChildWindows(hwnd, ApplyJsonViewerDarkModeChild, 0);
+    RedrawWindow(hwnd, nullptr, nullptr, kDarkModeRedrawFlags);
     DarkModeUpdateListViewColors(hwnd, RGB(0xFF, 0xFF, 0xFF), RGB(56, 56, 56), true);
 }

--- a/src/plugins/jsonviewer/managed_bridge.cpp
+++ b/src/plugins/jsonviewer/managed_bridge.cpp
@@ -217,6 +217,13 @@ void ShowLoadError(HWND parent, const wchar_t* text)
     MessageBoxW(parent, text, L"JSON Viewer .NET Plugin", MB_ICONERROR | MB_OK);
 }
 
+BOOL CALLBACK ApplyJsonViewerDarkModeChild(HWND hwnd, LPARAM)
+{
+    DarkModeAllowDarkScrollbars(hwnd);
+    DarkModeApplyTree(hwnd);
+    return TRUE;
+}
+
 } // namespace
 
 bool ManagedBridge_EnsureInitialized(HWND parent)
@@ -372,11 +379,13 @@ extern "C" __declspec(dllexport) void __stdcall JsonViewer_ApplyDarkModeTree(HWN
 {
     DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
+    EnumChildWindows(hwnd, ApplyJsonViewerDarkModeChild, 0);
 }
 
 extern "C" __declspec(dllexport) void __stdcall JsonViewer_UpdateListViewDarkMode(HWND hwnd)
 {
     DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
+    EnumChildWindows(hwnd, ApplyJsonViewerDarkModeChild, 0);
     DarkModeUpdateListViewColors(hwnd, RGB(0xFF, 0xFF, 0xFF), RGB(56, 56, 56), true);
 }

--- a/src/plugins/jsonviewer/managed_bridge.cpp
+++ b/src/plugins/jsonviewer/managed_bridge.cpp
@@ -16,7 +16,6 @@
 namespace
 {
 ICLRRuntimeHost* gRuntimeHost = nullptr;
-bool gJsonViewerDarkModeEnabled = false;
 std::wstring gAssemblyPath;
 const wchar_t* const kManagedType = L"OpenSalamander.JsonViewer.EntryPoint";
 const wchar_t* const kManagedMethod = L"Dispatch";
@@ -218,21 +217,6 @@ void ShowLoadError(HWND parent, const wchar_t* text)
     MessageBoxW(parent, text, L"JSON Viewer .NET Plugin", MB_ICONERROR | MB_OK);
 }
 
-BOOL CALLBACK ApplyJsonViewerDarkModeChild(HWND hwnd, LPARAM)
-{
-    DarkModeAllowDarkScrollbars(hwnd);
-    DarkModeApplyTree(hwnd);
-
-    wchar_t className[64] = {0};
-    if (GetClassNameW(hwnd, className, _countof(className)) != 0 &&
-        lstrcmpiW(className, WC_LISTVIEWW) == 0)
-    {
-        DarkModeUpdateListViewColors(hwnd, RGB(0xFF, 0xFF, 0xFF), RGB(56, 56, 56), true);
-    }
-
-    return TRUE;
-}
-
 } // namespace
 
 bool ManagedBridge_EnsureInitialized(HWND parent)
@@ -381,33 +365,18 @@ extern "C" __declspec(dllexport) UINT32 __stdcall JsonViewer_GetCurrentColor(int
 
 extern "C" __declspec(dllexport) void __stdcall JsonViewer_SetDarkModeState(BOOL enabled)
 {
-    gJsonViewerDarkModeEnabled = enabled != FALSE;
-    DarkModeSetEnabled(gJsonViewerDarkModeEnabled);
+    DarkModeSetEnabled(enabled != FALSE);
 }
 
 extern "C" __declspec(dllexport) void __stdcall JsonViewer_ApplyDarkModeTree(HWND hwnd)
 {
-    if (!gJsonViewerDarkModeEnabled)
-    {
-        DarkModeApplyTree(hwnd);
-        return;
-    }
-
     DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
-    EnumChildWindows(hwnd, ApplyJsonViewerDarkModeChild, 0);
 }
 
 extern "C" __declspec(dllexport) void __stdcall JsonViewer_UpdateListViewDarkMode(HWND hwnd)
 {
-    if (!gJsonViewerDarkModeEnabled)
-    {
-        DarkModeApplyTree(hwnd);
-        return;
-    }
-
     DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
-    EnumChildWindows(hwnd, ApplyJsonViewerDarkModeChild, 0);
     DarkModeUpdateListViewColors(hwnd, RGB(0xFF, 0xFF, 0xFF), RGB(56, 56, 56), true);
 }


### PR DESCRIPTION
### Motivation
- The JSON viewer shows light native scrollbars and combobox/listbox on first open when the Colors - Scheme is set to the Windows Dark Mode scheme, because WinForms-owned HWNDs are not reliably themed before initial paint.  This must match the Samandarin update notifier behavior where scrollbars are dark. 
- The intent is to ensure Win32 scrollbar theming and native dark-mode hooks are applied eagerly and to force a non-client redraw so scrollbars don't remain light until a repaint or user interaction.

### Description
- Reworked `src/plugins/jsonviewer/managed/ThemeHelper.cs` to centralize which controls require native scrollbar theming via a new helper `ControlNeedsNativeScrollbarTheme` and to call `NativeMethods.ApplyDarkScrollbarTheme` plus `NativeMethods.RedrawNonClientArea` after applying native dark mode for those controls.
- Changed the `SetWindowTheme` call to apply the scrollbar id-list as `SetWindowTheme(handle, null, "DarkMode_Explorer::ScrollBar")` and added `RedrawWindow` P/Invoke with `RDW_*` flags to force a non-client redraw so scrollbars update immediately.
- Updated `src/plugins/jsonviewer/managed/JsonViewer.ThemeAdapter.cs` to reapply native dark mode to `cbVisualizers` and introduced `ReapplyNativeThemeAfterFirstLayout()` which runs on the UI thread after the initial layout (`BeginInvoke`) to reapply native theming to `pnlVisualizer` and any child visualizer controls (e.g. `GridVisualizer`).
- Small safety/fallback handling added so `ApplyDarkScrollbarTheme`/`RedrawNonClientArea` are no-ops if platform symbols are missing, matching existing try/catch patterns.

### Testing
- Ran `git diff --check` and repository checks which reported no whitespace/errors and the two modified files were committed successfully (`Fix JSON viewer dark scrollbar theming`).
- Attempted to run .NET/Windows build commands (`dotnet`, `msbuild`, `xbuild`) but Windows/.NET Framework build tooling is unavailable in this Linux container, so no binary build or runtime test was executed. 
- Verified source-level changes and local static edits; manual runtime verification is required on Windows to confirm the visual fix (expected: scrollbars and combobox visuals are dark on first open).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c92c7ffb48329a642d24f42b1c2f6)