### PR TITLE
Ensure Inno installer supports silent mode

### DIFF
--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -7,6 +7,12 @@
 ; Build example:
 ;   iscc.exe "doc\runbook-setup\inno_setup_salamander_x64.iss" /DPayloadDir="H:\_projects\salamander\output\salamander\Release_x64"
 ;
+; Silent install example:
+;   5.0-samandarin-0.12_win_x64.exe /VERYSILENT /DIR="C:\Path\To\Install" /NORESTART
+;
+; Custom [Code] message boxes are guarded with WizardSilent/UninstallSilent so
+; unattended installs and uninstalls do not block on application prompts.
+;
 ; If /DPayloadDir is not supplied, OPENSAL_BUILD_DIR is used when present; otherwise
 ; the fallback path below is relative to this .iss file.
 
@@ -1816,9 +1822,12 @@ begin
     DeleteFile(BackupPath);
     RenameFile(ConfigPath, BackupPath);
 
-    Msg := CustomMessage('KeepConfigQuestion');
-    StringChangeEx(Msg, '\n', #13#10, True);
-    MsgBox(Msg, mbInformation, MB_OK);
+    if not WizardSilent then
+    begin
+      Msg := CustomMessage('KeepConfigQuestion');
+      StringChangeEx(Msg, '\n', #13#10, True);
+      MsgBox(Msg, mbInformation, MB_OK);
+    end;
   end;
 end;
 
@@ -1996,7 +2005,8 @@ end;
 function InitializeSetup(): Boolean;
 begin
   Result := True;
-  CheckCodePageCompatibility;
+  if not WizardSilent then
+    CheckCodePageCompatibility;
 end;
 
 procedure InitializeWizard();
@@ -2072,6 +2082,9 @@ begin
   DeleteUserConfiguration := False;
   DeleteUserConfigurationFilePath := '';
   DeleteUserConfigurationFromFile := IsFileConfigurationStorageSelected();
+
+  if UninstallSilent then
+    Exit;
 
   if DeleteUserConfigurationFromFile then
   begin


### PR DESCRIPTION
### Motivation
- Make the Inno Setup script usable in unattended/silent installs (e.g. for Microsoft Store publishing) without custom message boxes blocking the process.
- Ensure uninstall also does not prompt interactively when run in silent mode.

### Description
- Added a `Silent install example` comment showing `...exe /VERYSILENT /DIR="C:\Path\To\Install" /NORESTART` to document the supported CLI usage in `doc/runbook-setup/inno_setup_salamander_x64.iss`.
- Guarded custom `[Code]` message boxes so they only show when not `WizardSilent` (wrapped the `MsgBox` in `ShouldInstallConfigStorage` and skipped the code-page check during silent installs).
- Prevent interactive uninstall prompts by returning early when `UninstallSilent` is set so confirmation `MsgBox` calls are not shown.
- Verified that the post-install run entry already uses `skipifsilent` so the installed application is not launched during silent installs.

### Testing
- Ran `rg -n "MsgBox|WizardSilent|UninstallSilent|skipifsilent|Silent install" doc/runbook-setup/inno_setup_salamander_x64.iss` and confirmed the new guards and documentation lines are present (succeeded).
- Ran `git diff --check` to ensure there are no whitespace/patch issues (succeeded).
- Checked for Inno Setup compiler with `command -v iscc || command -v ISCC.exe` and could not find `iscc` in this environment, so the `.iss` file was not compiled here (manual/CI compile required to validate binary behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f0919af288329add7f6044fe73bdd)