### PR TITLE
Select installed plugins in setup by default

### DIFF
--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -1753,13 +1753,15 @@ end;
 procedure AddPlugin(const PluginId, DisplayName, Version: String; const CheckedByDefault: Boolean);
 var
   InstalledVersion: String;
+  Checked: Boolean;
 begin
   InstalledVersion := GetInstalledPluginVersion(PluginId);
+  Checked := CheckedByDefault or (InstalledVersion <> '');
   PluginList.AddCheckBox(
     DisplayName,
     FormatPluginVersionText(Version, InstalledVersion),
     0,
-    CheckedByDefault,
+    Checked,
     True,
     False,
     False,


### PR DESCRIPTION
### Motivation
- Make the installer selection page respect the installer's `CheckedByDefault` settings while automatically re-selecting any plugin already present on the system so users do not accidentally deselect previously installed plugins.

### Description
- Updated `AddPlugin` in `doc/runbook-setup/inno_setup_salamander_x64.iss` to compute `Checked := CheckedByDefault or (InstalledVersion <> '');` and pass `Checked` to `PluginList.AddCheckBox` instead of the raw `CheckedByDefault` value.
- Preserved existing behavior that shows installed version text via `FormatPluginVersionText` and highlights newer installer versions via `IsInstallerPluginVersionNewer`.
- As a result, plugins with `CheckedByDefault = False` (for example `demoplug`) are now auto-selected when an installed version is detected.

### Testing
- Verified presence of the new logic by running a Python assertion that checks for the line `Checked := CheckedByDefault or (InstalledVersion <> '');` in `doc/runbook-setup/inno_setup_salamander_x64.iss`, which succeeded.
- Ran a whitespace/format validation (`git diff --check`) to ensure no styling issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6011b9e44483298c32a028506618a8)