### PR TITLE
Make minidump generation more robust: use client pointers and fallback dump types

### DIFF
--- a/src/salmon/minidump.cpp
+++ b/src/salmon/minidump.cpp
@@ -51,7 +51,14 @@ BOOL GenerateMiniDump(CMinidumpParams* minidumpParams, CSalmonSharedMemory* mem,
                 ePtrs.ExceptionRecord = &mem->ExceptionRecord;
                 expParam.ThreadId = mem->ThreadId;
                 expParam.ExceptionPointers = &ePtrs;
-                expParam.ClientPointers = FALSE;
+                // Salmon writes the dump from a helper process.  The exception
+                // records above are copies stored in Salmon's address space, not
+                // pointers inside the crashed Salamander process, so DbgHelp must
+                // treat them as client-side pointers.  Passing FALSE makes newer
+                // DbgHelp versions validate those addresses in the target process
+                // and MiniDumpWriteDump can fail with HRESULT_FROM_WIN32(
+                // ERROR_INVALID_USER_BUFFER), shown in the UI as -2147023112.
+                expParam.ClientPointers = TRUE;
 
                 // great explanation of the flags (better than on MSDN): http://www.debuginfo.com/articles/effminidumps.html#minidumptypes
                 static MINIDUMP_TYPE dumpType;
@@ -76,20 +83,64 @@ BOOL GenerateMiniDump(CMinidumpParams* minidumpParams, CSalmonSharedMemory* mem,
                                                MiniDumpIgnoreInaccessibleMemory); // under no circumstances do we want the function to fail
                 }
 
-                BOOL bMiniDumpSuccessful;
-                bMiniDumpSuccessful = funcMiniDumpWriteDump(mem->Process, mem->ProcessId,
-                                                            hDumpFile, dumpType,
-                                                            &expParam,
-                                                            NULL, NULL);
-                if (bMiniDumpSuccessful)
+                // MiniDumpWriteDump can still fail during a real crash when optional
+                // streams require reading memory that is already gone from the crashing
+                // process.  ERROR_PARTIAL_COPY is one observed case.  Keep the richer
+                // dump as the first choice, but progressively fall back to dump types
+                // that avoid the most fragile optional streams; a smaller dump is much
+                // more useful than no dump and no report upload.
+                MINIDUMP_TYPE fallbackDumpTypes[3];
+                fallbackDumpTypes[0] = dumpType;
+                fallbackDumpTypes[1] = (MINIDUMP_TYPE)(MiniDumpWithDataSegs |
+                                                       MiniDumpWithFullMemoryInfo |
+                                                       MiniDumpWithUnloadedModules |
+                                                       MiniDumpIgnoreInaccessibleMemory);
+                fallbackDumpTypes[2] = (MINIDUMP_TYPE)(MiniDumpNormal |
+                                                       MiniDumpWithUnloadedModules |
+                                                       MiniDumpIgnoreInaccessibleMemory);
+
+                DWORD firstErr = ERROR_SUCCESS;
+                DWORD lastErr = ERROR_SUCCESS;
+                for (int dumpAttempt = 0; dumpAttempt < 3 && !ret; dumpAttempt++)
                 {
-                    ret = TRUE;
+                    SetFilePointer(hDumpFile, 0, NULL, FILE_BEGIN);
+                    SetEndOfFile(hDumpFile);
+
+                    BOOL bMiniDumpSuccessful = funcMiniDumpWriteDump(mem->Process, mem->ProcessId,
+                                                                     hDumpFile, fallbackDumpTypes[dumpAttempt],
+                                                                     &expParam,
+                                                                     NULL, NULL);
+                    if (bMiniDumpSuccessful)
+                    {
+                        ret = TRUE;
+                        break;
+                    }
+
+                    lastErr = GetLastError();
+                    if (firstErr == ERROR_SUCCESS)
+                        firstErr = lastErr;
                 }
-                else
+
+                if (!ret)
                 {
-                    // generation fails on W7 with the x64/Debug build launched from MSVC; if I run it outside MSVC, everything works fine
-                    DWORD err = GetLastError();
-                    sprintf(minidumpParams->ErrorMessage, LoadStr(IDS_SALMON_MINIDUMP_CALL, HLanguage), err);
+                    // If even the minimal dump with the copied exception information
+                    // fails, make one last attempt without exception pointers.  This
+                    // loses the precise exception stream, but still preserves stacks,
+                    // modules and enough process state for many crash reports.
+                    SetFilePointer(hDumpFile, 0, NULL, FILE_BEGIN);
+                    SetEndOfFile(hDumpFile);
+
+                    ret = funcMiniDumpWriteDump(mem->Process, mem->ProcessId,
+                                                hDumpFile, fallbackDumpTypes[2],
+                                                NULL,
+                                                NULL, NULL);
+                    if (!ret)
+                    {
+                        // generation fails on W7 with the x64/Debug build launched from MSVC; if I run it outside MSVC, everything works fine
+                        lastErr = GetLastError();
+                        sprintf(minidumpParams->ErrorMessage, LoadStr(IDS_SALMON_MINIDUMP_CALL, HLanguage),
+                                firstErr != ERROR_SUCCESS ? firstErr : lastErr);
+                    }
                 }
                 // regardless of whether minidump generation returned TRUE or FALSE, check the size of the produced dump
                 DWORD sizeHigh = 0;


### PR DESCRIPTION
### Motivation

- Ensure minidump generation from the helper process works reliably when exception records are copies in the helper's address space and avoid failures like `ERROR_INVALID_USER_BUFFER` or `ERROR_PARTIAL_COPY` during crashes.

### Description

- Set `MINIDUMP_EXCEPTION_INFORMATION::ClientPointers = TRUE` so DbgHelp treats the provided exception records as client-side pointers from the helper process.
- Introduce a prioritized list of `MINIDUMP_TYPE` values and attempt up to three dump types in sequence to fall back from richer to more conservative dumps when memory reads fail.
- Reset the dump file between attempts using `SetFilePointer`/`SetEndOfFile` and capture the first and last error codes to improve the generated error message.
- As a last resort, attempt a dump without exception pointers to still produce a usable dump when the exception stream cannot be written.

### Testing

- Built successfully on Windows with MSVC and the project compiled without errors.
- Executed the repository's automated unit test suite and all tests passed.
- Verified the modified minidump generation path in automated CI Windows build which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55d69aea8083298449708bb077d77b)