### PR TITLE
Salamatrix → Automation Framework: add scripted-extension menu metadata, manifest support and menu wiring

### DIFF
--- a/doc/catalogs-base/plugins-stable.json
+++ b/doc/catalogs-base/plugins-stable.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "catalogName": "Stable",
   "generatedAt": "2026-07-13T00:14:37Z",
   "plugins": [
@@ -25,7 +25,8 @@
       "latestVersion": "1.33 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "automation",
@@ -59,7 +60,8 @@
       "latestVersion": "1.7 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "dbviewer",
@@ -93,7 +95,8 @@
       "latestVersion": "1.25 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "diskmap",
@@ -127,7 +130,8 @@
       "latestVersion": "1.12 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "filecomp",
@@ -161,7 +165,8 @@
       "latestVersion": "1.19 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "folders",
@@ -195,7 +200,8 @@
       "latestVersion": "0.2 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "ftp",
@@ -229,7 +235,8 @@
       "latestVersion": "1.36 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "hypervm",
@@ -263,7 +270,8 @@
       "latestVersion": "1.06 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "checksum",
@@ -297,7 +305,8 @@
       "latestVersion": "2.2 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "ieviewer",
@@ -331,7 +340,8 @@
       "latestVersion": "1.12 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "jsonviewer",
@@ -365,7 +375,8 @@
       "latestVersion": "1.01 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "mmviewer",
@@ -399,7 +410,8 @@
       "latestVersion": "1.16 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "nethood",
@@ -433,7 +445,8 @@
       "latestVersion": "1.09 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "pak",
@@ -467,7 +480,8 @@
       "latestVersion": "1.72 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "peviewer",
@@ -501,7 +515,8 @@
       "latestVersion": "3.0 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "pictview",
@@ -535,7 +550,8 @@
       "latestVersion": "2.23 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "portables",
@@ -569,7 +585,8 @@
       "latestVersion": "0.3 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "regedt",
@@ -603,7 +620,8 @@
       "latestVersion": "1.15 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "renamer",
@@ -637,7 +655,8 @@
       "latestVersion": "1.14 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "samandarin",
@@ -671,7 +690,8 @@
       "latestVersion": "0.5 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "serviceexplorer",
@@ -705,7 +725,8 @@
       "latestVersion": "0.013 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "splitcbn",
@@ -739,7 +760,8 @@
       "latestVersion": "1.11 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "tar",
@@ -773,7 +795,8 @@
       "latestVersion": "3.34 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "textviewer",
@@ -807,7 +830,8 @@
       "latestVersion": "1.01 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "unarj",
@@ -821,7 +845,8 @@
       "latestVersion": "1.22 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "uncab",
@@ -835,7 +860,8 @@
       "latestVersion": "1.28 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "undelete",
@@ -869,7 +895,8 @@
       "latestVersion": "1.12 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "unfat",
@@ -883,7 +910,8 @@
       "latestVersion": "1.2 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "unchm",
@@ -897,7 +925,8 @@
       "latestVersion": "1.04 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "uniso",
@@ -911,7 +940,8 @@
       "latestVersion": "1.38 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "unlha",
@@ -945,7 +975,8 @@
       "latestVersion": "1.14 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "unmime",
@@ -979,7 +1010,8 @@
       "latestVersion": "1.15 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "unole",
@@ -993,7 +1025,8 @@
       "latestVersion": "1.02 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "unrar",
@@ -1007,7 +1040,8 @@
       "latestVersion": "3.03 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "webview2renderviewer",
@@ -1041,7 +1075,8 @@
       "latestVersion": "1.02 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "wmobile",
@@ -1075,7 +1110,8 @@
       "latestVersion": "1.09 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     },
     {
       "id": "zip",
@@ -1109,7 +1145,8 @@
       "latestVersion": "1.6 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download"
+      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
+      "icon": "plugin"
     }
   ]
 }

--- a/doc/catalogs-base/plugins-unofficial.json
+++ b/doc/catalogs-base/plugins-unofficial.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "catalogName": "Unofficial 3rd party",
   "generatedAt": "2026-06-29T03:07:00Z",
   "plugins": [
@@ -35,7 +35,8 @@
       "latestVersion": "5.0 beta (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/Dupl3xx/salamander-sftp-plugin",
-      "downloadPageUrl": "https://github.com/Dupl3xx/salamander-sftp-plugin/tree/master/bin"
+      "downloadPageUrl": "https://github.com/Dupl3xx/salamander-sftp-plugin/tree/master/bin",
+      "icon": "plugin"
     },
     {
       "id": "tar",
@@ -69,7 +70,8 @@
       "latestVersion": "3.5 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/OpenSalamander/salamander/pull/5#issuecomment-3289439303",
-      "downloadPageUrl": "https://github.com/user-attachments/files/22319444/tar-plugin-x64.zip"
+      "downloadPageUrl": "https://github.com/user-attachments/files/22319444/tar-plugin-x64.zip",
+      "icon": "plugin"
     },
     {
       "id": "certview",
@@ -103,7 +105,8 @@
       "latestVersion": "1.3 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/lejcik/certviewer",
-      "downloadPageUrl": "https://github.com/lejcik/certviewer/releases/latest"
+      "downloadPageUrl": "https://github.com/lejcik/certviewer/releases/latest",
+      "icon": "plugin"
     },
     {
       "id": "x-tc-proxy",
@@ -137,7 +140,8 @@
       "latestVersion": "0.84 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://forum.altap.cz/viewtopic.php?t=2166",
-      "downloadPageUrl": "https://www.manison.cz/products/tcproxy.php?Lang=en"
+      "downloadPageUrl": "https://www.manison.cz/products/tcproxy.php?Lang=en",
+      "icon": "plugin"
     },
     {
       "id": "syntax-viewer",
@@ -171,7 +175,8 @@
       "latestVersion": "1.0 (x64)",
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/umpalump7/SyntaxView/",
-      "downloadPageUrl": "https://github.com/umpalump7/SyntaxView/"
+      "downloadPageUrl": "https://github.com/umpalump7/SyntaxView/",
+      "icon": "plugin"
     }
   ]
 }

--- a/doc/plugin-catalog-example.json
+++ b/doc/plugin-catalog-example.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "catalogName": "Sample Plugin Catalog",
   "generatedAt": "2026-06-29T03:07:00Z",
   "plugins": [
@@ -35,7 +35,8 @@
       "latestVersion": "plugin-version",
       "versionScheme": "fileversion | opaque",
       "homepageUrl": "Your plugin homepage URL or repository URL etc.",
-      "downloadPageUrl": "Your plugin download page URL"
+      "downloadPageUrl": "Your plugin download page URL",
+      "icon": "plugin"
     }
   ]
 }

--- a/doc/salamatrix-platform.md
+++ b/doc/salamatrix-platform.md
@@ -4,7 +4,7 @@
 
 Salamatrix is the working technical name for the unified extensibility platform in
 Open Salamander. It is intended to connect the Salamander core, native plugins,
-scripted extensions, automation runtimes, shared UI services, and future SDK
+scripted extensions, future language runtime adapters, shared UI services, and future SDK
 surface area without creating separate APIs for each runtime.
 
 This document captures the initial platform foundation for the first MVP. It is a
@@ -13,22 +13,22 @@ at once.
 
 ## Component name and location
 
-The first runtime component should use the technical name **Salamatrix**. The
-preferred source-tree location for the runtime plugin is:
+The first Automation Framework provider component uses the technical name **Salamatrix**. The
+preferred source-tree location for the framework plugin is:
 
 ```text
 src/plugins/salamatrix/
 ```
 
-The component should be packaged and registered as a runtime/service plugin, not
-as a user-facing command plugin. It may expose a small About/configuration page
+The component should be packaged and registered as an Automation Framework/service plugin, not
+as a language runtime or user-facing command plugin. It may expose a small About/configuration page
 and demo commands while the MVP is developed, but its primary purpose is to
-provide shared services to other plugins and script runtimes.
+provide shared services to other plugins and future script runtime adapters.
 
 Recommended user-visible names:
 
-- `Salamatrix Runtime`
-- `Salamatrix UI Runtime`
+- `Salamatrix Framework`
+- `Salamatrix UI Framework`
 - `Salamatrix SDK` for developer-facing documentation and headers
 
 ## Naming model
@@ -79,8 +79,8 @@ Salamander.FileOperations.copy_interactive(...)
 ```
 
 In this model, **Salamatrix** is the platform and SDK name, while
-**Salamander** is the user-friendly script root object. Runtime adapters may also
-expose advanced metadata under `Salamander.Runtime` when needed.
+**Salamander** is the user-friendly script root object. Future runtime adapters such as Python, JavaScript, PowerShell, or WSH may also
+expose advanced adapter metadata under `Salamander.Runtime` when needed.
 
 ## Service identifiers and versioning
 
@@ -113,7 +113,7 @@ Implemented C-style constants in the Salamatrix headers:
 #define SALAMATRIX_AUTOMATION_VERSION_1_0     0x00010000
 ```
 
-The runtime service id is reserved for the provider/runtime surface; the current
+The `Salamatrix.Runtime` service id is reserved for compatibility/provider metadata; `SALAMATRIX.SPL` itself is an Automation Framework provider. The current
 host registration publishes the UI, Commands, FileOperations, and Automation
 adapter services.
 
@@ -158,7 +158,7 @@ its local registry and the host registry while the runtime object is alive.
 
 ### Provider registration
 
-Runtime plugins should register services during their plugin entry/init phase,
+Automation Framework providers should register services during their plugin entry/init phase,
 after their own version check and language/resource initialization succeed.
 
 Implemented MVP shape:
@@ -203,7 +203,7 @@ if (!SalamanderGeneral->QueryService(&query, &result) || result.Interface == NUL
 {
     SalamanderGeneral->SalMessageBox(
         parent,
-        "This plugin requires Salamatrix UI Runtime.",
+        "This plugin requires Salamatrix UI Framework.",
         pluginName,
         MB_OK | MB_ICONERROR);
     return FALSE;
@@ -216,8 +216,8 @@ Script runtimes should translate missing required services into clear runtime
 exceptions. Recommended wording:
 
 ```text
-This script requires Salamatrix UI Runtime 1.0 or newer. Install or enable the
-Salamatrix Runtime plugin and try again.
+This script requires Salamatrix UI Framework 1.0 or newer. Install or enable the
+Salamatrix Framework plugin and try again.
 ```
 
 The exception should include:
@@ -233,11 +233,11 @@ When a user invokes an extension whose required service is missing, the UI shoul
 show a localized message in this form:
 
 ```text
-This extension requires Salamatrix UI Runtime.
-Install or enable Salamatrix Runtime and try again.
+This extension requires Salamatrix UI Framework.
+Install or enable Salamatrix Framework and try again.
 ```
 
-If the Plugin Manager supports runtime classification, Salamatrix should be shown
+If the Plugin Manager supports Automation Framework classification, Salamatrix should be shown
 as a runtime/service component rather than as an ordinary menu extension.
 
 ## Integration with existing plugin registration
@@ -389,7 +389,7 @@ Salamander.FileOperations.move_interactive()            // returns "ok", "cancel
 ```
 
 Missing Salamatrix runtime services are converted by the Automation wrapper to a
-readable script exception: `This script requires Salamatrix Runtime to be
+readable script exception: `This script requires Salamatrix Framework to be
 installed and loaded.`
 
 ## Salamatrix Automation adapter MVP
@@ -498,10 +498,10 @@ is missing, the PoC keeps a local fallback so the demo remains runnable.
 
 The Automation plugin is the first non-demo consumer bridge. Its
 `CAutomationSalamatrixBridge` queries `CSalamanderGeneral::QueryService` for the
-runtime-provided `Salamatrix.Automation`, `Salamatrix.UI`,
+framework-provided `Salamatrix.Automation`, `Salamatrix.UI`,
 `Salamatrix.Commands`, and `Salamatrix.FileOperations` services when the plugin
 connects and immediately before script execution. It does not create a local
-fallback runtime, so the Automation layer remains an adapter/consumer of
+fallback framework provider, so the Automation layer remains an adapter/consumer of
 `SALAMATRIX.SPL` rather than another provider of duplicated UI or command logic.
 
 
@@ -527,6 +527,9 @@ Inline script metadata remains supported for tiny single-file samples:
 ```javascript
 // Salamatrix.CommandId: Salamatrix.ProgressDemo
 // Salamatrix.CommandTitle: Salamatrix Progress Demo
+// Salamatrix.CommandMenu: both
+// Salamatrix.CommandContextMenu: true
+// Salamatrix.CommandRequires: file
 ```
 
 The manifest-based MVP uses an `extension.json` file next to the script entry
@@ -541,17 +544,30 @@ point:
   "commands": [
     {
       "id": "Salamatrix.ProgressDemo",
-      "title": "Salamatrix Progress Demo"
+      "title": "Salamatrix Progress Demo",
+      "menu": "both",
+      "contextMenu": true,
+      "requires": "file"
     }
   ]
 }
 ```
 
-The current manifest reader intentionally supports only the MVP fields required
-by the sample: `id`, `name`/`title`, `runtime`, and `entryPoint`. The script is
-still executed by the existing Automation script command workflow; the manifest
-sets the stable Salamatrix command id and overrides the menu caption when
-`entryPoint` matches the discovered script file.
+The current manifest reader intentionally remains a simple MVP parser. It supports
+the package-level fields `id`, `name`/`title`, `runtime`, and `entryPoint`, plus
+command placement fields `menu`/`placement`, `contextMenu`, and `requires`. The
+script is still executed by the existing Automation script command workflow; the
+manifest sets the stable Salamatrix command id, overrides the menu caption when
+`entryPoint` matches the discovered script file, and controls whether the command
+appears in the plugin menu, context menu, both, or neither.
+
+MVP `requires` values map to Salamander menu event masks as follows:
+
+- `any`: no special context; enabled by `MENU_EVENT_TRUE`.
+- `disk`: requires a disk panel context.
+- `focused`: requires a focused file or directory on disk.
+- `file`: requires a focused file or selected files on disk.
+- `selection`: requires selected files or directories on disk.
 
 ## MVP acceptance criteria
 
@@ -579,7 +595,7 @@ The platform skeleton is ready when:
    Automation adapters, a local service registry, and the core-facing
    `CSalamanderGeneral` service registry together and is exposed as a DemoPlug
    `Salamatrix PoC` menu sample.
-11. `SALAMATRIX.SPL` exists as the first runtime provider plugin, creates the
+11. `SALAMATRIX.SPL` exists as the first Automation Framework provider plugin, creates the
    persistent `Runtime::RuntimeServices` aggregate, registers the MVP services
    with `CSalamanderGeneral`, and unregisters them during plugin release.
 12. The Automation plugin contains a consumer-only bridge that refreshes and
@@ -589,3 +605,5 @@ The platform skeleton is ready when:
    `Salamander.FileOperations` backed by the Salamatrix runtime bridge.
 14. Script discovery supports the first command-registration metadata and a
    minimal `extension.json` manifest for the sample scripted extension.
+15. Scripted-extension command placement controls plugin-menu vs context-menu
+   visibility and applies MVP `requires` context masks to Automation menu items.

--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -330,8 +330,8 @@ void CPluginsDlg::OnSelChanged()
                              buf[0] == 0 ? LoadStr(IDS_PLUGINFSNONE) : buf);
         // Functions
         // Salamatrix may already be installed in user configurations saved before
-        // FUNCTION_AUTOMATIONRUNTIME existed; identify it by its stable registry key too.
-        BOOL supportAutomationRuntime = p->SupportAutomationRuntime ||
+        // Preserve older configurations; identify Salamatrix by its stable registry key too.
+        BOOL supportAutomationFramework = p->SupportAutomationFramework ||
                                         (p->RegKeyName != NULL && StrICmp(p->RegKeyName, "SALAMATRIX") == 0);
         buf[0] = 0;
         if (p->SupportPanelView)
@@ -390,7 +390,7 @@ void CPluginsDlg::OnSelChanged()
             strcat(buf, LoadStr(IDS_PLUGINFUNCFILESYSTEM));
         }
 
-        if (supportAutomationRuntime)
+        if (supportAutomationFramework)
         {
             if (p->SupportViewer || p->MenuItems.Count > 0 || p->SupportDynMenuExt || p->SupportFS)
                 strcat(buf, ", ");
@@ -405,7 +405,7 @@ void CPluginsDlg::OnSelChanged()
         // Thumbnails
         if (p->ThumbnailMasks.GetMasksString()[0] != 0)
         {
-            if (p->SupportViewer || p->MenuItems.Count > 0 || p->SupportDynMenuExt || p->SupportFS || supportAutomationRuntime)
+            if (p->SupportViewer || p->MenuItems.Count > 0 || p->SupportDynMenuExt || p->SupportFS || supportAutomationFramework)
                 strcat(buf, ", ");
             else
             {

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -1369,7 +1369,7 @@ STRINGTABLE
  IDS_PLUGINFUNCMENUEXTENSION, "Menu Extension"
  IDS_PLUGINFUNCFILESYSTEM, "File System (FS)"
  IDS_PLUGINFUNCTHUMBLOADER, "Thumbnail Loader"
- IDS_PLUGINFUNCAUTORUNTIME, "Automation Runtime"
+ IDS_PLUGINFUNCAUTORUNTIME, "Automation Framework"
  IDS_PLUGINADDTITLE, "Add Plugins"
  IDS_PLUGINTESTOK, "%s plugin seems to work correctly."
  IDS_PLUGINTESTALLOK, "All plugins seem to work correctly."

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -2424,7 +2424,7 @@ public:
     BOOL SupportViewer;        // TRUE => supports ViewFile and CanViewFile (file viewer)
     BOOL SupportFS;            // TRUE => supports a file system
     BOOL SupportDynMenuExt;    // TRUE => menu is added in PluginIfaceForMenuExt::BuildMenu instead of PluginIface::Connect (menu is dynamic and rebuilt before each plugin menu open)
-    BOOL SupportAutomationRuntime; // TRUE => provides automation/script runtime services
+    BOOL SupportAutomationFramework; // TRUE => provides automation framework services
 
     BOOL LoadOnStart; // should the plugin load at every Salamander start?
 
@@ -2511,7 +2511,7 @@ public:
     CPluginData(const char* name, const char* dllName, BOOL supportPanelView,
                 BOOL supportPanelEdit, BOOL supportCustomPack, BOOL supportCustomUnpack,
                 BOOL supportConfiguration, BOOL supportLoadSave, BOOL supportViewer,
-                BOOL supportFS, BOOL supportDynMenuExt, BOOL supportAutomationRuntime, const char* version,
+                BOOL supportFS, BOOL supportDynMenuExt, BOOL supportAutomationFramework, const char* version,
                 const char* copyright, const char* description, const char* regKeyName,
                 const char* extensions, TIndirectArray<char>* fsNames, BOOL loadOnStart,
                 char* lastSLGName, const char* pluginHomePageURL);
@@ -2930,7 +2930,7 @@ public:
     BOOL AddPlugin(const char* name, const char* dllName, BOOL supportPanelView,
                    BOOL supportPanelEdit, BOOL supportCustomPack, BOOL supportCustomUnpack,
                    BOOL supportConfiguration, BOOL supportLoadSave, BOOL supportViewer,
-                   BOOL supportFS, BOOL supportDynMenuExt, BOOL supportAutomationRuntime, const char* version,
+                   BOOL supportFS, BOOL supportDynMenuExt, BOOL supportAutomationFramework, const char* version,
                    const char* copyright, const char* description, const char* regKeyName,
                    const char* extensions, TIndirectArray<char>* fsNames, BOOL loadOnStart,
                    char* lastSLGName, const char* pluginHomePageURL);

--- a/src/plugins/automation/automationplug.cpp
+++ b/src/plugins/automation/automationplug.cpp
@@ -123,6 +123,16 @@ DWORD WINAPI CAutomationMenuExtInterface::GetMenuItemState(
     else
     {
         // preloaded script item
+        CScriptInfo* pScript = g_oScriptLookup.LookupScript(id);
+        if (pScript == NULL)
+            return 0;
+
+        if ((eventMask & pScript->GetMenuEventAndMask()) != pScript->GetMenuEventAndMask())
+            return 0;
+
+        if ((eventMask & pScript->GetMenuEventOrMask()) == 0)
+            return 0;
+
         return MENU_ITEM_STATE_ENABLED;
     }
 }
@@ -235,6 +245,9 @@ void CAutomationMenuExtInterface::AddScriptContainerToPopup(
     mii.ImageIndex = PluginIconScript;
     for (pScript = pContainer->FirstScript(); pScript; pScript = pScript->Next(), i++)
     {
+        if (!pScript->ShowInPluginMenu())
+            continue;
+
         mii.ID = pScript->GetId();
 
         StringCchCopy(szDisplayName, _countof(szDisplayName), pScript->GetDisplayName());
@@ -382,6 +395,12 @@ void CAutomationMenuExtInterface::AddScriptContainerToMenu(
     pScript = pContainer->FirstScript();
     while (pScript)
     {
+        if (!pScript->ShowInPluginMenu() && !pScript->ShowInContextMenu())
+        {
+            pScript = pScript->Next();
+            continue;
+        }
+
         StringCchCopy(szDisplayName, _countof(szDisplayName), pScript->GetDisplayName());
         SalamanderGeneral->DuplicateAmpersands(szDisplayName, _countof(szDisplayName));
 
@@ -390,9 +409,9 @@ void CAutomationMenuExtInterface::AddScriptContainerToMenu(
             szDisplayName,
             0,                // hotkey
             pScript->GetId(), // id
-            TRUE,             // callGetState
-            MENU_EVENT_TRUE,  // or-mask
-            MENU_EVENT_TRUE,  // and-mask
+            TRUE,                         // callGetState
+            pScript->GetMenuEventOrMask(),  // or-mask
+            pScript->GetMenuEventAndMask(), // and-mask
             MENU_SKILLLEVEL_ALL);
 
         pScript = pScript->Next();
@@ -512,7 +531,7 @@ void CAutomationPluginInterface::About(HWND parent)
                     TEXT("%s ") TEXT(VERSINFO_VERSION) TEXT("\n\n")
                         TEXT(VERSINFO_COPYRIGHT) TEXT("\n\n")
                             TEXT("%s\n\n")
-                                TEXT("Salamatrix Runtime: %s"),
+                                TEXT("Salamatrix Framework: %s"),
                     SalamanderGeneral->LoadStr(g_hLangInst, IDS_PLUGINNAME),
                     SalamanderGeneral->LoadStr(g_hLangInst, IDS_DESCRIPTION),
                     szSalamatrixStatus);

--- a/src/plugins/automation/salamatrixaut.cpp
+++ b/src/plugins/automation/salamatrixaut.cpp
@@ -21,7 +21,7 @@ extern HINSTANCE g_hLangInst;
 
 static HRESULT RaiseMissingRuntime(LPCOLESTR objectName)
 {
-    ::RaiseError(L"This script requires Salamatrix Runtime to be installed and loaded.", __uuidof(ISalamander), objectName);
+    ::RaiseError(L"This script requires Salamatrix Framework to be installed and loaded.", __uuidof(ISalamander), objectName);
     return E_FAIL;
 }
 

--- a/src/plugins/automation/salamatrixbridge.cpp
+++ b/src/plugins/automation/salamatrixbridge.cpp
@@ -103,7 +103,7 @@ void CAutomationSalamatrixBridge::GetStatusText(PTSTR buffer, int cchBuffer) con
 
     if (!IsAvailable())
     {
-        StringCchCopy(buffer, cchBuffer, TEXT("not available (install/load Salamatrix Runtime)"));
+        StringCchCopy(buffer, cchBuffer, TEXT("not available (install/load Salamatrix Framework)"));
         return;
     }
 

--- a/src/plugins/automation/sample-scripts/Salamatrix Progress Demo/extension.json
+++ b/src/plugins/automation/sample-scripts/Salamatrix Progress Demo/extension.json
@@ -6,7 +6,10 @@
   "commands": [
     {
       "id": "Salamatrix.ProgressDemo",
-      "title": "Salamatrix Progress Demo"
+      "title": "Salamatrix Progress Demo",
+      "menu": "both",
+      "contextMenu": true,
+      "requires": "file"
     }
   ]
 }

--- a/src/plugins/automation/sample-scripts/Salamatrix Progress Demo/main.js
+++ b/src/plugins/automation/sample-scripts/Salamatrix Progress Demo/main.js
@@ -1,5 +1,5 @@
-// Demonstrates the Salamatrix-backed Automation API.
-// Requires the Salamatrix Runtime plugin to be installed and loaded.
+﻿// Demonstrates the Salamatrix-backed Automation API.
+// Requires the Salamatrix Framework plugin to be installed and loaded.
 
 var progress = Salamander.UI.progress("Salamatrix progress demo");
 progress.Maximum = 5;

--- a/src/plugins/automation/scriptlist.cpp
+++ b/src/plugins/automation/scriptlist.cpp
@@ -46,6 +46,36 @@ static BOOL ReadSmallTextFile(PCTSTR path, char* buffer, DWORD bufferSize)
     return TRUE;
 }
 
+static BOOL FindJsonBoolValue(const char* json, const char* key, BOOL* value)
+{
+    char quotedKey[96];
+    _snprintf_s(quotedKey, _countof(quotedKey), _TRUNCATE, "\"%s\"", key);
+
+    const char* keyPos = strstr(json, quotedKey);
+    if (keyPos == NULL)
+        return FALSE;
+
+    const char* colon = strchr(keyPos + strlen(quotedKey), ':');
+    if (colon == NULL)
+        return FALSE;
+
+    const char* start = colon + 1;
+    while (*start == ' ' || *start == '\t' || *start == '\r' || *start == '\n')
+        ++start;
+
+    if (_strnicmp(start, "true", 4) == 0)
+    {
+        *value = TRUE;
+        return TRUE;
+    }
+    if (_strnicmp(start, "false", 5) == 0)
+    {
+        *value = FALSE;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 static BOOL FindJsonStringValue(const char* json, const char* key, char* value, DWORD valueSize)
 {
     char quotedKey[96];
@@ -91,6 +121,10 @@ CScriptInfo::CScriptInfo(
     pszNameEnd = PathFindExtension(pszNameStart);
     StringCchCopyN(m_szDisplayName, _countof(m_szDisplayName), pszNameStart, pszNameEnd - pszNameStart);
     m_szSalamatrixCommandId[0] = _T('\0');
+    m_bShowInPluginMenu = true;
+    m_bShowInContextMenu = false;
+    m_dwMenuEventOrMask = MENU_EVENT_TRUE;
+    m_dwMenuEventAndMask = MENU_EVENT_TRUE;
     LoadSalamatrixMetadata();
     LoadSalamatrixManifestMetadata();
 
@@ -127,10 +161,72 @@ CScriptInfo::~CScriptInfo()
 }
 
 
+
+void CScriptInfo::ApplySalamatrixPlacement(PCTSTR pszValue)
+{
+    if (_tcsicmp(pszValue, _T("plugin")) == 0)
+    {
+        m_bShowInPluginMenu = true;
+        m_bShowInContextMenu = false;
+    }
+    else if (_tcsicmp(pszValue, _T("context")) == 0)
+    {
+        m_bShowInPluginMenu = false;
+        m_bShowInContextMenu = true;
+    }
+    else if (_tcsicmp(pszValue, _T("both")) == 0)
+    {
+        m_bShowInPluginMenu = true;
+        m_bShowInContextMenu = true;
+    }
+    else if (_tcsicmp(pszValue, _T("none")) == 0)
+    {
+        m_bShowInPluginMenu = false;
+        m_bShowInContextMenu = false;
+    }
+}
+
+void CScriptInfo::ApplySalamatrixContextMenu(bool value)
+{
+    m_bShowInContextMenu = value;
+}
+
+void CScriptInfo::ApplySalamatrixRequires(PCTSTR pszValue)
+{
+    if (_tcsicmp(pszValue, _T("any")) == 0)
+    {
+        m_dwMenuEventOrMask = MENU_EVENT_TRUE;
+        m_dwMenuEventAndMask = MENU_EVENT_TRUE;
+    }
+    else if (_tcsicmp(pszValue, _T("disk")) == 0)
+    {
+        m_dwMenuEventOrMask = MENU_EVENT_TRUE;
+        m_dwMenuEventAndMask = MENU_EVENT_DISK;
+    }
+    else if (_tcsicmp(pszValue, _T("focused")) == 0)
+    {
+        m_dwMenuEventOrMask = MENU_EVENT_FILE_FOCUSED | MENU_EVENT_DIR_FOCUSED;
+        m_dwMenuEventAndMask = MENU_EVENT_DISK;
+    }
+    else if (_tcsicmp(pszValue, _T("file")) == 0)
+    {
+        m_dwMenuEventOrMask = MENU_EVENT_FILE_FOCUSED | MENU_EVENT_FILES_SELECTED;
+        m_dwMenuEventAndMask = MENU_EVENT_DISK;
+    }
+    else if (_tcsicmp(pszValue, _T("selection")) == 0)
+    {
+        m_dwMenuEventOrMask = MENU_EVENT_FILES_SELECTED | MENU_EVENT_DIRS_SELECTED;
+        m_dwMenuEventAndMask = MENU_EVENT_DISK;
+    }
+}
+
 void CScriptInfo::ApplySalamatrixMetadataLine(PCTSTR pszLine)
 {
     static const TCHAR COMMAND_ID_PREFIX[] = _T("// Salamatrix.CommandId:");
     static const TCHAR COMMAND_TITLE_PREFIX[] = _T("// Salamatrix.CommandTitle:");
+    static const TCHAR COMMAND_MENU_PREFIX[] = _T("// Salamatrix.CommandMenu:");
+    static const TCHAR COMMAND_CONTEXT_MENU_PREFIX[] = _T("// Salamatrix.CommandContextMenu:");
+    static const TCHAR COMMAND_REQUIRES_PREFIX[] = _T("// Salamatrix.CommandRequires:");
 
     while (*pszLine == _T(' ') || *pszLine == _T('\t'))
         ++pszLine;
@@ -148,6 +244,27 @@ void CScriptInfo::ApplySalamatrixMetadataLine(PCTSTR pszLine)
         while (*pszLine == _T(' ') || *pszLine == _T('\t'))
             ++pszLine;
         StringCchCopy(m_szDisplayName, _countof(m_szDisplayName), pszLine);
+    }
+    else if (_tcsnicmp(pszLine, COMMAND_MENU_PREFIX, _countof(COMMAND_MENU_PREFIX) - 1) == 0)
+    {
+        pszLine += _countof(COMMAND_MENU_PREFIX) - 1;
+        while (*pszLine == _T(' ') || *pszLine == _T('\t'))
+            ++pszLine;
+        ApplySalamatrixPlacement(pszLine);
+    }
+    else if (_tcsnicmp(pszLine, COMMAND_CONTEXT_MENU_PREFIX, _countof(COMMAND_CONTEXT_MENU_PREFIX) - 1) == 0)
+    {
+        pszLine += _countof(COMMAND_CONTEXT_MENU_PREFIX) - 1;
+        while (*pszLine == _T(' ') || *pszLine == _T('\t'))
+            ++pszLine;
+        ApplySalamatrixContextMenu(_tcsicmp(pszLine, _T("true")) == 0);
+    }
+    else if (_tcsnicmp(pszLine, COMMAND_REQUIRES_PREFIX, _countof(COMMAND_REQUIRES_PREFIX) - 1) == 0)
+    {
+        pszLine += _countof(COMMAND_REQUIRES_PREFIX) - 1;
+        while (*pszLine == _T(' ') || *pszLine == _T('\t'))
+            ++pszLine;
+        ApplySalamatrixRequires(pszLine);
     }
 }
 
@@ -172,6 +289,14 @@ void CScriptInfo::ApplySalamatrixManifestValue(const char* key, const char* valu
     else if (strcmp(key, "title") == 0 || strcmp(key, "name") == 0)
     {
         StringCchCopy(m_szDisplayName, _countof(m_szDisplayName), converted);
+    }
+    else if (strcmp(key, "menu") == 0 || strcmp(key, "placement") == 0)
+    {
+        ApplySalamatrixPlacement(converted);
+    }
+    else if (strcmp(key, "requires") == 0)
+    {
+        ApplySalamatrixRequires(converted);
     }
 }
 
@@ -208,6 +333,15 @@ void CScriptInfo::LoadSalamatrixManifestMetadata()
         ApplySalamatrixManifestValue("title", value);
     else if (FindJsonStringValue(json, "name", value, sizeof(value)))
         ApplySalamatrixManifestValue("name", value);
+    if (FindJsonStringValue(json, "menu", value, sizeof(value)))
+        ApplySalamatrixManifestValue("menu", value);
+    else if (FindJsonStringValue(json, "placement", value, sizeof(value)))
+        ApplySalamatrixManifestValue("placement", value);
+    BOOL boolValue;
+    if (FindJsonBoolValue(json, "contextMenu", &boolValue))
+        ApplySalamatrixContextMenu(boolValue != FALSE);
+    if (FindJsonStringValue(json, "requires", value, sizeof(value)))
+        ApplySalamatrixManifestValue("requires", value);
 }
 
 void CScriptInfo::LoadSalamatrixMetadata()

--- a/src/plugins/automation/scriptlist.h
+++ b/src/plugins/automation/scriptlist.h
@@ -58,6 +58,10 @@ private:
     TCHAR m_szFileName[MAX_PATH];
     TCHAR m_szDisplayName[64];
     TCHAR m_szSalamatrixCommandId[64];
+    bool m_bShowInPluginMenu;
+    bool m_bShowInContextMenu;
+    DWORD m_dwMenuEventOrMask;
+    DWORD m_dwMenuEventAndMask;
     CLSID m_clsidEngine;
     IActiveScript* m_pScript;
     class CScriptSite* m_pSite;
@@ -100,6 +104,9 @@ private:
     void LoadSalamatrixManifestMetadata();
     void ApplySalamatrixMetadataLine(PCTSTR pszLine);
     void ApplySalamatrixManifestValue(const char* key, const char* value);
+    void ApplySalamatrixPlacement(PCTSTR pszValue);
+    void ApplySalamatrixRequires(PCTSTR pszValue);
+    void ApplySalamatrixContextMenu(bool value);
 
     void ScriptEnter();
     void ScriptLeave();
@@ -134,6 +141,26 @@ public:
     PCTSTR GetSalamatrixCommandId() const
     {
         return m_szSalamatrixCommandId;
+    }
+
+    bool ShowInPluginMenu() const
+    {
+        return m_bShowInPluginMenu;
+    }
+
+    bool ShowInContextMenu() const
+    {
+        return m_bShowInContextMenu;
+    }
+
+    DWORD GetMenuEventOrMask() const
+    {
+        return m_dwMenuEventOrMask;
+    }
+
+    DWORD GetMenuEventAndMask() const
+    {
+        return m_dwMenuEventAndMask;
     }
 
     REFCLSID GetEngineCLSID() const

--- a/src/plugins/salamatrix/salamatrix.cpp
+++ b/src/plugins/salamatrix/salamatrix.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 /*
-    Salamatrix Runtime plugin for Open Salamander
+    Salamatrix Framework plugin for Open Salamander
 
     This plugin is the first concrete provider of the Salamatrix service set. It
     owns the native RuntimeServices aggregate and registers versioned services in
@@ -15,7 +15,7 @@
 
 CPluginInterface PluginInterface;
 
-const char* PluginNameEN = "Salamatrix Runtime";
+const char* PluginNameEN = "Salamatrix Framework";
 const char* PluginNameShort = "SALAMATRIX";
 
 HINSTANCE DLLInstance = NULL;
@@ -81,7 +81,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     SalamanderDebug = salamander->GetSalamanderDebug();
     SalamanderVersion = salamander->GetVersion();
     HANDLES_CAN_USE_TRACE();
-    CALL_STACK_MESSAGE1("SalamanderPluginEntry() - Salamatrix Runtime");
+    CALL_STACK_MESSAGE1("SalamanderPluginEntry() - Salamatrix Framework");
 
     if (SalamanderVersion < LAST_VERSION_OF_SALAMANDER)
     {
@@ -91,8 +91,8 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     SalamanderGeneral = salamander->GetSalamanderGeneral();
     SalamanderGUI = salamander->GetSalamanderGUI();
-    salamander->SetBasicPluginData(PluginNameEN, FUNCTION_AUTOMATIONRUNTIME, "0.1", "Open Salamander Authors",
-                                   "Runtime provider for Salamatrix UI, Commands, FileOperations and Automation services.",
+    salamander->SetBasicPluginData(PluginNameEN, FUNCTION_AUTOMATIONFRAMEWORK, "0.1", "Open Salamander Authors",
+                                   "Automation Framework provider for Salamatrix UI, Commands, FileOperations and Automation services.",
                                    PluginNameShort, NULL, NULL);
     salamander->SetPluginHomePageURL("https://samandarin.krtkovo.eu/");
 
@@ -101,7 +101,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     if (!CreateRuntimeServices())
     {
         SalamanderGeneral->SalMessageBox(salamander->GetParentWindow(),
-                                         "Salamatrix Runtime could not register its services. Another provider may already be active.",
+                                         "Salamatrix Framework could not register its services. Another provider may already be active.",
                                          PluginNameEN, MB_OK | MB_ICONERROR);
         return NULL;
     }
@@ -113,7 +113,7 @@ void WINAPI CPluginInterface::About(HWND parent)
 {
     char buf[1000];
     _snprintf_s(buf, _TRUNCATE,
-                "Salamatrix Runtime 0.1\n\n"
+                "Salamatrix Framework 0.1\n\n"
                 "Registered services: %s\n"
                 "Service count: %d\n\n"
                 "Provides Salamatrix.UI, Salamatrix.Commands, Salamatrix.FileOperations and the Automation adapter.",
@@ -124,7 +124,7 @@ void WINAPI CPluginInterface::About(HWND parent)
 
 void WINAPI CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamander)
 {
-    CALL_STACK_MESSAGE1("CPluginInterface::Connect(,) - Salamatrix Runtime");
+    CALL_STACK_MESSAGE1("CPluginInterface::Connect(,) - Salamatrix Framework");
 
     if (SalamanderGUI != NULL)
     {

--- a/src/plugins/salamatrix/salamatrix_runtime.h
+++ b/src/plugins/salamatrix/salamatrix_runtime.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 /*
-    Salamatrix Runtime for Open Salamander
+    Salamatrix Framework for Open Salamander
 
     salamatrix_runtime.h
     Minimal in-process service registry and runtime service wiring.
@@ -203,18 +203,18 @@ public:
           HostRegistered(FALSE)
     {
         Registered = TRUE;
-        Registered &= Registry.RegisterService(SALAMATRIX_SERVICE_UI, SALAMATRIX_UI_VERSION_1_0, &UIService, "Salamatrix Runtime");
-        Registered &= Registry.RegisterService(SALAMATRIX_SERVICE_COMMANDS, SALAMATRIX_COMMANDS_VERSION_1_0, &CommandService, "Salamatrix Runtime");
-        Registered &= Registry.RegisterService(SALAMATRIX_SERVICE_FILEOPERATIONS, SALAMATRIX_FILEOPERATIONS_VERSION_1_0, &FileOperationsService, "Salamatrix Runtime");
-        Registered &= Registry.RegisterService(SALAMATRIX_SERVICE_AUTOMATION_ADAPTER, SALAMATRIX_AUTOMATION_VERSION_1_0, &ScriptRoot, "Salamatrix Runtime");
+        Registered &= Registry.RegisterService(SALAMATRIX_SERVICE_UI, SALAMATRIX_UI_VERSION_1_0, &UIService, "Salamatrix Framework");
+        Registered &= Registry.RegisterService(SALAMATRIX_SERVICE_COMMANDS, SALAMATRIX_COMMANDS_VERSION_1_0, &CommandService, "Salamatrix Framework");
+        Registered &= Registry.RegisterService(SALAMATRIX_SERVICE_FILEOPERATIONS, SALAMATRIX_FILEOPERATIONS_VERSION_1_0, &FileOperationsService, "Salamatrix Framework");
+        Registered &= Registry.RegisterService(SALAMATRIX_SERVICE_AUTOMATION_ADAPTER, SALAMATRIX_AUTOMATION_VERSION_1_0, &ScriptRoot, "Salamatrix Framework");
 
         if (General != NULL && registerHostServices)
         {
             HostRegistered = TRUE;
-            HostRegistered &= General->RegisterService(SALAMATRIX_SERVICE_UI, SALAMATRIX_UI_VERSION_1_0, &UIService, "Salamatrix Runtime");
-            HostRegistered &= General->RegisterService(SALAMATRIX_SERVICE_COMMANDS, SALAMATRIX_COMMANDS_VERSION_1_0, &CommandService, "Salamatrix Runtime");
-            HostRegistered &= General->RegisterService(SALAMATRIX_SERVICE_FILEOPERATIONS, SALAMATRIX_FILEOPERATIONS_VERSION_1_0, &FileOperationsService, "Salamatrix Runtime");
-            HostRegistered &= General->RegisterService(SALAMATRIX_SERVICE_AUTOMATION_ADAPTER, SALAMATRIX_AUTOMATION_VERSION_1_0, &ScriptRoot, "Salamatrix Runtime");
+            HostRegistered &= General->RegisterService(SALAMATRIX_SERVICE_UI, SALAMATRIX_UI_VERSION_1_0, &UIService, "Salamatrix Framework");
+            HostRegistered &= General->RegisterService(SALAMATRIX_SERVICE_COMMANDS, SALAMATRIX_COMMANDS_VERSION_1_0, &CommandService, "Salamatrix Framework");
+            HostRegistered &= General->RegisterService(SALAMATRIX_SERVICE_FILEOPERATIONS, SALAMATRIX_FILEOPERATIONS_VERSION_1_0, &FileOperationsService, "Salamatrix Framework");
+            HostRegistered &= General->RegisterService(SALAMATRIX_SERVICE_AUTOMATION_ADAPTER, SALAMATRIX_AUTOMATION_VERSION_1_0, &ScriptRoot, "Salamatrix Framework");
         }
     }
 

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 using System.Collections.Generic;
 using System.IO;
@@ -1030,6 +1031,7 @@ internal sealed class PluginUpdatesDialog : Form
     private readonly CheckBox _showOnlyUpdates;
     private readonly Label _statusLabel;
     private readonly ContextMenuStrip _listContextMenu;
+    private readonly ImageList _pluginImages;
     private readonly Label _detailNameValue;
     private readonly Label _detailAuthorValue;
     private readonly Label _detailInstalledValue;
@@ -1040,8 +1042,8 @@ internal sealed class PluginUpdatesDialog : Form
     private readonly LinkLabel _detailDownloadValue;
     private readonly TextBox _detailDescriptionValue;
     private ListViewItem? _contextMenuItem;
-    private static readonly int[] ListColumnMinimumWidths = { 120, 180, 90, 90, 120, 110 };
-    private static readonly float[] ListColumnWidthWeights = { 0.16f, 0.30f, 0.12f, 0.12f, 0.17f, 0.13f };
+    private static readonly int[] ListColumnMinimumWidths = { 46, 120, 180, 90, 90, 120, 110 };
+    private static readonly float[] ListColumnWidthWeights = { 0.00f, 0.15f, 0.30f, 0.12f, 0.12f, 0.18f, 0.13f };
     private int _contextMenuSubItemIndex;
     private readonly List<PluginUpdateRow> _rows = new();
     private int _sortColumn = 1;
@@ -1084,6 +1086,9 @@ internal sealed class PluginUpdatesDialog : Form
             Scrollable = true,
             View = View.Details,
         };
+        _pluginImages = new ImageList { ColorDepth = ColorDepth.Depth32Bit, ImageSize = new System.Drawing.Size(16, 16) };
+        _listView.SmallImageList = _pluginImages;
+        _listView.Columns.Add(string.Empty, 46);
         _listView.Columns.Add(NativeStrings.Get(NativeStringId.PluginColumnSource), 140);
         _listView.Columns.Add(NativeStrings.Get(NativeStringId.PluginColumnName), 240);
         _listView.Columns.Add(NativeStrings.Get(NativeStringId.PluginColumnInstalled), 120);
@@ -1253,7 +1258,8 @@ internal sealed class PluginUpdatesDialog : Form
             _listView.Items.Clear();
             foreach (var row in rows)
             {
-                var item = new ListViewItem(row.Source) { Tag = row };
+                var item = new ListViewItem(row.IconLabel) { Tag = row, ImageKey = EnsurePluginImage(row) };
+                item.SubItems.Add(row.Source);
                 item.SubItems.Add(row.Name);
                 item.SubItems.Add(row.InstalledVersion);
                 item.SubItems.Add(row.LatestVersion);
@@ -1275,6 +1281,35 @@ internal sealed class PluginUpdatesDialog : Form
         NativeListView.SetSortArrow(_listView, _sortColumn, _sortOrder);
         ThemeHelper.ApplyNativeDarkMode(_listView);
         UpdateDetails();
+    }
+
+    private string EnsurePluginImage(PluginUpdateRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.IconPath))
+        {
+            return string.Empty;
+        }
+
+        var key = row.IconPath!;
+        if (_pluginImages.Images.ContainsKey(key))
+        {
+            return key;
+        }
+
+        try
+        {
+            using var icon = Icon.ExtractAssociatedIcon(key);
+            if (icon is not null)
+            {
+                _pluginImages.Images.Add(key, icon);
+                return key;
+            }
+        }
+        catch
+        {
+        }
+
+        return string.Empty;
     }
 
     private void UpdateDetails()
@@ -1418,12 +1453,13 @@ internal sealed class PluginUpdatesDialog : Form
 
         private string GetValue(PluginUpdateRow row) => _column switch
         {
-            1 => row.Name,
-            2 => row.InstalledVersion,
-            3 => row.LatestVersion,
-            4 => row.StatusText,
-            5 => row.Author,
-            _ => row.Source,
+            1 => row.Source,
+            2 => row.Name,
+            3 => row.InstalledVersion,
+            4 => row.LatestVersion,
+            5 => row.StatusText,
+            6 => row.Author,
+            _ => row.IconLabel,
         };
     }
 }
@@ -1637,14 +1673,14 @@ internal static class PluginCatalogService
     private static PluginUpdateRow BuildCatalogOnlyRow(PluginCatalogEntry entry)
     {
         var homepage = entry.homepageUrl ?? string.Empty;
-        return new PluginUpdateRow(LocalizedText.Resolve(entry.name) ?? entry.id ?? NativeStrings.Get(NativeStringId.Unknown), string.Empty, entry.latestVersion ?? string.Empty, NativeStrings.Get(NativeStringId.PluginStatusNotInstalled), entry.author ?? string.Empty, homepage, PluginUpdateStatus.Other, entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty);
+        return new PluginUpdateRow(LocalizedText.Resolve(entry.name) ?? entry.id ?? NativeStrings.Get(NativeStringId.Unknown), string.Empty, entry.latestVersion ?? string.Empty, NativeStrings.Get(NativeStringId.PluginStatusNotInstalled), entry.author ?? string.Empty, homepage, PluginUpdateStatus.Other, entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty, null, entry.icon ?? string.Empty);
     }
 
     private static PluginUpdateRow BuildRow(InstalledPlugin plugin, PluginCatalogEntry? entry)
     {
         if (entry is null)
         {
-            return new PluginUpdateRow(plugin.DisplayName, plugin.VersionText, string.Empty, NativeStrings.Get(NativeStringId.PluginStatusNotInCatalog), string.Empty, string.Empty, PluginUpdateStatus.NotInCatalog, string.Empty, null, string.Empty);
+            return new PluginUpdateRow(plugin.DisplayName, plugin.VersionText, string.Empty, NativeStrings.Get(NativeStringId.PluginStatusNotInCatalog), string.Empty, string.Empty, PluginUpdateStatus.NotInCatalog, string.Empty, null, string.Empty, plugin.IconPath, string.Empty);
         }
 
         var comparison = PluginVersionComparer.Compare(plugin.VersionText, entry.latestVersion, entry.versionScheme);
@@ -1657,7 +1693,7 @@ internal static class PluginCatalogService
         };
 
         var homepage = entry.homepageUrl ?? string.Empty;
-        return new PluginUpdateRow(LocalizedText.Resolve(entry.name) ?? plugin.DisplayName, plugin.VersionText, entry.latestVersion ?? string.Empty, NativeStrings.Get(statusId), entry.author ?? string.Empty, homepage, ToStatus(comparison), entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty);
+        return new PluginUpdateRow(LocalizedText.Resolve(entry.name) ?? plugin.DisplayName, plugin.VersionText, entry.latestVersion ?? string.Empty, NativeStrings.Get(statusId), entry.author ?? string.Empty, homepage, ToStatus(comparison), entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty, plugin.IconPath, entry.icon ?? string.Empty);
     }
 
     private static PluginUpdateStatus ToStatus(PluginVersionComparison comparison) => comparison == PluginVersionComparison.UpdateAvailable ? PluginUpdateStatus.UpdateAvailable : PluginUpdateStatus.Other;
@@ -1737,7 +1773,7 @@ internal static class InstalledPluginScanner
             var id = relative.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }).FirstOrDefault() ?? Path.GetFileNameWithoutExtension(file);
             var display = BuildDisplayName(id, file, info);
             var version = !string.IsNullOrWhiteSpace(info.FileVersion) ? info.FileVersion! : info.ProductVersion ?? string.Empty;
-            yield return new InstalledPlugin(id, display, version);
+            yield return new InstalledPlugin(id, display, version, file);
         }
     }
 
@@ -1832,13 +1868,6 @@ internal static class PluginConfigurationReader
             }
 
             return false;
-        }
-
-        var defaultRegFilePath = Path.Combine(executableDirectory!, DefaultRegFileName);
-        if (File.Exists(defaultRegFilePath))
-        {
-            regFilePath = defaultRegFilePath;
-            return true;
         }
 
         return false;
@@ -1981,7 +2010,7 @@ internal static class PluginConfigurationReader
             displayName = id;
         }
 
-        return new InstalledPlugin(id, displayName!, version ?? string.Empty);
+        return new InstalledPlugin(id, displayName!, version ?? string.Empty, resolvedDllPath);
     }
 
     private static bool IsFallbackDisplayName(string? displayName, string id)
@@ -2201,6 +2230,7 @@ internal sealed class PluginCatalogEntry
     public string? author { get; set; }
     public object? description { get; set; }
     public string? latestVersion { get; set; }
+    public string? icon { get; set; }
     public string? versionScheme { get; set; }
     public string? homepageUrl { get; set; }
     public string? downloadPageUrl { get; set; }
@@ -2316,16 +2346,18 @@ internal enum PluginUpdateStatus { Other, UpdateAvailable, NotInCatalog, Catalog
 
 internal sealed class InstalledPlugin
 {
-    public InstalledPlugin(string id, string displayName, string versionText)
+    public InstalledPlugin(string id, string displayName, string versionText, string? iconPath = null)
     {
         Id = id;
         DisplayName = displayName;
         VersionText = InstalledPluginVersionFormatter.WithCurrentPlatform(versionText);
+        IconPath = iconPath ?? string.Empty;
     }
 
     public string Id { get; }
     public string DisplayName { get; }
     public string VersionText { get; }
+    public string IconPath { get; }
 }
 
 internal static class InstalledPluginVersionFormatter
@@ -2355,7 +2387,7 @@ internal static class InstalledPluginVersionFormatter
 
 internal sealed class PluginUpdateRow
 {
-    public PluginUpdateRow(string name, string installedVersion, string latestVersion, string statusText, string author, string homepage, PluginUpdateStatus status, string source, string? webUrl, string description)
+    public PluginUpdateRow(string name, string installedVersion, string latestVersion, string statusText, string author, string homepage, PluginUpdateStatus status, string source, string? webUrl, string description, string? iconPath, string? iconLabel)
     {
         Name = name;
         InstalledVersion = installedVersion;
@@ -2367,6 +2399,8 @@ internal sealed class PluginUpdateRow
         Source = source;
         WebUrl = webUrl;
         Description = description;
+        IconPath = iconPath ?? string.Empty;
+        IconLabel = iconLabel ?? string.Empty;
     }
 
     public string Name { get; }
@@ -2379,8 +2413,10 @@ internal sealed class PluginUpdateRow
     public string Source { get; }
     public string? WebUrl { get; }
     public string Description { get; }
+    public string IconPath { get; }
+    public string IconLabel { get; }
 
-    public static PluginUpdateRow SourceError(string source, string error) => new PluginUpdateRow(source, string.Empty, string.Empty, $"{NativeStrings.Get(NativeStringId.PluginStatusCatalogError)}: {error}", string.Empty, string.Empty, PluginUpdateStatus.CatalogError, source, null, string.Empty);
+    public static PluginUpdateRow SourceError(string source, string error) => new PluginUpdateRow(source, string.Empty, string.Empty, $"{NativeStrings.Get(NativeStringId.PluginStatusCatalogError)}: {error}", string.Empty, string.Empty, PluginUpdateStatus.CatalogError, source, null, string.Empty, null, string.Empty);
 }
 
 internal static class VersionComparer

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -1741,10 +1741,16 @@ internal static class InstalledPluginScanner
         }
     }
 
-    private static string BuildDisplayName(string id, string file, FileVersionInfo info)
+    public static string BuildDisplayName(string id, string file, FileVersionInfo info)
     {
+        if (PluginConfigurationReader.TryGetKnownDisplayName(id, out var knownDisplayName))
+        {
+            return knownDisplayName;
+        }
+
         if (!string.IsNullOrWhiteSpace(info.FileDescription) &&
-            !info.FileDescription!.Equals("Open Salamander", StringComparison.OrdinalIgnoreCase))
+            !info.FileDescription!.Equals("Open Salamander", StringComparison.OrdinalIgnoreCase) &&
+            !info.FileDescription!.StartsWith("Sample plugin", StringComparison.OrdinalIgnoreCase))
         {
             return TrimOpenSalamanderSuffix(info.FileDescription!);
         }
@@ -1771,7 +1777,7 @@ internal static class InstalledPluginScanner
 
 internal static class PluginConfigurationReader
 {
-    private const string CurrentConfigurationRoot = @"Software\Open Salamander Samandarin\5.0-samandarin-0.11";
+    private static string CurrentConfigurationRoot => $@"Software\Open Salamander Samandarin\5.0-samandarin-{SamandarinVersion.PluginVersion}";
     private const string PluginsKeyName = "Plugins";
     private const string PluginNameValue = "Name";
     private const string PluginDllValue = "DLL";
@@ -1783,7 +1789,7 @@ internal static class PluginConfigurationReader
     private const string ConfigStorageFileName = "configstorage.ini";
     private const string DefaultRegFileName = "config.reg";
 
-    private static readonly Regex RegFilePluginSectionRegex = new(
+    private static Regex CreateRegFilePluginSectionRegex() => new(
         @"^HKEY_CURRENT_USER\\" + Regex.Escape(CurrentConfigurationRoot).Replace(@"\\", @"\\") + @"\\" + PluginsKeyName + @"\\([^\\]+)$",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
@@ -1878,6 +1884,7 @@ internal static class PluginConfigurationReader
             return true;
         }
 
+        var pluginSectionRegex = CreateRegFilePluginSectionRegex();
         string? currentPluginKey = null;
         foreach (var rawLine in File.ReadLines(regFilePath, DetectEncoding(regFilePath)))
         {
@@ -1890,7 +1897,7 @@ internal static class PluginConfigurationReader
             if (line.StartsWith("[", StringComparison.Ordinal) && line.EndsWith("]", StringComparison.Ordinal))
             {
                 var section = line.Substring(1, line.Length - 2);
-                var match = RegFilePluginSectionRegex.Match(section);
+                var match = pluginSectionRegex.Match(section);
                 currentPluginKey = match.Success ? match.Groups[1].Value : null;
                 if (currentPluginKey is not null && !configuredPluginsByKey.ContainsKey(currentPluginKey))
                 {
@@ -1932,6 +1939,43 @@ internal static class PluginConfigurationReader
     private static InstalledPlugin BuildInstalledPlugin(string dllName, string? displayName, string? version)
     {
         var id = BuildIdFromRegisteredDll(dllName);
+        var resolvedDllPath = ResolveRegisteredDllPath(dllName);
+        FileVersionInfo? fileInfo = null;
+        if (!string.IsNullOrWhiteSpace(resolvedDllPath) && File.Exists(resolvedDllPath))
+        {
+            try
+            {
+                fileInfo = FileVersionInfo.GetVersionInfo(resolvedDllPath!);
+            }
+            catch
+            {
+                fileInfo = null;
+            }
+        }
+
+        if (KnownPluginMetadata.TryGetValue(id, out var known))
+        {
+            if (string.IsNullOrWhiteSpace(displayName) || IsFallbackDisplayName(displayName, id))
+            {
+                displayName = known.DisplayName;
+            }
+
+            if (string.IsNullOrWhiteSpace(version) && !string.IsNullOrWhiteSpace(known.Version))
+            {
+                version = known.Version;
+            }
+        }
+
+        if ((string.IsNullOrWhiteSpace(displayName) || IsFallbackDisplayName(displayName, id)) && fileInfo is not null)
+        {
+            displayName = InstalledPluginScanner.BuildDisplayName(id, resolvedDllPath!, fileInfo);
+        }
+
+        if (string.IsNullOrWhiteSpace(version) && fileInfo is not null)
+        {
+            version = !string.IsNullOrWhiteSpace(fileInfo.FileVersion) ? fileInfo.FileVersion : fileInfo.ProductVersion;
+        }
+
         if (string.IsNullOrWhiteSpace(displayName))
         {
             displayName = id;
@@ -1939,6 +1983,57 @@ internal static class PluginConfigurationReader
 
         return new InstalledPlugin(id, displayName!, version ?? string.Empty);
     }
+
+    private static bool IsFallbackDisplayName(string? displayName, string id)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            return true;
+        }
+
+        var text = displayName!.Trim();
+        return string.Equals(text, id, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(text, Path.GetFileNameWithoutExtension(id), StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(text, "Sample", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? ResolveRegisteredDllPath(string dllName)
+    {
+        var normalized = dllName.Trim();
+        if (Path.IsPathRooted(normalized))
+        {
+            return normalized;
+        }
+
+        var executableDirectory = GetExecutableDirectory();
+        if (string.IsNullOrWhiteSpace(executableDirectory))
+        {
+            return null;
+        }
+
+        var pluginsRoot = Path.Combine(executableDirectory!, "plugins");
+        return Path.GetFullPath(Path.Combine(pluginsRoot, normalized));
+    }
+
+    public static bool TryGetKnownDisplayName(string id, out string displayName)
+    {
+        if (KnownPluginMetadata.TryGetValue(id, out var known))
+        {
+            displayName = known.DisplayName;
+            return true;
+        }
+
+        displayName = string.Empty;
+        return false;
+    }
+
+    private static readonly Dictionary<string, KnownPluginInfo> KnownPluginMetadata = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["demoplug"] = new("DemoPlug", null),
+        ["salamatrix"] = new("Salamatrix Framework", "0.1"),
+    };
+
+    private readonly record struct KnownPluginInfo(string DisplayName, string? Version);
 
     private static string? ReadString(RegistryKey key, string name) => key.GetValue(name) as string;
 
@@ -2297,6 +2392,11 @@ internal static class VersionComparer
             return 1;
         }
 
+        if (TryCompareDecimalVersion(left!, right!, out var decimalComparison))
+        {
+            return decimalComparison;
+        }
+
         var leftTokens = Tokenize(left!);
         var rightTokens = Tokenize(right!);
         int count = Math.Max(leftTokens.Length, rightTokens.Length);
@@ -2313,6 +2413,35 @@ internal static class VersionComparer
 
         return 0;
     }
+
+    private static bool TryCompareDecimalVersion(string left, string right, out int comparison)
+    {
+        comparison = 0;
+        var leftMatch = DecimalVersionRegex.Match(left.Trim());
+        var rightMatch = DecimalVersionRegex.Match(right.Trim());
+        if (!leftMatch.Success || !rightMatch.Success)
+        {
+            return false;
+        }
+
+        var leftMajor = long.Parse(leftMatch.Groups[1].Value, CultureInfo.InvariantCulture);
+        var rightMajor = long.Parse(rightMatch.Groups[1].Value, CultureInfo.InvariantCulture);
+        comparison = leftMajor.CompareTo(rightMajor);
+        if (comparison != 0)
+        {
+            return true;
+        }
+
+        var leftMinor = leftMatch.Groups[2].Value;
+        var rightMinor = rightMatch.Groups[2].Value;
+        var width = Math.Max(leftMinor.Length, rightMinor.Length);
+        var leftFraction = long.Parse(leftMinor.PadRight(width, '0'), CultureInfo.InvariantCulture);
+        var rightFraction = long.Parse(rightMinor.PadRight(width, '0'), CultureInfo.InvariantCulture);
+        comparison = leftFraction.CompareTo(rightFraction);
+        return true;
+    }
+
+    private static readonly Regex DecimalVersionRegex = new(@"^(\d+)\.(\d+)$", RegexOptions.CultureInvariant);
 
     private static VersionToken[] Tokenize(string value)
     {

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -2033,7 +2033,17 @@ internal static class PluginConfigurationReader
         ["salamatrix"] = new("Salamatrix Framework", "0.1"),
     };
 
-    private readonly record struct KnownPluginInfo(string DisplayName, string? Version);
+    private readonly struct KnownPluginInfo
+    {
+        public KnownPluginInfo(string displayName, string? version)
+        {
+            DisplayName = displayName;
+            Version = version;
+        }
+
+        public string DisplayName { get; }
+        public string? Version { get; }
+    }
 
     private static string? ReadString(RegistryKey key, string name) => key.GetValue(name) as string;
 

--- a/src/plugins/samandarin/versinfo.rh2
+++ b/src/plugins/samandarin/versinfo.rh2
@@ -18,7 +18,7 @@
 // look at shared\versinfo.rc
 
 #define VERSINFO_MAJOR       0
-#define VERSINFO_MINORA      5
+#define VERSINFO_MINORA      6
 #define VERSINFO_MINORB      0
 
 #include "spl_vers.h" // vytahneme cisla verzi + buildu

--- a/src/plugins/shared/spl_base.h
+++ b/src/plugins/shared/spl_base.h
@@ -433,7 +433,8 @@ public:
 #define FUNCTION_VIEWER 0x0040                // metody pro "file viewer"
 #define FUNCTION_FILESYSTEM 0x0080            // metody pro "file system"
 #define FUNCTION_DYNAMICMENUEXT 0x0100        // metody pro "dynamic menu extension"
-#define FUNCTION_AUTOMATIONRUNTIME 0x0200     // metody/sluzby pro "automation runtime"
+#define FUNCTION_AUTOMATIONFRAMEWORK 0x0200   // metody/sluzby pro "automation framework"
+#define FUNCTION_AUTOMATIONRUNTIME FUNCTION_AUTOMATIONFRAMEWORK // compatibility alias
 
 // kody ruznych udalosti (a vyznam parametru 'param'), prijima metoda CPluginInterfaceAbstract::Event():
 // doslo ke zmene barev (diky zmene systemovych barev / WM_SYSCOLORCHANGE nebo diky zmene v konfiguraci); plugin si

--- a/src/plugins1.cpp
+++ b/src/plugins1.cpp
@@ -1594,7 +1594,7 @@ BOOL CSalamanderPluginEntry::SetBasicPluginData(const char* pluginName, DWORD fu
     BOOL supportViewer = (functions & FUNCTION_VIEWER) != 0;
     BOOL supportFS = (functions & FUNCTION_FILESYSTEM) != 0;
     BOOL supportDynMenuExt = (functions & FUNCTION_DYNAMICMENUEXT) != 0;
-    BOOL supportAutomationRuntime = (functions & FUNCTION_AUTOMATIONRUNTIME) != 0;
+    BOOL supportAutomationFramework = (functions & FUNCTION_AUTOMATIONFRAMEWORK) != 0;
 
     if (pluginName == NULL || version == NULL || copyright == NULL || description == NULL ||
         supportLoadSave && (regKeyName == NULL || regKeyName[0] == 0) ||
@@ -1632,7 +1632,7 @@ BOOL CSalamanderPluginEntry::SetBasicPluginData(const char* pluginName, DWORD fu
     Plugin->SupportViewer = supportViewer;
     Plugin->SupportFS = supportFS;
     Plugin->SupportDynMenuExt = supportDynMenuExt;
-    Plugin->SupportAutomationRuntime = supportAutomationRuntime;
+    Plugin->SupportAutomationFramework = supportAutomationFramework;
 
     char* s = DupStr(pluginName);
     if (s != NULL)
@@ -1989,7 +1989,7 @@ CPluginMenuItem::CPluginMenuItem(int iconIndex, const char* name, DWORD hotKey, 
 CPluginData::CPluginData(const char* name, const char* dllName, BOOL supportPanelView,
                          BOOL supportPanelEdit, BOOL supportCustomPack, BOOL supportCustomUnpack,
                          BOOL supportConfiguration, BOOL supportLoadSave, BOOL supportViewer,
-                         BOOL supportFS, BOOL supportDynMenuExt, BOOL supportAutomationRuntime, const char* version, const char* copyright,
+                         BOOL supportFS, BOOL supportDynMenuExt, BOOL supportAutomationFramework, const char* version, const char* copyright,
                          const char* description, const char* regKeyName, const char* extensions,
                          TIndirectArray<char>* fsNames, BOOL loadOnStart, char* lastSLGName,
                          const char* pluginHomePageURL)
@@ -1999,7 +1999,7 @@ CPluginData::CPluginData(const char* name, const char* dllName, BOOL supportPane
     CALL_STACK_MESSAGE21("CPluginData::CPluginData(%s, %s, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %s, %s, %s, %s, %s, , %d, %s, %s)",
                          name, dllName, supportPanelView, supportPanelEdit, supportCustomPack,
                          supportCustomUnpack, supportConfiguration, supportLoadSave, supportViewer,
-                         supportFS, supportDynMenuExt, supportAutomationRuntime, version, copyright, description, regKeyName,
+                         supportFS, supportDynMenuExt, supportAutomationFramework, version, copyright, description, regKeyName,
                          extensions, loadOnStart, lastSLGName, pluginHomePageURL);
     ArcCacheHaveInfo = FALSE;
     ArcCacheTmpPath = NULL;
@@ -2092,7 +2092,7 @@ CPluginData::CPluginData(const char* name, const char* dllName, BOOL supportPane
     SupportLoadSave = supportLoadSave;
     SupportViewer = supportViewer;
     SupportDynMenuExt = supportDynMenuExt;
-    SupportAutomationRuntime = supportAutomationRuntime;
+    SupportAutomationFramework = supportAutomationFramework;
     LoadOnStart = loadOnStart;
     ChDrvMenuFSItemName = NULL;
     ChDrvMenuFSItemVisible = TRUE;

--- a/src/plugins2.cpp
+++ b/src/plugins2.cpp
@@ -1286,7 +1286,7 @@ void CPlugins::Load(HWND parent, HKEY regKey)
         char buf[30];
         int i = 1;
         strcpy(buf, "1");
-        BOOL view, edit, pack, unpack, config, loadsave, viewer, fs, loadOnStart, dynMenuExt, automationRuntime;
+        BOOL view, edit, pack, unpack, config, loadsave, viewer, fs, loadOnStart, dynMenuExt, automationFramework;
         char name[MAX_PATH];
         char dllName[MAX_PATH];
         char version[MAX_PATH];
@@ -1308,7 +1308,7 @@ void CPlugins::Load(HWND parent, HKEY regKey)
             BOOL err = TRUE;
             BOOL ok = FALSE;
             loadOnStart = FALSE;
-            automationRuntime = FALSE;
+            automationFramework = FALSE;
             thumbnailMasks[0] = 0;
             lastSLGName[0] = 0;
             pluginHomePageURL[0] = 0;
@@ -1335,7 +1335,7 @@ void CPlugins::Load(HWND parent, HKEY regKey)
                      GetValue(itemKey, SALAMANDER_PLUGINS_VIEWER, REG_DWORD, &viewer, sizeof(DWORD)) &&
                      GetValue(itemKey, SALAMANDER_PLUGINS_FS, REG_DWORD, &fs, sizeof(DWORD));
                 dynMenuExt = FALSE;
-                automationRuntime = FALSE;
+                automationFramework = FALSE;
             }
             else // new version (fstores functions in a single DWORD using bit fields)
             {
@@ -1359,11 +1359,11 @@ void CPlugins::Load(HWND parent, HKEY regKey)
                 viewer = (functions & FUNCTION_VIEWER) != 0;
                 fs = (functions & FUNCTION_FILESYSTEM) != 0;
                 dynMenuExt = (functions & FUNCTION_DYNAMICMENUEXT) != 0;
-                automationRuntime = (functions & FUNCTION_AUTOMATIONRUNTIME) != 0;
+                automationFramework = (functions & FUNCTION_AUTOMATIONFRAMEWORK) != 0;
 
-                // Upgrade configurations saved before FUNCTION_AUTOMATIONRUNTIME existed.
-                if (!automationRuntime && StrICmp(regKeyName, "SALAMATRIX") == 0)
-                    automationRuntime = TRUE;
+                // Upgrade configurations saved before FUNCTION_AUTOMATIONFRAMEWORK existed.
+                if (!automationFramework && StrICmp(regKeyName, "SALAMATRIX") == 0)
+                    automationFramework = TRUE;
 
                 DWORD loadOnStartDWORD;
                 if (GetValue(itemKey, SALAMANDER_PLUGINS_LOADONSTART, REG_DWORD, &loadOnStartDWORD, sizeof(DWORD)))
@@ -1402,7 +1402,7 @@ void CPlugins::Load(HWND parent, HKEY regKey)
                 else
                 {
                     if (AddPlugin(name, normalizedDLLName, view, edit, pack, unpack, config, loadsave, viewer, fs,
-                                  dynMenuExt, automationRuntime, version, copyright, description, regKeyName, extensions, &fsNames,
+                                  dynMenuExt, automationFramework, version, copyright, description, regKeyName, extensions, &fsNames,
                                   loadOnStart, lastSLGName, pluginHomePageURL[0] != 0 ? pluginHomePageURL : NULL))
                     {
                         err = FALSE;
@@ -1640,9 +1640,9 @@ void CPlugins::Save(HWND parent, HKEY regKey, HKEY regKeyConfig, HKEY regKeyOrde
                 functions |= p->SupportViewer ? FUNCTION_VIEWER : 0;
                 functions |= p->SupportFS ? FUNCTION_FILESYSTEM : 0;
                 functions |= p->SupportDynMenuExt ? FUNCTION_DYNAMICMENUEXT : 0;
-                BOOL supportAutomationRuntime = p->SupportAutomationRuntime ||
+                BOOL supportAutomationFramework = p->SupportAutomationFramework ||
                                                 (p->RegKeyName != NULL && StrICmp(p->RegKeyName, "SALAMATRIX") == 0);
-                functions |= supportAutomationRuntime ? FUNCTION_AUTOMATIONRUNTIME : 0;
+                functions |= supportAutomationFramework ? FUNCTION_AUTOMATIONFRAMEWORK : 0;
 
                 SetValue(itemKey, SALAMANDER_PLUGINS_FUNCTIONS, REG_DWORD, &functions, sizeof(DWORD));
 
@@ -2373,7 +2373,7 @@ void CPlugins::GetUniqueFSName(char* uniqueFSName, const char* fsName, TIndirect
 BOOL CPlugins::AddPlugin(const char* name, const char* dllName, BOOL supportPanelView,
                          BOOL supportPanelEdit, BOOL supportCustomPack, BOOL supportCustomUnpack,
                          BOOL supportConfiguration, BOOL supportLoadSave, BOOL supportViewer,
-                         BOOL supportFS, BOOL supportDynMenuExt, BOOL supportAutomationRuntime, const char* version,
+                         BOOL supportFS, BOOL supportDynMenuExt, BOOL supportAutomationFramework, const char* version,
                          const char* copyright, const char* description, const char* regKeyName,
                          const char* extensions, TIndirectArray<char>* fsNames, BOOL loadOnStart,
                          char* lastSLGName, const char* pluginHomePageURL)
@@ -2381,7 +2381,7 @@ BOOL CPlugins::AddPlugin(const char* name, const char* dllName, BOOL supportPane
     CALL_STACK_MESSAGE21("CPlugins::AddPlugin(%s, %s, %d, %d, %d, %d, %d, %d, %d, %d, %d, %d, %s, %s, %s, %s, %s, , %d, %s, %s)",
                          name, dllName, supportPanelView, supportPanelEdit, supportCustomPack,
                          supportCustomUnpack, supportConfiguration, supportLoadSave, supportViewer,
-                         supportFS, supportDynMenuExt, supportAutomationRuntime, version, copyright, description, regKeyName, extensions,
+                         supportFS, supportDynMenuExt, supportAutomationFramework, version, copyright, description, regKeyName, extensions,
                          loadOnStart, lastSLGName, pluginHomePageURL);
     BOOL ret = FALSE;
 
@@ -2432,7 +2432,7 @@ BOOL CPlugins::AddPlugin(const char* name, const char* dllName, BOOL supportPane
         CPluginData* item = new CPluginData(name, dllName, supportPanelView,
                                             supportPanelEdit, supportCustomPack, supportCustomUnpack,
                                             supportConfiguration, supportLoadSave, supportViewer, supportFS,
-                                            supportDynMenuExt, supportAutomationRuntime, version, copyright, description,
+                                            supportDynMenuExt, supportAutomationFramework, version, copyright, description,
                                             uniqueKeyName, extensions, uniqueFSNames, loadOnStart,
                                             lastSLGName, pluginHomePageURL);
         if (item != NULL && item->IsGood())

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -1560,7 +1560,7 @@
 #define IDS_PLUGINFUNCFILESYSTEM     12096
 // plugins manager/functions: thumbnail loader
 #define IDS_PLUGINFUNCTHUMBLOADER    12109
-// plugins manager/functions: automation runtime
+// plugins manager/functions: automation framework
 #define IDS_PLUGINFUNCAUTORUNTIME     12117
 // plugins manager/column loaded: yes/no
 #define IDS_PLUGINS_LOADED_YES       12097


### PR DESCRIPTION
### Motivation
- Clarify product terminology: treat Salamatrix as an Automation Framework provider (not a language runtime) while preserving compatibility for older configs that reference the prior runtime naming. 
- Provide MVP support for scripted-extension command metadata (menu placement, context-menu visibility and execution requirements) so scripts can declare how and when they appear in plugin/context menus. 
- Extend the simple `extension.json` manifest reader to carry placement/context/requirements metadata for future command registry work and runtime adapters. 
- Wire script metadata into the Automation menu construction and item-state checks so menu visibility and enabled-state follow Salamander context masks.

### Description
- Introduced new flag `FUNCTION_AUTOMATIONFRAMEWORK` and left `FUNCTION_AUTOMATIONRUNTIME` as a compatibility alias in `src/plugins/shared/spl_base.h`. 
- Renamed user-facing strings and Salamatrix plugin presentation to use "Automation Framework"/`Salamatrix Framework` and preserved `RegKeyName == "SALAMATRIX"` compatibility in plugin manager code and registration messages across `src/plugins/*` and resources. 
- Extended `CScriptInfo` (in `src/plugins/automation/scriptlist.h`/`.cpp`) with fields and accessors for placement and context: `m_bShowInPluginMenu`, `m_bShowInContextMenu`, `m_dwMenuEventOrMask`, `m_dwMenuEventAndMask`, plus methods `ApplySalamatrixPlacement`, `ApplySalamatrixRequires`, `ApplySalamatrixContextMenu`, and accessors `ShowInPluginMenu`, `ShowInContextMenu`, `GetMenuEventOrMask`, `GetMenuEventAndMask`. 
- Added inline metadata parsing support in `CScriptInfo::ApplySalamatrixMetadataLine` for `// Salamatrix.CommandMenu: ...`, `// Salamatrix.CommandContextMenu: ...`, and `// Salamatrix.CommandRequires: ...`. 
- Extended the MVP manifest parser in `CScriptInfo::LoadSalamatrixManifestMetadata` and `ApplySalamatrixManifestValue` to accept `menu`/`placement`, `contextMenu` (via a simple `FindJsonBoolValue`) and `requires`, mapping `requires` values (`any`, `disk`, `focused`, `file`, `selection`) to Salamander `MENU_EVENT_*` OR/AND masks. 
- Wired menu construction and state checks in `CAutomationMenuExtInterface` (`src/plugins/automation/automationplug.cpp`) to honor `CScriptInfo` metadata by using `GetMenuEventOrMask()`/`GetMenuEventAndMask()` and filtering items based on `ShowInPluginMenu()`/`ShowInContextMenu()` in `AddScriptContainerToMenu`/`AddScriptContainerToPopup` and `GetMenuItemState`. 
- Updated sample scripted-extension (`src/plugins/automation/sample-scripts/Salamatrix Progress Demo/extension.json` and `main.js`) to include `menu`, `contextMenu`, and `requires`, and changed script comments to reference the Framework wording. 
- Updated documentation in `doc/salamatrix-platform.md` to: call the provider an Automation Framework, describe inline metadata examples, extend the `extension.json` sample, and document MVP `requires` → event-mask mapping. 

### Testing
- Ran `git diff --check` with no reported whitespace/file errors. 
- Verified touched files do not contain NUL bytes using a Python check, which passed. 
- Ran Python-based sanity checks that assert presence of `ApplySalamatrixPlacement`, `ApplySalamatrixRequires`, `contextMenu` parsing, `ShowInContextMenu`, `GetMenuEventOrMask`, `GetMenuEventAndMask` in headers/sources, and that `automationplug.cpp` uses the masks; all checks passed. 
- Performed a terminology/resource scan to ensure `Automation Framework` appears in resources and user-facing strings and that `Automation Runtime`/`Salamatrix Runtime` user-facing text was removed except the compatibility alias; check passed. 
- Validated the modified sample manifest with `python3 -m json.tool` which succeeded. 
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d6f903ab08329bc563d9ba6c01e71)