### PR TITLE
Fix Samandarin Plugin Updates theming and runtime color-scheme refresh

### DIFF
--- a/doc/catalogs-base/extension-runtimes.json
+++ b/doc/catalogs-base/extension-runtimes.json
@@ -34,9 +34,44 @@
       },
       "latestVersion": "0.1 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/automation",
-      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander/releases/latest",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_salamatrix_0.1_x64/plugin_5.0_salamatrix_0.1_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/salamatrix.png"
+    },
+    {
+      "id": "demoplug",
+      "name": {
+        "english": "Demo Plugin",
+        "chinesesimplified": "Demo Plugin",
+        "czech": "Demo Plugin",
+        "german": "Demo Plugin",
+        "dutch": "Demo Plugin",
+        "hungarian": "Demo Plugin",
+        "russian": "Demo Plugin",
+        "french": "Demo Plugin",
+        "slovak": "Demo Plugin",
+        "romanian": "Demo Plugin",
+        "spanish": "Demo Plugin"
+      },
+      "author": "Ondřej Kotas (KRtekTM)",
+      "description": {
+        "english": "Demo Plugin for testing purposes.",
+        "chinesesimplified": "用于测试目的的演示插件。",
+        "czech": "Demo Plugin pro testovací účely.",
+        "german": "Demo-Plugin für Testzwecke.",
+        "dutch": "Demo-plugin voor testdoeleinden.",
+        "hungarian": "Demo plugin tesztelési célokra.",
+        "russian": "Демо-плагин для тестирования.",
+        "french": "Plugin de démonstration à des fins de test.",
+        "slovak": "Demo plugin na testovacie účely.",
+        "romanian": "Plugin de demonstrație pentru scopuri de testare.",
+        "spanish": "Plugin de demostración para fines de prueba."
+      },
+      "latestVersion": "1.96 (x64)",
+      "versionScheme": "fileversion",
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_demoplug_1.96_x64/plugin_5.0_demoplug_1.96_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/demoplug.png"
     }
   ]
 }

--- a/doc/catalogs-base/plugins-stable.json
+++ b/doc/catalogs-base/plugins-stable.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "catalogName": "Stable",
-  "generatedAt": "2026-07-22T03:04:21Z",
+  "generatedAt": "2026-07-23T00:18:13Z",
   "plugins": [
     {
       "id": "7zip",
@@ -24,9 +24,9 @@
       },
       "latestVersion": "1.34 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_7zip_1.34_x64/plugin_5.0_7zip_1.34_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/7zip.png"
     },
     {
       "id": "automation",
@@ -59,9 +59,9 @@
       },
       "latestVersion": "2.0 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_automation_2.0_x64/plugin_5.0_automation_2.0_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/automation.png"
     },
     {
       "id": "dbviewer",
@@ -94,9 +94,9 @@
       },
       "latestVersion": "1.25 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_dbviewer_1.25_x64/plugin_5.0_dbviewer_1.25_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/dbviewer.png"
     },
     {
       "id": "diskmap",
@@ -129,9 +129,9 @@
       },
       "latestVersion": "1.13 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_diskmap_1.13_x64/plugin_5.0_diskmap_1.13_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/diskmap.png"
     },
     {
       "id": "filecomp",
@@ -164,9 +164,9 @@
       },
       "latestVersion": "1.20 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_filecomp_1.20_x64/plugin_5.0_filecomp_1.20_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/filecomp.png"
     },
     {
       "id": "folders",
@@ -199,9 +199,9 @@
       },
       "latestVersion": "0.2 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_folders_0.2_x64/plugin_5.0_folders_0.2_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/folders.png"
     },
     {
       "id": "ftp",
@@ -234,9 +234,9 @@
       },
       "latestVersion": "1.36 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_ftp_1.36_x64/plugin_5.0_ftp_1.36_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/ftp.png"
     },
     {
       "id": "hypervm",
@@ -269,9 +269,9 @@
       },
       "latestVersion": "1.07 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_hypervm_1.07_x64/plugin_5.0_hypervm_1.07_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/hyperv.png"
     },
     {
       "id": "checksum",
@@ -304,9 +304,9 @@
       },
       "latestVersion": "2.3 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_checksum_2.3_x64/plugin_5.0_checksum_2.3_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/checksum.png"
     },
     {
       "id": "ieviewer",
@@ -339,9 +339,9 @@
       },
       "latestVersion": "1.12 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_ieviewer_1.12_x64/plugin_5.0_ieviewer_1.12_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/ieviewer.png"
     },
     {
       "id": "jsonviewer",
@@ -374,9 +374,9 @@
       },
       "latestVersion": "1.02 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_jsonviewer_1.02_x64/plugin_5.0_jsonviewer_1.02_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/jsonviewer.png"
     },
     {
       "id": "mmviewer",
@@ -409,9 +409,9 @@
       },
       "latestVersion": "1.16 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_mmviewer_1.16_x64/plugin_5.0_mmviewer_1.16_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/mmviewer.png"
     },
     {
       "id": "nethood",
@@ -444,9 +444,9 @@
       },
       "latestVersion": "1.09 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_nethood_1.09_x64/plugin_5.0_nethood_1.09_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/nethood.png"
     },
     {
       "id": "pak",
@@ -479,9 +479,9 @@
       },
       "latestVersion": "1.72 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_pak_1.72_x64/plugin_5.0_pak_1.72_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/pak.png"
     },
     {
       "id": "peviewer",
@@ -514,9 +514,9 @@
       },
       "latestVersion": "3.0 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_peviewer_3.0_x64/plugin_5.0_peviewer_3.0_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "pictview",
@@ -549,9 +549,9 @@
       },
       "latestVersion": "2.24 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_pictview_2.24_x64/plugin_5.0_pictview_2.24_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/pictview.png"
     },
     {
       "id": "portables",
@@ -584,9 +584,9 @@
       },
       "latestVersion": "0.4 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_portables_0.4_x64/plugin_5.0_portables_0.4_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/portables.png"
     },
     {
       "id": "regedt",
@@ -619,9 +619,9 @@
       },
       "latestVersion": "1.15 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_regedt_1.15_x64/plugin_5.0_regedt_1.15_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/regedit.png"
     },
     {
       "id": "renamer",
@@ -654,9 +654,9 @@
       },
       "latestVersion": "1.15 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_renamer_1.15_x64/plugin_5.0_renamer_1.15_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/renamer.png"
     },
     {
       "id": "samandarin",
@@ -687,11 +687,11 @@
         "romanian": "Verifică lansările GitHub și oferă să deschidă cea mai recentă versiune Samandarin.",
         "spanish": "Comprueba las versiones de GitHub y ofrece abrir la última compilación de Samandarin."
       },
-      "latestVersion": "0.6 (x64)",
+      "latestVersion": "0.7 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_samandarin_0.7_x64/plugin_5.0_samandarin_0.7_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/samandarin.png"
     },
     {
       "id": "serviceexplorer",
@@ -724,9 +724,9 @@
       },
       "latestVersion": "0.013 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_serviceexplorer_0.013_x64/plugin_5.0_serviceexplorer_0.013_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/serviceexplorer.png"
     },
     {
       "id": "splitcbn",
@@ -759,9 +759,9 @@
       },
       "latestVersion": "1.11 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_splitcbn_1.11_x64/plugin_5.0_splitcbn_1.11_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/split.png"
     },
     {
       "id": "tar",
@@ -794,9 +794,9 @@
       },
       "latestVersion": "3.34 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_tar_3.34_x64/plugin_5.0_tar_3.34_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "textviewer",
@@ -829,9 +829,9 @@
       },
       "latestVersion": "1.02 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_textviewer_1.02_x64/plugin_5.0_textviewer_1.02_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/textviewer.png"
     },
     {
       "id": "unarj",
@@ -844,9 +844,9 @@
       },
       "latestVersion": "1.22 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_unarj_1.22_x64/plugin_5.0_unarj_1.22_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "uncab",
@@ -859,9 +859,9 @@
       },
       "latestVersion": "1.28 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_uncab_1.28_x64/plugin_5.0_uncab_1.28_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "undelete",
@@ -894,9 +894,9 @@
       },
       "latestVersion": "1.12 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_undelete_1.12_x64/plugin_5.0_undelete_1.12_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/undelete.png"
     },
     {
       "id": "unfat",
@@ -909,9 +909,9 @@
       },
       "latestVersion": "1.2 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_unfat_1.2_x64/plugin_5.0_unfat_1.2_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "unchm",
@@ -924,9 +924,9 @@
       },
       "latestVersion": "1.05 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_unchm_1.05_x64/plugin_5.0_unchm_1.05_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "uniso",
@@ -939,9 +939,9 @@
       },
       "latestVersion": "1.38 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_uniso_1.38_x64/plugin_5.0_uniso_1.38_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "unlha",
@@ -974,9 +974,9 @@
       },
       "latestVersion": "1.14 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_unlha_1.14_x64/plugin_5.0_unlha_1.14_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "unmime",
@@ -1009,9 +1009,9 @@
       },
       "latestVersion": "1.15 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_unmime_1.15_x64/plugin_5.0_unmime_1.15_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "unole",
@@ -1024,9 +1024,9 @@
       },
       "latestVersion": "1.02 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_unole_1.02_x64/plugin_5.0_unole_1.02_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "unrar",
@@ -1039,9 +1039,9 @@
       },
       "latestVersion": "3.03 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_unrar_3.03_x64/plugin_5.0_unrar_3.03_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "webview2renderviewer",
@@ -1074,9 +1074,9 @@
       },
       "latestVersion": "1.03 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_webview2renderviewer_1.03_x64/plugin_5.0_webview2renderviewer_1.03_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/webview2.png"
     },
     {
       "id": "wmobile",
@@ -1109,9 +1109,9 @@
       },
       "latestVersion": "1.09 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_wmobile_1.09_x64/plugin_5.0_wmobile_1.09_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/wmobile.png"
     },
     {
       "id": "zip",
@@ -1144,9 +1144,9 @@
       },
       "latestVersion": "1.7 (x64)",
       "versionScheme": "fileversion",
-      "homepageUrl": "https://samandarin.krtkovo.eu/download",
-      "downloadPageUrl": "https://samandarin.krtkovo.eu/download",
-      "icon": "plugin"
+      "homepageUrl": "https://samandarin.krtkovo.eu/",
+      "downloadPageUrl": "https://github.com/KRtkovo-eu-AI/salamander-plugins/releases/download/plugin_5.0_zip_1.7_x64/plugin_5.0_zip_1.7_x64.7z",
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/zip.png"
     }
   ]
 }

--- a/doc/catalogs-base/plugins-unofficial.json
+++ b/doc/catalogs-base/plugins-unofficial.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "catalogName": "Unofficial 3rd party",
-  "generatedAt": "2026-06-29T03:07:00Z",
+  "generatedAt": "2026-07-23T02:00:00Z",
   "plugins": [
     {
       "id": "sftp",
@@ -36,7 +36,7 @@
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/Dupl3xx/salamander-sftp-plugin",
       "downloadPageUrl": "https://github.com/Dupl3xx/salamander-sftp-plugin/tree/master/bin",
-      "icon": "plugin"
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "tar",
@@ -71,7 +71,7 @@
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/OpenSalamander/salamander/pull/5#issuecomment-3289439303",
       "downloadPageUrl": "https://github.com/user-attachments/files/22319444/tar-plugin-x64.zip",
-      "icon": "plugin"
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "certview",
@@ -106,7 +106,7 @@
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/lejcik/certviewer",
       "downloadPageUrl": "https://github.com/lejcik/certviewer/releases/latest",
-      "icon": "plugin"
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "x-tc-proxy",
@@ -141,7 +141,7 @@
       "versionScheme": "fileversion",
       "homepageUrl": "https://forum.altap.cz/viewtopic.php?t=2166",
       "downloadPageUrl": "https://www.manison.cz/products/tcproxy.php?Lang=en",
-      "icon": "plugin"
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     },
     {
       "id": "syntax-viewer",
@@ -176,7 +176,7 @@
       "versionScheme": "fileversion",
       "homepageUrl": "https://github.com/umpalump7/SyntaxView/",
       "downloadPageUrl": "https://github.com/umpalump7/SyntaxView/",
-      "icon": "plugin"
+      "icon": "https://samandarin.krtkovo.eu/catalogs/img/plugin.png"
     }
   ]
 }

--- a/doc/runbook-setup/inno_setup_salamander_x64.iss
+++ b/doc/runbook-setup/inno_setup_salamander_x64.iss
@@ -1991,7 +1991,7 @@ begin
   AddPlugin('textviewer', 'PrismSharp Text Viewer .NET', '1.02 (x64)', True);
   AddPlugin('regedt', 'Registry Editor', '1.15 (x64)', True);
   AddPlugin('renamer', 'Renamer', '1.15 (x64)', True);
-  AddPlugin('samandarin', 'Samandarin Update Notifier', '0.6 (x64)', True);
+  AddPlugin('samandarin', 'Samandarin Update Notifier', '0.7 (x64)', True);
   AddPlugin('serviceexplorer', 'Service Explorer', '0.013 (x64)', True);
   AddPlugin('splitcbn', 'Split & Combine', '1.11 (x64)', True);
   AddPlugin('tar', 'TAR', '3.34 (x64)', True);

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -100,6 +100,7 @@ public static class EntryPoint
     private static int ColorsChanged()
     {
         ThemeHelper.InvalidatePalette();
+        ThemeHelper.RefreshOpenForms();
         return 0;
     }
 
@@ -1085,6 +1086,7 @@ internal sealed class PluginUpdatesDialog : Form
             MultiSelect = false,
             Scrollable = true,
             View = View.Details,
+            OwnerDraw = true,
         };
         _pluginImages = new ImageList { ColorDepth = ColorDepth.Depth32Bit, ImageSize = new System.Drawing.Size(16, 16) };
         _listView.SmallImageList = _pluginImages;
@@ -1096,6 +1098,8 @@ internal sealed class PluginUpdatesDialog : Form
         _listView.Columns.Add(NativeStrings.Get(NativeStringId.PluginColumnStatus), 150);
         _listView.Columns.Add(NativeStrings.Get(NativeStringId.PluginColumnAuthor), 140);
         _listView.ColumnClick += ListViewOnColumnClick;
+        _listView.DrawColumnHeader += ListViewOnDrawColumnHeader;
+        _listView.DrawSubItem += ListViewOnDrawSubItem;
         _listView.MouseDoubleClick += ListViewOnMouseDoubleClick;
         _listView.MouseDown += ListViewOnMouseDown;
         _listView.Resize += (_, _) => AdjustListViewColumns();
@@ -1163,6 +1167,64 @@ internal sealed class PluginUpdatesDialog : Form
             AdjustListViewColumns();
         };
         UpdateDetails();
+    }
+
+    private void ListViewOnDrawColumnHeader(object? sender, DrawListViewColumnHeaderEventArgs e)
+    {
+        e.DrawDefault = true;
+    }
+
+    private void ListViewOnDrawSubItem(object? sender, DrawListViewSubItemEventArgs e)
+    {
+        bool selected = e.Item.Selected;
+        var background = selected ? SystemColors.Highlight : _listView.BackColor;
+        var foreground = selected ? SystemColors.HighlightText : _listView.ForeColor;
+
+        using (var backgroundBrush = new SolidBrush(background))
+        {
+            e.Graphics.FillRectangle(backgroundBrush, e.Bounds);
+        }
+
+        if (e.ColumnIndex == 0)
+        {
+            DrawListViewImage(e.Graphics, e.Item, e.Bounds);
+        }
+        else
+        {
+            TextRenderer.DrawText(
+                e.Graphics,
+                e.SubItem.Text,
+                _listView.Font,
+                new Rectangle(e.Bounds.Left + 4, e.Bounds.Top, Math.Max(0, e.Bounds.Width - 8), e.Bounds.Height),
+                foreground,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis | TextFormatFlags.SingleLine);
+        }
+
+        using var gridPen = new Pen(ControlPaint.Dark(_listView.BackColor));
+        e.Graphics.DrawLine(gridPen, e.Bounds.Left, e.Bounds.Bottom - 1, e.Bounds.Right, e.Bounds.Bottom - 1);
+        e.Graphics.DrawLine(gridPen, e.Bounds.Right - 1, e.Bounds.Top, e.Bounds.Right - 1, e.Bounds.Bottom);
+    }
+
+    private void DrawListViewImage(Graphics graphics, ListViewItem item, Rectangle bounds)
+    {
+        Image? image = null;
+        if (!string.IsNullOrEmpty(item.ImageKey) && _pluginImages.Images.ContainsKey(item.ImageKey))
+        {
+            image = _pluginImages.Images[item.ImageKey];
+        }
+        else if (item.ImageIndex >= 0 && item.ImageIndex < _pluginImages.Images.Count)
+        {
+            image = _pluginImages.Images[item.ImageIndex];
+        }
+
+        if (image is null)
+        {
+            return;
+        }
+
+        int x = bounds.Left + Math.Max(0, (bounds.Width - image.Width) / 2);
+        int y = bounds.Top + Math.Max(0, (bounds.Height - image.Height) / 2);
+        graphics.DrawImage(image, x, y, image.Width, image.Height);
     }
 
     private void AdjustListViewColumns()

--- a/src/plugins/samandarin/managed/ThemeHelper.cs
+++ b/src/plugins/samandarin/managed/ThemeHelper.cs
@@ -7,6 +7,7 @@ using System;
 using System.Drawing;
 using System.Resources;
 using System.Runtime.InteropServices;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace OpenSalamander.Samandarin;
@@ -69,6 +70,15 @@ internal static class ThemeHelper
     public static void InvalidatePalette()
     {
         s_cachedPalette = null;
+    }
+
+    public static void RefreshOpenForms()
+    {
+        foreach (Form form in Application.OpenForms.Cast<Form>().ToArray())
+        {
+            ApplyTheme(form);
+            form.Invalidate(true);
+        }
     }
 
     public static void CenterDialogOverOwner(Form dialog, IWin32Window? owner)

--- a/src/plugins/samandarin/managed_bridge.cpp
+++ b/src/plugins/samandarin/managed_bridge.cpp
@@ -277,7 +277,18 @@ extern "C" __declspec(dllexport) void __stdcall Samandarin_UpdateListViewDarkMod
 {
     DarkModeAllowDarkScrollbars(hwnd);
     DarkModeApplyTree(hwnd);
-    DarkModeUpdateListViewColors(hwnd, RGB(0xFF, 0xFF, 0xFF), RGB(56, 56, 56), true);
+
+    if (SalamanderGeneral != nullptr)
+    {
+        const COLORREF text = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_FG_NORMAL);
+        const COLORREF background = SalamanderGeneral->GetCurrentColor(SALCOL_ITEM_BK_NORMAL);
+        const bool useCustomColors = text != GetSysColor(COLOR_WINDOWTEXT) ||
+                                     background != GetSysColor(COLOR_WINDOW);
+        DarkModeUpdateListViewColors(hwnd, text, background, useCustomColors);
+        return;
+    }
+
+    DarkModeUpdateListViewColors(hwnd);
 }
 
 

--- a/translations/chinesesimplified/samandarin.slt
+++ b/translations/chinesesimplified/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\chinesesimplified\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,2052

--- a/translations/czech/samandarin.slt
+++ b/translations/czech/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\czech\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,1029

--- a/translations/dutch/samandarin.slt
+++ b/translations/dutch/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\dutch\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,1043

--- a/translations/french/samandarin.slt
+++ b/translations/french/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\french\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,1036

--- a/translations/german/samandarin.slt
+++ b/translations/german/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\german\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,1031

--- a/translations/hungarian/samandarin.slt
+++ b/translations/hungarian/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\hungarian\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,1038

--- a/translations/romanian/samandarin.slt
+++ b/translations/romanian/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\romanian\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,1048

--- a/translations/russian/samandarin.slt
+++ b/translations/russian/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\russian\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,1049

--- a/translations/slovak/samandarin.slt
+++ b/translations/slovak/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\slovak\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,1051

--- a/translations/spanish/samandarin.slt
+++ b/translations/spanish/samandarin.slt
@@ -1,7 +1,7 @@
 ﻿[EXPORTINFO]
 PROJECTNAME,"localization-openai\projects\spanish\samandarin\samandarin.atp"
-TEXTVERSION,"0.6 (x64)"
-VERSION,"0,6,0,194"
+TEXTVERSION,"0.7 (x64)"
+VERSION,"0,7,0,195"
 
 [TRANSLATION]
 LANGID,3082


### PR DESCRIPTION
### Motivation
- The Plugin Updates dialog showed a mismatched background for the icon column in dark mode and a dark rectangle in light schemes, so row rendering must be unified across schemes. 
- The plugin must respond to color-scheme changes at runtime so open managed dialogs update immediately when the user changes the color scheme.

### Description
- Enabled owner-draw on the Plugin Updates `ListView` and added `DrawColumnHeader`/`DrawSubItem` handlers plus `DrawListViewImage` to paint a consistent row background and correctly render the icon column (`src/plugins/samandarin/managed/EntryPoint.cs`).
- Added `ThemeHelper.RefreshOpenForms()` and call it from the `ColorsChanged` path so the cached palette is invalidated and theming is re-applied to all open managed forms at runtime (`src/plugins/samandarin/managed/ThemeHelper.cs` and `src/plugins/samandarin/managed/EntryPoint.cs`).
- Updated the native bridge `Samandarin_UpdateListViewDarkMode` to use `SalamanderGeneral->GetCurrentColor(...)` for list-view foreground/background and pass `useCustomColors` to `DarkModeUpdateListViewColors` instead of using hard-coded dark colors (`src/plugins/samandarin/managed_bridge.cpp`).

### Testing
- Ran `git diff --check` to validate whitespace and simple diffs and it succeeded.
- Attempted `dotnet build src/plugins/samandarin/managed/Samandarin.Managed.csproj --no-restore` but `dotnet` is not available in this environment so the managed assembly build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a615a29502c83298ef6fd4fd8083bcc)