### PR TITLE
Add 'Copy All Values to Clipboard' to Checksum Calculate context menu

### DIFF
--- a/src/plugins/checksum/checksum.rh2
+++ b/src/plugins/checksum/checksum.rh2
@@ -25,7 +25,8 @@
 #define IDS_COPYTOCBOARD_SHA1           46
 #define IDS_COPYTOCBOARD_SHA256         47
 #define IDS_COPYTOCBOARD_SHA512         48
-// 49-52 Reserved for other IDS_COPYTOCBOARD_xxx
+#define IDS_COPYALLTOCBOARD             49
+// 50-52 Reserved for other IDS_COPYTOCBOARD_xxx
 #define IDS_REMOVEITEM                  53
 #define IDS_SAVE_OVERWRITE              54
 #define IDS_ERRORCREATINGFILE           55

--- a/src/plugins/checksum/checksum.rh2
+++ b/src/plugins/checksum/checksum.rh2
@@ -25,8 +25,8 @@
 #define IDS_COPYTOCBOARD_SHA1           46
 #define IDS_COPYTOCBOARD_SHA256         47
 #define IDS_COPYTOCBOARD_SHA512         48
-#define IDS_COPYALLTOCBOARD             49
-// 50-52 Reserved for other IDS_COPYTOCBOARD_xxx
+// 49-51 Reserved for other IDS_COPYTOCBOARD_xxx
+#define IDS_COPYALLTOCBOARD             52
 #define IDS_REMOVEITEM                  53
 #define IDS_SAVE_OVERWRITE              54
 #define IDS_ERRORCREATINGFILE           55

--- a/src/plugins/checksum/dialogs.cpp
+++ b/src/plugins/checksum/dialogs.cpp
@@ -1174,15 +1174,22 @@ MENU_TEMPLATE_ITEM CalculateDialogMenu[] =
             char num[64];
             SalamanderGeneral->NumberToStr(num, FileList[focIndex]->Size);
 
-            rowText = FileList[focIndex]->Name != NULL ? FileList[focIndex]->Name : "";
-            rowText += "\t";
+            rowText = LoadStr(IDS_COLUMN_FILE);
+            rowText += ": ";
+            rowText += FileList[focIndex]->Name != NULL ? FileList[focIndex]->Name : "";
+            rowText += "\r\n";
+
+            rowText += LoadStr(IDS_COLUMN_SIZE);
+            rowText += ": ";
             rowText += num;
 
             for (int hashIndex = 0; hashIndex < HT_COUNT; hashIndex++)
             {
                 if (HashInfo[hashIndex].bCalculate)
                 {
-                    rowText += "\t";
+                    rowText += "\r\n";
+                    rowText += LoadStr(HashInfo[hashIndex].idColumnHeader);
+                    rowText += ": ";
                     if (FileList[focIndex]->Hashes[hashIndex] != NULL)
                         rowText += FileList[focIndex]->Hashes[hashIndex];
                 }

--- a/src/plugins/checksum/dialogs.cpp
+++ b/src/plugins/checksum/dialogs.cpp
@@ -19,6 +19,7 @@ CThreadQueue ThreadQueue("CheckSum Dialogs and Workers"); // list of all dialog 
 #define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
 
 #define CM_REMOVEITEM 100
+#define CM_COPYALLVALUES 101
 
 // even for small files we want to move the progress bar
 // originally this constant was 1, but the progress behaved very non-linearly when processing thousands
@@ -1105,8 +1106,6 @@ void CCalculateDialog::OnContextMenu(int x, int y, eHASH_TYPE forceCopyHash)
     mii.Mask = MENU_MASK_TYPE | MENU_MASK_STRING | MENU_MASK_ID;
     mii.Type = MENU_TYPE_STRING;
 
-    bool bSomeValue = false;
-
     int forcedHashIndex = -1;
 
     /* used by the export_mnu.py script, which generates salmenu.mnu for Translator
@@ -1119,6 +1118,7 @@ MENU_TEMPLATE_ITEM CalculateDialogMenu[] =
   {MNTT_IT, IDS_COPYTOCBOARD_SHA1
   {MNTT_IT, IDS_COPYTOCBOARD_SHA256
   {MNTT_IT, IDS_COPYTOCBOARD_SHA512
+  {MNTT_IT, IDS_COPYALLTOCBOARD
   {MNTT_IT, IDS_REMOVEITEM
   {MNTT_PE, 0
 };
@@ -1138,15 +1138,17 @@ MENU_TEMPLATE_ITEM CalculateDialogMenu[] =
                 popup->InsertItem(-1, TRUE, &mii);
                 if (forceCopyHash != HT_COUNT && forceCopyHash == i)
                     forcedHashIndex = mii.ID;
-                bSomeValue = true;
             }
         }
     }
-    if (bSomeValue)
-    {
-        mii.Type = MENU_TYPE_SEPARATOR;
-        popup->InsertItem(-1, TRUE, &mii);
-    }
+    mii.Mask = MENU_MASK_TYPE | MENU_MASK_STRING | MENU_MASK_ID;
+    mii.Type = MENU_TYPE_STRING;
+    mii.String = LoadStr(IDS_COPYALLTOCBOARD);
+    mii.ID = CM_COPYALLVALUES;
+    popup->InsertItem(-1, TRUE, &mii);
+
+    mii.Type = MENU_TYPE_SEPARATOR;
+    popup->InsertItem(-1, TRUE, &mii);
 
     mii.Mask = MENU_MASK_TYPE | MENU_MASK_STRING | MENU_MASK_ID | MENU_MASK_STATE;
     mii.Type = MENU_TYPE_STRING;
@@ -1163,6 +1165,30 @@ MENU_TEMPLATE_ITEM CalculateDialogMenu[] =
     if (id == CM_REMOVEITEM)
     {
         DeleteItem(focIndex);
+    }
+    else if (id == CM_COPYALLVALUES)
+    {
+        std::string rowText;
+        if (focIndex >= 0 && focIndex < FileList.Count)
+        {
+            char num[64];
+            SalamanderGeneral->NumberToStr(num, FileList[focIndex]->Size);
+
+            rowText = FileList[focIndex]->Name != NULL ? FileList[focIndex]->Name : "";
+            rowText += "\t";
+            rowText += num;
+
+            for (int hashIndex = 0; hashIndex < HT_COUNT; hashIndex++)
+            {
+                if (HashInfo[hashIndex].bCalculate)
+                {
+                    rowText += "\t";
+                    if (FileList[focIndex]->Hashes[hashIndex] != NULL)
+                        rowText += FileList[focIndex]->Hashes[hashIndex];
+                }
+            }
+        }
+        SalamanderGeneral->CopyTextToClipboard(rowText.c_str(), -1, FALSE, NULL);
     }
     else if ((id >= 1) && (id <= HT_COUNT))
     {

--- a/src/plugins/checksum/lang/lang.rc2
+++ b/src/plugins/checksum/lang/lang.rc2
@@ -30,6 +30,7 @@ STRINGTABLE
  IDS_COPYTOCBOARD_SHA1 "Copy SHA-&1 Checksum to Clipboard\tCtrl+1"
  IDS_COPYTOCBOARD_SHA256 "Copy SHA-&256 Checksum to Clipboard\tCtrl+2"
  IDS_COPYTOCBOARD_SHA512 "Copy SHA-&512 Checksum to Clipboard\tCtrl+5"
+ IDS_COPYALLTOCBOARD "Copy &All Values to Clipboard"
  IDS_REMOVEITEM "&Remove Item\tDelete"
  IDS_SAVE_TITLE  "Save Checksum File"
  IDS_SAVE_FILTER_CRC  "SFV Files (*.sfv)|*.sfv|"


### PR DESCRIPTION
### Motivation
- Provide an easy way to copy the entire selected row from the Calculate Checksum dialog (all columns: file name, size, and enabled checksum columns) to the clipboard as a single tab-separated line.

### Description
- Added a new localized string `IDS_COPYALLTOCBOARD` and resource ID to the plugin resources (`src/plugins/checksum/lang/lang.rc2`, `src/plugins/checksum/checksum.rh2`).
- Introduced a new context menu command `CM_COPYALLVALUES` and inserted it into the Calculate dialog ListView context menu in `src/plugins/checksum/dialogs.cpp`.
- Implemented logic to build a tab-separated row containing file name, size (via `SalamanderGeneral->NumberToStr`), and all enabled checksum column values, and copy it to the clipboard using `SalamanderGeneral->CopyTextToClipboard` in `src/plugins/checksum/dialogs.cpp`.

### Testing
- Ran the repository consistency/static check `git diff --check`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fda73136c8329812fbc71eca8a8c9)