### PR TITLE
Enable sorting for Explorer property (custom) columns

### DIFF
--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -1401,7 +1401,9 @@ Source: "{#PayloadDir}\toolbars\ChangeCase.svg"; DestDir: "{app}\toolbars"; Flag
 Source: "{#PayloadDir}\toolbars\ChangeDirectory.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\Modify.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\Move.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
+Source: "{#PayloadDir}\toolbars\MoveItemBottom.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\MoveItemDown.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
+Source: "{#PayloadDir}\toolbars\MoveItemTop.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\MoveItemUp.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\New.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\NTFSCompress.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
@@ -1518,7 +1520,9 @@ Source: "{#PayloadDir}\toolbars\darkmode\ChangeCase.svg"; DestDir: "{app}\toolba
 Source: "{#PayloadDir}\toolbars\darkmode\ChangeDirectory.svg"; DestDir: "{app}\toolbars\darkmode"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\darkmode\Modify.svg"; DestDir: "{app}\toolbars\darkmode"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\darkmode\Move.svg"; DestDir: "{app}\toolbars\darkmode"; Flags: ignoreversion
+Source: "{#PayloadDir}\toolbars\darkmode\MoveItemBottom.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\darkmode\MoveItemDown.svg"; DestDir: "{app}\toolbars\darkmode"; Flags: ignoreversion
+Source: "{#PayloadDir}\toolbars\darkmode\MoveItemTop.svg"; DestDir: "{app}\toolbars"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\darkmode\MoveItemUp.svg"; DestDir: "{app}\toolbars\darkmode"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\darkmode\New.svg"; DestDir: "{app}\toolbars\darkmode"; Flags: ignoreversion
 Source: "{#PayloadDir}\toolbars\darkmode\NTFSCompress.svg"; DestDir: "{app}\toolbars\darkmode"; Flags: ignoreversion

--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -597,6 +597,9 @@ protected:
     HWND HListView;
     CToolbarHeader* Header2;
     HWND HListView2;
+    HWND HAvailableColumnsFilter;
+    BOOL AvailableColumnsFilterVisible;
+    char AvailableColumnsFilterText[100];
     CViewTemplates Config;
     BOOL DisableNotification;
     BOOL LabelEdit;
@@ -620,6 +623,10 @@ public:
     void StoreControls();
     void EnableControls();
     void EnableHeader();
+    void ApplyAvailableColumnsFilter();
+    BOOL IsAvailableColumnsFilterActive();
+    BOOL AvailableColumnMatchesFilter(const char* text);
+    void ToggleAvailableColumnsFilter();
     void LayoutViewsListControls();
     DWORD GetEnabledFunctions();
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -1709,14 +1709,27 @@ void CCfgPageView::LayoutViewsListControls()
                                       SWP_NOZORDER));
         if (HAvailableColumnsFilter != NULL)
         {
-            const int filterLeft = rightLeft + 48;
-            int filterWidth = AvailableColumnsWidth - 48 - 4;
+            int listHeaderHeight = header2Height;
+            HWND listHeader = ListView_GetHeader(HListView2);
+            if (listHeader != NULL)
+            {
+                RECT listHeaderRect;
+                GetWindowRect(listHeader, &listHeaderRect);
+                listHeaderHeight = listHeaderRect.bottom - listHeaderRect.top;
+            }
+
+            const int filterLeftOffset = 100;
+            const int filterMargin = 4;
+            int filterWidth = AvailableColumnsWidth - filterLeftOffset - GetSystemMetrics(SM_CXVSCROLL) - filterMargin;
             if (filterWidth < 20)
                 filterWidth = 20;
+            int filterHeight = listHeaderHeight - 4;
+            if (filterHeight < 10)
+                filterHeight = 10;
             hdwp = HANDLES(DeferWindowPos(hdwp, HAvailableColumnsFilter, HWND_TOP,
-                                          filterLeft, rightTop.y - header2Height + 2,
-                                          filterWidth, header2Height - 4,
-                                          SWP_NOZORDER | (AvailableColumnsFilterVisible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW)));
+                                          rightLeft + filterLeftOffset, rightTop.y + 2,
+                                          filterWidth, filterHeight,
+                                          AvailableColumnsFilterVisible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW));
         }
         HANDLES(EndDeferWindowPos(hdwp));
     }

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -2006,14 +2006,14 @@ void CCfgPageView::EnableHeader()
             if (colIndex > 1 && GetAvailableColumnIndex(HListView2, colIndex - 1) >= 0)
                 mask |= TLBHDRMASK_UP | TLBHDRMASK_TOP;
             if (colIndex > 0 && colIndex < CFGP2ItemsCount - 1 && GetAvailableColumnIndex(HListView2, colIndex + 1) >= 0)
-                mask |= TLBHDRMASK_DOWN;
+                mask |= TLBHDRMASK_DOWN | TLBHDRMASK_BOTTOM;
         }
         else
         {
             if (colIndex > CFGP2ExplorerColumnsStart && GetAvailableColumnIndex(HListView2, colIndex - 1) < 0)
                 mask |= TLBHDRMASK_UP | TLBHDRMASK_TOP;
             if (colIndex < ListView_GetItemCount(HListView2) - 1 && GetAvailableColumnIndex(HListView2, colIndex + 1) < 0)
-                mask |= TLBHDRMASK_DOWN;
+                mask |= TLBHDRMASK_DOWN | TLBHDRMASK_BOTTOM;
         }
     }
     Header2->EnableToolbar(mask);
@@ -2101,7 +2101,7 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         HListView2 = GetDlgItem(HWindow, IDC_VIEW_LIST2);
         Header = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER, HListView,
                                     TLBHDRMASK_MODIFY | TLBHDRMASK_DELETE);
-        Header2 = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER2, HListView2, TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN | TLBHDRMASK_FILTER);
+        Header2 = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER2, HListView2, TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN | TLBHDRMASK_BOTTOM | TLBHDRMASK_FILTER);
         HAvailableColumnsFilter = CreateWindowEx(WS_EX_CLIENTEDGE, "EDIT", "",
                                                  WS_CHILD | WS_TABSTOP | ES_AUTOHSCROLL,
                                                  0, 0, 0, 0, HWindow,
@@ -2591,7 +2591,7 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 ToggleAvailableColumnsFilter();
             }
-            else if (HIWORD(wParam) == TLBHDR_TOP || HIWORD(wParam) == TLBHDR_UP || HIWORD(wParam) == TLBHDR_DOWN)
+            else if (HIWORD(wParam) == TLBHDR_TOP || HIWORD(wParam) == TLBHDR_UP || HIWORD(wParam) == TLBHDR_DOWN || HIWORD(wParam) == TLBHDR_BOTTOM)
             {
                 int index = ListView_GetNextItem(HListView, -1, LVNI_SELECTED);
                 int item = ListView_GetNextItem(HListView2, -1, LVNI_SELECTED);
@@ -2628,6 +2628,40 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         ListView_SetItemState(HListView2, -1, 0, LVIS_FOCUSED | LVIS_SELECTED);
                         ListView_SetItemState(HListView2, topItem, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
                         ListView_EnsureVisible(HListView2, topItem, FALSE);
+                        Dirty = TRUE;
+                    }
+                }
+                else if (HIWORD(wParam) == TLBHDR_BOTTOM)
+                {
+                    int bottomItem = columnIndex >= 0 ? CFGP2ItemsCount - 1 : ListView_GetItemCount(HListView2) - 1;
+                    if (index >= 2 && item >= 0 && item < bottomItem &&
+                        ((columnIndex >= 0 && item > 0 && item < CFGP2ItemsCount) ||
+                         (columnIndex < 0 && item >= CFGP2ExplorerColumnsStart)))
+                    {
+                        StoreControls();
+                        if (columnIndex >= 0)
+                        {
+                            BYTE tmp = Config.Items[index].ColumnOrder[item];
+                            memmove(Config.Items[index].ColumnOrder + item,
+                                    Config.Items[index].ColumnOrder + item + 1,
+                                    bottomItem - item);
+                            Config.Items[index].ColumnOrder[bottomItem] = tmp;
+                        }
+                        else
+                        {
+                            int explorerItem = item - CFGP2ExplorerColumnsStart;
+                            int bottomExplorerItem = bottomItem - CFGP2ExplorerColumnsStart;
+                            WORD tmp = Config.Items[index].ExplorerColumnOrder[explorerItem];
+                            memmove(Config.Items[index].ExplorerColumnOrder + explorerItem,
+                                    Config.Items[index].ExplorerColumnOrder + explorerItem + 1,
+                                    (bottomExplorerItem - explorerItem) * sizeof(WORD));
+                            Config.Items[index].ExplorerColumnOrder[bottomExplorerItem] = tmp;
+                        }
+                        ListView_DeleteAllItems(HListView2);
+                        LoadControls();
+                        ListView_SetItemState(HListView2, -1, 0, LVIS_FOCUSED | LVIS_SELECTED);
+                        ListView_SetItemState(HListView2, bottomItem, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
+                        ListView_EnsureVisible(HListView2, bottomItem, FALSE);
                         Dirty = TRUE;
                     }
                 }

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -2102,10 +2102,10 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         Header = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER, HListView,
                                     TLBHDRMASK_MODIFY | TLBHDRMASK_DELETE);
         Header2 = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER2, HListView2, TLBHDRMASK_UP | TLBHDRMASK_DOWN | TLBHDRMASK_FILTER);
-        HAvailableColumnsFilter = HANDLES(CreateWindowEx(WS_EX_CLIENTEDGE, "EDIT", "",
-                                                         WS_CHILD | WS_TABSTOP | ES_AUTOHSCROLL,
-                                                         0, 0, 0, 0, HWindow,
-                                                         (HMENU)IDC_VIEW_COLUMNS_FILTER, HInstance, NULL));
+        HAvailableColumnsFilter = CreateWindowEx(WS_EX_CLIENTEDGE, "EDIT", "",
+                                                 WS_CHILD | WS_TABSTOP | ES_AUTOHSCROLL,
+                                                 0, 0, 0, 0, HWindow,
+                                                 (HMENU)IDC_VIEW_COLUMNS_FILTER, HInstance, NULL);
         if (HAvailableColumnsFilter != NULL)
         {
             SendMessage(HAvailableColumnsFilter, WM_SETFONT, SendMessage(HListView2, WM_GETFONT, 0, 0), TRUE);

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -2004,14 +2004,14 @@ void CCfgPageView::EnableHeader()
         if (selectedColumnIndex >= 0)
         {
             if (colIndex > 1 && GetAvailableColumnIndex(HListView2, colIndex - 1) >= 0)
-                mask |= TLBHDRMASK_UP;
+                mask |= TLBHDRMASK_UP | TLBHDRMASK_TOP;
             if (colIndex > 0 && colIndex < CFGP2ItemsCount - 1 && GetAvailableColumnIndex(HListView2, colIndex + 1) >= 0)
                 mask |= TLBHDRMASK_DOWN;
         }
         else
         {
             if (colIndex > CFGP2ExplorerColumnsStart && GetAvailableColumnIndex(HListView2, colIndex - 1) < 0)
-                mask |= TLBHDRMASK_UP;
+                mask |= TLBHDRMASK_UP | TLBHDRMASK_TOP;
             if (colIndex < ListView_GetItemCount(HListView2) - 1 && GetAvailableColumnIndex(HListView2, colIndex + 1) < 0)
                 mask |= TLBHDRMASK_DOWN;
         }
@@ -2101,7 +2101,7 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         HListView2 = GetDlgItem(HWindow, IDC_VIEW_LIST2);
         Header = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER, HListView,
                                     TLBHDRMASK_MODIFY | TLBHDRMASK_DELETE);
-        Header2 = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER2, HListView2, TLBHDRMASK_UP | TLBHDRMASK_DOWN | TLBHDRMASK_FILTER);
+        Header2 = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER2, HListView2, TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN | TLBHDRMASK_FILTER);
         HAvailableColumnsFilter = CreateWindowEx(WS_EX_CLIENTEDGE, "EDIT", "",
                                                  WS_CHILD | WS_TABSTOP | ES_AUTOHSCROLL,
                                                  0, 0, 0, 0, HWindow,
@@ -2591,16 +2591,49 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 ToggleAvailableColumnsFilter();
             }
-            else if (HIWORD(wParam) == TLBHDR_UP || HIWORD(wParam) == TLBHDR_DOWN)
+            else if (HIWORD(wParam) == TLBHDR_TOP || HIWORD(wParam) == TLBHDR_UP || HIWORD(wParam) == TLBHDR_DOWN)
             {
                 int index = ListView_GetNextItem(HListView, -1, LVNI_SELECTED);
                 int item = ListView_GetNextItem(HListView2, -1, LVNI_SELECTED);
                 int item2 = HIWORD(wParam) == TLBHDR_UP ? item - 1 : item + 1;
                 int columnIndex = GetAvailableColumnIndex(HListView2, item);
                 int columnIndex2 = GetAvailableColumnIndex(HListView2, item2);
-                if (index >= 2 && item > 0 && item2 > 0 &&
-                    ((columnIndex >= 0 && columnIndex2 >= 0 && item2 < CFGP2ItemsCount) ||
-                     (columnIndex < 0 && columnIndex2 < 0 && item >= CFGP2ExplorerColumnsStart && item2 >= CFGP2ExplorerColumnsStart)))
+                if (HIWORD(wParam) == TLBHDR_TOP)
+                {
+                    int topItem = columnIndex >= 0 ? 1 : CFGP2ExplorerColumnsStart;
+                    if (index >= 2 && item > topItem &&
+                        ((columnIndex >= 0 && item < CFGP2ItemsCount) ||
+                         (columnIndex < 0 && item >= CFGP2ExplorerColumnsStart)))
+                    {
+                        StoreControls();
+                        if (columnIndex >= 0)
+                        {
+                            BYTE tmp = Config.Items[index].ColumnOrder[item];
+                            memmove(Config.Items[index].ColumnOrder + topItem + 1,
+                                    Config.Items[index].ColumnOrder + topItem,
+                                    item - topItem);
+                            Config.Items[index].ColumnOrder[topItem] = tmp;
+                        }
+                        else
+                        {
+                            int explorerItem = item - CFGP2ExplorerColumnsStart;
+                            WORD tmp = Config.Items[index].ExplorerColumnOrder[explorerItem];
+                            memmove(Config.Items[index].ExplorerColumnOrder + 1,
+                                    Config.Items[index].ExplorerColumnOrder,
+                                    explorerItem * sizeof(WORD));
+                            Config.Items[index].ExplorerColumnOrder[0] = tmp;
+                        }
+                        ListView_DeleteAllItems(HListView2);
+                        LoadControls();
+                        ListView_SetItemState(HListView2, -1, 0, LVIS_FOCUSED | LVIS_SELECTED);
+                        ListView_SetItemState(HListView2, topItem, LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
+                        ListView_EnsureVisible(HListView2, topItem, FALSE);
+                        Dirty = TRUE;
+                    }
+                }
+                else if (index >= 2 && item > 0 && item2 > 0 &&
+                         ((columnIndex >= 0 && columnIndex2 >= 0 && item2 < CFGP2ItemsCount) ||
+                          (columnIndex < 0 && columnIndex2 < 0 && item >= CFGP2ExplorerColumnsStart && item2 >= CFGP2ExplorerColumnsStart)))
                 {
                     StoreControls();
                     if (columnIndex >= 0)

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -1624,7 +1624,7 @@ static void InitColumnOrder(BYTE* order)
     }
 }
 
-static void InitExplorerColumnOrder(BYTE* order)
+static void InitExplorerColumnOrder(WORD* order)
 {
     BOOL used[EXPLORER_COLUMNS_COUNT];
     ZeroMemory(used, sizeof(used));
@@ -1633,18 +1633,18 @@ static void InitExplorerColumnOrder(BYTE* order)
         if (order[i] < EXPLORER_COLUMNS_COUNT && !used[order[i]])
             used[order[i]] = TRUE;
         else
-            order[i] = 0xff;
+            order[i] = 0xffff;
     }
     int next = 0;
     for (int i = 0; i < EXPLORER_COLUMNS_COUNT; i++)
     {
-        if (order[i] == 0xff)
+        if (order[i] == 0xffff)
         {
             while (next < EXPLORER_COLUMNS_COUNT && used[next])
                 next++;
             if (next < EXPLORER_COLUMNS_COUNT)
             {
-                order[i] = (BYTE)next;
+                order[i] = (WORD)next;
                 used[next] = TRUE;
             }
         }
@@ -1920,7 +1920,7 @@ void CCfgPageView::StoreControls()
                 {
                     DWORD state = ListView_GetItemState(HListView2, i, LVIS_STATEIMAGEMASK);
                     Config.Items[index].ExplorerColumnVisible[explorerIndex] = state == INDEXTOSTATEIMAGEMASK(2);
-                    Config.Items[index].ExplorerColumnOrder[i - CFGP2ExplorerColumnsStart] = (BYTE)explorerIndex;
+                    Config.Items[index].ExplorerColumnOrder[i - CFGP2ExplorerColumnsStart] = (WORD)explorerIndex;
                 }
             }
         }
@@ -2613,7 +2613,7 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     {
                         int explorerItem = item - CFGP2ExplorerColumnsStart;
                         int explorerItem2 = item2 - CFGP2ExplorerColumnsStart;
-                        BYTE tmp = Config.Items[index].ExplorerColumnOrder[explorerItem];
+                        WORD tmp = Config.Items[index].ExplorerColumnOrder[explorerItem];
                         Config.Items[index].ExplorerColumnOrder[explorerItem] = Config.Items[index].ExplorerColumnOrder[explorerItem2];
                         Config.Items[index].ExplorerColumnOrder[explorerItem2] = tmp;
                     }

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -1495,6 +1495,9 @@ CCfgPageView::CCfgPageView(int index)
     HListView = NULL;
     Header2 = NULL;
     HListView2 = NULL;
+    HAvailableColumnsFilter = NULL;
+    AvailableColumnsFilterVisible = FALSE;
+    AvailableColumnsFilterText[0] = 0;
     DisableNotification = FALSE;
     LabelEdit = FALSE;
     AvailableColumnsWidth = 0;
@@ -1688,7 +1691,7 @@ void CCfgPageView::LayoutViewsListControls()
     const int headerHeight = headerRect.bottom - headerRect.top;
     const int header2Height = header2Rect.bottom - header2Rect.top;
 
-    HDWP hdwp = HANDLES(BeginDeferWindowPos(4));
+    HDWP hdwp = HANDLES(BeginDeferWindowPos(5));
     if (hdwp != NULL)
     {
         hdwp = HANDLES(DeferWindowPos(hdwp, HListView, NULL,
@@ -1704,12 +1707,72 @@ void CCfgPageView::LayoutViewsListControls()
                                       rightLeft, rightTop.y - header2Height,
                                       AvailableColumnsWidth, header2Height,
                                       SWP_NOZORDER));
+        if (HAvailableColumnsFilter != NULL)
+        {
+            const int filterLeft = rightLeft + 48;
+            int filterWidth = AvailableColumnsWidth - 48 - 4;
+            if (filterWidth < 20)
+                filterWidth = 20;
+            hdwp = HANDLES(DeferWindowPos(hdwp, HAvailableColumnsFilter, HWND_TOP,
+                                          filterLeft, rightTop.y - header2Height + 2,
+                                          filterWidth, header2Height - 4,
+                                          SWP_NOZORDER | (AvailableColumnsFilterVisible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW)));
+        }
         HANDLES(EndDeferWindowPos(hdwp));
     }
 
     SetViewsAvailableColumnsColumnWidth(HListView2);
     InvalidateRect(HListView, NULL, TRUE);
     InvalidateRect(HListView2, NULL, TRUE);
+}
+
+BOOL CCfgPageView::IsAvailableColumnsFilterActive()
+{
+    return AvailableColumnsFilterVisible && AvailableColumnsFilterText[0] != 0;
+}
+
+BOOL CCfgPageView::AvailableColumnMatchesFilter(const char* text)
+{
+    if (!IsAvailableColumnsFilterActive())
+        return TRUE;
+    if (text == NULL)
+        return FALSE;
+
+    char filter[100];
+    lstrcpyn(filter, AvailableColumnsFilterText, _countof(filter));
+    CharLowerBuffA(filter, lstrlen(filter));
+
+    char name[COLUMN_DESCRIPTION_MAX];
+    lstrcpyn(name, text, _countof(name));
+    CharLowerBuffA(name, lstrlen(name));
+    return strstr(name, filter) != NULL;
+}
+
+void CCfgPageView::ApplyAvailableColumnsFilter()
+{
+    if (HAvailableColumnsFilter != NULL)
+        GetWindowText(HAvailableColumnsFilter, AvailableColumnsFilterText, _countof(AvailableColumnsFilterText));
+    LoadControls();
+    EnableHeader();
+}
+
+void CCfgPageView::ToggleAvailableColumnsFilter()
+{
+    AvailableColumnsFilterVisible = !AvailableColumnsFilterVisible;
+    if (!AvailableColumnsFilterVisible)
+        AvailableColumnsFilterText[0] = 0;
+
+    if (HAvailableColumnsFilter != NULL)
+    {
+        DisableNotification = TRUE;
+        SetWindowText(HAvailableColumnsFilter, AvailableColumnsFilterText);
+        ShowWindow(HAvailableColumnsFilter, AvailableColumnsFilterVisible ? SW_SHOW : SW_HIDE);
+        DisableNotification = FALSE;
+        if (AvailableColumnsFilterVisible)
+            SetFocus(HAvailableColumnsFilter);
+    }
+    ApplyAvailableColumnsFilter();
+    LayoutViewsListControls();
 }
 
 void CCfgPageView::LoadControls()
@@ -1738,13 +1801,16 @@ void CCfgPageView::LoadControls()
         for (i = 0; i < CFGP2ItemsCount; i++)
         {
             int columnIndex = Config.Items[index].ColumnOrder[i];
+            const char* columnName = LoadStr(CFGP2ResID[columnIndex]);
+            if (!AvailableColumnMatchesFilter(columnName))
+                continue;
             LVITEM lvi;
             lvi.mask = LVIF_TEXT | LVIF_STATE | LVIF_PARAM;
-            lvi.iItem = i;
+            lvi.iItem = ListView_GetItemCount(HListView2);
             lvi.iSubItem = 0;
             lvi.state = 0;
             lvi.lParam = columnIndex;
-            lvi.pszText = LoadStr(CFGP2ResID[columnIndex]);
+            lvi.pszText = (char*)columnName;
             ListView_InsertItem(HListView2, &lvi);
         }
         InitExplorerColumnOrder(Config.Items[index].ExplorerColumnOrder);
@@ -1754,7 +1820,9 @@ void CCfgPageView::LoadControls()
             int explorerIndex = Config.Items[index].ExplorerColumnOrder[i];
             LVITEM lvi;
             lvi.mask = LVIF_TEXT | LVIF_STATE | LVIF_PARAM;
-            lvi.iItem = CFGP2ExplorerColumnsStart + i;
+            if (!AvailableColumnMatchesFilter(GetExplorerColumnName(explorerIndex)))
+                continue;
+            lvi.iItem = ListView_GetItemCount(HListView2);
             lvi.iSubItem = 0;
             lvi.state = 0;
             lvi.lParam = -(explorerIndex + 1);
@@ -1810,6 +1878,8 @@ void CCfgPageView::LoadControls()
 void CCfgPageView::StoreControls()
 {
     int index = ListView_GetNextItem(HListView, -1, LVNI_SELECTED);
+    if (IsAvailableColumnsFilterActive())
+        return;
     if (index >= 2)
     {
         DWORD flags = 0;
@@ -1914,8 +1984,8 @@ void CCfgPageView::EnableHeader()
     Header->EnableToolbar(GetEnabledFunctions());
     int viewIndex = ListView_GetNextItem(HListView, -1, LVNI_SELECTED);
     int colIndex = ListView_GetNextItem(HListView2, -1, LVNI_SELECTED);
-    DWORD mask = 0;
-    if (!LabelEdit && viewIndex >= 2 && viewIndex != 3 && viewIndex != 4 && viewIndex != 5 && colIndex != -1)
+    DWORD mask = TLBHDRMASK_FILTER;
+    if (!LabelEdit && !IsAvailableColumnsFilterActive() && viewIndex >= 2 && viewIndex != 3 && viewIndex != 4 && viewIndex != 5 && colIndex != -1)
     {
         int selectedColumnIndex = GetAvailableColumnIndex(HListView2, colIndex);
         if (selectedColumnIndex >= 0)
@@ -1934,6 +2004,7 @@ void CCfgPageView::EnableHeader()
         }
     }
     Header2->EnableToolbar(mask);
+    Header2->CheckToolbar(AvailableColumnsFilterVisible ? TLBHDRMASK_FILTER : 0);
 }
 
 void CCfgPageView::OnModify()
@@ -2017,7 +2088,16 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         HListView2 = GetDlgItem(HWindow, IDC_VIEW_LIST2);
         Header = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER, HListView,
                                     TLBHDRMASK_MODIFY | TLBHDRMASK_DELETE);
-        Header2 = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER2, HListView2, TLBHDRMASK_UP | TLBHDRMASK_DOWN);
+        Header2 = new CToolbarHeader(HWindow, IDC_VIEWLIST_HEADER2, HListView2, TLBHDRMASK_UP | TLBHDRMASK_DOWN | TLBHDRMASK_FILTER);
+        HAvailableColumnsFilter = HANDLES(CreateWindowEx(WS_EX_CLIENTEDGE, "EDIT", "",
+                                                         WS_CHILD | WS_TABSTOP | ES_AUTOHSCROLL,
+                                                         0, 0, 0, 0, HWindow,
+                                                         (HMENU)IDC_VIEW_COLUMNS_FILTER, HInstance, NULL));
+        if (HAvailableColumnsFilter != NULL)
+        {
+            SendMessage(HAvailableColumnsFilter, WM_SETFONT, SendMessage(HListView2, WM_GETFONT, 0, 0), TRUE);
+            ShowWindow(HAvailableColumnsFilter, SW_HIDE);
+        }
 
         DWORD exFlags = LVS_EX_FULLROWSELECT /*| LVS_EX_CHECKBOXES*/;
         DWORD origFlags = ListView_GetExtendedListViewStyle(HListView);
@@ -2260,7 +2340,8 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 LPNMLISTVIEW nmhi = (LPNMLISTVIEW)nmh;
                 // disagree :-) beep when attempting to hide the Name column
-                if (nmhi->iItem == 0 && (nmhi->uOldState & 0xF000) != (nmhi->uNewState & 0xF000))
+                int columnIndex = GetAvailableColumnIndex(HListView2, nmhi->iItem);
+                if (columnIndex == 0 && (nmhi->uOldState & 0xF000) != (nmhi->uNewState & 0xF000))
                 {
                     MessageBeep(MB_ICONASTERISK);
                     SetWindowLongPtr(HWindow, DWLP_MSGRESULT, TRUE);
@@ -2276,7 +2357,31 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 LPNMLISTVIEW nmhi = (LPNMLISTVIEW)nmh;
                 if ((nmhi->uOldState & 0xF000) != (nmhi->uNewState & 0xF000))
                 {
-                    StoreControls(); // save data when the checkbox is clicked
+                    if (IsAvailableColumnsFilterActive())
+                    {
+                        int viewIndex = ListView_GetNextItem(HListView, -1, LVNI_SELECTED);
+                        int columnIndex = GetAvailableColumnIndex(HListView2, nmhi->iItem);
+                        BOOL checked = (nmhi->uNewState & 0xF000) == INDEXTOSTATEIMAGEMASK(2);
+                        if (viewIndex >= 2)
+                        {
+                            if (columnIndex > 0)
+                            {
+                                if (checked)
+                                    Config.Items[viewIndex].Flags |= CFGP2Flags[columnIndex];
+                                else
+                                    Config.Items[viewIndex].Flags &= ~CFGP2Flags[columnIndex];
+                            }
+                            else if (columnIndex < 0)
+                            {
+                                int explorerIndex = -columnIndex - 1;
+                                if (explorerIndex >= 0 && explorerIndex < EXPLORER_COLUMNS_COUNT)
+                                    Config.Items[viewIndex].ExplorerColumnVisible[explorerIndex] = checked;
+                            }
+                            Dirty = TRUE;
+                        }
+                    }
+                    else
+                        StoreControls(); // save data when the checkbox is clicked
                     EnableControls();
                 }
                 else if (!(nmhi->uOldState & LVIS_SELECTED) && nmhi->uNewState & LVIS_SELECTED)
@@ -2434,6 +2539,11 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         if (!DisableNotification && HIWORD(wParam) == EN_CHANGE)
         {
+            if (LOWORD(wParam) == IDC_VIEW_COLUMNS_FILTER)
+            {
+                ApplyAvailableColumnsFilter();
+                break;
+            }
             if (LOWORD(wParam) == IDC_VIEW_LEFT_WIDTH || LOWORD(wParam) == IDC_VIEW_RIGHT_WIDTH)
             {
                 int index = ListView_GetNextItem(HListView, -1, LVNI_SELECTED);
@@ -2464,7 +2574,11 @@ CCfgPageView::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             if (GetFocus() != HListView2)
                 SetFocus(HListView2);
-            if (HIWORD(wParam) == TLBHDR_UP || HIWORD(wParam) == TLBHDR_DOWN)
+            if (HIWORD(wParam) == TLBHDR_FILTER)
+            {
+                ToggleAvailableColumnsFilter();
+            }
+            else if (HIWORD(wParam) == TLBHDR_UP || HIWORD(wParam) == TLBHDR_DOWN)
             {
                 int index = ListView_GetNextItem(HListView, -1, LVNI_SELECTED);
                 int item = ListView_GetNextItem(HListView2, -1, LVNI_SELECTED);

--- a/src/edtlbwnd.cpp
+++ b/src/edtlbwnd.cpp
@@ -274,7 +274,7 @@ BOOL CEditListBox::MakeHeader(int ctrlID)
 {
     Header = new CToolbarHeader(HDlg, ctrlID, HWindow,
                                 TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
-                                    TLBHDRMASK_UP | TLBHDRMASK_DOWN);
+                                    TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN);
     if (Header == NULL)
     {
         TRACE_E(LOW_MEMORY);
@@ -312,7 +312,7 @@ void CEditListBox::CommandParent(UINT code)
 BYTE CEditListBox::GetEnabler()
 {
     BYTE enabler = TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
-                   TLBHDRMASK_UP | TLBHDRMASK_DOWN;
+                   TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN;
     if (Flags & ELB_ENABLECOMMANDS)
     {
         int index = (int)SendMessage(HWindow, LB_GETCURSEL, 0, 0);
@@ -337,11 +337,26 @@ void CEditListBox::OnSelChanged()
     if (!disableAll && ItemsCount > 0 && index != ItemsCount)
         mask |= (enabler & TLBHDRMASK_DELETE);
     if (!disableAll && index > 0 && index < ItemsCount)
-        mask |= (enabler & TLBHDRMASK_UP);
+        mask |= (enabler & (TLBHDRMASK_TOP | TLBHDRMASK_UP));
     if (!disableAll && index >= 0 && index < ItemsCount - 1)
         mask |= (enabler & TLBHDRMASK_DOWN);
 
     Header->EnableToolbar(mask);
+}
+
+
+void CEditListBox::OnMoveTop()
+{
+    CALL_STACK_MESSAGE1("CEditListBox::OnMoveTop()");
+    int index;
+    if (!GetCurSel(index))
+        return;
+    if (index == ItemsCount || index < 1)
+        return;
+    if ((GetEnabler() & TLBHDRMASK_TOP) == 0)
+        return;
+
+    MoveItem(0);
 }
 
 void CEditListBox::OnMoveUp()
@@ -812,6 +827,9 @@ CEditListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 break;
             case TLBHDR_DELETE:
                 OnDelete();
+                break;
+            case TLBHDR_TOP:
+                OnMoveTop();
                 break;
             case TLBHDR_UP:
                 OnMoveUp();

--- a/src/edtlbwnd.cpp
+++ b/src/edtlbwnd.cpp
@@ -283,7 +283,7 @@ BOOL CEditListBox::MakeHeader(int ctrlID)
     Header->SetNotifyWindow(HWindow);
     HSearchEdit = CreateWindowEx(WS_EX_CLIENTEDGE, "EDIT", "",
                                  WS_CHILD | WS_TABSTOP | ES_AUTOHSCROLL,
-                                 0, 0, 0, 0, HDlg,
+                                 0, 0, 0, 0, Header->HWindow,
                                  (HMENU)0, HInstance, NULL);
     if (HSearchEdit != NULL)
     {
@@ -363,9 +363,7 @@ void CEditListBox::LayoutSearchEdit()
         return;
 
     RECT headerRect;
-    GetWindowRect(Header->HWindow, &headerRect);
-    POINT headerTop = {headerRect.left, headerRect.top};
-    ScreenToClient(HDlg, &headerTop);
+    GetClientRect(Header->HWindow, &headerRect);
 
     const int buttonsWidth = 7 * 22 + 4; // Search, Modify, New, Delete, Top, Up, Down in edit-list headers.
     int width = headerRect.right - headerRect.left - buttonsWidth - 4;
@@ -376,7 +374,7 @@ void CEditListBox::LayoutSearchEdit()
     int left = headerRect.right - headerRect.left - buttonsWidth - width;
     if (left < 4)
         left = 4;
-    SetWindowPos(HSearchEdit, HWND_TOP, headerTop.x + left, headerTop.y + 2,
+    SetWindowPos(HSearchEdit, HWND_TOP, left, 2,
                  width, headerRect.bottom - headerRect.top - 4,
                  SearchVisible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW);
 }

--- a/src/edtlbwnd.cpp
+++ b/src/edtlbwnd.cpp
@@ -110,6 +110,9 @@ CEditListBox::CEditListBox(HWND hDlg, int ctrlID, DWORD flags, CObjectOrigin ori
 {
     HDlg = hDlg;
     Header = NULL;
+    HSearchEdit = NULL;
+    SearchVisible = FALSE;
+    SearchText[0] = 0;
     Flags = flags;
     DeleteAllItems();
     EditLine = NULL;
@@ -274,7 +277,7 @@ BOOL CEditListBox::MakeHeader(int ctrlID)
 {
     Header = new CToolbarHeader(HDlg, ctrlID, HWindow,
                                 TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
-                                    TLBHDRMASK_SEARCH | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN);
+                                    TLBHDRMASK_SEARCH | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN | TLBHDRMASK_BOTTOM);
     if (Header == NULL)
     {
         TRACE_E(LOW_MEMORY);
@@ -322,7 +325,7 @@ void CEditListBox::CommandParent(UINT code)
 DWORD CEditListBox::GetEnabler()
 {
     DWORD enabler = TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
-                   TLBHDRMASK_SEARCH | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN;
+                   TLBHDRMASK_SEARCH | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN | TLBHDRMASK_BOTTOM;
     if (Flags & ELB_ENABLECOMMANDS)
     {
         int index = (int)SendMessage(HWindow, LB_GETCURSEL, 0, 0);
@@ -349,7 +352,7 @@ void CEditListBox::OnSelChanged()
     if (!disableAll && index > 0 && index < ItemsCount)
         mask |= (enabler & (TLBHDRMASK_TOP | TLBHDRMASK_UP));
     if (!disableAll && index >= 0 && index < ItemsCount - 1)
-        mask |= (enabler & TLBHDRMASK_DOWN);
+        mask |= (enabler & (TLBHDRMASK_DOWN | TLBHDRMASK_BOTTOM));
 
     Header->EnableToolbar(mask);
     Header->CheckToolbar(SearchVisible ? TLBHDRMASK_SEARCH : 0);
@@ -365,7 +368,7 @@ void CEditListBox::LayoutSearchEdit()
     RECT headerRect;
     GetClientRect(Header->HWindow, &headerRect);
 
-    const int buttonsWidth = 7 * 22 + 4; // Search, Modify, New, Delete, Top, Up, Down in edit-list headers.
+    const int buttonsWidth = 8 * 22 + 4; // Search, Modify, New, Delete, Top, Up, Down, Bottom in edit-list headers.
     int width = headerRect.right - headerRect.left - buttonsWidth - 4;
     if (width > 180)
         width = 180;
@@ -483,6 +486,20 @@ void CEditListBox::OnMoveDown()
         return;
 
     MoveItem(index + 2);
+}
+
+void CEditListBox::OnMoveBottom()
+{
+    CALL_STACK_MESSAGE1("CEditListBox::OnMoveBottom()");
+    int index;
+    if (!GetCurSel(index))
+        return;
+    if (index >= ItemsCount - 1)
+        return;
+    if ((GetEnabler() & TLBHDRMASK_BOTTOM) == 0)
+        return;
+
+    MoveItem(ItemsCount);
 }
 
 void CEditListBox::MoveItem(int newIndex)
@@ -941,6 +958,9 @@ CEditListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 break;
             case TLBHDR_DOWN:
                 OnMoveDown();
+                break;
+            case TLBHDR_BOTTOM:
+                OnMoveBottom();
                 break;
             }
         }

--- a/src/edtlbwnd.cpp
+++ b/src/edtlbwnd.cpp
@@ -274,7 +274,7 @@ BOOL CEditListBox::MakeHeader(int ctrlID)
 {
     Header = new CToolbarHeader(HDlg, ctrlID, HWindow,
                                 TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
-                                    TLBHDRMASK_FILTER | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN);
+                                    TLBHDRMASK_SEARCH | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN);
     if (Header == NULL)
     {
         TRACE_E(LOW_MEMORY);
@@ -319,10 +319,10 @@ void CEditListBox::CommandParent(UINT code)
                 MAKELPARAM((WORD)(UINT_PTR)GetMenu(HWindow), code), (LPARAM)HWindow);
 }
 
-BYTE CEditListBox::GetEnabler()
+DWORD CEditListBox::GetEnabler()
 {
-    BYTE enabler = TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
-                   TLBHDRMASK_FILTER | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN;
+    DWORD enabler = TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
+                   TLBHDRMASK_SEARCH | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN;
     if (Flags & ELB_ENABLECOMMANDS)
     {
         int index = (int)SendMessage(HWindow, LB_GETCURSEL, 0, 0);
@@ -339,11 +339,11 @@ void CEditListBox::OnSelChanged()
     BOOL disableAll = EditLine != NULL;
     int index = (int)SendMessage(HWindow, LB_GETCURSEL, 0, 0);
 
-    BYTE enabler = GetEnabler();
+    DWORD enabler = GetEnabler();
 
     DWORD mask = 0;
     if (!disableAll)
-        mask |= (enabler & (TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_FILTER));
+        mask |= (enabler & (TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_SEARCH));
     if (!disableAll && ItemsCount > 0 && index != ItemsCount)
         mask |= (enabler & TLBHDRMASK_DELETE);
     if (!disableAll && index > 0 && index < ItemsCount)
@@ -352,7 +352,7 @@ void CEditListBox::OnSelChanged()
         mask |= (enabler & TLBHDRMASK_DOWN);
 
     Header->EnableToolbar(mask);
-    Header->CheckToolbar(SearchVisible ? TLBHDRMASK_FILTER : 0);
+    Header->CheckToolbar(SearchVisible ? TLBHDRMASK_SEARCH : 0);
 }
 
 
@@ -367,7 +367,7 @@ void CEditListBox::LayoutSearchEdit()
     POINT headerTop = {headerRect.left, headerRect.top};
     ScreenToClient(HDlg, &headerTop);
 
-    const int buttonsWidth = 4 * 22 + 4; // Search, Top, Up, Down in edit-list headers.
+    const int buttonsWidth = 7 * 22 + 4; // Search, Modify, New, Delete, Top, Up, Down in edit-list headers.
     int width = headerRect.right - headerRect.left - buttonsWidth - 4;
     if (width > 180)
         width = 180;
@@ -932,7 +932,7 @@ CEditListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             case TLBHDR_DELETE:
                 OnDelete();
                 break;
-            case TLBHDR_FILTER:
+            case TLBHDR_SEARCH:
                 ToggleSearch();
                 break;
             case TLBHDR_TOP:

--- a/src/edtlbwnd.cpp
+++ b/src/edtlbwnd.cpp
@@ -274,13 +274,23 @@ BOOL CEditListBox::MakeHeader(int ctrlID)
 {
     Header = new CToolbarHeader(HDlg, ctrlID, HWindow,
                                 TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
-                                    TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN);
+                                    TLBHDRMASK_FILTER | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN);
     if (Header == NULL)
     {
         TRACE_E(LOW_MEMORY);
         return FALSE;
     }
     Header->SetNotifyWindow(HWindow);
+    HSearchEdit = CreateWindowEx(WS_EX_CLIENTEDGE, "EDIT", "",
+                                 WS_CHILD | WS_TABSTOP | ES_AUTOHSCROLL,
+                                 0, 0, 0, 0, HDlg,
+                                 (HMENU)0, HInstance, NULL);
+    if (HSearchEdit != NULL)
+    {
+        SendMessage(HSearchEdit, WM_SETFONT, SendMessage(HWindow, WM_GETFONT, 0, 0), TRUE);
+        ShowWindow(HSearchEdit, SW_HIDE);
+    }
+    LayoutSearchEdit();
     return TRUE;
 }
 
@@ -312,7 +322,7 @@ void CEditListBox::CommandParent(UINT code)
 BYTE CEditListBox::GetEnabler()
 {
     BYTE enabler = TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_DELETE |
-                   TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN;
+                   TLBHDRMASK_FILTER | TLBHDRMASK_TOP | TLBHDRMASK_UP | TLBHDRMASK_DOWN;
     if (Flags & ELB_ENABLECOMMANDS)
     {
         int index = (int)SendMessage(HWindow, LB_GETCURSEL, 0, 0);
@@ -333,7 +343,7 @@ void CEditListBox::OnSelChanged()
 
     DWORD mask = 0;
     if (!disableAll)
-        mask |= (enabler & TLBHDRMASK_MODIFY) | (enabler & TLBHDRMASK_NEW);
+        mask |= (enabler & (TLBHDRMASK_MODIFY | TLBHDRMASK_NEW | TLBHDRMASK_FILTER));
     if (!disableAll && ItemsCount > 0 && index != ItemsCount)
         mask |= (enabler & TLBHDRMASK_DELETE);
     if (!disableAll && index > 0 && index < ItemsCount)
@@ -342,8 +352,98 @@ void CEditListBox::OnSelChanged()
         mask |= (enabler & TLBHDRMASK_DOWN);
 
     Header->EnableToolbar(mask);
+    Header->CheckToolbar(SearchVisible ? TLBHDRMASK_FILTER : 0);
 }
 
+
+
+void CEditListBox::LayoutSearchEdit()
+{
+    if (Header == NULL || HSearchEdit == NULL)
+        return;
+
+    RECT headerRect;
+    GetWindowRect(Header->HWindow, &headerRect);
+    POINT headerTop = {headerRect.left, headerRect.top};
+    ScreenToClient(HDlg, &headerTop);
+
+    const int buttonsWidth = 4 * 22 + 4; // Search, Top, Up, Down in edit-list headers.
+    int width = headerRect.right - headerRect.left - buttonsWidth - 4;
+    if (width > 180)
+        width = 180;
+    if (width < 40)
+        width = 40;
+    int left = headerRect.right - headerRect.left - buttonsWidth - width;
+    if (left < 4)
+        left = 4;
+    SetWindowPos(HSearchEdit, HWND_TOP, headerTop.x + left, headerTop.y + 2,
+                 width, headerRect.bottom - headerRect.top - 4,
+                 SearchVisible ? SWP_SHOWWINDOW : SWP_HIDEWINDOW);
+}
+
+BOOL CEditListBox::SearchMatches(const char* text)
+{
+    if (!SearchVisible || SearchText[0] == 0)
+        return FALSE;
+    if (text == NULL)
+        return FALSE;
+
+    char needle[100];
+    lstrcpyn(needle, SearchText, _countof(needle));
+    CharLowerBuffA(needle, lstrlen(needle));
+
+    char haystack[MAX_PATH];
+    lstrcpyn(haystack, text, _countof(haystack));
+    CharLowerBuffA(haystack, lstrlen(haystack));
+    return strstr(haystack, needle) != NULL;
+}
+
+void CEditListBox::ApplySearch()
+{
+    if (HSearchEdit != NULL)
+        GetWindowText(HSearchEdit, SearchText, _countof(SearchText));
+
+    if (SearchVisible && SearchText[0] != 0)
+    {
+        for (int i = 0; i < ItemsCount; i++)
+        {
+            DispInfo.ToDo = edtlbGetData;
+            DispInfo.Buffer = Buffer;
+            DispInfo.BufferLen = MAX_PATH;
+            DispInfo.Index = i;
+            DispInfo.ItemID = (INT_PTR)SendMessage(HWindow, LB_GETITEMDATA, i, 0);
+            DispInfo.HIcon = NULL;
+            DispInfo.Bold = FALSE;
+            Buffer[0] = 0;
+            NotifyParent(&DispInfo, EDTLBN_GETDISPINFO);
+            if (SearchMatches(Buffer))
+            {
+                SendMessage(HWindow, LB_SETCURSEL, i, 0);
+                CommandParent(LBN_SELCHANGE);
+                break;
+            }
+        }
+    }
+    InvalidateRect(HWindow, NULL, FALSE);
+    OnSelChanged();
+}
+
+void CEditListBox::ToggleSearch()
+{
+    SearchVisible = !SearchVisible;
+    if (!SearchVisible)
+        SearchText[0] = 0;
+
+    if (HSearchEdit != NULL)
+    {
+        SetWindowText(HSearchEdit, SearchText);
+        ShowWindow(HSearchEdit, SearchVisible ? SW_SHOW : SW_HIDE);
+        if (SearchVisible)
+            SetFocus(HSearchEdit);
+    }
+    LayoutSearchEdit();
+    ApplySearch();
+}
 
 void CEditListBox::OnMoveTop()
 {
@@ -662,6 +762,8 @@ void CEditListBox::OnDrawItem(LPARAM lParam)
                 DispInfo.Bold = FALSE;
                 NotifyParent(&DispInfo, EDTLBN_GETDISPINFO);
                 DispInfo.Buffer[MAX_PATH - 1] = 0;
+                if (SearchMatches(Buffer))
+                    DispInfo.Bold = TRUE;
 
                 if (Flags & ELB_SHOWICON)
                 {
@@ -812,6 +914,8 @@ CEditListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (HIWORD(wParam) == EN_KILLFOCUS)
             OnEndEdit();
+        if ((HWND)lParam == HSearchEdit && HIWORD(wParam) == EN_CHANGE)
+            ApplySearch();
 
         if (LOWORD(wParam) == (WORD)(UINT_PTR)GetMenu(Header->HWindow))
         {
@@ -828,6 +932,9 @@ CEditListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             case TLBHDR_DELETE:
                 OnDelete();
                 break;
+            case TLBHDR_FILTER:
+                ToggleSearch();
+                break;
             case TLBHDR_TOP:
                 OnMoveTop();
                 break;
@@ -841,6 +948,11 @@ CEditListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         return 0;
     }
+
+    case WM_SIZE:
+    case WM_WINDOWPOSCHANGED:
+        LayoutSearchEdit();
+        break;
 
     case WM_CHAR:
     {

--- a/src/edtlbwnd.h
+++ b/src/edtlbwnd.h
@@ -72,6 +72,9 @@ class CEditListBox : public CWindow
 protected:
     CToolbarHeader* Header;
     CEditLBEdit* EditLine;
+    HWND HSearchEdit;
+    BOOL SearchVisible;
+    char SearchText[100];
     HWND HDlg;
     EDTLB_DISPINFO DispInfo;
     char Buffer[MAX_PATH];
@@ -139,6 +142,10 @@ public:
     void OnMoveUp();
     void OnMoveDown();
     void MoveItem(int newIndex);
+    void ToggleSearch();
+    void ApplySearch();
+    void LayoutSearchEdit();
+    BOOL SearchMatches(const char* text);
 
     // returns which commands are enabled (can query the parent)
     BYTE GetEnabler();

--- a/src/edtlbwnd.h
+++ b/src/edtlbwnd.h
@@ -40,7 +40,7 @@ typedef struct
                   //  BOOL          Up;            // for EDTLBN_MOVEITEM
     HWND HEdit;   // for EDTLBN_CONTEXTMENU
     POINT Point;  // for EDTLBN_CONTEXTMENU
-    BYTE Enable;  // for EDTLBN_ENABLECOMMANDS, contains TLBHDRMASK_xxx
+    DWORD Enable; // for EDTLBN_ENABLECOMMANDS, contains TLBHDRMASK_xxx
     int NewIndex; // for EDTLBN_MOVEITEM2
 } EDTLB_DISPINFO;
 
@@ -148,7 +148,7 @@ public:
     BOOL SearchMatches(const char* text);
 
     // returns which commands are enabled (can query the parent)
-    BYTE GetEnabler();
+    DWORD GetEnabler();
 
     void RedrawFocusedItem();
 

--- a/src/edtlbwnd.h
+++ b/src/edtlbwnd.h
@@ -135,6 +135,7 @@ public:
 
     void OnNew();
     void OnDelete();
+    void OnMoveTop();
     void OnMoveUp();
     void OnMoveDown();
     void MoveItem(int newIndex);

--- a/src/edtlbwnd.h
+++ b/src/edtlbwnd.h
@@ -141,6 +141,7 @@ public:
     void OnMoveTop();
     void OnMoveUp();
     void OnMoveDown();
+    void OnMoveBottom();
     void MoveItem(int newIndex);
     void ToggleSearch();
     void ApplySearch();

--- a/src/filesbx2.cpp
+++ b/src/filesbx2.cpp
@@ -265,6 +265,9 @@ void CHeaderLine::PaintItem(HDC hDC, int index, int x)
             sort = TRUE;
         else if (column->ID == COLUMN_ID_ATTRIBUTES && panel->SortType == stAttr)
             sort = TRUE;
+        else if (column->ID == COLUMN_ID_CUSTOM && column->GetText == InternalGetExplorerColumn &&
+                 panel->SortType == stCustom && panel->SortCustomData == column->CustomData)
+            sort = TRUE;
 
         // arrow indicating sort direction
         GetTextExtentPoint32(ItemBitmap.HMemDC, column->Name, nameLen, &sz);
@@ -770,6 +773,11 @@ CHeaderLine::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     st = stTime;
                 else if (column->ID == COLUMN_ID_ATTRIBUTES)
                     st = stAttr;
+                else if (column->ID == COLUMN_ID_CUSTOM && column->GetText == InternalGetExplorerColumn)
+                {
+                    Parent->Parent->ChangeCustomSortType(column->CustomData, TRUE);
+                    return 0;
+                }
                 Parent->Parent->ChangeSortType(st, TRUE);
             }
         }

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -2412,6 +2412,7 @@ CFilesWindow::CFilesWindow(CMainWindow* parent, CPanelSide side)
     TreeViewSplitOffset = 0;
 
     SortType = stName;
+    SortCustomData = 0;
     ReverseSort = FALSE;
     SortedWithRegSet = FALSE;    // initial state doesn't matter; set in SortDirectory()
     SortedWithDetectNum = FALSE; // initial state doesn't matter; set in SortDirectory()

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -1313,11 +1313,13 @@ void CFilesWindow::ChangeCustomSortType(DWORD customData, BOOL reverse, BOOL for
     {
         SortType = stCustom;
         SortCustomData = customData;
-        ReverseSort = FALSE;
+        ReverseSort = force ? reverse : FALSE;
     }
     else
     {
-        if (reverse)
+        if (force)
+            ReverseSort = reverse;
+        else if (reverse)
             ReverseSort = !ReverseSort;
     }
 

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -1303,6 +1303,35 @@ void CFilesWindow::Execute(int index)
     EndStopRefresh();
 }
 
+
+void CFilesWindow::ChangeCustomSortType(DWORD customData, BOOL reverse, BOOL force)
+{
+    CALL_STACK_MESSAGE3("CFilesWindow::ChangeCustomSortType(%u, %d)", customData, reverse);
+    if (!force && SortType == stCustom && SortCustomData == customData && !reverse)
+        return;
+    if (SortType != stCustom || SortCustomData != customData)
+    {
+        SortType = stCustom;
+        SortCustomData = customData;
+        ReverseSort = FALSE;
+    }
+    else
+    {
+        if (reverse)
+            ReverseSort = !ReverseSort;
+    }
+
+    MainWindow->CancelPanelsUI();
+
+    int focusIndex = GetCaretIndex();
+    CFileData d1 = {0};
+    if (focusIndex >= 0 && focusIndex < Dirs->Count + Files->Count)
+        d1 = (focusIndex < Dirs->Count) ? Dirs->At(focusIndex) : Files->At(focusIndex - Dirs->Count);
+
+    SortDirectory();
+    RefreshListBox(-1, -1, FocusedIndex, FALSE, FALSE);
+}
+
 void CFilesWindow::ChangeSortType(CSortType newType, BOOL reverse, BOOL force)
 {
     CALL_STACK_MESSAGE3("CFilesWindow::ChangeSortType(%d, %d)", newType, reverse);
@@ -1311,6 +1340,7 @@ void CFilesWindow::ChangeSortType(CSortType newType, BOOL reverse, BOOL force)
     if (SortType != newType)
     {
         SortType = newType;
+        SortCustomData = 0;
         ReverseSort = FALSE;
 
         //    EnumFileNamesChangeSourceUID(HWindow, &EnumFileNamesSourceUID);    // only when sorting changes  // commented out, not sure why it's here: Petr
@@ -1364,6 +1394,9 @@ void CFilesWindow::ChangeSortType(CSortType newType, BOOL reverse, BOOL force)
 
     case stAttr:
         lessDirs = lessFiles = LessAttrNameExt;
+        break;
+    case stCustom:
+        lessDirs = lessFiles = LessNameExt;
         break;
     default: /*stSize*/
         lessDirs = lessFiles = LessSizeNameExt;

--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -19,6 +19,9 @@
 #include "shiconov.h"
 #include "common/widepath.h"
 
+#include <map>
+#include <string>
+
 namespace
 {
 void CopyFindDataWToA(const WIN32_FIND_DATAW& src, WIN32_FIND_DATA& dst)
@@ -70,6 +73,106 @@ wchar_t* AllocWideNameFromUtf8ACP(const char* name)
         return NULL;
     }
     return wideName;
+}
+
+
+struct CExplorerSortContext
+{
+    std::map<std::string, std::string> Values;
+    BOOL Reverse;
+};
+
+CExplorerSortContext* ExplorerSortContext = NULL;
+
+std::string ExplorerSortKey(const CFileData& file)
+{
+    std::map<std::string, std::string>::const_iterator it = ExplorerSortContext->Values.find(file.Name);
+    if (it != ExplorerSortContext->Values.end())
+        return it->second;
+    return std::string();
+}
+
+BOOL LessExplorerNameExt(const CFileData& f1, const CFileData& f2, BOOL reverse)
+{
+    std::string v1 = ExplorerSortKey(f1);
+    std::string v2 = ExplorerSortKey(f2);
+    BOOL empty1 = v1.empty();
+    BOOL empty2 = v2.empty();
+    if (empty1 != empty2)
+        return reverse ? !empty1 : empty1;
+    if (!empty1)
+    {
+        BOOL numericalyEqual;
+        int res = RegSetStrICmpEx(v1.c_str(), (int)v1.length(), v2.c_str(), (int)v2.length(), &numericalyEqual);
+        if (!numericalyEqual)
+            return reverse ? res > 0 : res < 0;
+        if (res != 0)
+            return reverse ? res > 0 : res < 0;
+    }
+    return LessNameExt(f1, f2, FALSE);
+}
+
+void SortExplorerNameExtAux(CFilesArray& files, int left, int right, BOOL reverse)
+{
+LABEL_SortExplorerNameExtAux:
+    int i = left, j = right;
+    CFileData pivot = files[(i + j) / 2];
+    do
+    {
+        while (LessExplorerNameExt(files[i], pivot, reverse) && i < right)
+            i++;
+        while (LessExplorerNameExt(pivot, files[j], reverse) && j > left)
+            j--;
+        if (i <= j)
+        {
+            CFileData swap = files[i];
+            files[i] = files[j];
+            files[j] = swap;
+            i++;
+            j--;
+        }
+    } while (i <= j);
+    if (left < j)
+    {
+        if (i < right)
+        {
+            if (j - left < right - i)
+            {
+                SortExplorerNameExtAux(files, left, j, reverse);
+                left = i;
+                goto LABEL_SortExplorerNameExtAux;
+            }
+            else
+            {
+                SortExplorerNameExtAux(files, i, right, reverse);
+                right = j;
+                goto LABEL_SortExplorerNameExtAux;
+            }
+        }
+        else
+        {
+            right = j;
+            goto LABEL_SortExplorerNameExtAux;
+        }
+    }
+    else if (i < right)
+    {
+        left = i;
+        goto LABEL_SortExplorerNameExtAux;
+    }
+}
+
+void FillExplorerSortCache(CExplorerSortContext& context, const char* path, CFilesArray* items, int firstIndex, int explorerIndex)
+{
+    char text[TRANSFER_BUFFER_MAX];
+    for (int i = firstIndex; i < items->Count; i++)
+    {
+        CFileData* file = &items->At(i);
+        if (GetExplorerColumnTextForFile(path, file, explorerIndex, text, TRANSFER_BUFFER_MAX))
+            context.Values[file->Name] = text;
+        else
+            context.Values[file->Name] = "";
+    }
 }
 } // namespace
 
@@ -1834,7 +1937,26 @@ void CFilesWindow::SortDirectory(CFilesArray* files, CFilesArray* dirs)
         files = Files;
     if (dirs == NULL)
         dirs = Dirs;
-    SortFilesAndDirectories(files, dirs, SortType, ReverseSort, Configuration.SortDirsByName);
+    if (SortType == stCustom && Is(ptDisk))
+    {
+        CExplorerSortContext context;
+        context.Reverse = ReverseSort;
+        ExplorerSortContext = &context;
+        BOOL hasRoot = dirs->Count > 0 && dirs->At(0).NameLen == 2 && dirs->At(0).Name[0] == '.' && dirs->At(0).Name[1] == '.';
+        int firstDirIndex = hasRoot ? 1 : 0;
+        FillExplorerSortCache(context, GetPath(), files, 0, (int)SortCustomData);
+        if (!Configuration.SortDirsByName)
+            FillExplorerSortCache(context, GetPath(), dirs, firstDirIndex, (int)SortCustomData);
+        if (!Configuration.SortDirsByName && dirs->Count - firstDirIndex > 1)
+            SortExplorerNameExtAux(*dirs, firstDirIndex, dirs->Count - 1, ReverseSort);
+        else if (dirs->Count - firstDirIndex > 1)
+            SortNameExt(*dirs, firstDirIndex, dirs->Count - 1, FALSE);
+        if (files->Count > 1)
+            SortExplorerNameExtAux(*files, 0, files->Count - 1, ReverseSort);
+        ExplorerSortContext = NULL;
+    }
+    else
+        SortFilesAndDirectories(files, dirs, SortType, ReverseSort, Configuration.SortDirsByName);
 
     // single-purpose monitors for changes of Configuration.SortUsesLocale and Configuration.SortDetectNumbers
     // variables for the method CFilesWindow::RefreshDirectory

--- a/src/fileswn9.cpp
+++ b/src/fileswn9.cpp
@@ -2134,7 +2134,7 @@ BOOL CFilesWindow::BuildColumnsTemplate()
             lstrcpyn(column.Name, GetExplorerColumnName(explorerIndex), COLUMN_NAME_MAX);
             lstrcpyn(column.Description, GetExplorerColumnName(explorerIndex), COLUMN_DESCRIPTION_MAX);
             column.GetText = InternalGetExplorerColumn;
-            column.SupportSorting = 0;
+            column.SupportSorting = 1;
             column.LeftAlignment = 1;
             column.ID = COLUMN_ID_CUSTOM;
             column.CustomData = explorerIndex;

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -842,6 +842,7 @@ public:
     DWORD ValidFileData; // it determines which CFileData variables are valid, see VALID_DATA_XXX constants; set via SetValidFileData()
 
     CSortType SortType;       // criterion used for sorting
+    DWORD SortCustomData;     // CustomData of the active custom sort column (stCustom)
     BOOL ReverseSort;         // reverse order
     BOOL SortedWithRegSet;    // used to monitor changes of the global variable Configuration.SortUsesLocale
     BOOL SortedWithDetectNum; // used to monitor changes of the global variable Configuration.SortDetectNumbers
@@ -1057,6 +1058,7 @@ public:
                             const POINT* editWithMenuPoint = NULL);
 
     void ChangeSortType(CSortType newType, BOOL reverse, BOOL force = FALSE);
+    void ChangeCustomSortType(DWORD customData, BOOL reverse, BOOL force = FALSE);
 
     // change drive to DefaultDir[drive], optionally offering a drive menu;
     // when 0, a dialog is shown, the change is applied immediately

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2867,6 +2867,7 @@ int TlbHdrTooltips[TLBHDR_COUNT] =
         IDS_EDTLB_SORT,
         IDS_EDTLB_UP,
         IDS_EDTLB_DOWN,
+        IDS_EDTLB_FILTER,
 };
 
 CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD buttonMask)
@@ -2892,6 +2893,7 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
         {3, "SortByName"},
         {4, "MoveItemUp"},
         {5, "MoveItemDown"},
+        {6, "Filter"},
     };
 
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
@@ -2963,13 +2965,13 @@ void CToolbarHeader::CreateImageLists(HIMAGELIST* enabled, HIMAGELIST* disabled)
 
     // http://stackoverflow.com/questions/2640823/is-it-possible-to-create-a-cimagelist-with-alpha-blending-transparency
     hEnabled = ImageList_Create(iconSize, iconSize,
-                                ILC_COLOR32, TOOLBARHDR_BUTTONS, 1);
+                                ILC_COLOR32, TLBHDR_COUNT, 1);
     hDisabled = ImageList_Create(iconSize, iconSize,
-                                 ILC_COLOR32 /*ILC_COLORDDB */, TOOLBARHDR_BUTTONS, 1);
+                                 ILC_COLOR32 /*ILC_COLORDDB */, TLBHDR_COUNT, 1);
 
     HDC hDC = HANDLES(CreateCompatibleDC(NULL));
 
-    int width = iconSize * TOOLBARHDR_BUTTONS;
+    int width = iconSize * TLBHDR_COUNT;
     int height = iconSize;
 
     BITMAPINFOHEADER bmhdr;
@@ -2986,7 +2988,7 @@ void CToolbarHeader::CreateImageLists(HIMAGELIST* enabled, HIMAGELIST* disabled)
 
     NSVGrasterizer* rast = nsvgCreateRasterizer();
     // JRYFIXME: temporarily reading from a file, switch to a shared storage with toolbars
-    const char* svgNames[] = {"Modify", "New_Insert", "Delete", "SortByName", "MoveItemUp", "MoveItemDown"};
+    const char* svgNames[] = {"Modify", "New_Insert", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "Filter"};
     for (int j = 0; j < 2; j++)
     {
         DWORD* p = (DWORD*)lpBits;
@@ -2994,7 +2996,7 @@ void CToolbarHeader::CreateImageLists(HIMAGELIST* enabled, HIMAGELIST* disabled)
             *p++ = 0x00000000;
 
         HBITMAP hOldBmp = (HBITMAP)SelectObject(hDC, hBmp);
-        for (int i = 0; i < TOOLBARHDR_BUTTONS; i++)
+        for (int i = 0; i < TLBHDR_COUNT; i++)
             RenderSVGImage(rast, hDC, i * iconSize, 0, svgNames[i], iconSize, RGB(0xff, 0xff, 0xff), j == 0 ? TRUE : FALSE);
         SelectObject(hDC, hOldBmp);
         ImageList_Add(j == 0 ? hEnabled : hDisabled, hBmp, hBmp);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2869,6 +2869,7 @@ int TlbHdrTooltips[TLBHDR_COUNT] =
         IDS_EDTLB_DOWN,
         IDS_EDTLB_TOP,
         IDS_EDTLB_FILTER,
+        IDS_EDTLB_SEARCH,
 };
 
 CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD buttonMask)
@@ -2895,7 +2896,8 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
         {4, "MoveItemUp"},
         {5, "MoveItemDown"},
         {6, "MoveItemTop"},
-        {7, "View"},
+        {7, "Filter"},
+        {8, "View"},
     };
 
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
@@ -2930,7 +2932,7 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
     TLBI_ITEM_INFO2 tii;
     tii.Mask = TLBI_MASK_ID | TLBI_MASK_IMAGEINDEX;
     int buttonsCount = 0;
-    const int buttonOrder[TLBHDR_COUNT] = {0, 1, 2, 3, 6, 4, 5, 7};
+    const int buttonOrder[TLBHDR_COUNT] = {8, 0, 1, 2, 3, 6, 4, 5, 7};
     for (int orderIndex = 0; orderIndex < TLBHDR_COUNT; orderIndex++)
     {
         int i = buttonOrder[orderIndex];
@@ -2991,7 +2993,7 @@ void CToolbarHeader::CreateImageLists(HIMAGELIST* enabled, HIMAGELIST* disabled)
 
     NSVGrasterizer* rast = nsvgCreateRasterizer();
     // JRYFIXME: temporarily reading from a file, switch to a shared storage with toolbars
-    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "MoveItemTop", "View"};
+    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "MoveItemTop", "Filter", "View"};
     for (int j = 0; j < 2; j++)
     {
         DWORD* p = (DWORD*)lpBits;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2870,6 +2870,7 @@ int TlbHdrTooltips[TLBHDR_COUNT] =
         IDS_EDTLB_TOP,
         IDS_EDTLB_FILTER,
         IDS_EDTLB_SEARCH,
+        IDS_EDTLB_BOTTOM,
 };
 
 CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD buttonMask)
@@ -2898,6 +2899,7 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
         {6, "MoveItemTop"},
         {7, "Filter"},
         {8, "View"},
+        {9, "MoveItemBottom"},
     };
 
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
@@ -2932,7 +2934,7 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
     TLBI_ITEM_INFO2 tii;
     tii.Mask = TLBI_MASK_ID | TLBI_MASK_IMAGEINDEX;
     int buttonsCount = 0;
-    const int buttonOrder[TLBHDR_COUNT] = {8, 0, 1, 2, 3, 6, 4, 5, 7};
+    const int buttonOrder[TLBHDR_COUNT] = {8, 0, 1, 2, 3, 6, 4, 5, 9, 7};
     for (int orderIndex = 0; orderIndex < TLBHDR_COUNT; orderIndex++)
     {
         int i = buttonOrder[orderIndex];
@@ -2993,7 +2995,7 @@ void CToolbarHeader::CreateImageLists(HIMAGELIST* enabled, HIMAGELIST* disabled)
 
     NSVGrasterizer* rast = nsvgCreateRasterizer();
     // JRYFIXME: temporarily reading from a file, switch to a shared storage with toolbars
-    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "MoveItemTop", "Filter", "View"};
+    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "MoveItemTop", "Filter", "View", "MoveItemBottom"};
     for (int j = 0; j < 2; j++)
     {
         DWORD* p = (DWORD*)lpBits;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2867,6 +2867,7 @@ int TlbHdrTooltips[TLBHDR_COUNT] =
         IDS_EDTLB_SORT,
         IDS_EDTLB_UP,
         IDS_EDTLB_DOWN,
+        IDS_EDTLB_TOP,
         IDS_EDTLB_FILTER,
 };
 
@@ -2893,7 +2894,8 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
         {3, "SortByName"},
         {4, "MoveItemUp"},
         {5, "MoveItemDown"},
-        {6, "Filter"},
+        {6, "MoveItemTop"},
+        {7, "Filter"},
     };
 
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
@@ -2928,9 +2930,10 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
     TLBI_ITEM_INFO2 tii;
     tii.Mask = TLBI_MASK_ID | TLBI_MASK_IMAGEINDEX;
     int buttonsCount = 0;
-    int i;
-    for (i = 0; i < TLBHDR_COUNT; i++)
+    const int buttonOrder[TLBHDR_COUNT] = {0, 1, 2, 3, 6, 4, 5, 7};
+    for (int orderIndex = 0; orderIndex < TLBHDR_COUNT; orderIndex++)
     {
+        int i = buttonOrder[orderIndex];
         if ((1 << i) & ButtonMask)
         {
             tii.ImageIndex = i;
@@ -2988,7 +2991,7 @@ void CToolbarHeader::CreateImageLists(HIMAGELIST* enabled, HIMAGELIST* disabled)
 
     NSVGrasterizer* rast = nsvgCreateRasterizer();
     // JRYFIXME: temporarily reading from a file, switch to a shared storage with toolbars
-    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "Filter"};
+    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "MoveItemTop", "Filter"};
     for (int j = 0; j < 2; j++)
     {
         DWORD* p = (DWORD*)lpBits;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2888,7 +2888,7 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
 
     CSVGIcon svgIcons[TLBHDR_COUNT] = {
         {0, "Modify"},
-        {1, "New_Insert"},
+        {1, "New"},
         {2, "Delete"},
         {3, "SortByName"},
         {4, "MoveItemUp"},
@@ -2988,7 +2988,7 @@ void CToolbarHeader::CreateImageLists(HIMAGELIST* enabled, HIMAGELIST* disabled)
 
     NSVGrasterizer* rast = nsvgCreateRasterizer();
     // JRYFIXME: temporarily reading from a file, switch to a shared storage with toolbars
-    const char* svgNames[] = {"Modify", "New_Insert", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "Filter"};
+    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "Filter"};
     for (int j = 0; j < 2; j++)
     {
         DWORD* p = (DWORD*)lpBits;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -3177,6 +3177,8 @@ CToolbarHeader::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if ((HWND)lParam == ToolBar->HWindow)
             PostMessage(HNotifyWindow, WM_COMMAND,
                         MAKEWPARAM((WORD)(UINT_PTR)GetMenu(HWindow), LOWORD(wParam)), (LPARAM)HWindow);
+        else if (HNotifyWindow != NULL)
+            SendMessage(HNotifyWindow, WM_COMMAND, wParam, lParam);
         break;
     }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -2895,7 +2895,7 @@ CToolbarHeader::CToolbarHeader(HWND hDlg, int ctrlID, HWND hAlignWindow, DWORD b
         {4, "MoveItemUp"},
         {5, "MoveItemDown"},
         {6, "MoveItemTop"},
-        {7, "Filter"},
+        {7, "View"},
     };
 
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
@@ -2991,7 +2991,7 @@ void CToolbarHeader::CreateImageLists(HIMAGELIST* enabled, HIMAGELIST* disabled)
 
     NSVGrasterizer* rast = nsvgCreateRasterizer();
     // JRYFIXME: temporarily reading from a file, switch to a shared storage with toolbars
-    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "MoveItemTop", "Filter"};
+    const char* svgNames[] = {"Modify", "New", "Delete", "SortByName", "MoveItemUp", "MoveItemDown", "MoveItemTop", "View"};
     for (int j = 0; j < 2; j++)
     {
         DWORD* p = (DWORD*)lpBits;

--- a/src/lang/lang.rh
+++ b/src/lang/lang.rh
@@ -143,6 +143,7 @@
 #define IDC_VIEW_TEXT7                  335
 #define IDC_VIEW_LEFT_SMARTMODE         336
 #define IDC_VIEW_RIGHT_SMARTMODE        337
+#define IDC_VIEW_COLUMNS_FILTER         338
 #define IDD_CFGPAGE_USERMENU            350
 #define IDL_MENUITEMS                   351
 #define IDE_COMMAND                     352

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -790,6 +790,7 @@ STRINGTABLE
  IDS_EDTLB_UP, "Move Item Up (Alt + Up Arrow)"
  IDS_EDTLB_DOWN, "Move Item Down (Alt + Down Arrow)"
  IDS_EDTLB_TOP, "Move Item to Top"
+ IDS_EDTLB_BOTTOM, "Move Item to Bottom"
  IDS_EDTLB_FILTER, "Filter Items"
 
  // Bottom ToolBar Texts for F1 - F12

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -782,6 +782,7 @@ STRINGTABLE
  IDS_FILEDATA_TAB          "TAB"
 
  // buttons for Edit ListBox ToolBar
+ IDS_EDTLB_SEARCH, "Search Items"
  IDS_EDTLB_MODIFY, "Modify (F2)"
  IDS_EDTLB_NEW, "New (Insert)"
  IDS_EDTLB_DELETE, "Delete (Delete)"
@@ -789,7 +790,7 @@ STRINGTABLE
  IDS_EDTLB_UP, "Move Item Up (Alt + Up Arrow)"
  IDS_EDTLB_DOWN, "Move Item Down (Alt + Down Arrow)"
  IDS_EDTLB_TOP, "Move Item to Top"
- IDS_EDTLB_FILTER, "Search Items"
+ IDS_EDTLB_FILTER, "Filter Items"
 
  // Bottom ToolBar Texts for F1 - F12
  IDS_BTBTEXTS,     "Help,Rename,View,Edit,Copy,Move,MakeDir,Delete,UsrMenu,Menu,Connect,Disconnect"

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -788,6 +788,7 @@ STRINGTABLE
  IDS_EDTLB_SORT, "Sort Items Alphabetically"
  IDS_EDTLB_UP, "Move Item Up (Alt + Up Arrow)"
  IDS_EDTLB_DOWN, "Move Item Down (Alt + Down Arrow)"
+ IDS_EDTLB_FILTER, "Filter Items"
 
  // Bottom ToolBar Texts for F1 - F12
  IDS_BTBTEXTS,     "Help,Rename,View,Edit,Copy,Move,MakeDir,Delete,UsrMenu,Menu,Connect,Disconnect"

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -789,7 +789,7 @@ STRINGTABLE
  IDS_EDTLB_UP, "Move Item Up (Alt + Up Arrow)"
  IDS_EDTLB_DOWN, "Move Item Down (Alt + Down Arrow)"
  IDS_EDTLB_TOP, "Move Item to Top"
- IDS_EDTLB_FILTER, "Filter Items"
+ IDS_EDTLB_FILTER, "Search Items"
 
  // Bottom ToolBar Texts for F1 - F12
  IDS_BTBTEXTS,     "Help,Rename,View,Edit,Copy,Move,MakeDir,Delete,UsrMenu,Menu,Connect,Disconnect"

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -788,6 +788,7 @@ STRINGTABLE
  IDS_EDTLB_SORT, "Sort Items Alphabetically"
  IDS_EDTLB_UP, "Move Item Up (Alt + Up Arrow)"
  IDS_EDTLB_DOWN, "Move Item Down (Alt + Down Arrow)"
+ IDS_EDTLB_TOP, "Move Item to Top"
  IDS_EDTLB_FILTER, "Filter Items"
 
  // Bottom ToolBar Texts for F1 - F12

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -396,6 +396,7 @@ public:
         std::string FallbackPath;
         int ViewTemplateIndex;
         CSortType SortType;
+        DWORD SortCustomData;
         BOOL ReverseSort;
         BOOL StatusLineVisible;
         BOOL DirectoryLineVisible;

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -1026,6 +1026,7 @@ const char* SALAMANDER_RIGHTP_REG = "Right Panel";
 const char* PANEL_PATH_REG = "Path";
 const char* PANEL_VIEW_REG = "View Type";
 const char* PANEL_SORT_REG = "Sort Type";
+const char* PANEL_SORT_CUSTOM_DATA_REG = "Sort Custom Data";
 const char* PANEL_REVERSE_REG = "Reverse Sort";
 const char* PANEL_DIRLINE_REG = "Directory Line";
 const char* PANEL_STATUS_REG = "Status Line";
@@ -2389,6 +2390,8 @@ static void SavePanelSettingsToKey(CFilesWindow* panel, HKEY key, BOOL useGenera
     SetValue(key, PANEL_VIEW_REG, REG_DWORD, &value, sizeof(DWORD));
     value = panel->SortType;
     SetValue(key, PANEL_SORT_REG, REG_DWORD, &value, sizeof(DWORD));
+    value = panel->SortCustomData;
+    SetValue(key, PANEL_SORT_CUSTOM_DATA_REG, REG_DWORD, &value, sizeof(DWORD));
     value = panel->ReverseSort;
     SetValue(key, PANEL_REVERSE_REG, REG_DWORD, &value, sizeof(DWORD));
     value = (panel->DirectoryLine->HWindow != NULL);
@@ -2459,11 +2462,14 @@ static void LoadPanelSettingsFromKey(CFilesWindow* panel, HKEY key, char* pathBu
         }
         if (GetValue(key, PANEL_REVERSE_REG, REG_DWORD, &value, sizeof(DWORD)))
             panel->ReverseSort = value;
+        DWORD sortCustomData = 0;
+        BOOL hasSortCustomData = GetValue(key, PANEL_SORT_CUSTOM_DATA_REG, REG_DWORD, &sortCustomData, sizeof(DWORD));
         if (GetValue(key, PANEL_SORT_REG, REG_DWORD, &value, sizeof(DWORD)))
         {
-            if (value > stAttr)
+            if (value > stCustom || (value == stCustom && !hasSortCustomData))
                 value = stName;
             panel->SortType = (CSortType)value;
+            panel->SortCustomData = value == stCustom ? sortCustomData : 0;
         }
         if (GetValue(key, PANEL_DIRLINE_REG, REG_DWORD, &value, sizeof(DWORD)))
             if ((BOOL)value != (panel->DirectoryLine->HWindow != NULL))

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -477,6 +477,7 @@ void CMainWindow::RememberClosedTab(CPanelSide side, CFilesWindow* panel, int in
 
     info.ViewTemplateIndex = panel->GetViewTemplateIndex();
     info.SortType = panel->SortType;
+    info.SortCustomData = panel->SortCustomData;
     info.ReverseSort = panel->ReverseSort;
     info.StatusLineVisible = panel->StatusLineVisible;
     info.DirectoryLineVisible = panel->DirectoryLineVisible;
@@ -1967,7 +1968,10 @@ CFilesWindow* CMainWindow::CreateDuplicatePanelTab(CPanelSide targetSide, CFiles
     if (newPanel->IsViewTemplateValid(viewTemplate))
         newPanel->SelectViewTemplate(viewTemplate, TRUE, FALSE);
 
-    newPanel->ChangeSortType(sourcePanel->SortType, sourcePanel->ReverseSort, TRUE);
+    if (sourcePanel->SortType == stCustom)
+        newPanel->ChangeCustomSortType(sourcePanel->SortCustomData, sourcePanel->ReverseSort, TRUE);
+    else
+        newPanel->ChangeSortType(sourcePanel->SortType, sourcePanel->ReverseSort, TRUE);
 
     if ((sourcePanel->DirectoryLine != NULL && sourcePanel->DirectoryLine->HWindow != NULL) !=
         (newPanel->DirectoryLine != NULL && newPanel->DirectoryLine->HWindow != NULL))
@@ -2134,7 +2138,10 @@ bool CMainWindow::CommandReopenClosedTab(CPanelSide side)
     if (panel->IsViewTemplateValid(entry.ViewTemplateIndex))
         panel->SelectViewTemplate(entry.ViewTemplateIndex, TRUE, FALSE);
 
-    panel->ChangeSortType(entry.SortType, entry.ReverseSort, TRUE);
+    if (entry.SortType == stCustom)
+        panel->ChangeCustomSortType(entry.SortCustomData, entry.ReverseSort, TRUE);
+    else
+        panel->ChangeSortType(entry.SortType, entry.ReverseSort, TRUE);
 
     if (!!panel->StatusLineVisible != !!entry.StatusLineVisible)
         panel->ToggleStatusLine();

--- a/src/plugins/shared/spl_gui.h
+++ b/src/plugins/shared/spl_gui.h
@@ -1919,7 +1919,8 @@ public:
 #define TLBHDRMASK_SORT 0x08
 #define TLBHDRMASK_UP 0x10
 #define TLBHDRMASK_DOWN 0x20
-#define TLBHDRMASK_FILTER 0x40
+#define TLBHDRMASK_TOP 0x40
+#define TLBHDRMASK_FILTER 0x80
 
 // Identifikace tlacitek pro WM_COMMAND, viz SetNotifyWindow()
 #define TLBHDR_MODIFY 1
@@ -1928,9 +1929,10 @@ public:
 #define TLBHDR_SORT 4
 #define TLBHDR_UP 5
 #define TLBHDR_DOWN 6
-#define TLBHDR_FILTER 7
+#define TLBHDR_TOP 7
+#define TLBHDR_FILTER 8
 // Pocet polozek
-#define TLBHDR_COUNT 7
+#define TLBHDR_COUNT 8
 
 class CGUIToolbarHeaderAbstract
 {

--- a/src/plugins/shared/spl_gui.h
+++ b/src/plugins/shared/spl_gui.h
@@ -1919,6 +1919,7 @@ public:
 #define TLBHDRMASK_SORT 0x08
 #define TLBHDRMASK_UP 0x10
 #define TLBHDRMASK_DOWN 0x20
+#define TLBHDRMASK_FILTER 0x40
 
 // Identifikace tlacitek pro WM_COMMAND, viz SetNotifyWindow()
 #define TLBHDR_MODIFY 1
@@ -1927,8 +1928,9 @@ public:
 #define TLBHDR_SORT 4
 #define TLBHDR_UP 5
 #define TLBHDR_DOWN 6
+#define TLBHDR_FILTER 7
 // Pocet polozek
-#define TLBHDR_COUNT 6
+#define TLBHDR_COUNT 7
 
 class CGUIToolbarHeaderAbstract
 {

--- a/src/plugins/shared/spl_gui.h
+++ b/src/plugins/shared/spl_gui.h
@@ -1922,6 +1922,7 @@ public:
 #define TLBHDRMASK_TOP 0x40
 #define TLBHDRMASK_FILTER 0x80
 #define TLBHDRMASK_SEARCH 0x100
+#define TLBHDRMASK_BOTTOM 0x200
 
 // Identifikace tlacitek pro WM_COMMAND, viz SetNotifyWindow()
 #define TLBHDR_MODIFY 1
@@ -1933,8 +1934,9 @@ public:
 #define TLBHDR_TOP 7
 #define TLBHDR_FILTER 8
 #define TLBHDR_SEARCH 9
+#define TLBHDR_BOTTOM 10
 // Pocet polozek
-#define TLBHDR_COUNT 9
+#define TLBHDR_COUNT 10
 
 class CGUIToolbarHeaderAbstract
 {

--- a/src/plugins/shared/spl_gui.h
+++ b/src/plugins/shared/spl_gui.h
@@ -1921,6 +1921,7 @@ public:
 #define TLBHDRMASK_DOWN 0x20
 #define TLBHDRMASK_TOP 0x40
 #define TLBHDRMASK_FILTER 0x80
+#define TLBHDRMASK_SEARCH 0x100
 
 // Identifikace tlacitek pro WM_COMMAND, viz SetNotifyWindow()
 #define TLBHDR_MODIFY 1
@@ -1931,8 +1932,9 @@ public:
 #define TLBHDR_DOWN 6
 #define TLBHDR_TOP 7
 #define TLBHDR_FILTER 8
+#define TLBHDR_SEARCH 9
 // Pocet polozek
-#define TLBHDR_COUNT 8
+#define TLBHDR_COUNT 9
 
 class CGUIToolbarHeaderAbstract
 {

--- a/src/res/toolbars/MoveItemBottom.svg
+++ b/src/res/toolbars/MoveItemBottom.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<rect x="3" y="14" fill="#00539C" width="10" height="1"/>
+<polygon fill="#00539C" points="3,9 8,14 13,9 "/>
+<polygon fill="#00539C" points="6,7 6,8 6,9 10,9 10,8 10,7 "/>
+<rect x="6" y="1" fill="#00539C" width="4" height="1"/>
+<rect x="6" y="3" fill="#00539C" width="4" height="1"/>
+<rect x="6" y="5" fill="#00539C" width="4" height="1"/>
+</svg>

--- a/src/res/toolbars/MoveItemTop.svg
+++ b/src/res/toolbars/MoveItemTop.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<rect x="3" y="1" fill="#00539C" width="10" height="1"/>
+<polygon fill="#00539C" points="13,7 8,2 3,7 "/>
+<polygon fill="#00539C" points="6,7 6,8 6,9 10,9 10,8 10,7 "/>
+<rect x="6" y="12" fill="#00539C" width="4" height="1"/>
+<rect x="6" y="14" fill="#00539C" width="4" height="1"/>
+<rect x="6" y="10" fill="#00539C" width="4" height="1"/>
+</svg>

--- a/src/res/toolbars/darkmode/MoveItemBottom.svg
+++ b/src/res/toolbars/darkmode/MoveItemBottom.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<rect x="3" y="14" fill="#4DA3FF" width="10" height="1"/>
+<polygon fill="#4DA3FF" points="3,9 8,14 13,9 "/>
+<polygon fill="#4DA3FF" points="6,7 6,8 6,9 10,9 10,8 10,7 "/>
+<rect x="6" y="1" fill="#4DA3FF" width="4" height="1"/>
+<rect x="6" y="3" fill="#4DA3FF" width="4" height="1"/>
+<rect x="6" y="5" fill="#4DA3FF" width="4" height="1"/>
+</svg>

--- a/src/res/toolbars/darkmode/MoveItemTop.svg
+++ b/src/res/toolbars/darkmode/MoveItemTop.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<rect x="3" y="1" fill="#4DA3FF" width="10" height="1"/>
+<polygon fill="#4DA3FF" points="13,7 8,2 3,7 "/>
+<polygon fill="#4DA3FF" points="6,7 6,8 6,9 10,9 10,8 10,7 "/>
+<rect x="6" y="12" fill="#4DA3FF" width="4" height="1"/>
+<rect x="6" y="14" fill="#4DA3FF" width="4" height="1"/>
+<rect x="6" y="10" fill="#4DA3FF" width="4" height="1"/>
+</svg>

--- a/src/salamand.h
+++ b/src/salamand.h
@@ -329,10 +329,13 @@ void WINAPI InternalGetType();
 void WINAPI InternalGetDate();
 void WINAPI InternalGetDateOnlyForDisk();
 void WINAPI InternalGetTime();
+struct CFileData;
+
 void WINAPI InternalGetTimeOnlyForDisk();
 void WINAPI InternalGetAttr();
 void WINAPI InternalGetDescr();
 void WINAPI InternalGetExplorerColumn();
+BOOL GetExplorerColumnTextForFile(const char* panelPath, const CFileData* fileData, int columnIndex, char* buffer, int bufferSize);
 int GetExplorerColumnCount();
 const char* GetExplorerColumnName(int index);
 

--- a/src/salamand.h
+++ b/src/salamand.h
@@ -348,7 +348,7 @@ int WINAPI InternalGetPluginIconIndex();
 //
 
 #define STANDARD_COLUMNS_COUNT 9 // number of standard columns for the view
-#define EXPLORER_COLUMNS_COUNT 256 // maximum Windows Explorer property columns shown in the view configuration
+#define EXPLORER_COLUMNS_COUNT 1024 // maximum Windows Explorer property columns shown in the view configuration
 #define VIEW_TEMPLATES_COUNT 10
 #define VIEW_NAME_MAX 100
 // column Name is always visible and if the flag VIEW_SHOW_EXTENSION is not set, it also contains the extension
@@ -407,7 +407,7 @@ struct CViewTemplate
     CColumnConfig Columns[STANDARD_COLUMNS_COUNT]; // stores widths and elasticity of columns
     CColumnConfig ExplorerColumns[EXPLORER_COLUMNS_COUNT]; // stores widths and elasticity of Explorer property columns
     BYTE ExplorerColumnVisible[EXPLORER_COLUMNS_COUNT]; // visible Explorer property columns
-    BYTE ExplorerColumnOrder[EXPLORER_COLUMNS_COUNT]; // order of Explorer property columns
+    WORD ExplorerColumnOrder[EXPLORER_COLUMNS_COUNT]; // order of Explorer property columns
     BYTE ColumnOrder[STANDARD_COLUMNS_COUNT]; // order of standard columns in detailed views/configuration
 
     BOOL LeftSmartMode;  // smart mode for the left panel (only the elastic Name column: the column narrows so a horizontal scrollbar is not needed)
@@ -434,7 +434,9 @@ public:
     int SaveColumns(CColumnConfig* columns, char* buffer);  // convert the array to a string
     void LoadColumns(CColumnConfig* columns, char* buffer); // and back again
     int SaveColumnOrder(BYTE* order, char* buffer, int count = STANDARD_COLUMNS_COUNT); // convert the column order to a string
+    int SaveColumnOrder(WORD* order, char* buffer, int count);
     void LoadColumnOrder(BYTE* order, char* buffer, int count = STANDARD_COLUMNS_COUNT);  // and back again
+    void LoadColumnOrder(WORD* order, char* buffer, int count);
     int SaveExplorerColumnVisible(BYTE* visible, char* buffer);                           // convert Explorer column visibility to a string
     void LoadExplorerColumnVisible(BYTE* visible, char* buffer);                          // and back again
 

--- a/src/salamand.h
+++ b/src/salamand.h
@@ -348,7 +348,7 @@ int WINAPI InternalGetPluginIconIndex();
 //
 
 #define STANDARD_COLUMNS_COUNT 9 // number of standard columns for the view
-#define EXPLORER_COLUMNS_COUNT 1024 // maximum Windows Explorer property columns shown in the view configuration
+#define EXPLORER_COLUMNS_COUNT 4096 // maximum Windows Explorer property columns shown in the view configuration
 #define VIEW_TEMPLATES_COUNT 10
 #define VIEW_NAME_MAX 100
 // column Name is always visible and if the flag VIEW_SHOW_EXTENSION is not set, it also contains the extension

--- a/src/salamand.h
+++ b/src/salamand.h
@@ -348,7 +348,7 @@ int WINAPI InternalGetPluginIconIndex();
 //
 
 #define STANDARD_COLUMNS_COUNT 9 // number of standard columns for the view
-#define EXPLORER_COLUMNS_COUNT 4096 // maximum Windows Explorer property columns shown in the view configuration
+#define EXPLORER_COLUMNS_COUNT 1024 // maximum Windows Explorer property columns shown in the view configuration
 #define VIEW_TEMPLATES_COUNT 10
 #define VIEW_NAME_MAX 100
 // column Name is always visible and if the flag VIEW_SHOW_EXTENSION is not set, it also contains the extension

--- a/src/salamdr4.cpp
+++ b/src/salamdr4.cpp
@@ -1703,6 +1703,8 @@ static void LoadExplorerColumns()
                 propDesc->Release();
             }
         }
+        if (count > EXPLORER_COLUMNS_COUNT && ExplorerColumnsCount >= EXPLORER_COLUMNS_COUNT)
+            TRACE_E("Explorer property column list was truncated at " << EXPLORER_COLUMNS_COUNT << " entries (Windows reported " << count << ").");
     }
     propList->Release();
 }

--- a/src/salamdr4.cpp
+++ b/src/salamdr4.cpp
@@ -1056,7 +1056,7 @@ CViewTemplates::CViewTemplates()
         ZeroMemory(Items[i].ExplorerColumns, sizeof(Items[i].ExplorerColumns));
         ZeroMemory(Items[i].ExplorerColumnVisible, sizeof(Items[i].ExplorerColumnVisible));
         for (int j = 0; j < EXPLORER_COLUMNS_COUNT; j++)
-            Items[i].ExplorerColumnOrder[j] = (BYTE)j;
+            Items[i].ExplorerColumnOrder[j] = (WORD)j;
         for (int j = 0; j < STANDARD_COLUMNS_COUNT; j++)
             Items[i].ColumnOrder[j] = (BYTE)j;
     }
@@ -1192,6 +1192,20 @@ int CViewTemplates::SaveColumnOrder(BYTE* order, char* buffer, int count)
     return (int)(s - buffer);
 }
 
+
+int CViewTemplates::SaveColumnOrder(WORD* order, char* buffer, int count)
+{
+    char* s = buffer;
+    for (int i = 0; i < count; i++)
+    {
+        if (i > 0)
+            *s++ = ',';
+        s += sprintf(s, "%u", (unsigned)order[i]);
+    }
+    *s = 0;
+    return (int)(s - buffer);
+}
+
 void CViewTemplates::LoadColumnOrder(BYTE* order, char* buffer, int count)
 {
     BOOL used[EXPLORER_COLUMNS_COUNT];
@@ -1213,6 +1227,32 @@ void CViewTemplates::LoadColumnOrder(BYTE* order, char* buffer, int count)
         if (!used[value])
             order[pos++] = (BYTE)value;
     }
+}
+
+
+void CViewTemplates::LoadColumnOrder(WORD* order, char* buffer, int count)
+{
+    BOOL* used = (BOOL*)calloc(count, sizeof(BOOL));
+    if (used == NULL)
+        return;
+    int pos = 0;
+    char* p = strtok(buffer, ",");
+    while (p != NULL && pos < count)
+    {
+        unsigned int value;
+        if (sscanf(p, "%u", &value) == 1 && value < (unsigned int)count && !used[value])
+        {
+            order[pos++] = (WORD)value;
+            used[value] = TRUE;
+        }
+        p = strtok(NULL, ",");
+    }
+    for (int value = 0; pos < count && value < count; value++)
+    {
+        if (!used[value])
+            order[pos++] = (WORD)value;
+    }
+    free(used);
 }
 
 int CViewTemplates::SaveExplorerColumnVisible(BYTE* visible, char* buffer)
@@ -1245,7 +1285,7 @@ void CViewTemplates::LoadExplorerColumnVisible(BYTE* visible, char* buffer)
 
 BOOL CViewTemplates::Save(HKEY hKey)
 {
-    char buff[4 * EXPLORER_COLUMNS_COUNT + 1];
+    char buff[6 * EXPLORER_COLUMNS_COUNT + 1];
     char keyName[5];
     int i;
     for (i = 0; i < VIEW_TEMPLATES_COUNT; i++)
@@ -1270,7 +1310,7 @@ BOOL CViewTemplates::Save(HKEY hKey)
 
 BOOL CViewTemplates::Load(HKEY hKey)
 {
-    char buff[4 * EXPLORER_COLUMNS_COUNT + 1];
+    char buff[6 * EXPLORER_COLUMNS_COUNT + 1];
     char keyName[5];
     int i;
     for (i = 0; i < VIEW_TEMPLATES_COUNT; i++)

--- a/src/salamdr4.cpp
+++ b/src/salamdr4.cpp
@@ -1910,30 +1910,32 @@ void WINAPI InternalGetDescr()
     }
 }
 
-void WINAPI InternalGetExplorerColumn()
+BOOL GetExplorerColumnTextForFile(const char* panelPath, const CFileData* fileData, int columnIndex, char* buffer, int bufferSize)
 {
-    TransferLen = 0;
-    if (TransferIsDir == 2 || TransferPanelPath[0] == 0)
-        return;
+    if (buffer == NULL || bufferSize <= 0)
+        return FALSE;
+    buffer[0] = 0;
+    if (panelPath == NULL || panelPath[0] == 0 || fileData == NULL)
+        return FALSE;
 
-    int columnIndex = (int)TransferActCustomData;
     LoadExplorerColumns();
     if (columnIndex < 0 || columnIndex >= ExplorerColumnsCount)
-        return;
+        return FALSE;
 
     char path[SAL_MAX_PATH];
-    lstrcpyn(path, TransferPanelPath, SAL_MAX_PATH);
-    if (!SalPathAppend(path, TransferFileData->Name, SAL_MAX_PATH))
-        return;
+    lstrcpyn(path, panelPath, SAL_MAX_PATH);
+    if (!SalPathAppend(path, fileData->Name, SAL_MAX_PATH))
+        return FALSE;
 
     WCHAR pathW[SAL_MAX_PATH];
     if (MultiByteToWideChar(CP_ACP, 0, path, -1, pathW, SAL_MAX_PATH) <= 0)
-        return;
+        return FALSE;
 
     IPropertyStore* store = NULL;
     if (FAILED(SHGetPropertyStoreFromParsingName(pathW, NULL, GPS_DEFAULT, IID_IPropertyStore, (void**)&store)) || store == NULL)
-        return;
+        return FALSE;
 
+    BOOL ret = FALSE;
     PROPVARIANT value;
     PropVariantInit(&value);
     if (SUCCEEDED(store->GetValue(ExplorerColumnKeys[columnIndex], &value)))
@@ -1941,19 +1943,30 @@ void WINAPI InternalGetExplorerColumn()
         PWSTR display = NULL;
         if (SUCCEEDED(PSFormatForDisplayAlloc(ExplorerColumnKeys[columnIndex], value, PDFF_DEFAULT, &display)) && display != NULL)
         {
-            char text[TRANSFER_BUFFER_MAX];
-            if (WideCharToMultiByte(CP_ACP, 0, display, -1, text, TRANSFER_BUFFER_MAX, NULL, NULL) > 0)
-            {
-                TransferLen = (int)strlen(text);
-                if (TransferLen > TRANSFER_BUFFER_MAX)
-                    TransferLen = TRANSFER_BUFFER_MAX;
-                memcpy(TransferBuffer, text, TransferLen);
-            }
+            if (WideCharToMultiByte(CP_ACP, 0, display, -1, buffer, bufferSize, NULL, NULL) > 0)
+                ret = TRUE;
             CoTaskMemFree(display);
         }
     }
     PropVariantClear(&value);
     store->Release();
+    return ret;
+}
+
+void WINAPI InternalGetExplorerColumn()
+{
+    TransferLen = 0;
+    if (TransferIsDir == 2)
+        return;
+
+    char text[TRANSFER_BUFFER_MAX];
+    if (GetExplorerColumnTextForFile(TransferPanelPath, TransferFileData, (int)TransferActCustomData, text, TRANSFER_BUFFER_MAX))
+    {
+        TransferLen = (int)strlen(text);
+        if (TransferLen > TRANSFER_BUFFER_MAX)
+            TransferLen = TRANSFER_BUFFER_MAX;
+        memcpy(TransferBuffer, text, TransferLen);
+    }
 }
 
 

--- a/src/sort.h
+++ b/src/sort.h
@@ -13,7 +13,8 @@ enum CSortType
     stExtension,
     stTime,
     stSize,
-    stAttr
+    stAttr,
+    stCustom
 };
 
 void SortFilesAndDirectories(CFilesArray* files, CFilesArray* dirs,

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -601,6 +601,7 @@
 #define IDS_EDTLB_UP               10337
 #define IDS_EDTLB_DOWN             10338
 #define IDS_EDTLB_SORT             10339
+#define IDS_EDTLB_TOP              10341
 #define IDS_EDTLB_FILTER           10342
 
 // name of configuration page Alternative Viewers

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -601,6 +601,7 @@
 #define IDS_EDTLB_UP               10337
 #define IDS_EDTLB_DOWN             10338
 #define IDS_EDTLB_SORT             10339
+#define IDS_EDTLB_FILTER           10342
 
 // name of configuration page Alternative Viewers
 #define IDS_ALTVIEWERS             10340

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -595,6 +595,7 @@
 #define IDS_EXT_ACE16              10330
 
 // buttons for Edit ListBox ToolBar
+#define IDS_EDTLB_SEARCH           10331
 #define IDS_EDTLB_MODIFY           10334
 #define IDS_EDTLB_NEW              10335
 #define IDS_EDTLB_DELETE           10336

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -604,6 +604,7 @@
 #define IDS_EDTLB_SORT             10339
 #define IDS_EDTLB_TOP              10341
 #define IDS_EDTLB_FILTER           10342
+#define IDS_EDTLB_BOTTOM           10332
 
 // name of configuration page Alternative Viewers
 #define IDS_ALTVIEWERS             10340

--- a/toolbars/MoveItemBottom.svg
+++ b/toolbars/MoveItemBottom.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<rect x="3" y="14" fill="#00539C" width="10" height="1"/>
+<polygon fill="#00539C" points="3,9 8,14 13,9 "/>
+<polygon fill="#00539C" points="6,7 6,8 6,9 10,9 10,8 10,7 "/>
+<rect x="6" y="1" fill="#00539C" width="4" height="1"/>
+<rect x="6" y="3" fill="#00539C" width="4" height="1"/>
+<rect x="6" y="5" fill="#00539C" width="4" height="1"/>
+</svg>

--- a/toolbars/MoveItemTop.svg
+++ b/toolbars/MoveItemTop.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<rect x="3" y="1" fill="#00539C" width="10" height="1"/>
+<polygon fill="#00539C" points="13,7 8,2 3,7 "/>
+<polygon fill="#00539C" points="6,7 6,8 6,9 10,9 10,8 10,7 "/>
+<rect x="6" y="12" fill="#00539C" width="4" height="1"/>
+<rect x="6" y="14" fill="#00539C" width="4" height="1"/>
+<rect x="6" y="10" fill="#00539C" width="4" height="1"/>
+</svg>

--- a/toolbars/darkmode/MoveItemBottom.svg
+++ b/toolbars/darkmode/MoveItemBottom.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<rect x="3" y="14" fill="#4DA3FF" width="10" height="1"/>
+<polygon fill="#4DA3FF" points="3,9 8,14 13,9 "/>
+<polygon fill="#4DA3FF" points="6,7 6,8 6,9 10,9 10,8 10,7 "/>
+<rect x="6" y="1" fill="#4DA3FF" width="4" height="1"/>
+<rect x="6" y="3" fill="#4DA3FF" width="4" height="1"/>
+<rect x="6" y="5" fill="#4DA3FF" width="4" height="1"/>
+</svg>

--- a/toolbars/darkmode/MoveItemTop.svg
+++ b/toolbars/darkmode/MoveItemTop.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<rect x="3" y="1" fill="#4DA3FF" width="10" height="1"/>
+<polygon fill="#4DA3FF" points="13,7 8,2 3,7 "/>
+<polygon fill="#4DA3FF" points="6,7 6,8 6,9 10,9 10,8 10,7 "/>
+<rect x="6" y="12" fill="#4DA3FF" width="4" height="1"/>
+<rect x="6" y="14" fill="#4DA3FF" width="4" height="1"/>
+<rect x="6" y="10" fill="#4DA3FF" width="4" height="1"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Allow users to sort panel listings by Windows Explorer property columns shown in the detail view so header-clicks on those Explorer columns behave like standard sortable columns.
- Keep existing plugin custom columns behavior unchanged (only those advertising `SupportSorting` remain clickable) while distinguishing internal Explorer columns from arbitrary plugin-provided custom columns.
- Provide a performant sorting path by reusing Explorer property display text but caching values for the duration of a single `SortDirectory()` call to avoid repeated Property System lookups.

### Description
- Added a new sort code `stCustom` to `CSortType` and a new panel field `SortCustomData` to remember the active Explorer custom-column key (`src/sort.h`, `src/fileswnd.h`).
- Exposed a helper `GetExplorerColumnTextForFile(const char* panelPath, const CFileData* fileData, int columnIndex, char* buffer, int bufferSize)` and refactored `InternalGetExplorerColumn()` to call it for display and for sorting uses (`src/salamdr4.cpp`).
- Enabled sorting for Explorer-backed custom columns created in `BuildColumnsTemplate` by setting `column.SupportSorting = 1` only for columns using `InternalGetExplorerColumn` so plugin custom columns remain gated by their `SupportSorting` flag (`src/fileswn9.cpp`).
- Added `ChangeCustomSortType(DWORD customData, BOOL reverse, BOOL force)` and routed header-clicks on Explorer custom columns to this helper while preserving existing behavior for standard columns (`src/fileswn2.cpp`, `src/filesbx2.cpp`).
- Implemented a per-sort in-memory cache and comparator for Explorer property values and integrated it into `CFIlesWindow::SortDirectory()` so files (and directories where appropriate) are sorted by the cached property text with deterministic tie-breaker to `Name/Ext` (`src/fileswn3.cpp`).
- Updated header drawing logic to show the sort indicator for the active Explorer custom column and to only show the standard indicators for the corresponding standard `SortType` (`src/filesbx2.cpp`).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and the repository diff-check returned clean results (no new check warnings).
- Performed static inspections of modified files for obvious API/link errors in this environment but no Windows build or runtime UI tests were executed here due to the Linux container environment, so Windows manual validation is still required (see manual test steps in the task description).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f86bc4c2c83298ed13a82bf21033a)