### PR TITLE
Match Total Commander proxy plugin instances

### DIFF
--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -1763,10 +1763,9 @@ internal static class PluginCatalogService
             }
         }
 
-        var installedIds = new HashSet<string>(installed.Select(plugin => plugin.Id), StringComparer.OrdinalIgnoreCase);
         var rows = installed.SelectMany(plugin =>
         {
-            var entries = catalog.Where(entry => string.Equals(entry.id, plugin.Id, StringComparison.OrdinalIgnoreCase)).ToList();
+            var entries = catalog.Where(entry => IsCatalogEntryMatch(entry, plugin)).ToList();
             if (entries.Count == 0)
             {
                 return new[] { BuildRow(plugin, null) };
@@ -1775,7 +1774,7 @@ internal static class PluginCatalogService
             return entries.Select(entry => BuildRow(plugin, entry));
         }).ToList();
         rows.AddRange(catalog
-            .Where(entry => entry.id is not null && !installedIds.Contains(entry.id))
+            .Where(entry => entry.id is not null && !installed.Any(plugin => IsCatalogEntryMatch(entry, plugin)))
             .Select(BuildCatalogOnlyRow));
         LastErrors = sourceErrors;
         return rows.OrderBy(row => row.Name, StringComparer.CurrentCultureIgnoreCase).ToList();
@@ -1802,6 +1801,26 @@ internal static class PluginCatalogService
         return new Uri(uri, uri.PathAndQuery + separator + "samandarinRefresh=" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
     }
 
+    private static bool IsCatalogEntryMatch(PluginCatalogEntry entry, InstalledPlugin plugin)
+    {
+        if (string.Equals(entry.id, plugin.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return IsTotalCommanderProxyCatalogEntry(entry) && IsTotalCommanderProxyInstance(plugin);
+    }
+
+    private static bool IsTotalCommanderProxyCatalogEntry(PluginCatalogEntry entry)
+    {
+        return string.Equals(entry.id, "x-tc-proxy", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsTotalCommanderProxyInstance(InstalledPlugin plugin)
+    {
+        return Regex.IsMatch(plugin.DisplayName, @"^Total Commander Proxy \([^()]+\.(?:wcx|wfx|wlx|wdx)64?\)$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
     private static PluginUpdateRow BuildCatalogOnlyRow(PluginCatalogEntry entry)
     {
         var homepage = entry.homepageUrl ?? string.Empty;
@@ -1825,7 +1844,10 @@ internal static class PluginCatalogService
         };
 
         var homepage = entry.homepageUrl ?? string.Empty;
-        return new PluginUpdateRow(LocalizedText.Resolve(entry.name) ?? plugin.DisplayName, plugin.VersionText, entry.latestVersion ?? string.Empty, NativeStrings.Get(statusId), entry.author ?? string.Empty, homepage, ToStatus(comparison), entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty, plugin.IconPath, entry.icon ?? string.Empty);
+        var displayName = IsTotalCommanderProxyCatalogEntry(entry) && IsTotalCommanderProxyInstance(plugin)
+            ? plugin.DisplayName
+            : LocalizedText.Resolve(entry.name) ?? plugin.DisplayName;
+        return new PluginUpdateRow(displayName, plugin.VersionText, entry.latestVersion ?? string.Empty, NativeStrings.Get(statusId), entry.author ?? string.Empty, homepage, ToStatus(comparison), entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty, plugin.IconPath, entry.icon ?? string.Empty);
     }
 
     private static PluginUpdateStatus ToStatus(PluginVersionComparison comparison) => comparison == PluginVersionComparison.UpdateAvailable ? PluginUpdateStatus.UpdateAvailable : PluginUpdateStatus.Other;


### PR DESCRIPTION
### Motivation
- Plugin Updates showed `x-tc-proxy` catalog entry as “Not in catalog” when a user had an installed instance named like `Total Commander Proxy ({file}.wcx64)` or `Total Commander Proxy ({file}.wfx64)`, so the catalog entry should match those concrete instances. 
- Maintain the installed instance display name in the Plugin Updates UI while leveraging catalog metadata for version/status/source. 
- Avoid listing the base `x-tc-proxy` catalog entry as a separate “Not installed” row when a matching instance exists.

### Description
- Add `IsCatalogEntryMatch`, `IsTotalCommanderProxyCatalogEntry` and `IsTotalCommanderProxyInstance` helpers and a `Regex` that recognizes `Total Commander Proxy (filename.<wcx|wfx|wlx|wdx>64?)` display names. 
- Use `IsCatalogEntryMatch` when mapping installed plugins to catalog entries so `x-tc-proxy` matches proxy instances with wrapped Total Commander plugin filenames. 
- Prevent the base catalog entry from being emitted as `Not installed` by filtering catalog-only rows with `!installed.Any(plugin => IsCatalogEntryMatch(entry, plugin))`. 
- Preserve the concrete installed instance `DisplayName` in the `PluginUpdateRow` when a catalog entry matches a Total Commander Proxy instance, otherwise use the catalog `name`.

### Testing
- Ran `git diff --check` and it reported no whitespace or diff-check problems (success). 
- Attempted `dotnet build src/plugins/samandarin/managed/Samandarin.Managed.csproj --no-restore` but `dotnet` is not available in this environment so the project build was not executed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f2aaf8ae08329af128bd1a3919a10)