### PR TITLE
Suppress salmon minidump failure dialog

### DIFF
--- a/src/salmon/dialogs.cpp
+++ b/src/salmon/dialogs.cpp
@@ -422,13 +422,10 @@ CMainDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 Minidumping = FALSE;
 
-                // if minidump generation failed, just report the error but continue (some data may have been saved)
-                if (!MinidumpParams.Result)
-                {
-                    char msg[2 * MAX_PATH];
-                    sprintf(msg, LoadStr(IDS_SALMON_BUGREPORT_PROBLEM, HLanguage), MinidumpParams.ErrorMessage);
-                    SalmonMessageBox(HWindow, msg, LoadStr(IDS_SALMON_TITLE, HLanguage), MB_OK | MB_ICONEXCLAMATION | MB_SETFOREGROUND);
-                }
+                // If minidump generation fails after Salamander has crashed, keep the
+                // reporter UI focused on submitting any remaining crash data. Showing an
+                // additional error message from salmon.exe makes the crash flow look like
+                // the reporter itself failed.
 
                 if (GetBugReportNames() && GetUniqueBugReportCount() > 1)
                 {


### PR DESCRIPTION
### Motivation
- When Salmon fails to create a minidump after Salamander has already crashed, showing an extra error `MessageBox` from `salmon.exe` looks like the bug reporter itself failed; hide that dialog so the reporter stays focused on submitting whatever crash data was produced.

### Description
- Remove the block that displayed the minidump-failure message box in `src/salmon/dialogs.cpp` and replace it with a clarifying comment, allowing the reporter UI to continue to the main dialog without surfacing an additional error.

### Testing
- Ran `git diff --check` which reported no issues and `git status --short` which showed a clean working tree; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f1a23a7f48329accac40309fd9e24)