### PR TITLE
Target-side IPC for CLIPFAKE paste across integrity levels

### DIFF
--- a/doc/elevated-file-operations.md
+++ b/doc/elevated-file-operations.md
@@ -60,9 +60,12 @@ should mirror the same behavior locally.
 
 ## Current integration points
 
-The first connected file-operation path is direct file deletion: when `DeleteFile`
-fails in the worker with an elevation-candidate error, Salamander shows the retry
-prompt and routes the confirmed operation through `RunElevatedFileOperation()` with
-the `delete-file` broker verb. Copy, move, directory delete, and attribute changes
-should follow the same helper once their existing retry/skip UI paths are split
-cleanly enough to preserve current progress-dialog semantics.
+The connected worker paths are:
+
+- direct file deletion: `DeleteFile` failures can retry through `delete-file`;
+- target creation during copy: target open/create failures can retry through `copy-file`;
+- move/rename: normal move failures can retry through `move-file`;
+- attribute changes: `SetFileAttributes` failures can retry through `set-attributes`.
+
+Directory delete and security descriptor changes still need dedicated integration so their
+existing recycle-bin, recursive-delete, and permission-copy semantics are preserved.

--- a/doc/elevated-file-operations.md
+++ b/doc/elevated-file-operations.md
@@ -15,11 +15,11 @@ The central predicate is `CanOfferElevatedRetryForFileError(error, path)`. Once 
 ## Operations in scope
 
 The broker protocol is limited to file operations that Salamander already exposes:
-copy file, move/rename file, delete file/directory, create directory, and set attributes.
-It is intended for copy, move, delete, rename, attribute changes, and writes into
-Program Files or system directories. Owner/group/DACL changes remain out of the
-first executable broker version and must not be routed until a constrained
-security-descriptor format is implemented.
+copy file, move/rename file, delete file/directory, create directory, set attributes, and copy owner/group/DACL from an existing source path to an existing target path.
+It is intended for copy, move, delete, rename, attribute changes, permission-copy,
+and writes into Program Files or system directories. The broker does not accept
+arbitrary security descriptors from the unelevated process; it only copies security
+from a canonicalized source path that the request already names.
 
 ## Broker
 
@@ -34,7 +34,7 @@ Version 1 requests contain:
 
 - protocol version;
 - fixed verb: `copy-file`, `move-file`, `delete-file`, `create-dir`,
-  `set-attributes`;
+  `set-attributes`, or `copy-security`;
 - canonical source and/or target paths;
 - operation flags and attributes specific to the verb;
 - parent Salamander process ID for auditing/lifetime checks.
@@ -67,7 +67,5 @@ The connected worker paths are:
 - directory creation: `CreateDirectory` failures can retry through `create-dir`;
 - target creation during copy: target open/create failures can retry through `copy-file`;
 - move/rename: normal move failures can retry through `move-file`;
-- attribute changes: `SetFileAttributes` failures can retry through `set-attributes`.
-
-Security descriptor changes still need dedicated integration so permission-copy semantics
-and a constrained descriptor format are preserved.
+- attribute changes: `SetFileAttributes` failures can retry through `set-attributes`;
+- security copy: owner/group/DACL copy failures can retry through `copy-security`, which copies security from the canonicalized source path instead of accepting caller-supplied descriptors.

--- a/doc/elevated-file-operations.md
+++ b/doc/elevated-file-operations.md
@@ -57,3 +57,12 @@ not set `SHELLEXECUTEINFO::hwnd`, treats `ERROR_CANCELLED` as user cancellation,
 and restores focus to the owner instead of reporting cancellation as a normal
 operation failure. Plugin or setup code that cannot link to the main wrapper
 should mirror the same behavior locally.
+
+## Current integration points
+
+The first connected file-operation path is direct file deletion: when `DeleteFile`
+fails in the worker with an elevation-candidate error, Salamander shows the retry
+prompt and routes the confirmed operation through `RunElevatedFileOperation()` with
+the `delete-file` broker verb. Copy, move, directory delete, and attribute changes
+should follow the same helper once their existing retry/skip UI paths are split
+cleanly enough to preserve current progress-dialog semantics.

--- a/doc/elevated-file-operations.md
+++ b/doc/elevated-file-operations.md
@@ -63,9 +63,11 @@ should mirror the same behavior locally.
 The connected worker paths are:
 
 - direct file deletion: `DeleteFile` failures can retry through `delete-file`;
+- directory deletion: direct `RemoveDirectory` failures can retry through `delete-file`;
+- directory creation: `CreateDirectory` failures can retry through `create-dir`;
 - target creation during copy: target open/create failures can retry through `copy-file`;
 - move/rename: normal move failures can retry through `move-file`;
 - attribute changes: `SetFileAttributes` failures can retry through `set-attributes`.
 
-Directory delete and security descriptor changes still need dedicated integration so their
-existing recycle-bin, recursive-delete, and permission-copy semantics are preserved.
+Security descriptor changes still need dedicated integration so permission-copy semantics
+and a constrained descriptor format are preserved.

--- a/doc/elevated-file-operations.md
+++ b/doc/elevated-file-operations.md
@@ -46,3 +46,12 @@ only after UAC consent and the Salamander confirmation prompt.
 
 The shared strings added for the prompt are `IDS_ELEVATEDRETRY_TITLE`,
 `IDS_ELEVATEDRETRY_PROMPT`, and `IDS_ELEVATEDRETRY_BUTTON`.
+
+## UAC prompt ownership and cancellation
+
+All Salamander-owned `ShellExecuteEx` calls that can surface UAC UI should use
+`SalShellExecuteEx`. The wrapper supplies a safe owner window when the caller did
+not set `SHELLEXECUTEINFO::hwnd`, treats `ERROR_CANCELLED` as user cancellation,
+and restores focus to the owner instead of reporting cancellation as a normal
+operation failure. Plugin or setup code that cannot link to the main wrapper
+should mirror the same behavior locally.

--- a/doc/elevated-file-operations.md
+++ b/doc/elevated-file-operations.md
@@ -10,18 +10,20 @@ are candidates for an elevated retry only when all of the following are true:
    Program Files (x86), or ProgramW6432.
 
 This deliberately excludes normal ACL/share failures in user data directories.
-The central predicate is `CanOfferElevatedRetryForFileError(error, path)`.
+The central predicate is `CanOfferElevatedRetryForFileError(error, path)`. Once the user confirms the retry, `RunElevatedFileOperation()` starts `saladmin.exe` with `runas`, waits for completion, and returns the broker exit code to the caller.
 
 ## Operations in scope
 
 The broker protocol is limited to file operations that Salamander already exposes:
-copy file, move/rename file, delete file, create directory, set attributes, and
-set owner/group/DACL. It is intended for copy, move, delete, rename, attribute
-changes, owner/ACL changes, and writes into Program Files or system directories.
+copy file, move/rename file, delete file/directory, create directory, and set attributes.
+It is intended for copy, move, delete, rename, attribute changes, and writes into
+Program Files or system directories. Owner/group/DACL changes remain out of the
+first executable broker version and must not be routed until a constrained
+security-descriptor format is implemented.
 
 ## Broker
 
-`src/saladmin` contains the elevated broker executable. Its manifest is
+`src/saladmin` contains the elevated broker executable. Its first executable version implements copy-file, move-file, delete-file/delete-directory, create-dir, and set-attributes. Its manifest is
 `requireAdministrator`; it should be launched only after the user chooses the UI
 prompt "Retry as Administrator". The broker is not a shell and must never accept
 an arbitrary command line to execute.
@@ -32,7 +34,7 @@ Version 1 requests contain:
 
 - protocol version;
 - fixed verb: `copy-file`, `move-file`, `delete-file`, `create-dir`,
-  `set-attributes`, or `set-security`;
+  `set-attributes`;
 - canonical source and/or target paths;
 - operation flags and attributes specific to the verb;
 - parent Salamander process ID for auditing/lifetime checks.

--- a/doc/elevated-file-operations.md
+++ b/doc/elevated-file-operations.md
@@ -1,0 +1,48 @@
+# Elevated file-operation model
+
+Open Salamander remains an `asInvoker` process. File operations that fail with
+`ERROR_ACCESS_DENIED`, `ERROR_PRIVILEGE_NOT_HELD`, or `ERROR_ELEVATION_REQUIRED`
+are candidates for an elevated retry only when all of the following are true:
+
+1. the current process is not already elevated;
+2. the current account is a member of the local Administrators group;
+3. the affected path canonicalizes under Windows, System32, Program Files,
+   Program Files (x86), or ProgramW6432.
+
+This deliberately excludes normal ACL/share failures in user data directories.
+The central predicate is `CanOfferElevatedRetryForFileError(error, path)`.
+
+## Operations in scope
+
+The broker protocol is limited to file operations that Salamander already exposes:
+copy file, move/rename file, delete file, create directory, set attributes, and
+set owner/group/DACL. It is intended for copy, move, delete, rename, attribute
+changes, owner/ACL changes, and writes into Program Files or system directories.
+
+## Broker
+
+`src/saladmin` contains the elevated broker executable. Its manifest is
+`requireAdministrator`; it should be launched only after the user chooses the UI
+prompt "Retry as Administrator". The broker is not a shell and must never accept
+an arbitrary command line to execute.
+
+## IPC protocol
+
+Version 1 requests contain:
+
+- protocol version;
+- fixed verb: `copy-file`, `move-file`, `delete-file`, `create-dir`,
+  `set-attributes`, or `set-security`;
+- canonical source and/or target paths;
+- operation flags and attributes specific to the verb;
+- parent Salamander process ID for auditing/lifetime checks.
+
+The broker must canonicalize every received path before execution, reject paths
+that do not round-trip through Win32 canonicalization, and reject verbs outside
+the allow-list. The main process owns all user interaction; the broker executes
+only after UAC consent and the Salamander confirmation prompt.
+
+## UI
+
+The shared strings added for the prompt are `IDS_ELEVATEDRETRY_TITLE`,
+`IDS_ELEVATEDRETRY_PROMPT`, and `IDS_ELEVATEDRETRY_BUTTON`.

--- a/src/bugreprt.cpp
+++ b/src/bugreprt.cpp
@@ -1886,9 +1886,33 @@ void CCallStack::PrintBugReport(EXCEPTION_POINTERS* Exception, DWORD ThreadID, D
         // OTHER INFORMATION
         PrintLine(param, "Other Information:", FALSE);
 
-        strcpy(buf, "User is Admin: ");
-        strcat(buf, IsUserAdmin() ? "yes" : "no");
+        strcpy(buf, "User is in Administrators group: ");
+        strcat(buf, IsUserInAdministratorsGroup() ? "yes" : "no");
         PrintLine(param, buf, TRUE);
+
+        strcpy(buf, "Process is elevated: ");
+        strcat(buf, IsProcessElevated() ? "yes" : "no");
+        PrintLine(param, buf, TRUE);
+
+        TOKEN_ELEVATION_TYPE elevationType;
+        if (GetElevationType(&elevationType))
+        {
+            const char* elevationTypeText = "unknown";
+            switch (elevationType)
+            {
+            case TokenElevationTypeDefault:
+                elevationTypeText = "default";
+                break;
+            case TokenElevationTypeFull:
+                elevationTypeText = "full";
+                break;
+            case TokenElevationTypeLimited:
+                elevationTypeText = "limited";
+                break;
+            }
+            sprintf(buf, "Elevation Type: %s", elevationTypeText);
+            PrintLine(param, buf, TRUE);
+        }
 
         DWORD integrityLevel;
         if (GetProcessIntegrityLevel(&integrityLevel))

--- a/src/consts.h
+++ b/src/consts.h
@@ -2378,6 +2378,11 @@ BOOL IsProcessElevated();
 // na Windows Vista+ vraci TokenElevationTypeDefault/Full/Limited aktualniho procesu
 BOOL GetElevationType(TOKEN_ELEVATION_TYPE* elevationType);
 
+// centralni UAC heuristika pro souborove operace: vraci TRUE, pokud chyba typicky
+// znamena chybejici elevaci a ne-elevovanemu adminovi lze nabidnout opakovani jako spravce
+BOOL CanOfferElevatedRetryForFileError(DWORD error, const char* path);
+BOOL IsPathInElevatedWriteLocation(const char* path);
+
 //******************************************************************************
 
 // pro zajisteni uniku z odstranenych drivu na fixed drive (po vysunuti device - USB flash disk, atd.)

--- a/src/consts.h
+++ b/src/consts.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
@@ -2382,6 +2382,7 @@ BOOL GetElevationType(TOKEN_ELEVATION_TYPE* elevationType);
 // znamena chybejici elevaci a ne-elevovanemu adminovi lze nabidnout opakovani jako spravce
 BOOL CanOfferElevatedRetryForFileError(DWORD error, const char* path);
 BOOL IsPathInElevatedWriteLocation(const char* path);
+DWORD RunElevatedFileOperation(HWND parent, const char* verb, const char* source, const char* target, DWORD attributes, BOOL useAttributes);
 
 //******************************************************************************
 

--- a/src/consts.h
+++ b/src/consts.h
@@ -2364,9 +2364,19 @@ BOOL GetMyDocumentsOrDesktopPath(char* path, int pathLen);
 // application is running on the console.
 BOOL IsRemoteSession(void);
 
-// vraci TRUE, pokud je uzivatel mezi Administratory
-// v pripade chyby vraci FALSE
+// vraci TRUE, pokud je ucet uzivatele clenem skupiny Administrators
+// (i kdyz aktualni proces bezi s omezenym UAC tokenem); v pripade chyby vraci FALSE
+BOOL IsUserInAdministratorsGroup();
+
+// zpetne kompatibilni alias pro IsUserInAdministratorsGroup()
 BOOL IsUserAdmin();
+
+// vraci TRUE, pokud aktualni proces skutecne bezi s elevovanym tokenem
+// (na Windows Vista+ pouziva TokenElevation; na starsich Windows odpovida admin clenstvi)
+BOOL IsProcessElevated();
+
+// na Windows Vista+ vraci TokenElevationTypeDefault/Full/Limited aktualniho procesu
+BOOL GetElevationType(TOKEN_ELEVATION_TYPE* elevationType);
 
 //******************************************************************************
 

--- a/src/dialogs3.cpp
+++ b/src/dialogs3.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -2006,9 +2006,9 @@ void CDriveInfo::Validate(CTransferInfo& ti)
                 MainWindow->LeftPanel->HandsOff(TRUE);
             if (handsOffRight)
                 MainWindow->RightPanel->HandsOff(TRUE);
-            //      SAD_SetUACParentWindow(HWindow);
-            //      BOOL res = SAD_SetVolumeLabel(volumePathWithBackslash, newName);
-            //      DWORD err = SAD_GetLastError();
+            // Historical SAD_SetUACParentWindow(HWindow) hook was replaced by the
+            // centralized SalShellExecuteEx() wrapper for ShellExecuteEx/UAC prompts.
+            // SetVolumeLabel itself does not show UAC UI, so keep the direct call here.
             BOOL res = SetVolumeLabel(volumePathWithBackslash, newName);
             DWORD err = GetLastError();
             if (handsOffLeft)

--- a/src/fileswn9.cpp
+++ b/src/fileswn9.cpp
@@ -127,6 +127,67 @@ void CFilesWindow::ClearPluginFSFromHistory(CPluginFSInterfaceAbstract* fs)
     PathHistory->ClearPluginFSFromHistory(fs);
 }
 
+
+static BOOL RequestFakePasteFromSourceSalamander(const char* targetPath, DWORD pasteEffect)
+{
+    CALL_STACK_MESSAGE2("RequestFakePasteFromSourceSalamander(%s,)", targetPath);
+
+    if (SalShExtSharedMemView == NULL || SalShExtSharedMemMutex == NULL || targetPath == NULL ||
+        (pasteEffect != DROPEFFECT_COPY && pasteEffect != DROPEFFECT_MOVE))
+        return FALSE;
+
+    BOOL requested = FALSE;
+    HANDLE doPasteEvent = NULL;
+    WaitForSingleObject(SalShExtSharedMemMutex, INFINITE);
+    if (SalShExtSharedMemView->DoPasteFromSalamander &&
+        (SalShExtSharedMemView->SalamanderMainWndPID != GetCurrentProcessId() ||
+         SalShExtSharedMemView->SalamanderMainWndTID != GetCurrentThreadId()))
+    {
+        SalShExtSharedMemView->SalBusyState = 0;
+        SalShExtSharedMemView->PasteDone = FALSE;
+        doPasteEvent = HANDLES_Q(OpenEvent(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, SALSHEXT_DOPASTEEVENTNAME));
+        if (doPasteEvent != NULL)
+            SetEvent(doPasteEvent);
+        else
+        {
+            SalShExtSharedMemView->BlockPasteDataRelease = TRUE;
+            PostMessage((HWND)SalShExtSharedMemView->SalamanderMainWnd, WM_USER_SALSHEXT_PASTE,
+                        SalShExtSharedMemView->PostMsgIndex, 0);
+        }
+
+        int count = 0;
+        while (SalShExtSharedMemView->SalBusyState == 0 && count++ < 50)
+        {
+            ReleaseMutex(SalShExtSharedMemMutex);
+            Sleep(100);
+            WaitForSingleObject(SalShExtSharedMemMutex, INFINITE);
+        }
+
+        if (SalShExtSharedMemView->SalBusyState == 1)
+        {
+            lstrcpyn(SalShExtSharedMemView->TargetPath, targetPath, 2 * MAX_PATH);
+            SalShExtSharedMemView->Operation = pasteEffect == DROPEFFECT_COPY ? SALSHEXT_COPY : SALSHEXT_MOVE;
+            SalShExtSharedMemView->PasteDone = TRUE;
+            SalShExtSharedMemView->DropDone = FALSE;
+            requested = TRUE;
+        }
+        SalShExtSharedMemView->PostMsgIndex++;
+        if (doPasteEvent == NULL)
+        {
+            SalShExtSharedMemView->BlockPasteDataRelease = FALSE;
+            PostMessage((HWND)SalShExtSharedMemView->SalamanderMainWnd, WM_USER_SALSHEXT_TRYRELDATA, 0, 0);
+        }
+    }
+    ReleaseMutex(SalShExtSharedMemMutex);
+
+    if (doPasteEvent != NULL)
+    {
+        ResetEvent(doPasteEvent);
+        HANDLES(CloseHandle(doPasteEvent));
+    }
+    return requested;
+}
+
 BOOL SafeInvokeCommand(IContextMenu2* menu, CMINVOKECOMMANDINFO& ici)
 {
     CALL_STACK_MESSAGE_NONE
@@ -174,28 +235,42 @@ BOOL CFilesWindow::ClipboardPaste(BOOL onlyLinks, BOOL onlyTest, const char* pas
             }
             ReleaseMutex(SalShExtSharedMemMutex);
 
+            DWORD pasteEffect = 0;
+            if (OpenClipboard(HWindow))
+            {
+                HANDLE handle = GetClipboardData(RegisterClipboardFormat(CFSTR_PREFERREDDROPEFFECT));
+                if (handle != NULL)
+                {
+                    DWORD* effect = (DWORD*)HANDLES(GlobalLock(handle));
+                    if (effect != NULL)
+                    {
+                        pasteEffect = *effect;
+                        HANDLES(GlobalUnlock(handle));
+                    }
+                }
+                CloseClipboard();
+            }
+            else
+                TRACE_E("OpenClipboard() has failed!");
+            pasteEffect &= DROPEFFECT_COPY | DROPEFFECT_MOVE;
+
+            if (!pasteFromOurData)
+            {
+                if (RequestFakePasteFromSourceSalamander(pastePath != NULL ? pastePath : GetPath(), pasteEffect))
+                {
+                    dataObj->Release();
+                    FocusFirstNewItem = TRUE;
+                    return TRUE;
+                }
+                TRACE_E("Paste: fake Salamander clipboard data could not be handed to the source instance.");
+                dataObj->Release();
+                return TRUE; // do not let the generic shell path copy the CLIPFAKE directory
+            }
+
             if (pasteFromOurData)
             {
-                DWORD pasteEffect = 0;
-                if (OpenClipboard(HWindow))
-                {
-                    HANDLE handle = GetClipboardData(RegisterClipboardFormat(CFSTR_PREFERREDDROPEFFECT));
-                    if (handle != NULL)
-                    {
-                        DWORD* effect = (DWORD*)HANDLES(GlobalLock(handle));
-                        if (effect != NULL)
-                        {
-                            pasteEffect = *effect;
-                            HANDLES(GlobalUnlock(handle));
-                        }
-                    }
-                    CloseClipboard();
-                }
-                else
-                    TRACE_E("OpenClipboard() has failed!");
                 SalShExtPastedData.SetLock(TRUE);
                 dataObj->Release(); // one instance still remains on the clipboard
-                pasteEffect &= DROPEFFECT_COPY | DROPEFFECT_MOVE;
                 if (pasteEffect == DROPEFFECT_COPY || pasteEffect == DROPEFFECT_MOVE)
                 {
                     // move clears the clipboard after itself (cut&paste), release the clipboard before launching

--- a/src/lang/lang.rh
+++ b/src/lang/lang.rh
@@ -760,6 +760,9 @@
 #define IDC_MCD_GROUP_TARGET            6254
 #define IDC_MCD_SYNC_NAME                6255
 #define IDC_MCD_DELETE_SOURCE_AFTER      6256
+#define IDS_ELEVATEDRETRY_TITLE          6257
+#define IDS_ELEVATEDRETRY_PROMPT         6258
+#define IDS_ELEVATEDRETRY_BUTTON         6259
 
 // Next default values for new objects
 // 
@@ -767,7 +770,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        8201
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         6257
+#define _APS_NEXT_CONTROL_VALUE         6260
 #define _APS_NEXT_SYMED_VALUE           103
 #endif
 #endif

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -352,6 +352,9 @@ STRINGTABLE
  IDS_TOOLONGNAME2, "Path to target directory is too long, press Skip button to skip whole directory.\n\nPath: %s\n\nName: %s"
 
  IDS_ERRORTITLE, "Error"
+ IDS_ELEVATEDRETRY_TITLE, "Administrator rights required"
+ IDS_ELEVATEDRETRY_PROMPT, "The operation failed because administrator rights may be required for:\n\n%s\n\nDo you want to retry the operation as administrator?"
+ IDS_ELEVATEDRETRY_BUTTON, "Retry as &Administrator"
 
  IDS_ERRORFINDINGFILE, "Error Finding File"
 

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -335,7 +335,7 @@ static BOOL MCDRestartSalamanderAfterWelcome(HWND parent)
     se.lpFile = exePath;
     se.lpDirectory = initDir;
 
-    return ShellExecuteEx(&se);
+    return SalShellExecuteEx(&se, parent, "RestartSalamander");
 }
 
 static BOOL MCDGetCurrentInstancePath(char* path, int pathSize)

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -6018,7 +6018,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
                     *slash = 0;
                 se.lpDirectory = initDir;
 
-                BOOL started = ShellExecuteEx(&se);
+                BOOL started = SalShellExecuteEx(&se, HWindow, "Restart after configuration import");
 
                 // Zavrit aplikaci bez ulozeni konfigurace
                 if (started)
@@ -9557,9 +9557,9 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     {
         if (WindowsVistaAndLater)
         {
-            // Windows Vista UAC patch: when starting a file from the panels caused the UAC elevation prompt to appear
-            // and then was closed using Cancel, Salamander would lose focus from the panel.
-            // The main window is disabled at the time messages like WM_ACTIVATE or WM_SETFOCUS arrive, and the focus is received by Microsoft IME-supported popups.
+            // Windows Vista UAC patch: ShellExecuteEx/UAC prompts now go through SalShellExecuteEx(),
+            // which restores the owner on ERROR_CANCELLED. Keep this defensive focus repair because
+            // older shell paths may still disable the main window while IME helper popups take focus.
             BOOL enabled = (BOOL)wParam;
             if (enabled)
             {

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -1255,8 +1255,6 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                                    NULL, NULL, &si, &pi)))
                         {
                             DWORD err = GetLastError();
-                            if (err == ERROR_CANCELLED)
-                                break;
                             char buff[4 * MAX_PATH];
                             if (strlen(cmdLine) > 2 * MAX_PATH)
                                 strcpy(cmdLine + 2 * MAX_PATH, "..."); // shorten just in case (probably never needed)

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -1183,9 +1183,11 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                         sei.lpDirectory = (initDir[0] != 0) ? initDir : NULL;
                         sei.nShow = SW_SHOWNORMAL;
 
-                        if (!ShellExecuteEx(&sei))
+                        if (!SalShellExecuteEx(&sei, parent, "CMainWindow::UserMenu"))
                         {
                             DWORD err = GetLastError();
+                            if (err == ERROR_CANCELLED)
+                                break;
                             char buff[4 * MAX_PATH];
                             if (strlen(cmdLine) > 2 * MAX_PATH) // "always false" (arguments are in 'arguments'): shorten overly long command lines for error display
                                 strcpy(cmdLine + 2 * MAX_PATH - 4, "...");
@@ -1253,6 +1255,8 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                                    NULL, NULL, &si, &pi)))
                         {
                             DWORD err = GetLastError();
+                            if (err == ERROR_CANCELLED)
+                                break;
                             char buff[4 * MAX_PATH];
                             if (strlen(cmdLine) > 2 * MAX_PATH)
                                 strcpy(cmdLine + 2 * MAX_PATH, "..."); // shorten just in case (probably never needed)

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -2362,6 +2362,9 @@ public:
     virtual BOOL WINAPI RegisterService(const char* serviceId, DWORD version, void* serviceInterface, const char* providerName);
     virtual BOOL WINAPI UnregisterService(const char* serviceId, void* serviceInterface);
     virtual BOOL WINAPI QueryService(const CSalamanderServiceQuery* query, CSalamanderServiceResult* result);
+    virtual BOOL WINAPI IsUserInAdministratorsGroup();
+    virtual BOOL WINAPI IsProcessElevated();
+    virtual BOOL WINAPI GetElevationType(TOKEN_ELEVATION_TYPE* elevationType);
 };
 
 //

--- a/src/plugins/shared/spl_gen.h
+++ b/src/plugins/shared/spl_gen.h
@@ -3200,7 +3200,8 @@ public:
     // omezeni: hlavni thread
     virtual void WINAPI RemoveCurrentPathFromHistory(int panel) = 0;
 
-    // vracit TRUE, pokud je aktualni uzivatel clenem skupiny Administrators, jinak vraci FALSE
+    // vraci TRUE, pokud je aktualni uzivatel clenem skupiny Administrators, jinak vraci FALSE;
+    // tato zpetne kompatibilni metoda nerika, jestli proces skutecne bezi elevovane
     // mozne volat z libovolneho threadu
     virtual BOOL WINAPI IsUserAdmin() = 0;
 
@@ -3470,11 +3471,24 @@ public:
     virtual void WINAPI CloseAllOwnedEnabledDialogs(HWND parent, DWORD tid = 0) = 0;
 
     // Salamatrix/service-provider MVP: register, unregister, and query in-process runtime services.
-    // These must stay at the end of CSalamanderGeneralAbstract to preserve the vtable layout
-    // used by plug-ins built with older SDK headers.
+    // New virtual methods must stay at the end of CSalamanderGeneralAbstract to preserve the
+    // vtable layout used by plug-ins built with older SDK headers.
     virtual BOOL WINAPI RegisterService(const char* serviceId, DWORD version, void* serviceInterface, const char* providerName) = 0;
     virtual BOOL WINAPI UnregisterService(const char* serviceId, void* serviceInterface) = 0;
     virtual BOOL WINAPI QueryService(const CSalamanderServiceQuery* query, CSalamanderServiceResult* result) = 0;
+
+    // vraci TRUE, pokud je aktualni uzivatel clenem skupiny Administrators;
+    // odpovida IsUserAdmin(), ale nazev explicitne odlisuje clenstvi od elevace procesu
+    // mozne volat z libovolneho threadu
+    virtual BOOL WINAPI IsUserInAdministratorsGroup() = 0;
+
+    // vraci TRUE, pokud Salamander skutecne bezi s elevovanym tokenem procesu
+    // mozne volat z libovolneho threadu
+    virtual BOOL WINAPI IsProcessElevated() = 0;
+
+    // na Windows Vista+ vraci TokenElevationTypeDefault/Full/Limited aktualniho procesu
+    // mozne volat z libovolneho threadu
+    virtual BOOL WINAPI GetElevationType(TOKEN_ELEVATION_TYPE* elevationType) = 0;
 };
 
 #ifdef _MSC_VER

--- a/src/saladmin/manifest.xml
+++ b/src/saladmin/manifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="OpenSalamander.SalAdmin" type="win32"/>
+  <description>Open Salamander elevated file-operation broker</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/src/saladmin/saladmin.cpp
+++ b/src/saladmin/saladmin.cpp
@@ -6,6 +6,17 @@
 
 #define SALADMIN_PROTOCOL_VERSION 1
 
+struct CBrokerRequest
+{
+    const wchar_t* Verb;
+    wchar_t Source[MAX_PATH];
+    wchar_t Target[MAX_PATH];
+    DWORD Attributes;
+    BOOL HaveSource;
+    BOOL HaveTarget;
+    BOOL HaveAttributes;
+};
+
 static BOOL IsAllowedVerb(const wchar_t* verb)
 {
     return verb != NULL &&
@@ -13,8 +24,7 @@ static BOOL IsAllowedVerb(const wchar_t* verb)
             lstrcmpiW(verb, L"move-file") == 0 ||
             lstrcmpiW(verb, L"delete-file") == 0 ||
             lstrcmpiW(verb, L"create-dir") == 0 ||
-            lstrcmpiW(verb, L"set-attributes") == 0 ||
-            lstrcmpiW(verb, L"set-security") == 0);
+            lstrcmpiW(verb, L"set-attributes") == 0);
 }
 
 static BOOL CanonicalizeArgumentPath(const wchar_t* path, wchar_t* out, DWORD outCount)
@@ -34,30 +44,114 @@ static BOOL CanonicalizeArgumentPath(const wchar_t* path, wchar_t* out, DWORD ou
     return TRUE;
 }
 
-int wmain(int argc, wchar_t** argv)
+static BOOL ParseDword(const wchar_t* text, DWORD* value)
 {
-    // Minimal broker skeleton: it is intentionally not a general command runner.
-    // The main Salamander process must pass a fixed verb plus canonicalizable paths
-    // over the documented protocol before operation execution is enabled here.
-    if (argc < 3 || lstrcmpiW(argv[1], L"--protocol") != 0)
+    if (text == NULL || value == NULL)
+        return FALSE;
+
+    wchar_t* end = NULL;
+    unsigned long parsed = wcstoul(text, &end, 0);
+    if (end == text || *end != 0)
+        return FALSE;
+
+    *value = (DWORD)parsed;
+    return TRUE;
+}
+
+static DWORD ParseRequest(int argc, wchar_t** argv, CBrokerRequest* request)
+{
+    if (request == NULL)
+        return ERROR_INVALID_PARAMETER;
+
+    ZeroMemory(request, sizeof(*request));
+    request->Attributes = INVALID_FILE_ATTRIBUTES;
+
+    if (argc < 5 || lstrcmpiW(argv[1], L"--protocol") != 0)
         return ERROR_INVALID_PARAMETER;
 
     int version = _wtoi(argv[2]);
     if (version != SALADMIN_PROTOCOL_VERSION)
         return ERROR_REVISION_MISMATCH;
 
-    if (argc < 5 || lstrcmpiW(argv[3], L"--verb") != 0 || !IsAllowedVerb(argv[4]))
+    if (lstrcmpiW(argv[3], L"--verb") != 0 || !IsAllowedVerb(argv[4]))
         return ERROR_INVALID_PARAMETER;
+    request->Verb = argv[4];
 
     for (int i = 5; i < argc; ++i)
     {
-        if ((lstrcmpiW(argv[i], L"--source") == 0 || lstrcmpiW(argv[i], L"--target") == 0) && i + 1 < argc)
+        if (lstrcmpiW(argv[i], L"--source") == 0 && i + 1 < argc)
         {
-            wchar_t canonical[MAX_PATH];
-            if (!CanonicalizeArgumentPath(argv[++i], canonical, MAX_PATH))
+            if (!CanonicalizeArgumentPath(argv[++i], request->Source, MAX_PATH))
                 return ERROR_BAD_PATHNAME;
+            request->HaveSource = TRUE;
         }
+        else if (lstrcmpiW(argv[i], L"--target") == 0 && i + 1 < argc)
+        {
+            if (!CanonicalizeArgumentPath(argv[++i], request->Target, MAX_PATH))
+                return ERROR_BAD_PATHNAME;
+            request->HaveTarget = TRUE;
+        }
+        else if (lstrcmpiW(argv[i], L"--attributes") == 0 && i + 1 < argc)
+        {
+            if (!ParseDword(argv[++i], &request->Attributes))
+                return ERROR_INVALID_PARAMETER;
+            request->HaveAttributes = TRUE;
+        }
+        else
+            return ERROR_INVALID_PARAMETER;
     }
 
-    return ERROR_CALL_NOT_IMPLEMENTED;
+    return ERROR_SUCCESS;
+}
+
+static DWORD ExecuteRequest(const CBrokerRequest* request)
+{
+    if (request == NULL || request->Verb == NULL)
+        return ERROR_INVALID_PARAMETER;
+
+    if (lstrcmpiW(request->Verb, L"copy-file") == 0)
+    {
+        if (!request->HaveSource || !request->HaveTarget)
+            return ERROR_INVALID_PARAMETER;
+        return CopyFileW(request->Source, request->Target, FALSE) ? ERROR_SUCCESS : GetLastError();
+    }
+    if (lstrcmpiW(request->Verb, L"move-file") == 0)
+    {
+        if (!request->HaveSource || !request->HaveTarget)
+            return ERROR_INVALID_PARAMETER;
+        return MoveFileExW(request->Source, request->Target, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING) ? ERROR_SUCCESS : GetLastError();
+    }
+    if (lstrcmpiW(request->Verb, L"delete-file") == 0)
+    {
+        if (!request->HaveSource)
+            return ERROR_INVALID_PARAMETER;
+        DWORD attrs = GetFileAttributesW(request->Source);
+        if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY))
+            return RemoveDirectoryW(request->Source) ? ERROR_SUCCESS : GetLastError();
+        return DeleteFileW(request->Source) ? ERROR_SUCCESS : GetLastError();
+    }
+    if (lstrcmpiW(request->Verb, L"create-dir") == 0)
+    {
+        if (!request->HaveTarget)
+            return ERROR_INVALID_PARAMETER;
+        return CreateDirectoryW(request->Target, NULL) || GetLastError() == ERROR_ALREADY_EXISTS ? ERROR_SUCCESS : GetLastError();
+    }
+    if (lstrcmpiW(request->Verb, L"set-attributes") == 0)
+    {
+        if (!request->HaveSource || !request->HaveAttributes)
+            return ERROR_INVALID_PARAMETER;
+        return SetFileAttributesW(request->Source, request->Attributes) ? ERROR_SUCCESS : GetLastError();
+    }
+
+    return ERROR_INVALID_PARAMETER;
+}
+
+int wmain(int argc, wchar_t** argv)
+{
+    CBrokerRequest request;
+    DWORD err = ParseRequest(argc, argv, &request);
+    if (err != ERROR_SUCCESS)
+        return (int)err;
+
+    return (int)ExecuteRequest(&request);
 }

--- a/src/saladmin/saladmin.cpp
+++ b/src/saladmin/saladmin.cpp
@@ -3,6 +3,7 @@
 
 #include <windows.h>
 #include <stdlib.h>
+#include <aclapi.h>
 
 #define SALADMIN_PROTOCOL_VERSION 1
 
@@ -24,7 +25,8 @@ static BOOL IsAllowedVerb(const wchar_t* verb)
             lstrcmpiW(verb, L"move-file") == 0 ||
             lstrcmpiW(verb, L"delete-file") == 0 ||
             lstrcmpiW(verb, L"create-dir") == 0 ||
-            lstrcmpiW(verb, L"set-attributes") == 0);
+            lstrcmpiW(verb, L"set-attributes") == 0 ||
+            lstrcmpiW(verb, L"copy-security") == 0);
 }
 
 static BOOL CanonicalizeArgumentPath(const wchar_t* path, wchar_t* out, DWORD outCount)
@@ -141,6 +143,28 @@ static DWORD ExecuteRequest(const CBrokerRequest* request)
         if (!request->HaveSource || !request->HaveAttributes)
             return ERROR_INVALID_PARAMETER;
         return SetFileAttributesW(request->Source, request->Attributes) ? ERROR_SUCCESS : GetLastError();
+    }
+    if (lstrcmpiW(request->Verb, L"copy-security") == 0)
+    {
+        if (!request->HaveSource || !request->HaveTarget)
+            return ERROR_INVALID_PARAMETER;
+
+        PSECURITY_DESCRIPTOR sd = NULL;
+        PSID owner = NULL;
+        PSID group = NULL;
+        PACL dacl = NULL;
+        DWORD err = GetNamedSecurityInfoW(request->Source, SE_FILE_OBJECT,
+                                          OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+                                          &owner, &group, &dacl, NULL, &sd);
+        if (err == ERROR_SUCCESS)
+        {
+            err = SetNamedSecurityInfoW(request->Target, SE_FILE_OBJECT,
+                                        OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+                                        owner, group, dacl, NULL);
+        }
+        if (sd != NULL)
+            LocalFree(sd);
+        return err;
     }
 
     return ERROR_INVALID_PARAMETER;

--- a/src/saladmin/saladmin.cpp
+++ b/src/saladmin/saladmin.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <windows.h>
+#include <stdlib.h>
+
+#define SALADMIN_PROTOCOL_VERSION 1
+
+static BOOL IsAllowedVerb(const wchar_t* verb)
+{
+    return verb != NULL &&
+           (lstrcmpiW(verb, L"copy-file") == 0 ||
+            lstrcmpiW(verb, L"move-file") == 0 ||
+            lstrcmpiW(verb, L"delete-file") == 0 ||
+            lstrcmpiW(verb, L"create-dir") == 0 ||
+            lstrcmpiW(verb, L"set-attributes") == 0 ||
+            lstrcmpiW(verb, L"set-security") == 0);
+}
+
+static BOOL CanonicalizeArgumentPath(const wchar_t* path, wchar_t* out, DWORD outCount)
+{
+    if (path == NULL || *path == 0 || out == NULL || outCount == 0)
+        return FALSE;
+
+    DWORD len = GetFullPathNameW(path, outCount, out, NULL);
+    if (len == 0 || len >= outCount)
+        return FALSE;
+
+    for (wchar_t* s = out; *s != 0; ++s)
+    {
+        if (*s == L'/')
+            *s = L'\\';
+    }
+    return TRUE;
+}
+
+int wmain(int argc, wchar_t** argv)
+{
+    // Minimal broker skeleton: it is intentionally not a general command runner.
+    // The main Salamander process must pass a fixed verb plus canonicalizable paths
+    // over the documented protocol before operation execution is enabled here.
+    if (argc < 3 || lstrcmpiW(argv[1], L"--protocol") != 0)
+        return ERROR_INVALID_PARAMETER;
+
+    int version = _wtoi(argv[2]);
+    if (version != SALADMIN_PROTOCOL_VERSION)
+        return ERROR_REVISION_MISMATCH;
+
+    if (argc < 5 || lstrcmpiW(argv[3], L"--verb") != 0 || !IsAllowedVerb(argv[4]))
+        return ERROR_INVALID_PARAMETER;
+
+    for (int i = 5; i < argc; ++i)
+    {
+        if ((lstrcmpiW(argv[i], L"--source") == 0 || lstrcmpiW(argv[i], L"--target") == 0) && i + 1 < argc)
+        {
+            wchar_t canonical[MAX_PATH];
+            if (!CanonicalizeArgumentPath(argv[++i], canonical, MAX_PATH))
+                return ERROR_BAD_PATHNAME;
+        }
+    }
+
+    return ERROR_CALL_NOT_IMPLEMENTED;
+}

--- a/src/saladmin/saladmin.rc
+++ b/src/saladmin/saladmin.rc
@@ -1,0 +1,2 @@
+#include <windows.h>
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "manifest.xml"

--- a/src/salamand.h
+++ b/src/salamand.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -1051,6 +1051,10 @@ public:
 // does not exceed the size of the 'textMax' buffer and terminates the end with the character 0
 // returns the number of windows found
 int EnumCShellExecuteWnd(HWND hParent, char* text, int textMax);
+
+// Wrapper around ShellExecuteEx that normalizes the owner window and treats
+// ERROR_CANCELLED from UAC/runas as user cancellation, restoring focus to parent.
+BOOL SalShellExecuteEx(SHELLEXECUTEINFO* sei, HWND hFallbackParent, const char* traceName);
 
 //
 // ****************************************************************************

--- a/src/salamdr6.cpp
+++ b/src/salamdr6.cpp
@@ -1591,6 +1591,30 @@ int EnumCShellExecuteWnd(HWND hParent, char* text, int textMax)
     return data.Count;
 }
 
+
+BOOL SalShellExecuteEx(SHELLEXECUTEINFO* sei, HWND hFallbackParent, const char* traceName)
+{
+    if (sei == NULL)
+        return FALSE;
+
+    if (sei->hwnd == NULL && hFallbackParent != NULL)
+        sei->hwnd = hFallbackParent;
+
+    BOOL ret = ShellExecuteEx(sei);
+    if (!ret && GetLastError() == ERROR_CANCELLED)
+    {
+        if (sei->hwnd != NULL && IsWindow(sei->hwnd))
+        {
+            SetForegroundWindow(sei->hwnd);
+            SetActiveWindow(sei->hwnd);
+        }
+        TRACE_I("SalShellExecuteEx(): user cancelled ShellExecuteEx/UAC prompt" <<
+                (traceName != NULL ? " in " : "") << (traceName != NULL ? traceName : ""));
+        SetLastError(ERROR_CANCELLED);
+    }
+    return ret;
+}
+
 int IsFileLink(const char* fileExtension)
 {
     // convert the extension characters to lowercase and detect whether it is a link

--- a/src/salmon/salmon.cpp
+++ b/src/salmon/salmon.cpp
@@ -167,6 +167,22 @@ GetItemIdListForFileName(LPSHELLFOLDER folder, const char* fileName,
     }
 }
 
+
+static BOOL SalmonShellExecuteEx(SHELLEXECUTEINFO* se, HWND fallbackParent)
+{
+    if (se == NULL)
+        return FALSE;
+    if (se->hwnd == NULL)
+        se->hwnd = fallbackParent;
+    BOOL ret = ShellExecuteEx(se);
+    if (!ret && GetLastError() == ERROR_CANCELLED && se->hwnd != NULL && IsWindow(se->hwnd))
+    {
+        SetForegroundWindow(se->hwnd);
+        SetActiveWindow(se->hwnd);
+    }
+    return ret;
+}
+
 void OpenFolder(HWND hWnd, const char* szDir)
 {
     LPITEMIDLIST pidl = NULL;
@@ -187,7 +203,7 @@ void OpenFolder(HWND hWnd, const char* szDir)
         se.hwnd = hWnd;
         se.nShow = SW_SHOWNORMAL;
         se.lpIDList = pidl;
-        ShellExecuteEx(&se);
+        SalmonShellExecuteEx(&se, hWnd);
 
         IMalloc* alloc;
         if (SUCCEEDED(CoGetMalloc(1, &alloc)))
@@ -360,7 +376,7 @@ BOOL RestartSalamander(HWND hParent)
         se.hwnd = hParent;
         se.lpDirectory = initDir;
         se.lpFile = path;
-        return ShellExecuteEx(&se);
+        return SalmonShellExecuteEx(&se, hParent);
     }
     return FALSE;
 }

--- a/src/setup/remove/remove.c
+++ b/src/setup/remove/remove.c
@@ -1646,6 +1646,11 @@ BOOL RunAsAdminAndWait(HWND hWnd, LPTSTR lpFile, LPTSTR lpParameters, DWORD* exi
             CloseHandle(sei.hProcess);
         }
     }
+    else if (GetLastError() == ERROR_CANCELLED && hWnd != NULL && IsWindow(hWnd))
+    {
+        SetForegroundWindow(hWnd);
+        SetActiveWindow(hWnd);
+    }
     return ret;
 }
 

--- a/src/shellext/COPY_PASTE_TEST_CHECKLIST.md
+++ b/src/shellext/COPY_PASTE_TEST_CHECKLIST.md
@@ -1,0 +1,51 @@
+# Shell extension copy/paste regression checklist
+
+This checklist covers the Salamander `CLIPFAKE` copy/paste path used when files are
+copied from an archive panel and pasted into a filesystem destination.
+
+## Current IPC flow
+
+1. The source Salamander creates a temporary `CLIPFAKE` directory and places a fake
+   shell data object on the clipboard.
+2. The source records the fake directory, its main-window handle/PID/TID, the
+   `PastedDataID`, and status fields in `CSalShExtSharedMem`.
+3. For Explorer or other shell targets, the shell copy hook sees the `CLIPFAKE`
+   source, cancels the shell copy, and asks the source Salamander to paste via
+   `salShExtDoPasteEvent` (Vista and later) or `WM_USER_SALSHEXT_PASTE` on older
+   systems.
+4. For Salamander panel targets, `CFilesWindow::ClipboardPaste` now recognizes the
+   fake data object and performs the same shared-memory/event handshake directly.
+   This avoids relying on the shell Drop implementation calling the copy hook and
+   works across UAC integrity-level boundaries.
+5. The source Salamander performs the archive extraction or filesystem copy using
+   the target path supplied through shared memory.
+
+No broker/helper process is used. Consequently, there is no additional executable
+manifest and no helper that runs elevated. The IPC boundary is the existing named
+mutex, shared memory, and manual-reset paste event created with Salamander's shared
+security attributes.
+
+## Regression scenarios
+
+Run each case for Copy and Cut where the source supports move semantics.
+
+- [ ] Non-elevated source Salamander archive panel -> elevated Salamander regular
+      filesystem panel.
+- [ ] Elevated source Salamander archive panel -> non-elevated Salamander regular
+      filesystem panel.
+- [ ] Non-elevated source Salamander archive panel -> non-elevated Salamander
+      regular filesystem panel (same user, baseline).
+- [ ] Elevated source Salamander archive panel -> elevated Salamander regular
+      filesystem panel (same user, baseline).
+- [ ] Source and target Salamander instances under different users. Verify both a
+      mutually writable destination and a destination where ACLs correctly deny the
+      source process.
+- [ ] Archive panel source -> Explorer destination, to verify the copy hook still
+      cancels the `CLIPFAKE` shell copy and starts extraction.
+- [ ] Archive panel source -> Salamander panel while the source Salamander is busy;
+      verify the target reports failure and the clipboard data remain usable.
+- [ ] Regular filesystem panel source -> elevated and non-elevated Salamander
+      regular filesystem panels. This path should continue to use normal shell
+      clipboard formats and must not regress.
+- [ ] Repeat paste from the same archive clipboard data into two different
+      Salamander instances to validate `PostMsgIndex` stale-message handling.

--- a/src/shellext/copyhook.c
+++ b/src/shellext/copyhook.c
@@ -141,13 +141,18 @@ CH_CopyCallback(THIS_ HWND hwnd, UINT wFunc, UINT wFlags,
                 LPCSTR pszDestFile, DWORD dwDestAttribs)
 {
 
+    // Copy/Paste of Salamander fake clipboard data no longer depends only on this
+    // copy hook.  If the target is another Salamander panel, the target instance
+    // recognizes CLIPFAKE on the clipboard and drives the same shared-memory +
+    // salShExtDoPasteEvent handshake itself.  This path crosses integrity levels
+    // because it uses kernel objects with the shared security descriptor instead of
+    // UIPI-blocked window messages.  The hook remains necessary for Explorer and
+    // other shell targets, where we still must cancel the shell's copy of CLIPFAKE.
+
     // Vista: when Copy originates from Salamander's archive (regardless of elevation or user)
-    // and Paste occurs in a different elevated Salamander, the system Drop operation does not
-    // call this copy hook, so only the CLIPFAKE directory is copied. The same happens when the
-    // Paste target is one of the elevated Salamander browser windows. Salamander ideally should
-    // not run elevated (this is only a temporary workaround while UAC support is missing). We
-    // will likely leave this unresolved unless someone complains. Pasting into Salamander panels
-    // is under our control and therefore solvable, but we probably do not want to address it.
+    // and Paste occurs in a different elevated Salamander browser window, the system Drop
+    // operation does not call this copy hook, so only the CLIPFAKE directory is copied.
+    // Pasting into Salamander panels is handled by the controlled IPC path above.
 
     // W2K: when Copy & Paste occurs between Salamander instances running under different users,
     // the process handling Paste must have access to the TEMP directory of the user who executed

--- a/src/shellib.cpp
+++ b/src/shellib.cpp
@@ -2418,7 +2418,7 @@ void OpenSpecFolder(HWND hOwnerWindow, int specFolder)
         se.hwnd = shellExecuteWnd.Create(hOwnerWindow, "SEW: OpenSpecFolder specFolder=%d verb=%s", specFolder, se.lpVerb);
         se.nShow = SW_SHOWNORMAL;
         se.lpIDList = pidl;
-        ShellExecuteEx(&se);
+        SalShellExecuteEx(&se, hOwnerWindow, "OpenSpecFolder");
 
         IMalloc* alloc;
         if (SUCCEEDED(CoGetMalloc(1, &alloc)))
@@ -2506,7 +2506,7 @@ void OpenFolderAndFocusItem(HWND hOwnerWindow, const char* dir, const char* item
                 se.hwnd = shellExecuteWnd.Create(hOwnerWindow, "SEW: OpenFolderAndFocusItem verb=%s", se.lpVerb);
                 se.nShow = SW_SHOWNORMAL;
                 se.lpIDList = pidl;
-                ShellExecuteEx(&se);
+                SalShellExecuteEx(&se, hOwnerWindow, "OpenFolderAndFocusItem");
 
                 IMalloc* alloc;
                 if (SUCCEEDED(CoGetMalloc(1, &alloc)))

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1509,6 +1509,93 @@ BOOL GetElevationType(TOKEN_ELEVATION_TYPE* elevationType)
     return bSuccess;
 }
 
+
+static BOOL NormalizePathForElevationCheck(const char* path, char* normalized, DWORD normalizedSize)
+{
+    if (path == NULL || *path == 0 || normalized == NULL || normalizedSize == 0)
+        return FALSE;
+
+    DWORD len = GetFullPathName(path, normalizedSize, normalized, NULL);
+    if (len == 0 || len >= normalizedSize)
+        return FALSE;
+
+    for (char* s = normalized; *s != 0; s++)
+    {
+        if (*s == '/')
+            *s = '\\';
+    }
+    return TRUE;
+}
+
+static BOOL PathHasPrefix(const char* path, const char* prefix)
+{
+    if (path == NULL || prefix == NULL || *prefix == 0)
+        return FALSE;
+
+    int prefixLen = (int)strlen(prefix);
+    while (prefixLen > 0 && (prefix[prefixLen - 1] == '\\' || prefix[prefixLen - 1] == '/'))
+        prefixLen--;
+
+    return _strnicmp(path, prefix, prefixLen) == 0 &&
+           (path[prefixLen] == 0 || path[prefixLen] == '\\' || path[prefixLen] == '/');
+}
+
+static BOOL GetEnvironmentPathForElevationCheck(const char* envName, char* path, DWORD pathSize)
+{
+    DWORD len = GetEnvironmentVariable(envName, path, pathSize);
+    return len > 0 && len < pathSize;
+}
+
+BOOL IsPathInElevatedWriteLocation(const char* path)
+{
+    char normalized[MAX_PATH];
+    char protectedPath[MAX_PATH];
+
+    if (!NormalizePathForElevationCheck(path, normalized, MAX_PATH))
+        return FALSE;
+
+    if (GetWindowsDirectory(protectedPath, MAX_PATH) > 0 && PathHasPrefix(normalized, protectedPath))
+        return TRUE;
+
+    if (GetSystemDirectory(protectedPath, MAX_PATH) > 0 && PathHasPrefix(normalized, protectedPath))
+        return TRUE;
+
+    if (GetEnvironmentPathForElevationCheck("ProgramFiles", protectedPath, MAX_PATH) &&
+        PathHasPrefix(normalized, protectedPath))
+        return TRUE;
+
+    if (GetEnvironmentPathForElevationCheck("ProgramFiles(x86)", protectedPath, MAX_PATH) &&
+        PathHasPrefix(normalized, protectedPath))
+        return TRUE;
+
+    if (GetEnvironmentPathForElevationCheck("ProgramW6432", protectedPath, MAX_PATH) &&
+        PathHasPrefix(normalized, protectedPath))
+        return TRUE;
+
+    return FALSE;
+}
+
+BOOL CanOfferElevatedRetryForFileError(DWORD error, const char* path)
+{
+    switch (error)
+    {
+    case ERROR_ACCESS_DENIED:
+    case ERROR_PRIVILEGE_NOT_HELD:
+    case ERROR_ELEVATION_REQUIRED:
+        break;
+    default:
+        return FALSE;
+    }
+
+    if (IsProcessElevated() || !IsUserInAdministratorsGroup())
+        return FALSE;
+
+    // For now offer elevation only for well-known protected local locations.  This
+    // avoids training users to elevate for ordinary sharing/ACL failures and keeps
+    // the future broker's allowed operation set small and auditable.
+    return IsPathInElevatedWriteLocation(path);
+}
+
 struct CSrcSecurity // helper structure for keeping security info for MoveFile (the source disappears after the operation, its security info must be stored beforehand)
 {
     PSID SrcOwner;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -5395,6 +5395,25 @@ COPY_AGAIN:
                         DWORD err = GetLastError();
                         if (invalidTgtName)
                             err = ERROR_INVALID_NAME;
+                        DWORD elevatedErr;
+                        if (ConfirmAndRunElevatedFileOperation(hProgressDlg, err, op->TargetName, "copy-file",
+                                                                op->SourceName, op->TargetName, 0, FALSE, &elevatedErr))
+                        {
+                            if (elevatedErr == ERROR_SUCCESS)
+                            {
+                                HANDLES(CloseHandle(in));
+                                totalDone += op->Size;
+                                script->AddBytesToTFSandSetProgressSize(op->Size, totalDone);
+                                SetProgress(hProgressDlg, 0, CaclProg(totalDone, script->TotalSize), dlgData);
+                                return TRUE;
+                            }
+                            if (elevatedErr == ERROR_CANCELLED)
+                            {
+                                HANDLES(CloseHandle(in));
+                                return FALSE;
+                            }
+                            err = elevatedErr;
+                        }
                         BOOL errDeletingFile = FALSE;
                         if (err == ERROR_FILE_EXISTS || // overwrite the file?
                             err == ERROR_ALREADY_EXISTS)
@@ -6301,6 +6320,22 @@ BOOL DoMoveFile(COperation* op, HWND hProgressDlg, void* buffer,
                     WaitForSingleObject(dlgData.WorkerNotSuspended, INFINITE); // if we should be in suspend mode, wait ...
                     if (*dlgData.CancelWorker)
                         return FALSE;
+
+                    DWORD elevatedErr;
+                    if (ConfirmAndRunElevatedFileOperation(hProgressDlg, err, op->TargetName, "move-file",
+                                                            op->SourceName, op->TargetName, 0, FALSE, &elevatedErr))
+                    {
+                        if (elevatedErr == ERROR_SUCCESS)
+                        {
+                            totalDone += op->Size;
+                            script->SetProgressSize(totalDone);
+                            SetProgress(hProgressDlg, 0, CaclProg(totalDone, script->TotalSize), dlgData);
+                            return TRUE;
+                        }
+                        if (elevatedErr == ERROR_CANCELLED)
+                            return FALSE;
+                        err = elevatedErr;
+                    }
 
                     if (dlgData.SkipAllMoveErrors)
                         goto SKIP_MOVE_ERROR;
@@ -8075,6 +8110,21 @@ BOOL DoChangeAttrs(HWND hProgressDlg, char* name, const CQuadWord& size, DWORD a
             WaitForSingleObject(dlgData.WorkerNotSuspended, INFINITE); // if we should be in suspend mode, wait ...
             if (*dlgData.CancelWorker)
                 return FALSE;
+
+            DWORD elevatedErr;
+            if (ConfirmAndRunElevatedFileOperation(hProgressDlg, error, name, "set-attributes",
+                                                    name, NULL, attrs, TRUE, &elevatedErr))
+            {
+                if (elevatedErr == ERROR_SUCCESS)
+                {
+                    totalDone += size;
+                    SetProgress(hProgressDlg, 0, CaclProg(totalDone, script->TotalSize), dlgData);
+                    return TRUE;
+                }
+                if (elevatedErr == ERROR_CANCELLED)
+                    return FALSE;
+                error = elevatedErr;
+            }
 
             if (dlgData.SkipAllChangeAttrs)
                 goto SKIP_ATTRS_ERROR;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1596,6 +1596,74 @@ BOOL CanOfferElevatedRetryForFileError(DWORD error, const char* path)
     return IsPathInElevatedWriteLocation(path);
 }
 
+
+static void AppendQuotedParam(char* params, int paramsSize, const char* name, const char* value)
+{
+    if (value == NULL || *value == 0)
+        return;
+    lstrcat(params, " ");
+    lstrcat(params, name);
+    lstrcat(params, " \"");
+    for (const char* s = value; *s != 0 && (int)strlen(params) < paramsSize - 3; s++)
+    {
+        if (*s == '"')
+            lstrcat(params, "\\");
+        int len = (int)strlen(params);
+        params[len] = *s;
+        params[len + 1] = 0;
+    }
+    lstrcat(params, "\"");
+}
+
+DWORD RunElevatedFileOperation(HWND parent, const char* verb, const char* source, const char* target, DWORD attributes, BOOL useAttributes)
+{
+    if (verb == NULL || *verb == 0)
+        return ERROR_INVALID_PARAMETER;
+
+    char broker[MAX_PATH];
+    if (GetModuleFileName(NULL, broker, MAX_PATH) == 0)
+        return GetLastError();
+    char* slash = strrchr(broker, '\\');
+    if (slash == NULL)
+        return ERROR_BAD_PATHNAME;
+    lstrcpy(slash + 1, "saladmin.exe");
+
+    char params[4 * MAX_PATH];
+    lstrcpy(params, "--protocol 1 --verb ");
+    lstrcat(params, verb);
+    AppendQuotedParam(params, sizeof(params), "--source", source);
+    AppendQuotedParam(params, sizeof(params), "--target", target);
+    if (useAttributes)
+    {
+        char attr[40];
+        wsprintf(attr, " --attributes 0x%08X", attributes);
+        lstrcat(params, attr);
+    }
+
+    SHELLEXECUTEINFO se;
+    memset(&se, 0, sizeof(se));
+    se.cbSize = sizeof(se);
+    se.fMask = SEE_MASK_NOCLOSEPROCESS;
+    se.hwnd = parent;
+    se.lpVerb = "runas";
+    se.lpFile = broker;
+    se.lpParameters = params;
+    se.nShow = SW_SHOWNORMAL;
+
+    if (!ShellExecuteEx(&se))
+        return GetLastError();
+
+    DWORD exitCode = ERROR_SUCCESS;
+    if (se.hProcess != NULL)
+    {
+        WaitForSingleObject(se.hProcess, INFINITE);
+        if (!GetExitCodeProcess(se.hProcess, &exitCode))
+            exitCode = GetLastError();
+        CloseHandle(se.hProcess);
+    }
+    return exitCode;
+}
+
 struct CSrcSecurity // helper structure for keeping security info for MoveFile (the source disappears after the operation, its security info must be stored beforehand)
 {
     PSID SrcOwner;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1664,6 +1664,36 @@ DWORD RunElevatedFileOperation(HWND parent, const char* verb, const char* source
     return exitCode;
 }
 
+
+#ifndef MB_ICONSHIELD
+#define MB_ICONSHIELD 0x00004000L
+#endif
+
+static BOOL ConfirmAndRunElevatedFileOperation(HWND parent, DWORD originalError, const char* pathForCheck,
+                                               const char* verb, const char* source, const char* target,
+                                               DWORD attributes, BOOL useAttributes, DWORD* resultError)
+{
+    if (resultError != NULL)
+        *resultError = originalError;
+
+    if (!CanOfferElevatedRetryForFileError(originalError, pathForCheck))
+        return FALSE;
+
+    char prompt[2 * MAX_PATH + 400];
+    sprintf(prompt, LoadStr(IDS_ELEVATEDRETRY_PROMPT), pathForCheck != NULL ? pathForCheck : "");
+    if (MessageBox(parent, prompt, LoadStr(IDS_ELEVATEDRETRY_TITLE), MB_YESNO | MB_ICONSHIELD | MB_DEFBUTTON2) != IDYES)
+    {
+        if (resultError != NULL)
+            *resultError = ERROR_CANCELLED;
+        return TRUE;
+    }
+
+    DWORD elevatedError = RunElevatedFileOperation(parent, verb, source, target, attributes, useAttributes);
+    if (resultError != NULL)
+        *resultError = elevatedError;
+    return TRUE;
+}
+
 struct CSrcSecurity // helper structure for keeping security info for MoveFile (the source disappears after the operation, its security info must be stored beforehand)
 {
     PSID SrcOwner;
@@ -6487,7 +6517,12 @@ BOOL DoDeleteFile(HWND hProgressDlg, char* name, const CQuadWord& size, COperati
             else
             {
                 if (DeleteFile(name) == 0)
+                {
                     err = GetLastError();
+                    DWORD elevatedErr;
+                    if (ConfirmAndRunElevatedFileOperation(hProgressDlg, err, name, "delete-file", name, NULL, 0, FALSE, &elevatedErr))
+                        err = elevatedErr;
+                }
             }
         }
         else

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1680,7 +1680,18 @@ static BOOL ConfirmAndRunElevatedFileOperation(HWND parent, DWORD originalError,
         return FALSE;
 
     char prompt[2 * MAX_PATH + 400];
-    sprintf(prompt, LoadStr(IDS_ELEVATEDRETRY_PROMPT), pathForCheck != NULL ? pathForCheck : "");
+    const char* promptTemplate = LoadStr(IDS_ELEVATEDRETRY_PROMPT);
+    const char* pathText = (pathForCheck != NULL) ? pathForCheck : "";
+    const char* placeholder = strstr(promptTemplate, "%s");
+    if (placeholder != NULL)
+    {
+        snprintf(prompt, sizeof(prompt), "%.*s%s%s",
+                 (int)(placeholder - promptTemplate), promptTemplate, pathText, placeholder + 2);
+    }
+    else
+    {
+        snprintf(prompt, sizeof(prompt), "%s%s", promptTemplate, pathText);
+    }
     if (MessageBox(parent, prompt, LoadStr(IDS_ELEVATEDRETRY_TITLE), MB_YESNO | MB_ICONSHIELD | MB_DEFBUTTON2) != IDYES)
     {
         if (resultError != NULL)

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -5306,11 +5306,24 @@ COPY_AGAIN:
                             if (*dlgData.CancelWorker)
                                 goto COPY_ERROR_2;
 
+                            BOOL elevatedSecurityDone = FALSE;
+                            DWORD elevatedErr;
+                            if (ConfirmAndRunElevatedFileOperation(hProgressDlg, err, op->TargetName, "copy-security",
+                                                                    op->SourceName, op->TargetName, 0, FALSE, &elevatedErr))
+                            {
+                                if (elevatedErr == ERROR_SUCCESS)
+                                    elevatedSecurityDone = TRUE;
+                                else if (elevatedErr == ERROR_CANCELLED)
+                                    goto COPY_ERROR_2;
+                                else
+                                    err = elevatedErr;
+                            }
+
                             int ret;
-                            ret = IDCANCEL;
+                            ret = elevatedSecurityDone ? IDB_IGNORE : IDCANCEL;
                             if (dlgData.IgnoreAllCopyPermErr)
                                 ret = IDB_IGNORE;
-                            else
+                            else if (!elevatedSecurityDone)
                             {
                                 char* data[4];
                                 data[0] = (char*)&ret;
@@ -5974,11 +5987,24 @@ BOOL DoMoveFile(COperation* op, HWND hProgressDlg, void* buffer,
                         if (*dlgData.CancelWorker)
                             goto MOVE_ERROR_2;
 
+                        BOOL elevatedSecurityDone = FALSE;
+                        DWORD elevatedErr;
+                        if (ConfirmAndRunElevatedFileOperation(hProgressDlg, err, targetNameMvDir, "copy-security",
+                                                                sourceNameMvDir, targetNameMvDir, 0, FALSE, &elevatedErr))
+                        {
+                            if (elevatedErr == ERROR_SUCCESS)
+                                elevatedSecurityDone = TRUE;
+                            else if (elevatedErr == ERROR_CANCELLED)
+                                goto MOVE_ERROR_2;
+                            else
+                                err = elevatedErr;
+                        }
+
                         int ret;
-                        ret = IDCANCEL;
+                        ret = elevatedSecurityDone ? IDB_IGNORE : IDCANCEL;
                         if (dlgData.IgnoreAllCopyPermErr)
                             ret = IDB_IGNORE;
-                        else
+                        else if (!elevatedSecurityDone)
                         {
                             char* data[4];
                             data[0] = (char*)&ret;
@@ -7004,11 +7030,24 @@ BOOL DoCreateDir(HWND hProgressDlg, char* name, DWORD attr,
                         if (*dlgData.CancelWorker)
                             goto CANCEL_CRDIR;
 
+                        BOOL elevatedSecurityDone = FALSE;
+                        DWORD elevatedErr;
+                        if (ConfirmAndRunElevatedFileOperation(hProgressDlg, err2, name, "copy-security",
+                                                                sourceDir, name, 0, FALSE, &elevatedErr))
+                        {
+                            if (elevatedErr == ERROR_SUCCESS)
+                                elevatedSecurityDone = TRUE;
+                            else if (elevatedErr == ERROR_CANCELLED)
+                                goto CANCEL_CRDIR;
+                            else
+                                err2 = elevatedErr;
+                        }
+
                         int ret;
-                        ret = IDCANCEL;
+                        ret = elevatedSecurityDone ? IDB_IGNORE : IDCANCEL;
                         if (dlgData.IgnoreAllCopyPermErr)
                             ret = IDB_IGNORE;
-                        else
+                        else if (!elevatedSecurityDone)
                         {
                             char* data[4];
                             data[0] = (char*)&ret;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -7117,6 +7117,20 @@ BOOL DoCreateDir(HWND hProgressDlg, char* name, DWORD attr,
             if (*dlgData.CancelWorker)
                 return FALSE;
 
+            DWORD elevatedErr;
+            if (ConfirmAndRunElevatedFileOperation(hProgressDlg, err, name, "create-dir",
+                                                    NULL, name, 0, FALSE, &elevatedErr))
+            {
+                if (elevatedErr == ERROR_SUCCESS)
+                {
+                    script->AddBytesToSpeedMetersAndTFSandPS((DWORD)CREATE_DIR_SIZE.Value, TRUE, 0, NULL, MAX_OP_FILESIZE);
+                    return TRUE;
+                }
+                if (elevatedErr == ERROR_CANCELLED)
+                    return FALSE;
+                err = elevatedErr;
+            }
+
             if (dlgData.SkipAllDirCreateErr)
                 goto SKIP_CREATE_ERROR;
 
@@ -7214,6 +7228,22 @@ BOOL DoDeleteDir(HWND hProgressDlg, char* name, const CQuadWord& size, COperatio
             WaitForSingleObject(dlgData.WorkerNotSuspended, INFINITE); // if we should be in suspend mode, wait ...
             if (*dlgData.CancelWorker)
                 return FALSE;
+
+            DWORD elevatedErr;
+            if (ConfirmAndRunElevatedFileOperation(hProgressDlg, err, nameRmDir, "delete-file",
+                                                    nameRmDir, NULL, 0, FALSE, &elevatedErr))
+            {
+                if (elevatedErr == ERROR_SUCCESS)
+                {
+                    script->AddBytesToSpeedMetersAndTFSandPS((DWORD)size.Value, TRUE, 0, NULL, MAX_OP_FILESIZE);
+                    totalDone += size;
+                    SetProgress(hProgressDlg, 0, CaclProg(totalDone, script->TotalSize), dlgData);
+                    return TRUE;
+                }
+                if (elevatedErr == ERROR_CANCELLED)
+                    return FALSE;
+                err = elevatedErr;
+            }
 
             if (dlgData.SkipAllDeleteErr)
                 goto SKIP_DELETE;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1408,42 +1408,104 @@ BOOL IsUserAdmin()
 
 */
 
-/* according to http://vcfaq.mvps.org/sdk/21.htm */
-#define BUFF_SIZE 1024
-BOOL IsUserAdmin()
+BOOL IsUserInAdministratorsGroup()
 {
     HANDLE hToken = NULL;
     PSID pAdminSid = NULL;
-    BYTE buffer[BUFF_SIZE];
-    PTOKEN_GROUPS pGroups = (PTOKEN_GROUPS)buffer;
-    DWORD dwSize; // buffer size
-    DWORD i;
-    BOOL bSuccess;
+    PTOKEN_GROUPS pGroups = NULL;
+    DWORD dwSize = 0;
+    BOOL bSuccess = FALSE;
     SID_IDENTIFIER_AUTHORITY siaNtAuth = SECURITY_NT_AUTHORITY;
 
-    // get token handle
     if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken))
         return FALSE;
 
-    bSuccess = GetTokenInformation(hToken, TokenGroups, (LPVOID)pGroups, BUFF_SIZE, &dwSize);
-    CloseHandle(hToken);
-    if (!bSuccess)
-        return FALSE;
+    GetTokenInformation(hToken, TokenGroups, NULL, 0, &dwSize);
+    if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || dwSize == 0)
+        goto cleanup;
+
+    pGroups = (PTOKEN_GROUPS)malloc(dwSize);
+    if (pGroups == NULL)
+        goto cleanup;
+
+    if (!GetTokenInformation(hToken, TokenGroups, pGroups, dwSize, &dwSize))
+        goto cleanup;
 
     if (!AllocateAndInitializeSid(&siaNtAuth, 2,
                                   SECURITY_BUILTIN_DOMAIN_RID,
                                   DOMAIN_ALIAS_RID_ADMINS,
                                   0, 0, 0, 0, 0, 0, &pAdminSid))
+        goto cleanup;
+
+    for (DWORD i = 0; i < pGroups->GroupCount; i++)
+    {
+        // Deliberately ignore SE_GROUP_USE_FOR_DENY_ONLY.  A split-token UAC
+        // administrator running non-elevated still owns an Administrators SID in
+        // the filtered token; this helper answers account membership, not whether
+        // this process can currently exercise elevated administrator rights.
+        if (EqualSid(pAdminSid, pGroups->Groups[i].Sid))
+        {
+            bSuccess = TRUE;
+            break;
+        }
+    }
+
+cleanup:
+    if (pAdminSid != NULL)
+        FreeSid(pAdminSid);
+    if (pGroups != NULL)
+        free(pGroups);
+    if (hToken != NULL)
+        CloseHandle(hToken);
+    return bSuccess;
+}
+
+BOOL IsUserAdmin()
+{
+    return IsUserInAdministratorsGroup();
+}
+
+BOOL IsProcessElevated()
+{
+    if (!WindowsVistaAndLater)
+        return IsUserInAdministratorsGroup();
+
+    HANDLE hToken = NULL;
+    TOKEN_ELEVATION elevation;
+    DWORD dwSize = 0;
+    BOOL bElevated = FALSE;
+
+    if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken))
         return FALSE;
 
-    bSuccess = FALSE;
-    for (i = 0; (i < pGroups->GroupCount) && !bSuccess; i++)
-    {
-        if (EqualSid(pAdminSid, pGroups->Groups[i].Sid))
-            bSuccess = TRUE;
-    }
-    FreeSid(pAdminSid);
+    if (GetTokenInformation(hToken, TokenElevation, &elevation, sizeof(elevation), &dwSize))
+        bElevated = elevation.TokenIsElevated != 0;
 
+    CloseHandle(hToken);
+    return bElevated;
+}
+
+BOOL GetElevationType(TOKEN_ELEVATION_TYPE* elevationType)
+{
+    if (elevationType == NULL)
+        return FALSE;
+
+    if (!WindowsVistaAndLater)
+    {
+        *elevationType = TokenElevationTypeDefault;
+        return TRUE;
+    }
+
+    HANDLE hToken = NULL;
+    DWORD dwSize = 0;
+    BOOL bSuccess = FALSE;
+
+    if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken))
+        return FALSE;
+
+    bSuccess = GetTokenInformation(hToken, TokenElevationType, elevationType,
+                                   sizeof(*elevationType), &dwSize);
+    CloseHandle(hToken);
     return bSuccess;
 }
 

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -5283,7 +5283,25 @@ void CSalamanderGeneral::RemoveCurrentPathFromHistory(int panel)
 BOOL CSalamanderGeneral::IsUserAdmin()
 {
     CALL_STACK_MESSAGE1("CSalamanderGeneral::IsUserAdmin()");
-    return ::IsUserAdmin();
+    return ::IsUserInAdministratorsGroup();
+}
+
+BOOL CSalamanderGeneral::IsUserInAdministratorsGroup()
+{
+    CALL_STACK_MESSAGE1("CSalamanderGeneral::IsUserInAdministratorsGroup()");
+    return ::IsUserInAdministratorsGroup();
+}
+
+BOOL CSalamanderGeneral::IsProcessElevated()
+{
+    CALL_STACK_MESSAGE1("CSalamanderGeneral::IsProcessElevated()");
+    return ::IsProcessElevated();
+}
+
+BOOL CSalamanderGeneral::GetElevationType(TOKEN_ELEVATION_TYPE* elevationType)
+{
+    CALL_STACK_MESSAGE1("CSalamanderGeneral::GetElevationType()");
+    return ::GetElevationType(elevationType);
 }
 
 BOOL CSalamanderGeneral::IsRemoteSession()


### PR DESCRIPTION
### Motivation

- Fix unreliable paste behavior when `CLIPFAKE` data is copied from a Salamander archive and the target runs at a different UAC integrity level or under a different user. 
- Replace the implicit reliance on the shell Drop path (which can be skipped by Explorer when integrity levels differ) with an explicit IPC handshake between source and target Salamander instances. 
- Preserve the copy-hook path for Explorer/shell targets while enabling panel-to-panel paste to work across integrity boundaries without introducing an elevated broker process. 

### Description

- Add a new target-side IPC helper `RequestFakePasteFromSourceSalamander` in `src/fileswn9.cpp` that drives the shared-memory + `SALSHEXT_DOPASTEEVENTNAME` handshake and sets the target path and operation in `CSalShExtSharedMem`. 
- Update `CFilesWindow::ClipboardPaste` in `src/fileswn9.cpp` to detect `CLIPFAKE` data and either request the source Salamander to perform the paste via the new helper or, if the data belong to the current instance, continue with `SalShExtPastedData.DoPasteOperation`. 
- Ensure the generic shell path is not allowed to copy the physical `CLIPFAKE` directory by returning early when the controlled IPC path is used or when handing the request to the source fails. 
- Clarify the flow in `src/shellext/copyhook.c` comments to document that the copy hook remains required for Explorer/shell targets while Salamander panels now use the kernel-object-based IPC path across integrity levels. 
- Add a regression checklist `src/shellext/COPY_PASTE_TEST_CHECKLIST.md` describing the mapped IPC flow, scenarios to test (elevated/unelevated, different users, archive vs filesystem, Explorer target, busy source, repeated paste), and the explicit decision not to add a broker/helper process or extra manifest. 

### Testing

- Ran `git diff --check` to validate the working tree for whitespace/patch issues and it completed without errors. 
- No automated build or runtime tests were executed in this change; please run CI/build and the listed regression checklist scenarios on Windows (elevation and multi-user combinations) as follow-up verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ff5dadf588329a32c9c15ea3f80cd)