### PR TITLE
Persist Explorer view template columns

### DIFF
--- a/src/salamand.h
+++ b/src/salamand.h
@@ -430,8 +430,10 @@ public:
 
     int SaveColumns(CColumnConfig* columns, char* buffer);  // convert the array to a string
     void LoadColumns(CColumnConfig* columns, char* buffer); // and back again
-    int SaveColumnOrder(BYTE* order, char* buffer);        // convert the column order to a string
-    void LoadColumnOrder(BYTE* order, char* buffer);       // and back again
+    int SaveColumnOrder(BYTE* order, char* buffer, int count = STANDARD_COLUMNS_COUNT); // convert the column order to a string
+    void LoadColumnOrder(BYTE* order, char* buffer, int count = STANDARD_COLUMNS_COUNT);  // and back again
+    int SaveExplorerColumnVisible(BYTE* visible, char* buffer);                           // convert Explorer column visibility to a string
+    void LoadExplorerColumnVisible(BYTE* visible, char* buffer);                          // and back again
 
     BOOL Save(HKEY hKey); // saves the entire array
     BOOL Load(HKEY hKey); // loads the entire array

--- a/src/salamdr4.cpp
+++ b/src/salamdr4.cpp
@@ -1031,6 +1031,8 @@ const char* SALAMANDER_VIEWTEMPLATE_NAME = "Name";
 const char* SALAMANDER_VIEWTEMPLATE_FLAGS = "Flags";
 const char* SALAMANDER_VIEWTEMPLATE_COLUMNS = "Columns";
 const char* SALAMANDER_VIEWTEMPLATE_COLUMNORDER = "Column Order";
+const char* SALAMANDER_VIEWTEMPLATE_EXPLORERCOLUMNVISIBLE = "Explorer Column Visible";
+const char* SALAMANDER_VIEWTEMPLATE_EXPLORERCOLUMNORDER = "Explorer Column Order";
 const char* SALAMANDER_VIEWTEMPLATE_LEFTSMARTMODE = "Left Smart Mode";
 const char* SALAMANDER_VIEWTEMPLATE_RIGHTSMARTMODE = "Right Smart Mode";
 
@@ -1177,10 +1179,10 @@ void CViewTemplates::LoadColumns(CColumnConfig* columns, char* buffer)
     }
 }
 
-int CViewTemplates::SaveColumnOrder(BYTE* order, char* buffer)
+int CViewTemplates::SaveColumnOrder(BYTE* order, char* buffer, int count)
 {
     char* s = buffer;
-    for (int i = 0; i < STANDARD_COLUMNS_COUNT; i++)
+    for (int i = 0; i < count; i++)
     {
         if (i > 0)
             *s++ = ',';
@@ -1190,32 +1192,60 @@ int CViewTemplates::SaveColumnOrder(BYTE* order, char* buffer)
     return (int)(s - buffer);
 }
 
-void CViewTemplates::LoadColumnOrder(BYTE* order, char* buffer)
+void CViewTemplates::LoadColumnOrder(BYTE* order, char* buffer, int count)
 {
-    BOOL used[STANDARD_COLUMNS_COUNT];
+    BOOL used[EXPLORER_COLUMNS_COUNT];
     ZeroMemory(used, sizeof(used));
     int pos = 0;
     char* p = strtok(buffer, ",");
-    while (p != NULL && pos < STANDARD_COLUMNS_COUNT)
+    while (p != NULL && pos < count)
     {
         unsigned int value;
-        if (sscanf(p, "%u", &value) == 1 && value < STANDARD_COLUMNS_COUNT && !used[value])
+        if (sscanf(p, "%u", &value) == 1 && value < (unsigned int)count && !used[value])
         {
             order[pos++] = (BYTE)value;
             used[value] = TRUE;
         }
         p = strtok(NULL, ",");
     }
-    for (int value = 0; pos < STANDARD_COLUMNS_COUNT && value < STANDARD_COLUMNS_COUNT; value++)
+    for (int value = 0; pos < count && value < count; value++)
     {
         if (!used[value])
             order[pos++] = (BYTE)value;
     }
 }
 
+int CViewTemplates::SaveExplorerColumnVisible(BYTE* visible, char* buffer)
+{
+    char* s = buffer;
+    for (int i = 0; i < EXPLORER_COLUMNS_COUNT; i++)
+    {
+        if (i > 0)
+            *s++ = ',';
+        s += sprintf(s, "%u", visible[i] ? 1 : 0);
+    }
+    *s = 0;
+    return (int)(s - buffer);
+}
+
+void CViewTemplates::LoadExplorerColumnVisible(BYTE* visible, char* buffer)
+{
+    ZeroMemory(visible, EXPLORER_COLUMNS_COUNT * sizeof(BYTE));
+    int pos = 0;
+    char* p = strtok(buffer, ",");
+    while (p != NULL && pos < EXPLORER_COLUMNS_COUNT)
+    {
+        unsigned int value;
+        if (sscanf(p, "%u", &value) == 1 && value != 0)
+            visible[pos] = TRUE;
+        pos++;
+        p = strtok(NULL, ",");
+    }
+}
+
 BOOL CViewTemplates::Save(HKEY hKey)
 {
-    char buff[512];
+    char buff[4 * EXPLORER_COLUMNS_COUNT + 1];
     char keyName[5];
     int i;
     for (i = 0; i < VIEW_TEMPLATES_COUNT; i++)
@@ -1228,6 +1258,8 @@ BOOL CViewTemplates::Save(HKEY hKey)
             SetValue(actKey, SALAMANDER_VIEWTEMPLATE_FLAGS, REG_DWORD, &Items[i].Flags, sizeof(DWORD));
             SetValue(actKey, SALAMANDER_VIEWTEMPLATE_COLUMNS, REG_SZ, buff, SaveColumns(Items[i].Columns, buff));
             SetValue(actKey, SALAMANDER_VIEWTEMPLATE_COLUMNORDER, REG_SZ, buff, SaveColumnOrder(Items[i].ColumnOrder, buff));
+            SetValue(actKey, SALAMANDER_VIEWTEMPLATE_EXPLORERCOLUMNVISIBLE, REG_SZ, buff, SaveExplorerColumnVisible(Items[i].ExplorerColumnVisible, buff));
+            SetValue(actKey, SALAMANDER_VIEWTEMPLATE_EXPLORERCOLUMNORDER, REG_SZ, buff, SaveColumnOrder(Items[i].ExplorerColumnOrder, buff, EXPLORER_COLUMNS_COUNT));
             SetValue(actKey, SALAMANDER_VIEWTEMPLATE_LEFTSMARTMODE, REG_DWORD, &Items[i].LeftSmartMode, sizeof(DWORD));
             SetValue(actKey, SALAMANDER_VIEWTEMPLATE_RIGHTSMARTMODE, REG_DWORD, &Items[i].RightSmartMode, sizeof(DWORD));
             CloseKey(actKey);
@@ -1238,7 +1270,7 @@ BOOL CViewTemplates::Save(HKEY hKey)
 
 BOOL CViewTemplates::Load(HKEY hKey)
 {
-    char buff[512];
+    char buff[4 * EXPLORER_COLUMNS_COUNT + 1];
     char keyName[5];
     int i;
     for (i = 0; i < VIEW_TEMPLATES_COUNT; i++)
@@ -1260,11 +1292,15 @@ BOOL CViewTemplates::Load(HKEY hKey)
             GetValue(actKey, SALAMANDER_VIEWTEMPLATE_RIGHTSMARTMODE, REG_DWORD, &rightSM, sizeof(DWORD));
             if (GetValue(actKey, SALAMANDER_VIEWTEMPLATE_NAME, REG_SZ, name, SAL_MAX_PATH) &&
                 GetValue(actKey, SALAMANDER_VIEWTEMPLATE_FLAGS, REG_DWORD, &flags, sizeof(DWORD)) &&
-                GetValue(actKey, SALAMANDER_VIEWTEMPLATE_COLUMNS, REG_SZ, buff, 512))
+                GetValue(actKey, SALAMANDER_VIEWTEMPLATE_COLUMNS, REG_SZ, buff, sizeof(buff)))
             {
                 LoadColumns(Items[i].Columns, buff);
-                if (GetValue(actKey, SALAMANDER_VIEWTEMPLATE_COLUMNORDER, REG_SZ, buff, 512))
+                if (GetValue(actKey, SALAMANDER_VIEWTEMPLATE_COLUMNORDER, REG_SZ, buff, sizeof(buff)))
                     LoadColumnOrder(Items[i].ColumnOrder, buff);
+                if (GetValue(actKey, SALAMANDER_VIEWTEMPLATE_EXPLORERCOLUMNVISIBLE, REG_SZ, buff, sizeof(buff)))
+                    LoadExplorerColumnVisible(Items[i].ExplorerColumnVisible, buff);
+                if (GetValue(actKey, SALAMANDER_VIEWTEMPLATE_EXPLORERCOLUMNORDER, REG_SZ, buff, sizeof(buff)))
+                    LoadColumnOrder(Items[i].ExplorerColumnOrder, buff, EXPLORER_COLUMNS_COUNT);
                 CleanName(name);
 
                 // overwrite file names the user could not change anyway


### PR DESCRIPTION
### Motivation
- Persist per-template Explorer column visibility and order so user changes in the Views configuration survive application restart.
- Reuse existing column-order serialization helpers and validation logic to keep load/save robust and backward-compatible with older configs.

### Description
- Added registry value names `SALAMANDER_VIEWTEMPLATE_EXPLORERCOLUMNVISIBLE` and `SALAMANDER_VIEWTEMPLATE_EXPLORERCOLUMNORDER` next to the existing `SALAMANDER_VIEWTEMPLATE_COLUMNORDER` constant.
- Extended `CViewTemplates::SaveColumnOrder` and `CViewTemplates::LoadColumnOrder` to accept a `count` parameter (defaulting to `STANDARD_COLUMNS_COUNT`) so the same validated logic can handle `EXPLORER_COLUMNS_COUNT` arrays, and updated the header prototypes in `src/salamand.h` accordingly.
- Implemented `CViewTemplates::SaveExplorerColumnVisible` and `CViewTemplates::LoadExplorerColumnVisible` to serialize/deserialize Explorer checkbox visibility in a compatible, robust comma-separated format that leaves missing/short legacy data as `FALSE`.
- Increased the local registry buffer in `CViewTemplates::Save`/`Load` to `4 * EXPLORER_COLUMNS_COUNT + 1` and wired saving/loading of `ExplorerColumnVisible` and `ExplorerColumnOrder` with `SetValue`/`GetValue`, using the new helpers and calling `LoadColumnOrder(..., EXPLORER_COLUMNS_COUNT)` to validate/repair order data while falling back to constructor defaults when values are absent.

### Testing
- Ran `git diff --check` and static inspections; no whitespace/errors were reported.
- Reviewed `CCfgPageView::StoreControls()` to confirm UI already writes into `Config.Items[index].ExplorerColumnVisible` and `ExplorerColumnOrder` and reviewed `fileswn9.cpp` to confirm runtime uses `ViewTemplate->ExplorerColumnOrder` and `ExplorerColumnVisible`; these checks passed.
- Performed repository commands (`git status`, `git commit`) to record the change; no build or Windows runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f80801b908329aabcfd4d944aa479)