### PR TITLE
Add Salamatrix version resource metadata

### DIFF
--- a/src/plugins/salamatrix/precomp.h
+++ b/src/plugins/salamatrix/precomp.h
@@ -26,6 +26,7 @@
 #include "../shared/spl_menu.h"
 #include "../shared/spl_view.h"
 #include "../shared/spl_thum.h"
+#include "versinfo.rh2"
 #include "../shared/spl_vers.h"
 #include "../shared/spl_gui.h"
 #include "../shared/dbg.h"

--- a/src/plugins/salamatrix/salamatrix.cpp
+++ b/src/plugins/salamatrix/salamatrix.cpp
@@ -91,8 +91,8 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     SalamanderGeneral = salamander->GetSalamanderGeneral();
     SalamanderGUI = salamander->GetSalamanderGUI();
-    salamander->SetBasicPluginData(PluginNameEN, FUNCTION_AUTOMATIONFRAMEWORK, "0.1", "Open Salamander Authors",
-                                   "Automation Framework provider for Salamatrix UI, Commands, FileOperations and Automation services.",
+    salamander->SetBasicPluginData(PluginNameEN, FUNCTION_AUTOMATIONFRAMEWORK, VERSINFO_VERSION_NO_PLATFORM, VERSINFO_COPYRIGHT,
+                                   VERSINFO_DESCRIPTION,
                                    PluginNameShort, NULL, NULL);
     salamander->SetPluginHomePageURL("https://samandarin.krtkovo.eu/");
 

--- a/src/plugins/salamatrix/salamatrix.rc
+++ b/src/plugins/salamatrix/salamatrix.rc
@@ -9,3 +9,7 @@
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 IDI_PLUGINICON ICON "..\\..\\res\\sal_r.ico"
+
+#ifndef APSTUDIO_INVOKED
+#include "salamatrix.rc2"   // non-Microsoft Visual C++ edited resources
+#endif

--- a/src/plugins/salamatrix/salamatrix.rc2
+++ b/src/plugins/salamatrix/salamatrix.rc2
@@ -1,0 +1,16 @@
+﻿// SPDX-FileCopyrightText: 2026 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//
+// salamatrix.rc2 - resources Microsoft Visual C++ does not edit directly
+//
+
+#ifdef APSTUDIO_INVOKED
+#error this file is not editable by Microsoft Visual C++
+#endif //APSTUDIO_INVOKED
+
+/////////////////////////////////////////////////////////////////////////////
+// Add manually edited resources here...
+
+#include "versinfo.rh2"
+#include "versinfo.rc2"

--- a/src/plugins/salamatrix/vcxproj/salamatrix.vcxproj
+++ b/src/plugins/salamatrix/vcxproj/salamatrix.vcxproj
@@ -98,6 +98,7 @@
     <ClInclude Include="..\..\shared\spl_vers.h" />
     <ClInclude Include="..\salamatrix.h" />
     <ClInclude Include="..\salamatrix.rh" />
+    <ClInclude Include="..\versinfo.rh2" />
     <ClInclude Include="..\salamatrix_automation.h" />
     <ClInclude Include="..\salamatrix_commands.h" />
     <ClInclude Include="..\salamatrix_poc.h" />
@@ -107,6 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\salamatrix.def" />
+    <None Include="..\salamatrix.rc2" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\salamatrix.rc" />

--- a/src/plugins/salamatrix/vcxproj/salamatrix.vcxproj.filters
+++ b/src/plugins/salamatrix/vcxproj/salamatrix.vcxproj.filters
@@ -20,10 +20,12 @@
     <ClInclude Include="..\salamatrix_poc.h"><Filter>Header Files</Filter></ClInclude>
     <ClInclude Include="..\salamatrix_runtime.h"><Filter>Header Files</Filter></ClInclude>
     <ClInclude Include="..\salamatrix_ui.h"><Filter>Header Files</Filter></ClInclude>
+    <ClInclude Include="..\versinfo.rh2"><Filter>Header Files</Filter></ClInclude>
     <ClInclude Include="..\precomp.h"><Filter>Header Files</Filter></ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\salamatrix.def"><Filter>Definition Files</Filter></None>
+    <None Include="..\salamatrix.rc2"><Filter>Resource Files</Filter></None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\salamatrix.rc"><Filter>Resource Files</Filter></ResourceCompile>

--- a/src/plugins/salamatrix/versinfo.rh2
+++ b/src/plugins/salamatrix/versinfo.rh2
@@ -1,0 +1,29 @@
+﻿// SPDX-FileCopyrightText: 2026 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+#ifndef __SALAMATRIX_VERSINFO_RH2
+#define __SALAMATRIX_VERSINFO_RH2
+
+#if defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+#error this file is not editable by Microsoft Visual C++
+#endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
+
+// defines for plugin.SPL VERSIONINFO
+// look at shared\versinfo.rc2
+
+#define VERSINFO_MAJOR       0
+#define VERSINFO_MINORA      1
+#define VERSINFO_MINORB      0
+
+#include "spl_vers.h" // retrieve version and build numbers
+
+#define VERSINFO_COPYRIGHT   "Copyright © 2026 Open Salamander Authors"
+#define VERSINFO_COMPANY     "Open Salamander"
+
+#define VERSINFO_DESCRIPTION "Automation Framework provider for Salamatrix UI, Commands, FileOperations and Automation services."
+
+#define VERSINFO_INTERNAL    "SALAMATRIX"
+#define VERSINFO_ORIGINAL    VERSINFO_INTERNAL ".SPL"
+
+#endif // __SALAMATRIX_VERSINFO_RH2


### PR DESCRIPTION
### Motivation
- Bring the Salamatrix plugin in line with other plugins by using the unified version resource flow (`versinfo.rh2` + shared `versinfo.rc2`) so plugin version, description and copyright are centralized and consistent.
- Replace hardcoded runtime metadata strings with the shared version macros to ensure build tooling and catalog scripts can discover the plugin version consistently.

### Description
- Add `src/plugins/salamatrix/versinfo.rh2` with `VERSINFO_*` macros and plugin metadata so the plugin participates in the shared VERSIONINFO flow.
- Add `src/plugins/salamatrix/salamatrix.rc2` that includes `versinfo.rh2` and the shared `versinfo.rc2` template, and include it from `salamatrix.rc` for non-MSVC resource compilation.
- Include `versinfo.rh2` from `precomp.h` so plugin sources can use `VERSINFO_VERSION_NO_PLATFORM`, `VERSINFO_COPYRIGHT`, and `VERSINFO_DESCRIPTION` macros.
- Update `SetBasicPluginData` call in `salamatrix.cpp` to use `VERSINFO_VERSION_NO_PLATFORM`, `VERSINFO_COPYRIGHT`, and `VERSINFO_DESCRIPTION`, and add the new resource files to the Visual Studio project and filters (`vcxproj` / `vcxproj.filters`).

### Testing
- Ran `git diff --check` to ensure no whitespace or diff errors and it returned clean results.
- Performed a static wiring check (small Python script) verifying `versinfo.rh2` defines and `salamatrix.rc2` includes; the script completed successfully.
- Ran `python3 -m unittest tools.localization.tests.test_serviceexplorer_resources` and all tests passed (`Ran 4 tests ... OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f4d8bc5f08329a648dcf9eaf09afe)