### PR TITLE
Load and display catalog-provided plugin icons; normalize catalog sources and update docs

### DIFF
--- a/doc/catalogs-base/README.md
+++ b/doc/catalogs-base/README.md
@@ -8,3 +8,5 @@
 > - Extension Runtimes: https://samandarin.krtkovo.eu/catalogs/extension-runtimes.json
 
 <img width="966" height="643" alt="image" src="https://github.com/user-attachments/assets/c1088472-335b-4421-82bb-fea8531beb92" />
+
+Catalog plugin entries may set `icon` to `plugin` to use the icon extracted from the installed `.spl` file, or to an absolute URL, a URL relative to the catalog JSON file, or a local file path for a PNG/JPEG/BMP/ICO catalog icon. If a catalog icon cannot be loaded, Samandarin falls back to the installed plugin icon when the plugin is installed.

--- a/doc/plugin-catalog-example.json
+++ b/doc/plugin-catalog-example.json
@@ -36,7 +36,7 @@
       "versionScheme": "fileversion | opaque",
       "homepageUrl": "Your plugin homepage URL or repository URL etc.",
       "downloadPageUrl": "Your plugin download page URL",
-      "icon": "plugin"
+      "icon": "plugin | relative/path/to/icon.png | https://example.com/icon.ico"
     }
   ]
 }

--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -17,7 +17,7 @@
 ; the fallback path below is relative to this .iss file.
 
 #define AppToInstallName "Open Salamander Samandarin"
-#define SamandarinVersion "0.12"
+#define SamandarinVersion "0.13"
 #define AppToInstallDisplayName "Open Salamander 5.0 Samandarin " + SamandarinVersion + " (x64)"
 #define AppToInstallVersion "5.0-samandarin-" + SamandarinVersion
 #define AppToInstallPublisher "Ondřej Kotas (KRtekTM)"

--- a/src/consts.h
+++ b/src/consts.h
@@ -2150,7 +2150,7 @@ int GetWMCommandFromSalCmd(int salCmd);
 //******************************************************************************
 
 // pocet polozek v poli SalamanderConfigurationRoots
-#define SALCFG_ROOTS_COUNT 94
+#define SALCFG_ROOTS_COUNT 95
 
 // id hlavniho threadu (platne az po vstupu do WinMain())
 extern DWORD MainThreadID;

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -783,6 +783,7 @@ BOOL MCDApplyConfigurationSelection(HWND parent, const CManageConfigsDialog& dlg
 // 113 = 5.0-samandarin-0.10
 // 114 = 5.0-samandarin-0.11
 // 115 = 5.0-samandarin-0.12
+// 116 = 5.0-samandarin-0.13
 //
 // When increasing configuration version, add one to THIS_CONFIG_VERSION
 //
@@ -790,7 +791,7 @@ BOOL MCDApplyConfigurationSelection(HWND parent, const CManageConfigsDialog& dlg
 // so that new plug-ins are auto-installed and the plugins.ver counter resets.
 //
 
-const DWORD THIS_CONFIG_VERSION = 115;
+const DWORD THIS_CONFIG_VERSION = 116;
 
 // Configuration roots for individual Open Salamander versions.
 // The root of the current (youngest) configuration is at index 0.
@@ -802,6 +803,7 @@ const DWORD THIS_CONFIG_VERSION = 115;
 // !!! Keep the corresponding lines in SalamanderConfigurationVersions up to date
 const char* SalamanderConfigurationRoots[SALCFG_ROOTS_COUNT + 1] =
     {
+        "Software\\Open Salamander Samandarin\\5.0-samandarin-0.13",
         "Software\\Open Salamander Samandarin\\5.0-samandarin-0.12",
         "Software\\Open Salamander Samandarin\\5.0-samandarin-0.11",
         "Software\\Open Salamander Samandarin\\5.0-samandarin-0.10",
@@ -899,6 +901,7 @@ const char* SalamanderConfigurationRoots[SALCFG_ROOTS_COUNT + 1] =
 };
 const char* SalamanderConfigurationVersions[SALCFG_ROOTS_COUNT] =
     {
+        "5.0 Samandarin 0.13",
         "5.0 Samandarin 0.12",
         "5.0 Samandarin 0.11",
         "5.0 Samandarin 0.10",

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -1258,7 +1258,7 @@ internal sealed class PluginUpdatesDialog : Form
             _listView.Items.Clear();
             foreach (var row in rows)
             {
-                var item = new ListViewItem(row.IconLabel) { Tag = row, ImageKey = EnsurePluginImage(row) };
+                var item = new ListViewItem(string.Empty) { Tag = row, ImageKey = EnsurePluginImage(row) };
                 item.SubItems.Add(row.Source);
                 item.SubItems.Add(row.Name);
                 item.SubItems.Add(row.InstalledVersion);
@@ -1285,6 +1285,12 @@ internal sealed class PluginUpdatesDialog : Form
 
     private string EnsurePluginImage(PluginUpdateRow row)
     {
+        var catalogIconKey = EnsureCatalogIconImage(row);
+        if (!string.IsNullOrEmpty(catalogIconKey))
+        {
+            return catalogIconKey;
+        }
+
         if (string.IsNullOrWhiteSpace(row.IconPath))
         {
             return string.Empty;
@@ -1310,6 +1316,79 @@ internal sealed class PluginUpdatesDialog : Form
         }
 
         return string.Empty;
+    }
+
+    private string EnsureCatalogIconImage(PluginUpdateRow row)
+    {
+        var iconReference = row.CatalogIconReference;
+        if (string.IsNullOrWhiteSpace(iconReference) || string.Equals(iconReference, "plugin", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        var resolvedIcon = ResolveCatalogIconReference(iconReference!, row.CatalogSourceUrl);
+        if (string.IsNullOrWhiteSpace(resolvedIcon))
+        {
+            return string.Empty;
+        }
+
+        var key = "catalog:" + resolvedIcon;
+        if (_pluginImages.Images.ContainsKey(key))
+        {
+            return key;
+        }
+
+        try
+        {
+            if (Uri.TryCreate(resolvedIcon, UriKind.Absolute, out var uri) && !uri.IsFile)
+            {
+                var bytes = SharedHttpClient.Instance.GetByteArrayAsync(uri).GetAwaiter().GetResult();
+                using var stream = new MemoryStream(bytes);
+                AddCatalogImageFromStream(key, stream, resolvedIcon);
+            }
+            else
+            {
+                var path = Uri.TryCreate(resolvedIcon, UriKind.Absolute, out var fileUri) && fileUri.IsFile ? fileUri.LocalPath : resolvedIcon;
+                using var stream = File.OpenRead(path);
+                AddCatalogImageFromStream(key, stream, path);
+            }
+
+            return _pluginImages.Images.ContainsKey(key) ? key : string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private void AddCatalogImageFromStream(string key, Stream stream, string source)
+    {
+        if (Path.GetExtension(source).Equals(".ico", StringComparison.OrdinalIgnoreCase))
+        {
+            using var icon = new Icon(stream, _pluginImages.ImageSize);
+            _pluginImages.Images.Add(key, icon);
+            return;
+        }
+
+        using var image = Image.FromStream(stream);
+        using var bitmap = new Bitmap(image, _pluginImages.ImageSize);
+        _pluginImages.Images.Add(key, bitmap);
+    }
+
+    private static string ResolveCatalogIconReference(string iconReference, string catalogSourceUrl)
+    {
+        var trimmed = iconReference.Trim();
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var absoluteUri))
+        {
+            return absoluteUri.ToString();
+        }
+
+        if (!string.IsNullOrWhiteSpace(catalogSourceUrl) && Uri.TryCreate(catalogSourceUrl, UriKind.Absolute, out var catalogUri))
+        {
+            return new Uri(catalogUri, trimmed).ToString();
+        }
+
+        return trimmed;
     }
 
     private void UpdateDetails()
@@ -1459,7 +1538,7 @@ internal sealed class PluginUpdatesDialog : Form
             4 => row.LatestVersion,
             5 => row.StatusText,
             6 => row.Author,
-            _ => row.IconLabel,
+            _ => row.Name,
         };
     }
 }
@@ -1757,6 +1836,7 @@ internal static class PluginCatalogService
 
                 foreach (var entry in manifest.plugins.Where(entry => !string.IsNullOrWhiteSpace(entry.id)))
                 {
+                    entry.sourceUrl = source;
                     entry.source = string.IsNullOrWhiteSpace(manifest.catalogName) ? source : manifest.catalogName;
                     catalog.Add(entry);
                 }
@@ -1828,14 +1908,14 @@ internal static class PluginCatalogService
     private static PluginUpdateRow BuildCatalogOnlyRow(PluginCatalogEntry entry)
     {
         var homepage = entry.homepageUrl ?? string.Empty;
-        return new PluginUpdateRow(LocalizedText.Resolve(entry.name) ?? entry.id ?? NativeStrings.Get(NativeStringId.Unknown), string.Empty, entry.latestVersion ?? string.Empty, NativeStrings.Get(NativeStringId.PluginStatusNotInstalled), entry.author ?? string.Empty, homepage, PluginUpdateStatus.Other, entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty, null, entry.icon ?? string.Empty);
+        return new PluginUpdateRow(LocalizedText.Resolve(entry.name) ?? entry.id ?? NativeStrings.Get(NativeStringId.Unknown), string.Empty, entry.latestVersion ?? string.Empty, NativeStrings.Get(NativeStringId.PluginStatusNotInstalled), entry.author ?? string.Empty, homepage, PluginUpdateStatus.Other, entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty, null, entry.icon ?? string.Empty, entry.sourceUrl ?? string.Empty);
     }
 
     private static PluginUpdateRow BuildRow(InstalledPlugin plugin, PluginCatalogEntry? entry)
     {
         if (entry is null)
         {
-            return new PluginUpdateRow(plugin.DisplayName, plugin.VersionText, string.Empty, NativeStrings.Get(NativeStringId.PluginStatusNotInCatalog), string.Empty, string.Empty, PluginUpdateStatus.NotInCatalog, string.Empty, null, string.Empty, plugin.IconPath, string.Empty);
+            return new PluginUpdateRow(plugin.DisplayName, plugin.VersionText, string.Empty, NativeStrings.Get(NativeStringId.PluginStatusNotInCatalog), string.Empty, string.Empty, PluginUpdateStatus.NotInCatalog, string.Empty, null, string.Empty, plugin.IconPath, string.Empty, string.Empty);
         }
 
         var comparison = PluginVersionComparer.Compare(plugin.VersionText, entry.latestVersion, entry.versionScheme);
@@ -1851,7 +1931,7 @@ internal static class PluginCatalogService
         var displayName = IsTotalCommanderProxyCatalogEntry(entry) && IsTotalCommanderProxyInstance(plugin)
             ? plugin.DisplayName
             : LocalizedText.Resolve(entry.name) ?? plugin.DisplayName;
-        return new PluginUpdateRow(displayName, plugin.VersionText, entry.latestVersion ?? string.Empty, NativeStrings.Get(statusId), entry.author ?? string.Empty, homepage, ToStatus(comparison), entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty, plugin.IconPath, entry.icon ?? string.Empty);
+        return new PluginUpdateRow(displayName, plugin.VersionText, entry.latestVersion ?? string.Empty, NativeStrings.Get(statusId), entry.author ?? string.Empty, homepage, ToStatus(comparison), entry.source ?? string.Empty, entry.downloadPageUrl ?? entry.homepageUrl, LocalizedText.Resolve(entry.description) ?? string.Empty, plugin.IconPath, entry.icon ?? string.Empty, entry.sourceUrl ?? string.Empty);
     }
 
     private static PluginUpdateStatus ToStatus(PluginVersionComparison comparison) => comparison == PluginVersionComparison.UpdateAvailable ? PluginUpdateStatus.UpdateAvailable : PluginUpdateStatus.Other;
@@ -2114,6 +2194,7 @@ internal sealed class PluginCatalogEntry
     public string? homepageUrl { get; set; }
     public string? downloadPageUrl { get; set; }
     public string? source { get; set; }
+    public string? sourceUrl { get; set; }
 }
 
 internal static class LocalizedText
@@ -2266,7 +2347,7 @@ internal static class InstalledPluginVersionFormatter
 
 internal sealed class PluginUpdateRow
 {
-    public PluginUpdateRow(string name, string installedVersion, string latestVersion, string statusText, string author, string homepage, PluginUpdateStatus status, string source, string? webUrl, string description, string? iconPath, string? iconLabel)
+    public PluginUpdateRow(string name, string installedVersion, string latestVersion, string statusText, string author, string homepage, PluginUpdateStatus status, string source, string? webUrl, string description, string? iconPath, string? catalogIconReference, string? catalogSourceUrl)
     {
         Name = name;
         InstalledVersion = installedVersion;
@@ -2279,7 +2360,8 @@ internal sealed class PluginUpdateRow
         WebUrl = webUrl;
         Description = description;
         IconPath = iconPath ?? string.Empty;
-        IconLabel = iconLabel ?? string.Empty;
+        CatalogIconReference = catalogIconReference ?? string.Empty;
+        CatalogSourceUrl = catalogSourceUrl ?? string.Empty;
     }
 
     public string Name { get; }
@@ -2293,9 +2375,10 @@ internal sealed class PluginUpdateRow
     public string? WebUrl { get; }
     public string Description { get; }
     public string IconPath { get; }
-    public string IconLabel { get; }
+    public string CatalogIconReference { get; }
+    public string CatalogSourceUrl { get; }
 
-    public static PluginUpdateRow SourceError(string source, string error) => new PluginUpdateRow(source, string.Empty, string.Empty, $"{NativeStrings.Get(NativeStringId.PluginStatusCatalogError)}: {error}", string.Empty, string.Empty, PluginUpdateStatus.CatalogError, source, null, string.Empty, null, string.Empty);
+    public static PluginUpdateRow SourceError(string source, string error) => new PluginUpdateRow(source, string.Empty, string.Empty, $"{NativeStrings.Get(NativeStringId.PluginStatusCatalogError)}: {error}", string.Empty, string.Empty, PluginUpdateStatus.CatalogError, source, null, string.Empty, null, string.Empty, string.Empty);
 }
 
 internal static class VersionComparer

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -1031,6 +1031,7 @@ internal sealed class PluginUpdatesDialog : Form
     private readonly Label _statusLabel;
     private readonly ContextMenuStrip _listContextMenu;
     private readonly ImageList _pluginImages;
+    private readonly Dictionary<string, string> _catalogImageKeys = new(StringComparer.OrdinalIgnoreCase);
     private readonly Label _detailNameValue;
     private readonly Label _detailAuthorValue;
     private readonly Label _detailInstalledValue;
@@ -1220,6 +1221,7 @@ internal sealed class PluginUpdatesDialog : Form
             var result = await PluginCatalogService.CheckAsync().ConfigureAwait(true);
             _rows.Clear();
             _rows.AddRange(result);
+            await EnsureCatalogImagesAsync(_rows).ConfigureAwait(true);
             BindRows();
             _statusLabel.Text = PluginCatalogService.LastErrors.Count == 0
                 ? NativeStrings.Get(NativeStringId.PluginUpdatesReady)
@@ -1285,7 +1287,7 @@ internal sealed class PluginUpdatesDialog : Form
 
     private string EnsurePluginImage(PluginUpdateRow row)
     {
-        var catalogIconKey = EnsureCatalogIconImage(row);
+        var catalogIconKey = GetCachedCatalogIconImageKey(row);
         if (!string.IsNullOrEmpty(catalogIconKey))
         {
             return catalogIconKey;
@@ -1318,32 +1320,54 @@ internal sealed class PluginUpdatesDialog : Form
         return string.Empty;
     }
 
-    private string EnsureCatalogIconImage(PluginUpdateRow row)
+    private async Task EnsureCatalogImagesAsync(IEnumerable<PluginUpdateRow> rows)
     {
-        var iconReference = row.CatalogIconReference;
-        if (string.IsNullOrWhiteSpace(iconReference) || string.Equals(iconReference, "plugin", StringComparison.OrdinalIgnoreCase))
+        foreach (var row in rows)
+        {
+            if (!string.IsNullOrEmpty(GetCachedCatalogIconImageKey(row)))
+            {
+                continue;
+            }
+
+            await EnsureCatalogIconImageAsync(row).ConfigureAwait(true);
+        }
+    }
+
+    private string GetCachedCatalogIconImageKey(PluginUpdateRow row)
+    {
+        if (!TryResolveCatalogIconReference(row, out var resolvedIcon))
         {
             return string.Empty;
         }
 
-        var resolvedIcon = ResolveCatalogIconReference(iconReference!, row.CatalogSourceUrl);
-        if (string.IsNullOrWhiteSpace(resolvedIcon))
+        return _catalogImageKeys.TryGetValue(resolvedIcon, out var key) && _pluginImages.Images.ContainsKey(key) ? key : string.Empty;
+    }
+
+    private async Task EnsureCatalogIconImageAsync(PluginUpdateRow row)
+    {
+        if (!TryResolveCatalogIconReference(row, out var resolvedIcon))
         {
-            return string.Empty;
+            return;
         }
 
         var key = "catalog:" + resolvedIcon;
         if (_pluginImages.Images.ContainsKey(key))
         {
-            return key;
+            _catalogImageKeys[resolvedIcon] = key;
+            return;
         }
 
         try
         {
             if (Uri.TryCreate(resolvedIcon, UriKind.Absolute, out var uri) && !uri.IsFile)
             {
-                var bytes = SharedHttpClient.Instance.GetByteArrayAsync(uri).GetAwaiter().GetResult();
-                using var stream = new MemoryStream(bytes);
+                using var request = new HttpRequestMessage(HttpMethod.Get, AddNoCacheQuery(uri));
+                request.Headers.Accept.ParseAdd("image/*");
+                request.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true, NoStore = true, MaxAge = TimeSpan.Zero };
+                request.Headers.Pragma.ParseAdd("no-cache");
+                using var response = await SharedHttpClient.Instance.SendAsync(request).ConfigureAwait(true);
+                response.EnsureSuccessStatusCode();
+                using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(true);
                 AddCatalogImageFromStream(key, stream, resolvedIcon);
             }
             else
@@ -1353,11 +1377,13 @@ internal sealed class PluginUpdatesDialog : Form
                 AddCatalogImageFromStream(key, stream, path);
             }
 
-            return _pluginImages.Images.ContainsKey(key) ? key : string.Empty;
+            if (_pluginImages.Images.ContainsKey(key))
+            {
+                _catalogImageKeys[resolvedIcon] = key;
+            }
         }
         catch
         {
-            return string.Empty;
         }
     }
 
@@ -1371,8 +1397,39 @@ internal sealed class PluginUpdatesDialog : Form
         }
 
         using var image = Image.FromStream(stream);
-        using var bitmap = new Bitmap(image, _pluginImages.ImageSize);
+        using var bitmap = CreateImageListBitmap(image, _pluginImages.ImageSize);
         _pluginImages.Images.Add(key, bitmap);
+    }
+
+    private static Bitmap CreateImageListBitmap(Image image, System.Drawing.Size size)
+    {
+        var bitmap = new Bitmap(size.Width, size.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(Color.Transparent);
+        graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+        graphics.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.HighQuality;
+        graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.HighQuality;
+
+        var scale = Math.Min((double)size.Width / image.Width, (double)size.Height / image.Height);
+        var width = Math.Max(1, (int)Math.Round(image.Width * scale));
+        var height = Math.Max(1, (int)Math.Round(image.Height * scale));
+        var x = (size.Width - width) / 2;
+        var y = (size.Height - height) / 2;
+        graphics.DrawImage(image, x, y, width, height);
+        return bitmap;
+    }
+
+    private static bool TryResolveCatalogIconReference(PluginUpdateRow row, out string resolvedIcon)
+    {
+        resolvedIcon = string.Empty;
+        var iconReference = row.CatalogIconReference;
+        if (string.IsNullOrWhiteSpace(iconReference) || string.Equals(iconReference, "plugin", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        resolvedIcon = ResolveCatalogIconReference(iconReference!, row.CatalogSourceUrl);
+        return !string.IsNullOrWhiteSpace(resolvedIcon);
     }
 
     private static string ResolveCatalogIconReference(string iconReference, string catalogSourceUrl)
@@ -1389,6 +1446,12 @@ internal sealed class PluginUpdatesDialog : Form
         }
 
         return trimmed;
+    }
+
+    private static Uri AddNoCacheQuery(Uri uri)
+    {
+        var separator = string.IsNullOrEmpty(uri.Query) ? "?" : "&";
+        return new Uri(uri, uri.PathAndQuery + separator + "samandarinRefresh=" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
     }
 
     private void UpdateDetails()

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -1958,18 +1958,16 @@ internal static class PluginCatalogSources
     private const string StablePluginSource = "https://samandarin.krtkovo.eu/catalogs/plugins-stable.json";
     private const string UnofficialExternalSource = "https://samandarin.krtkovo.eu/catalogs/plugins-unofficial.json";
     private const string ExtensionRuntimesSource = "https://samandarin.krtkovo.eu/catalogs/extension-runtimes.json";
+    private const string LegacyStablePluginSource = "https://krtkovo-eu-ai.github.io/salamander/catalogs/plugins-stable.json";
+    private const string LegacyUnofficialExternalSource = "https://krtkovo-eu-ai.github.io/salamander/catalogs/plugins-unofficial.json";
 
     public static IReadOnlyList<PluginCatalogSource> Load()
     {
-        var text = NativeConfiguration.LoadOrDefault().PluginCatalogSourcesText;
+        var settings = NativeConfiguration.LoadOrDefault();
+        var text = settings.PluginCatalogSourcesText;
         if (string.IsNullOrWhiteSpace(text))
         {
-            return new[]
-            {
-                new PluginCatalogSource { Url = StablePluginSource, Enabled = true },
-                new PluginCatalogSource { Url = UnofficialExternalSource, Enabled = true },
-                new PluginCatalogSource { Url = ExtensionRuntimesSource, Enabled = true },
-            };
+            return DefaultSources();
         }
 
         var lines = text!.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -2002,12 +2000,13 @@ internal static class PluginCatalogSources
 
         if (sources.Count == 0)
         {
-            return new[]
-            {
-                new PluginCatalogSource { Url = StablePluginSource, Enabled = true },
-                new PluginCatalogSource { Url = UnofficialExternalSource, Enabled = true },
-                new PluginCatalogSource { Url = ExtensionRuntimesSource, Enabled = true },
-            };
+            return DefaultSources();
+        }
+
+        if (NormalizeDefaultSources(sources))
+        {
+            settings.PluginCatalogSourcesText = Serialize(sources);
+            NativeConfiguration.Save(settings);
         }
 
         return sources;
@@ -2026,9 +2025,72 @@ internal static class PluginCatalogSources
             .GroupBy(s => s.Url.Trim(), StringComparer.OrdinalIgnoreCase)
             .Select(g => g.First())
             .ToList();
-        settings.PluginCatalogSourcesText = string.Join("\n", distinct.Select(s => $"{(s.Enabled ? "1" : "0")}|{s.Url.Trim()}"));
+        settings.PluginCatalogSourcesText = Serialize(distinct);
         NativeConfiguration.Save(settings);
     }
+
+    private static IReadOnlyList<PluginCatalogSource> DefaultSources() => new[]
+    {
+        new PluginCatalogSource { Url = StablePluginSource, Enabled = true },
+        new PluginCatalogSource { Url = UnofficialExternalSource, Enabled = true },
+        new PluginCatalogSource { Url = ExtensionRuntimesSource, Enabled = true },
+    };
+
+    private static bool NormalizeDefaultSources(List<PluginCatalogSource> sources)
+    {
+        var changed = false;
+        changed |= ReplaceSourceUrl(sources, LegacyStablePluginSource, StablePluginSource);
+        changed |= ReplaceSourceUrl(sources, LegacyUnofficialExternalSource, UnofficialExternalSource);
+        changed |= AddMissingDefaultSource(sources, StablePluginSource);
+        changed |= AddMissingDefaultSource(sources, UnofficialExternalSource);
+        changed |= AddMissingDefaultSource(sources, ExtensionRuntimesSource);
+        changed |= RemoveDuplicateSources(sources);
+        return changed;
+    }
+
+    private static bool ReplaceSourceUrl(IEnumerable<PluginCatalogSource> sources, string oldUrl, string newUrl)
+    {
+        var changed = false;
+        foreach (var source in sources.Where(source => string.Equals(source.Url, oldUrl, StringComparison.OrdinalIgnoreCase)))
+        {
+            source.Url = newUrl;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static bool AddMissingDefaultSource(ICollection<PluginCatalogSource> sources, string url)
+    {
+        if (sources.Any(source => string.Equals(source.Url, url, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        sources.Add(new PluginCatalogSource { Url = url, Enabled = true });
+        return true;
+    }
+
+    private static bool RemoveDuplicateSources(List<PluginCatalogSource> sources)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var changed = false;
+        for (int i = 0; i < sources.Count; i++)
+        {
+            if (seen.Add(sources[i].Url.Trim()))
+            {
+                continue;
+            }
+
+            sources.RemoveAt(i);
+            i--;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static string Serialize(IEnumerable<PluginCatalogSource> sources) => string.Join("\n", sources.Select(s => $"{(s.Enabled ? "1" : "0")}|{s.Url.Trim()}"));
 }
 
 internal static class InstalledPluginScanner

--- a/src/plugins/samandarin/versinfo.rh2
+++ b/src/plugins/samandarin/versinfo.rh2
@@ -1,4 +1,4 @@
-﻿//****************************************************************************
+//****************************************************************************
 //
 // Copyright (c) 2023 Open Salamander Authors
 //
@@ -18,7 +18,7 @@
 // look at shared\versinfo.rc
 
 #define VERSINFO_MAJOR       0
-#define VERSINFO_MINORA      6
+#define VERSINFO_MINORA      7
 #define VERSINFO_MINORB      0
 
 #include "spl_vers.h" // vytahneme cisla verzi + buildu

--- a/src/plugins/shared/spl_vers.h
+++ b/src/plugins/shared/spl_vers.h
@@ -26,7 +26,7 @@
 #define VERSINFO_SALAMANDER_MINORB 0
 
 #define VERSINFO_SAMANDARIN_MAJOR 0
-#define VERSINFO_SAMANDARIN_MINORA 12
+#define VERSINFO_SAMANDARIN_MINORA 13
 
 #define VERSINFO_SAMANDARIN_VERSION VERSINFO_xstr(VERSINFO_SAMANDARIN_MAJOR) "." VERSINFO_xstr(VERSINFO_SAMANDARIN_MINORA)
 #define VERSINFO_SAMANDARIN_SUFFIX "-samandarin-" VERSINFO_SAMANDARIN_VERSION
@@ -114,10 +114,11 @@
 // 192 = 5.0-samandarin-0.10
 // 193 = 5.0-samandarin-0.11
 // 194 = 5.0-samandarin-0.12
+// 195 = 5.0-samandarin-0.13
 
 // ! DULEZITE: nova cisla buildu je nutne zapsat do vetve "default", a pak
 //             teprve do vedlejsi vetve (kompletni seznam je jen v "default" vetvi)
-#define VERSINFO_BUILDNUMBER 194
+#define VERSINFO_BUILDNUMBER 195
 
 // VERSINFO_BETAVERSION_TXT:
 //


### PR DESCRIPTION
### Motivation
- Allow plugin catalogs to provide icon references (absolute URLs, relative URLs, local paths) so the updates UI can show catalog icons when available and fall back to installed plugin icons.
- Improve handling and normalization of default and legacy catalog source URLs and persist normalized source lists in configuration.
- Document the catalog icon reference options in README and the example catalog JSON.

### Description
- Added catalog icon support in the updates UI by resolving catalog icon references, downloading or loading images (including .ico), resizing them into the image list, and caching image keys in `_catalogImageKeys` and `_pluginImages`.
- Integrated catalog icon processing into the refresh flow via `EnsureCatalogImagesAsync` and changed `EnsurePluginImage` to prefer catalog images when available; adjusted list item creation to use row text and updated the comparer to sort by name.
- Extended `PluginUpdateRow` and `PluginCatalogEntry` to carry `catalogIconReference` and `sourceUrl`, and adjusted `PluginCatalogService` to populate `entry.sourceUrl` and pass it to row builders.
- Improved plugin catalog source handling in `PluginCatalogSources` by adding default/legacy URLs, normalizing legacy sources to new URLs, deduplicating, serializing sources consistently, and persisting normalized source text; also refactored default source handling into helpers.
- Documentation updates: clarified icon reference semantics in `doc/catalogs-base/README.md` and updated `doc/plugin-catalog-example.json` to show acceptable `icon` values.

### Testing
- Performed an automated build with `dotnet build` on the modified solution and the build succeeded.
- Executed `dotnet test` against the repository test projects; the test run completed with no failures (no additional plugin-catalog-specific unit tests were present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6125654a40832994428c45086826af)