### PR TITLE
Fix saving Samandarin plugin catalog sources

### DIFF
--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -1539,14 +1539,20 @@ internal sealed class PluginCatalogSourcesDialog : Form
                 _listView.Items.Add(item);
             }
 
-            var addItem = new ListViewItem(string.Empty) { Tag = new PluginCatalogSource { Url = string.Empty, Enabled = true } };
-            addItem.Checked = true;
-            _listView.Items.Add(addItem);
+            AddEmptySourceRow();
         }
         finally
         {
             _listView.EndUpdate();
         }
+    }
+
+    private void AddEmptySourceRow()
+    {
+        var source = new PluginCatalogSource { Url = string.Empty, Enabled = true };
+        _sources.Add(source);
+        var addItem = new ListViewItem(string.Empty) { Tag = source, Checked = true };
+        _listView.Items.Add(addItem);
     }
 
     private void ListViewOnItemCheck(object? sender, ItemCheckEventArgs e)
@@ -1613,9 +1619,7 @@ internal sealed class PluginCatalogSourcesDialog : Form
         if (item.Index == _listView.Items.Count - 1 && source.Url.Length > 0)
         {
             source.Enabled = true;
-            var addItem = new ListViewItem(string.Empty) { Tag = new PluginCatalogSource { Url = string.Empty, Enabled = true } };
-            addItem.Checked = true;
-            _listView.Items.Add(addItem);
+            AddEmptySourceRow();
         }
     }
 


### PR DESCRIPTION
### Motivation
- Fix a bug where user-added catalog sources in the "Plugin Updates - Configure Sources" dialog were not persisted because the editable blank row was only present in the `ListView` and not in the backing `_sources` list.

### Description
- Add a helper `AddEmptySourceRow()` and call it from `PopulateList()` and after the last-row label edit so the blank placeholder is added to both `_sources` and the `ListView` (change in `src/plugins/samandarin/managed/EntryPoint.cs`).

### Testing
- Attempted to run `dotnet build src/plugins/samandarin/managed/Samandarin.Managed.csproj --no-restore`, but the command could not run in this environment because `dotnet` is not installed, so no automated build/test was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f43c83ac883299e56f1fb9a849907)