### PR TITLE
Show ICO file images as small icons

### DIFF
--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -144,7 +144,7 @@ int GetBestIcoImageSize(const char* path, int maxSize)
     return bestFitSize != 0 ? bestFitSize : smallestOversize;
 }
 
-BOOL LoadIcoThumbnail(const char* path, int thumbnailSize, CSalamanderThumbnailMaker* thumbMaker)
+BOOL LoadIcoThumbnail(const char* path, int thumbnailSize, COLORREF bkgndColor, CSalamanderThumbnailMaker* thumbMaker)
 {
     if (!IsIcoFileName(path) || thumbnailSize <= 0 || thumbMaker == NULL)
         return FALSE;
@@ -176,7 +176,10 @@ BOOL LoadIcoThumbnail(const char* path, int thumbnailSize, CSalamanderThumbnailM
     if (bitmap != NULL && bits != NULL)
     {
         oldBitmap = (HBITMAP)SelectObject(memDC, bitmap);
-        memset(bits, 0, iconSize * iconSize * sizeof(DWORD));
+        DWORD* pixel = (DWORD*)bits;
+        DWORD bkgndPixel = bkgndColor & 0x00ffffff;
+        for (int i = 0; i < iconSize * iconSize; i++)
+            pixel[i] = bkgndPixel;
         if (DrawIconEx(memDC, 0, 0, hIcon, iconSize, iconSize, 0, NULL, DI_NORMAL))
         {
             thumbMaker->Clear(thumbnailSize);
@@ -1876,7 +1879,7 @@ unsigned IconThreadThreadFBody(void* parameter)
                                             if (strlen(s) + (name - path) < MAX_PATH)
                                             {
                                                 strcpy(name, s);
-                                                if (LoadIcoThumbnail(path, thumbnailSize, &thumbMaker))
+                                                if (LoadIcoThumbnail(path, thumbnailSize, GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]), &thumbMaker))
                                                 {
                                                     thumbnailFlag = 5;
                                                     thumbnailLoaded = TRUE;

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -57,6 +57,149 @@ std::wstring PathToWideMirror(const char* path)
 std::string TreeViewWideToText(const wchar_t* text)
 {
     return SalWideToMultiBytePath(text, CP_UTF8);
+}
+
+
+BOOL IsIcoFileName(const char* fileName)
+{
+    if (fileName == NULL)
+        return FALSE;
+
+    const char* slash = strrchr(fileName, '\\');
+    const char* slash2 = strrchr(fileName, '/');
+    if (slash2 != NULL && (slash == NULL || slash2 > slash))
+        slash = slash2;
+
+    const char* dot = strrchr(fileName, '.');
+    return dot != NULL && (slash == NULL || dot > slash) && stricmp(dot + 1, "ico") == 0;
+}
+
+WORD ReadWordLE(const BYTE* data)
+{
+    return (WORD)(data[0] | (data[1] << 8));
+}
+
+DWORD ReadDWordLE(const BYTE* data)
+{
+    return (DWORD)data[0] | ((DWORD)data[1] << 8) | ((DWORD)data[2] << 16) | ((DWORD)data[3] << 24);
+}
+
+int GetBestIcoImageSize(const char* path, int maxSize)
+{
+    HANDLE file = HANDLES_Q(CreateFile(path, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                                       OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
+    if (file == INVALID_HANDLE_VALUE)
+        return 0;
+
+    BYTE header[6];
+    DWORD read = 0;
+    BOOL ok = ReadFile(file, header, sizeof(header), &read, NULL) && read == sizeof(header) &&
+              ReadWordLE(header) == 0 && ReadWordLE(header + 2) == 1;
+    WORD count = ok ? ReadWordLE(header + 4) : 0;
+    if (count > 512) // sanity limit for malformed files
+        ok = FALSE;
+
+    int bestFitSize = 0;
+    int bestFitBpp = -1;
+    DWORD bestFitBytes = 0;
+    int smallestOversize = 0;
+    int smallestOversizeBpp = -1;
+    DWORD smallestOversizeBytes = 0;
+
+    for (WORD i = 0; ok && i < count; i++)
+    {
+        BYTE entry[16];
+        ok = ReadFile(file, entry, sizeof(entry), &read, NULL) && read == sizeof(entry);
+        if (!ok)
+            break;
+
+        int width = entry[0] == 0 ? 256 : entry[0];
+        int height = entry[1] == 0 ? 256 : entry[1];
+        int size = max(width, height);
+        int bpp = ReadWordLE(entry + 6);
+        if (bpp == 0)
+            bpp = entry[2] == 0 ? 256 : entry[2];
+        DWORD bytes = ReadDWordLE(entry + 8);
+
+        if (size <= maxSize)
+        {
+            if (size > bestFitSize ||
+                size == bestFitSize && (bpp > bestFitBpp || bpp == bestFitBpp && bytes > bestFitBytes))
+            {
+                bestFitSize = size;
+                bestFitBpp = bpp;
+                bestFitBytes = bytes;
+            }
+        }
+        else if (smallestOversize == 0 || size < smallestOversize ||
+                 size == smallestOversize && (bpp > smallestOversizeBpp || bpp == smallestOversizeBpp && bytes > smallestOversizeBytes))
+        {
+            smallestOversize = size;
+            smallestOversizeBpp = bpp;
+            smallestOversizeBytes = bytes;
+        }
+    }
+
+    HANDLES(CloseHandle(file));
+    return bestFitSize != 0 ? bestFitSize : smallestOversize;
+}
+
+BOOL LoadIcoThumbnail(const char* path, int thumbnailSize, CSalamanderThumbnailMaker* thumbMaker)
+{
+    if (!IsIcoFileName(path) || thumbnailSize <= 0 || thumbMaker == NULL)
+        return FALSE;
+
+    int iconSize = GetBestIcoImageSize(path, thumbnailSize);
+    if (iconSize <= 0)
+        iconSize = thumbnailSize;
+
+    HICON hIcon = (HICON)HANDLES(LoadImage(NULL, path, IMAGE_ICON, iconSize, iconSize,
+                                           LR_LOADFROMFILE | IconLRFlags));
+    if (hIcon == NULL)
+        return FALSE;
+
+    BITMAPINFO bi;
+    memset(&bi, 0, sizeof(bi));
+    bi.bmiHeader.biSize = sizeof(bi.bmiHeader);
+    bi.bmiHeader.biWidth = iconSize;
+    bi.bmiHeader.biHeight = -iconSize;
+    bi.bmiHeader.biPlanes = 1;
+    bi.bmiHeader.biBitCount = 32;
+    bi.bmiHeader.biCompression = BI_RGB;
+
+    void* bits = NULL;
+    HDC screenDC = HANDLES(GetDC(NULL));
+    HDC memDC = screenDC != NULL ? HANDLES(CreateCompatibleDC(screenDC)) : NULL;
+    HBITMAP bitmap = memDC != NULL ? HANDLES(CreateDIBSection(memDC, &bi, DIB_RGB_COLORS, &bits, NULL, 0)) : NULL;
+    HBITMAP oldBitmap = NULL;
+    BOOL ret = FALSE;
+    if (bitmap != NULL && bits != NULL)
+    {
+        oldBitmap = (HBITMAP)SelectObject(memDC, bitmap);
+        memset(bits, 0, iconSize * iconSize * sizeof(DWORD));
+        if (DrawIconEx(memDC, 0, 0, hIcon, iconSize, iconSize, 0, NULL, DI_NORMAL))
+        {
+            thumbMaker->Clear(thumbnailSize);
+            if (thumbMaker->SetParameters(iconSize, iconSize, 0))
+            {
+                thumbMaker->ProcessBuffer(bits, iconSize);
+                ret = thumbMaker->ThumbnailReady();
+            }
+        }
+        if (oldBitmap != NULL)
+            SelectObject(memDC, oldBitmap);
+    }
+
+    if (!ret)
+        thumbMaker->Clear();
+    if (bitmap != NULL)
+        HANDLES(DeleteObject(bitmap));
+    if (memDC != NULL)
+        HANDLES(DeleteDC(memDC));
+    if (screenDC != NULL)
+        HANDLES(ReleaseDC(NULL, screenDC));
+    HANDLES(DestroyIcon(hIcon));
+    return ret;
 }
 
 std::string BuildDiskThumbnailPathUtf8(CFilesWindow* window, const char* fileName)
@@ -1727,45 +1870,54 @@ unsigned IconThreadThreadFBody(void* parameter)
                                             int len = (int)strlen(s);
                                             int size = len + 4;
                                             size -= (size & 0x3); // size % 4 (alignment to four bytes)
-                                            std::string thumbnailPathUtf8 = BuildDiskThumbnailPathUtf8(window, s);
-                                            const char* thumbnailPath = NULL;
-                                            if (!thumbnailPathUtf8.empty())
-                                            {
-                                                thumbnailPath = thumbnailPathUtf8.c_str();
-                                            }
-                                            else if (strlen(s) + (name - path) < MAX_PATH)
+                                            int thumbnailSize = window->GetThumbnailSize();
+                                            BOOL thumbnailLoaded = FALSE;
+
+                                            if (strlen(s) + (name - path) < MAX_PATH)
                                             {
                                                 strcpy(name, s);
-                                                thumbnailPath = path;
+                                                if (LoadIcoThumbnail(path, thumbnailSize, &thumbMaker))
+                                                {
+                                                    thumbnailFlag = 5;
+                                                    thumbnailLoaded = TRUE;
+                                                }
                                             }
 
-                                            if (thumbnailPath != NULL)
+                                            if (!thumbnailLoaded)
                                             {
-                                                //                          TRACE_I("Load thumbnail for: " << name << "...");
-                                                CPluginInterfaceForThumbLoaderEncapsulation** loader;
-                                                loader = (CPluginInterfaceForThumbLoaderEncapsulation**)(s + size + sizeof(CQuadWord) + sizeof(FILETIME));
-                                                while (*loader != NULL)
+                                                std::string thumbnailPathUtf8 = BuildDiskThumbnailPathUtf8(window, s);
+                                                const char* thumbnailPath = NULL;
+                                                if (!thumbnailPathUtf8.empty())
                                                 {
-                                                    int thumbnailSize = window->GetThumbnailSize();
-                                                    thumbMaker.Clear(thumbnailSize);
-                                                    CALL_STACK_MESSAGE3("IconThreadThreadFBody::LoadThumbnail(%s, %d)", thumbnailPath, wanted == 4);
-                                                    if ((*loader)->LoadThumbnail(thumbnailPath, thumbnailSize, thumbnailSize, &thumbMaker, wanted == 4))
-                                                    {
-                                                        thumbnailFlag = wanted == 4 /* first thumbnail loading round */ ? (thumbMaker.IsOnlyPreview() ? 6 /* low-quality/smaller */ : 5 /* quality */) : 5 /* in the second round all obtained thumbnails are quality */;
-                                                        thumbMaker.HandleIncompleteImages();
-                                                        break; // the thumbnail may be loaded; do not try another plug-in
-                                                    }
-                                                    loader++; // try the next plug-in in line, it might load the thumbnail
+                                                    thumbnailPath = thumbnailPathUtf8.c_str();
                                                 }
-                                                if (*loader == NULL)
-                                                    thumbMaker.Clear(); // failed thumbnail -> clean it up
-                                                                        //                          TRACE_I("Load thumbnail is done.");
-                                            }
-                                            else
-                                            {
-                                                *name = 0;
-                                                TRACE_I("Too long filename to get thumbnail from: " << path << s);
-                                                thumbMaker.Clear();
+                                                else if (strlen(s) + (name - path) < MAX_PATH)
+                                                {
+                                                    strcpy(name, s);
+                                                    thumbnailPath = path;
+                                                }
+
+                                                if (thumbnailPath != NULL)
+                                                {
+                                                    //                          TRACE_I("Load thumbnail for: " << name << "...");
+                                                    CPluginInterfaceForThumbLoaderEncapsulation** loader;
+                                                    loader = (CPluginInterfaceForThumbLoaderEncapsulation**)(s + size + sizeof(CQuadWord) + sizeof(FILETIME));
+                                                    while (*loader != NULL)
+                                                    {
+                                                        thumbMaker.Clear(thumbnailSize);
+                                                        CALL_STACK_MESSAGE3("IconThreadThreadFBody::LoadThumbnail(%s, %d)", thumbnailPath, wanted == 4);
+                                                        if ((*loader)->LoadThumbnail(thumbnailPath, thumbnailSize, thumbnailSize, &thumbMaker, wanted == 4))
+                                                        {
+                                                            thumbnailFlag = wanted == 4 /* first thumbnail loading round */ ? (thumbMaker.IsOnlyPreview() ? 6 /* low-quality/smaller */ : 5 /* quality */) : 5 /* in the second round all obtained thumbnails are quality */;
+                                                            thumbMaker.HandleIncompleteImages();
+                                                            break; // the thumbnail may be loaded; do not try another plug-in
+                                                        }
+                                                        loader++; // try the next plug-in in line, it might load the thumbnail
+                                                    }
+                                                    if (*loader == NULL)
+                                                        thumbMaker.Clear(); // failed thumbnail -> clean it up
+                                                                            //                          TRACE_I("Load thumbnail is done.");
+                                                }
                                             }
                                         }
                                     }

--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -783,6 +783,12 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                         {
                             file.Association = Associations.IsAssociated(st, addtoIconCache, iconSize);
                             file.Archive = 0;
+                            if (iconSize == ICONSIZE_16 && *(DWORD*)st == *(DWORD*)"ico")
+                            {
+                                // ICO files are their own icon source, so cache them by file name
+                                // instead of sharing one association icon for all *.ico files.
+                                addtoIconCache = TRUE;
+                            }
                             if (*(DWORD*)st == *(DWORD*)"scr" || // few exceptions
                                 *(DWORD*)st == *(DWORD*)"pif")
                             {

--- a/src/fileswn4.cpp
+++ b/src/fileswn4.cpp
@@ -243,7 +243,8 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                     int index;
                     BOOL exceptions = *(DWORD*)lowerExtension == *(DWORD*)"scr" || // icons in the file,
                                       *(DWORD*)lowerExtension == *(DWORD*)"pif" || // even though it isn't visible
-                                      *(DWORD*)lowerExtension == *(DWORD*)"lnk";   // in the Registry
+                                      *(DWORD*)lowerExtension == *(DWORD*)"lnk" || // in the Registry
+                                      iconSize == ICONSIZE_16 && *(DWORD*)lowerExtension == *(DWORD*)"ico"; // each ICO is its own icon source
 
                     if (exceptions || Associations.GetIndex(lowerExtension, index)) // the extension has an icon (association)
                     {

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -757,7 +757,9 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 *((DWORD*)s1) = 0;
                 int index;
                 CIconSizeEnum iconSize = IconCache->GetIconSize();
-                if (Associations.GetIndex(buf, index) &&             // pripona ma ikonku (asociaci)
+                BOOL icoFileIcon = iconSize == ICONSIZE_16 && *(DWORD*)buf == *(DWORD*)"ico";
+                if (!icoFileIcon &&
+                    Associations.GetIndex(buf, index) &&             // pripona ma ikonku (asociaci)
                     (Associations[index].GetIndex(iconSize) == -1 || // jde o ikonku, ktera se nacita
                      Associations[index].GetIndex(iconSize) == -3))
                 {

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -522,6 +522,43 @@ LPITEMIDLIST SHILCreateFromPath(LPCSTR pszPath)
 }
 
 // comment see spl_gen.h/GetFileIcon
+
+static BOOL IsIconFilePath(LPCTSTR path)
+{
+    if (path == NULL)
+        return FALSE;
+
+    LPCTSTR slash = strrchr(path, '\\');
+    LPCTSTR slash2 = strrchr(path, '/');
+    if (slash2 != NULL && (slash == NULL || slash2 > slash))
+        slash = slash2;
+
+    LPCTSTR dot = strrchr(path, '.');
+    return dot != NULL && (slash == NULL || dot > slash) && stricmp(dot + 1, "ico") == 0;
+}
+
+static BOOL LoadIcoFileSmallIcon(LPCTSTR path, HICON* hIcon)
+{
+    if (hIcon == NULL)
+        return FALSE;
+
+    *hIcon = NULL;
+    if (!IsIconFilePath(path))
+        return FALSE;
+
+    int iconSize = IconSizes[ICONSIZE_16];
+    *hIcon = (HICON)HANDLES(LoadImage(NULL, path, IMAGE_ICON, iconSize, iconSize,
+                                       LR_LOADFROMFILE | IconLRFlags));
+    if (*hIcon != NULL)
+        return TRUE;
+
+    if (ExtractIcons(path, 0, iconSize, iconSize, hIcon, NULL, 1, IconLRFlags) == 1 && *hIcon != NULL)
+        return TRUE;
+
+    *hIcon = NULL;
+    return FALSE;
+}
+
 BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum iconSize,
                  BOOL fallbackToDefIcon, BOOL defIconIsDir)
 {
@@ -539,6 +576,9 @@ BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum 
   else
     TRACE_I("GetFileIcon() pathIsPIDL"); // not used by Salamander itself, only by the Folders plugin
 */
+    if (!pathIsPIDL && iconSize == ICONSIZE_16 && LoadIcoFileSmallIcon(path, hIcon))
+        return TRUE;
+
     if (!pathIsPIDL)
         pidlFull = SHILCreateFromPath(path);
     else


### PR DESCRIPTION
### Motivation
- .ico files currently only show their image in Thumbnails view while other views fall back to a generic document icon. 
- Improve file list/detail views by displaying the actual 16x16 image from the .ico file in best available color quality.

### Description
- Added `IsIconFilePath` helper to detect disk-backed `.ico` paths. 
- Added `LoadIcoFileSmallIcon` which attempts `LoadImage(..., LR_LOADFROMFILE | IconLRFlags)` and falls back to `ExtractIcons` to obtain a 16x16 `HICON`. 
- Integrated the ICO-specific loader into `GetFileIcon` so that non-PIDL requests for `ICONSIZE_16` return the ICO-sourced small icon before falling back to the shell extraction path.

### Testing
- Ran `git diff --check` which reported no issues. 
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f308f36988329b7dbaf9d14d323ee)