### PR TITLE
Fix WebView2 viewer loading from elevated mapped drives

### DIFF
--- a/src/plugins/webview2renderviewer/managed/ViewerHost.cs
+++ b/src/plugins/webview2renderviewer/managed/ViewerHost.cs
@@ -1192,10 +1192,17 @@ internal static class ViewerHost
                 return new DocumentView(DocumentViewKind.Html, caption, null, html);
             }
 
+            if (FileViewHelper.IsHtmlDocument(extension))
+            {
+                string source = File.ReadAllText(LongPathHelper.ToLongPath(displayPath));
+                string html = HtmlDocumentRenderer.BuildHtml(source, displayPath);
+                return new DocumentView(DocumentViewKind.Html, caption, null, html);
+            }
+
             if (FileViewHelper.IsRasterImage(extension))
             {
-                var imageUri = new Uri(Path.GetFullPath(displayPath));
-                return new DocumentView(DocumentViewKind.Navigate, caption, imageUri, null);
+                string html = RasterImageRenderer.BuildHtml(displayPath, caption);
+                return new DocumentView(DocumentViewKind.Image, caption, null, html);
             }
 
             var uri = new Uri(Path.GetFullPath(displayPath));
@@ -1210,6 +1217,11 @@ internal static class ViewerHost
             "md", "markdown", "mdown", "mkd", "mdx",
         };
 
+        private static readonly HashSet<string> s_htmlExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "html", "htm", "xhtml",
+        };
+
         private static readonly HashSet<string> s_rasterImageExtensions = new(StringComparer.OrdinalIgnoreCase)
         {
             "bmp", "dib", "gif", "ico", "jfif", "jpeg", "jpg", "jpe", "png", "tif", "tiff", "webp",
@@ -1220,17 +1232,40 @@ internal static class ViewerHost
             return s_markdownExtensions.Contains(extension);
         }
 
+        public static bool IsHtmlDocument(string extension)
+        {
+            return s_htmlExtensions.Contains(extension);
+        }
+
         public static bool IsRasterImage(string extension)
         {
             return s_rasterImageExtensions.Contains(extension);
+        }
+
+        public static string GetRasterImageMimeType(string extension)
+        {
+            return extension switch
+            {
+                "bmp" or "dib" => "image/bmp",
+                "gif" => "image/gif",
+                "ico" => "image/x-icon",
+                "jfif" or "jpeg" or "jpg" or "jpe" => "image/jpeg",
+                "png" => "image/png",
+                "tif" or "tiff" => "image/tiff",
+                "webp" => "image/webp",
+                _ => "application/octet-stream",
+            };
         }
     }
 
 
     private static class RasterImageRenderer
     {
-        public static string BuildHtml(Uri imageUri, string caption)
+        public static string BuildHtml(string imagePath, string caption)
         {
+            string extension = Path.GetExtension(imagePath)?.TrimStart('.')?.ToLowerInvariant() ?? string.Empty;
+            string mimeType = FileViewHelper.GetRasterImageMimeType(extension);
+            string imageSource = "data:" + mimeType + ";base64," + Convert.ToBase64String(File.ReadAllBytes(LongPathHelper.ToLongPath(imagePath)));
             ThemeHelper.ThemePalette? palette = ThemeHelper.TryGetPalette(out var value) ? value : null;
             Color background = palette?.Background ?? SystemColors.Window;
             Color foreground = palette?.Foreground ?? SystemColors.WindowText;
@@ -1259,9 +1294,73 @@ internal static class ViewerHost
             builder.Append("</head><body><img alt=\"")
                 .Append(WebUtility.HtmlEncode(caption))
                 .Append("\" src=\"")
-                .Append(WebUtility.HtmlEncode(imageUri.AbsoluteUri))
+                .Append(WebUtility.HtmlEncode(imageSource))
                 .Append("\"/></body></html>");
             return builder.ToString();
+        }
+    }
+
+    private static class HtmlDocumentRenderer
+    {
+        public static string BuildHtml(string html, string sourcePath)
+        {
+            string? baseUrl = TryGetBaseUrl(sourcePath);
+            if (string.IsNullOrEmpty(baseUrl) || ContainsBaseElement(html))
+            {
+                return html;
+            }
+
+            string baseElement = "<base href=\"" + WebUtility.HtmlEncode(baseUrl) + "\"/>";
+            int headStart = html.IndexOf("<head", StringComparison.OrdinalIgnoreCase);
+            if (headStart >= 0)
+            {
+                int headTagEnd = html.IndexOf('>', headStart);
+                if (headTagEnd >= 0)
+                {
+                    return html.Insert(headTagEnd + 1, baseElement);
+                }
+            }
+
+            int htmlStart = html.IndexOf("<html", StringComparison.OrdinalIgnoreCase);
+            if (htmlStart >= 0)
+            {
+                int htmlTagEnd = html.IndexOf('>', htmlStart);
+                if (htmlTagEnd >= 0)
+                {
+                    return html.Insert(htmlTagEnd + 1, "<head>" + baseElement + "</head>");
+                }
+            }
+
+            return baseElement + html;
+        }
+
+        private static bool ContainsBaseElement(string html)
+        {
+            return html.IndexOf("<base", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static string? TryGetBaseUrl(string sourcePath)
+        {
+            try
+            {
+                var directory = Path.GetDirectoryName(sourcePath);
+                if (string.IsNullOrEmpty(directory))
+                {
+                    return null;
+                }
+
+                var absolute = Path.GetFullPath(directory);
+                if (!absolute.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+                {
+                    absolute += Path.DirectorySeparatorChar;
+                }
+
+                return new Uri(absolute).AbsoluteUri;
+            }
+            catch (UriFormatException)
+            {
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- WebView2 failed to open files located on mapped network drives when Salamander was run elevated, because the control could not resolve mapped drive letters from an elevated process context. 
- The change makes the host process read file contents and inject them into WebView2 to avoid letting the control directly open `file://` paths on mapped drives.

### Description
- Added detection for HTML/XHTML files and a new `HtmlDocumentRenderer` that injects a `<base href="...">` when needed so relative links continue to resolve to the source directory. 
- Updated `DocumentView.Create` to load Markdown and HTML/XHTML via host-rendered HTML and to render raster images through host-generated HTML instead of navigating to a `file://` URI. 
- Extended `FileViewHelper` with `IsHtmlDocument` and `GetRasterImageMimeType` helpers and changed image rendering to produce `data:` URIs by reading image bytes via `LongPathHelper` to avoid mapped-drive access from WebView2. 
- All changes are contained in `src/plugins/webview2renderviewer/managed/ViewerHost.cs` (HTML base injection, raster image data-URI generation, and file-type helpers).

### Testing
- Ran `git diff --check` to validate whitespace and trivial issues, which succeeded. 
- Attempted to inspect the .NET toolchain with `dotnet --info` but `dotnet` is not available in this environment, so a full `dotnet build`/runtime test was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f49f884d48329b3ce0b7bd0344b75)