### PR TITLE
Sync tree-view state from window-level configuration to fix per-tab staleness

### DIFF
--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "precomp.h"
+#include <tchar.h>
 #include "darkmode_backend_darkmodelib.h"
 #include "darkmode.h"
 #include "salamand.rh"

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2593,12 +2593,18 @@ bool DarkModeHandleSettingChange(UINT message, LPARAM lParam)
     bool shouldRefresh = (message == WM_THEMECHANGED);
     if (lParam != 0)
     {
-        if (CompareStringOrdinal(reinterpret_cast<LPCWSTR>(lParam), -1, L"ImmersiveColorSet", -1, TRUE) == CSTR_EQUAL)
+        // WM_SETTINGCHANGE delivers lParam in the character format of the
+        // receiving window. Salamander's main window is an ANSI window in the
+        // regular build, so treating the pointer unconditionally as LPCWSTR can
+        // read past the short ANSI buffer when Windows broadcasts accent-color
+        // changes such as "ImmersiveColorSet".
+        LPCTSTR settingName = reinterpret_cast<LPCTSTR>(lParam);
+        if (_tcsicmp(settingName, _T("ImmersiveColorSet")) == 0)
         {
             isColor = true;
             shouldRefresh = true;
         }
-        else if (CompareStringOrdinal(reinterpret_cast<LPCWSTR>(lParam), -1, L"WindowsThemeElement", -1, TRUE) == CSTR_EQUAL)
+        else if (_tcsicmp(settingName, _T("WindowsThemeElement")) == 0)
         {
             isColor = true;
             shouldRefresh = true;

--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -3466,7 +3466,7 @@ void CFilesWindow::SetupListBoxScrollBars()
 void CFilesWindow::RefreshForConfig()
 {
     CALL_STACK_MESSAGE1("CFilesWindow::RefreshForConfig()");
-    UpdateTreeView(MainWindow->LeftPanel == this);
+    UpdateTreeView(IsActiveTreeViewHost());
     if (Is(ptZIPArchive))
     { // we ensure a refresh of the archive by corrupting the archive's size
         SetZIPArchiveSize(CQuadWord(-1, -1));

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -2382,6 +2382,8 @@ void CFilesWindow::UpdateTreeView(BOOL active)
     {
         if (MainWindow->DetachedPanels && MainWindow->RightPanel == this)
             MainWindow->LayoutDetachedPanels();
+        else if (MainWindow->DetachedPanels && MainWindow->LeftPanel == this)
+            MainWindow->LayoutMainWindow();
         else
             MainWindow->LayoutWindows();
     }

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -587,6 +587,27 @@ CFilesWindow* CFilesWindow::GetTreeViewSourcePanel()
     return this;
 }
 
+BOOL CFilesWindow::IsActiveTreeViewHost()
+{
+    return MainWindow != NULL &&
+           (MainWindow->LeftPanel == this ||
+            (MainWindow->DetachedPanels && MainWindow->RightPanel == this));
+}
+
+void CFilesWindow::RefreshHostedTreeViews()
+{
+    if (MainWindow == NULL)
+        return;
+
+    if (MainWindow->LeftPanel != NULL && MainWindow->LeftPanel->GetTreeViewSourcePanel() == this)
+        MainWindow->LeftPanel->RefreshTreeView();
+    if (MainWindow->DetachedPanels && MainWindow->RightPanel != NULL &&
+        MainWindow->RightPanel->GetTreeViewSourcePanel() == this)
+    {
+        MainWindow->RightPanel->RefreshTreeView();
+    }
+}
+
 void CFilesWindow::SyncTreeViewStateFromConfiguration()
 {
     // The tree-view panel is shared by the top-level window, not by the tab.
@@ -2358,7 +2379,12 @@ void CFilesWindow::UpdateTreeView(BOOL active)
         ShowWindow(HTreeSplit, TreeViewActive && (!TreeViewAutoHide || TreeViewAutoHideExpanded) ? SW_SHOW : SW_HIDE);
 
     if (MainWindow != NULL)
-        MainWindow->LayoutWindows();
+    {
+        if (MainWindow->DetachedPanels && MainWindow->RightPanel == this)
+            MainWindow->LayoutDetachedPanels();
+        else
+            MainWindow->LayoutWindows();
+    }
 }
 
 void CFilesWindow::CloseCurrentPath(HWND parent, BOOL cancel, BOOL detachFS, BOOL newPathIsTheSame,
@@ -2829,8 +2855,7 @@ BOOL CFilesWindow::ChangePathToDisk(HWND parent, const char* path, int suggested
             cannotList = !CommonRefresh(parent, suggestedTopIndex, suggestedFocusName, refreshListBox, TRUE, isRefresh);
             // Refresh tree view AFTER file list loads so the file list appears immediately
             // and the tree view update (which may do disk I/O) doesn't block the UI.
-            if (MainWindow != NULL && MainWindow->LeftPanel != NULL)
-                MainWindow->LeftPanel->RefreshTreeView();
+            RefreshHostedTreeViews();
             if (isRefresh && !cannotList && GetMonitorChanges() && !AutomaticRefresh)
             {                                                                                                                // auto-refresh failure; we verify whether the directory displayed in the panel is being deleted (happened to me while deleting through the network from another machine) ... If ignored, the panel will never refresh (because auto-refresh is broken)
                 Sleep(400);                                                                                                  // we take a break, so the deletion can proceed (so the directory becomes deleted enough to become unlistable)
@@ -3871,8 +3896,7 @@ BOOL CFilesWindow::ChangePathToPluginFS(const char* fsName, const char* fsUserPa
                             UpdateDriveIcon(FALSE); // get the icon for the current path from the plugin
                             CommonRefresh(HWindow, suggestedTopIndex, suggestedFocusName, refreshListBox, TRUE, isRefresh);
                             // Refresh tree view after file list loads
-                            if (MainWindow != NULL && MainWindow->LeftPanel != NULL)
-                                MainWindow->LeftPanel->RefreshTreeView();
+                            RefreshHostedTreeViews();
 
                             // notify the FS that it is finally opened
                             GetPluginFS()->Event(FSE_OPENED, GetPanelCode());

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -587,6 +587,23 @@ CFilesWindow* CFilesWindow::GetTreeViewSourcePanel()
     return this;
 }
 
+void CFilesWindow::SyncTreeViewStateFromConfiguration()
+{
+    // The tree-view panel is shared by the top-level window, not by the tab.
+    // Keep every host tab in sync with the window-level configuration before
+    // it creates or lays out its tree-view chrome.
+    if (MainWindow != NULL && MainWindow->DetachedPanels && MainWindow->RightPanel == this)
+    {
+        TreeViewWidth = Configuration.DetachedTreeViewWidth;
+        TreeViewAutoHide = Configuration.DetachedTreeViewAutoHide;
+    }
+    else
+    {
+        TreeViewWidth = Configuration.TreeViewWidth;
+        TreeViewAutoHide = Configuration.TreeViewAutoHide;
+    }
+}
+
 int CFilesWindow::GetTreeViewWidth(int clientWidth)
 {
     return ClampTreeViewWidth(clientWidth, TreeViewWidth);
@@ -2137,6 +2154,7 @@ BOOL CFilesWindow::PrepareCloseCurrentPath(HWND parent, BOOL canForce, BOOL canD
 void CFilesWindow::CreateTreeView()
 {
     CALL_STACK_MESSAGE1("CFilesWindow::CreateTreeView()");
+    SyncTreeViewStateFromConfiguration();
     if (!IsTreeViewHost() || HWindow == NULL)
     {
         if (HWindow == NULL)
@@ -2320,6 +2338,7 @@ void CFilesWindow::UpdateTreeView(BOOL active)
     }
     else
     {
+        SyncTreeViewStateFromConfiguration();
         TreeViewActive = active && Configuration.TreeViewVisible;
         if (Configuration.TreeViewVisible)
             CreateTreeView();

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -1096,7 +1096,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         SelectViewTemplate(index, FALSE, FALSE);
         ShowWindow(ListBox->HWindow, SW_SHOW);
-        UpdateTreeView(MainWindow->LeftPanel == this);
+        UpdateTreeView(IsActiveTreeViewHost());
 
         // srovname nastaveni promenne AutomaticRefresh a directory-liny
         SetAutomaticRefresh(AutomaticRefresh, TRUE);

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1346,7 +1346,9 @@ public:
     void ToggleDirectoryLine();
     void ToggleHeaderLine();
     BOOL IsTreeViewHost();
+    BOOL IsActiveTreeViewHost();
     CFilesWindow* GetTreeViewSourcePanel();
+    void RefreshHostedTreeViews();
     void SyncTreeViewStateFromConfiguration();
     int GetTreeViewWidth(int clientWidth);
     int GetTreeViewReservedWidth(int clientWidth);

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1347,6 +1347,7 @@ public:
     void ToggleHeaderLine();
     BOOL IsTreeViewHost();
     CFilesWindow* GetTreeViewSourcePanel();
+    void SyncTreeViewStateFromConfiguration();
     int GetTreeViewWidth(int clientWidth);
     int GetTreeViewReservedWidth(int clientWidth);
     int GetTreeViewHeaderHeight();

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -714,6 +714,7 @@ public:
     // returns TRUE if the key was handled
     BOOL HandleCtrlLetter(char c); // Ctrl+letter hotkeys
 
+    void LayoutMainWindow();
     void LayoutWindows();
     BOOL SetPanelsDetached(BOOL detached);
     BOOL TogglePanelsDetached();

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1830,12 +1830,17 @@ CMainWindow::ReleaseMenuNew()
 }
 */
 
-void CMainWindow::LayoutWindows()
+void CMainWindow::LayoutMainWindow()
 {
     RECT r;
     GetClientRect(HWindow, &r);
     SendMessage(HWindow, WM_SIZE, SIZE_RESTORED,
                 MAKELONG(r.right - r.left, r.bottom - r.top));
+}
+
+void CMainWindow::LayoutWindows()
+{
+    LayoutMainWindow();
     LayoutDetachedPanels();
 }
 
@@ -2921,10 +2926,23 @@ LRESULT CALLBACK CMainWindow::DetachedPanelWindowProc(HWND hWnd, UINT uMsg, WPAR
             return 0;
 
         case WM_COMMAND:
+        {
             if (mainWindow->CreatingDetachedChrome)
                 return 0;
-            mainWindow->SetActivePanel(side == cpsLeft ? mainWindow->LeftPanel : mainWindow->RightPanel);
+            WORD command = LOWORD(wParam);
+            if (side == cpsRight)
+            {
+                if (command == CM_ACTIVEBACK)
+                    command = CM_RBACK;
+                else if (command == CM_ACTIVEFORWARD)
+                    command = CM_RFORWARD;
+            }
+            if (command == LOWORD(wParam))
+                mainWindow->SetActivePanel(side == cpsLeft ? mainWindow->LeftPanel : mainWindow->RightPanel);
+            else
+                wParam = MAKEWPARAM(command, HIWORD(wParam));
             return SendMessage(mainWindow->HWindow, WM_COMMAND, wParam, lParam);
+        }
 
         case WM_NOTIFY:
             if (mainWindow->CreatingDetachedChrome)
@@ -2962,7 +2980,6 @@ LRESULT CALLBACK CMainWindow::DetachedPanelWindowProc(HWND hWnd, UINT uMsg, WPAR
             DWORD cmd = GET_APPCOMMAND_LPARAM(lParam);
             if (cmd == APPCOMMAND_BROWSER_BACKWARD || cmd == APPCOMMAND_BROWSER_FORWARD)
             {
-                mainWindow->SetActivePanel(side == cpsLeft ? mainWindow->LeftPanel : mainWindow->RightPanel);
                 return SendMessage(mainWindow->HWindow, WM_COMMAND,
                                    cmd == APPCOMMAND_BROWSER_BACKWARD ? CM_RBACK : CM_RFORWARD, 0);
             }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -344,6 +344,8 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
         }
         if (DetachedPanels && side == cpsRight)
             LayoutDetachedPanels();
+        else if (DetachedPanels && side == cpsLeft)
+            LayoutMainWindow();
         else
             LayoutWindows();
     }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -319,10 +319,10 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
     {
         if (previousPanel != panel)
         {
-            // Tree-view windows belong to individual left tabs but are children of the main
-            // window. Prepare the incoming tree while it is hidden and keep the outgoing one
-            // alive until the complete new layout is ready; otherwise the main window is
-            // briefly exposed across the reserved tree-view width.
+            // Tree-view windows belong to individual host tabs but are children of their
+            // top-level host window. Prepare the incoming tree while it is hidden and keep
+            // the outgoing one alive until the complete new layout is ready; otherwise the
+            // host window is briefly exposed across the reserved tree-view width.
             if ((side == cpsLeft || (DetachedPanels && side == cpsRight)) && Configuration.TreeViewVisible)
             {
                 panel->TreeViewActive = TRUE;
@@ -342,7 +342,10 @@ void CMainWindow::SwitchPanelTab(CFilesWindow* panel)
             if (newToolBar != NULL && newToolBar != previousToolBar)
                 SendMessage(newToolBar, WM_SETREDRAW, FALSE, 0);
         }
-        LayoutWindows();
+        if (DetachedPanels && side == cpsRight)
+            LayoutDetachedPanels();
+        else
+            LayoutWindows();
     }
 
     UpdatePanelTabVisibility(side);

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -1536,8 +1536,18 @@ void CMainWindow::FocusPanel(CFilesWindow* focus, BOOL testIfMainWndActive)
 
     CFilesWindow* old = GetActivePanel();
     SetActivePanel(focus);
-    LeftPanel->UpdateTreeView(TRUE);
-    RightPanel->UpdateTreeView(DetachedPanels);
+    if (DetachedPanels && focus == RightPanel)
+    {
+        // The detached window owns an independent tree-view host. Updating the
+        // main-window tree while focus only moves inside the detached window
+        // causes a visible blink in the main window.
+        RightPanel->UpdateTreeView(TRUE);
+    }
+    else
+    {
+        LeftPanel->UpdateTreeView(TRUE);
+        RightPanel->UpdateTreeView(DetachedPanels);
+    }
 
     if (LeftPanel != NULL)
         LeftPanel->SetPanelSide(cpsLeft);

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -1543,6 +1543,12 @@ void CMainWindow::FocusPanel(CFilesWindow* focus, BOOL testIfMainWndActive)
         // causes a visible blink in the main window.
         RightPanel->UpdateTreeView(TRUE);
     }
+    else if (DetachedPanels && focus == LeftPanel)
+    {
+        // Symmetrically, main-window focus changes must not relayout the
+        // detached tree-view host.
+        LeftPanel->UpdateTreeView(TRUE);
+    }
     else
     {
         LeftPanel->UpdateTreeView(TRUE);


### PR DESCRIPTION
### Motivation
- The tree-view panel started remembering width/auto-hide per-tab instead of using a single window-level setting, causing incorrect collapsed/pinned behaviour when switching tabs (including detached windows). 
- Restore the previous behaviour where the tree view state is shared by the top-level window and the detached-right window keeps its own configuration.

### Description
- Add `CFilesWindow::SyncTreeViewStateFromConfiguration()` which copies `TreeViewWidth` and `TreeViewAutoHide` from `Configuration` (using `DetachedTreeView*` values when the panel is the right detached window). 
- Call `SyncTreeViewStateFromConfiguration()` at the start of `CreateTreeView()` so a tab does not use stale per-tab values when creating the tree chrome. 
- Call `SyncTreeViewStateFromConfiguration()` in `UpdateTreeView()` before layout so tab switches use the window-level tree state. 
- Add the new method declaration to `src/fileswnd.h`.

### Testing
- Ran `git diff --check` which reported no whitespace or merge errors and succeeded. 
- Ran `git status --short` to confirm the working tree, and committed the change successfully. 
- No additional automated unit/integration tests were present or executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eca58a7788329ab3522f78cf7a5ee)