### PR TITLE
Defer fallback main window resize

### DIFF
--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -435,6 +435,7 @@ public:
     BOOL DetachedPanels;      // TRUE = left and right sides are hosted in separate top-level windows
     BOOL CreatingDetachedChrome; // suppress detached-window activation while its child chrome is being built
     BOOL DetachedPanelsSwapFixNeeded; // TRUE after Swap Sides while detached; reattach replays a double swap to refresh layout state
+    BOOL WindowPosSizeUpdatePending; // TRUE when WM_WINDOWPOSCHANGED posted a deferred WM_SIZE
 
     CHotPathItems HotPaths;
     CViewTemplates ViewTemplates;

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -364,6 +364,7 @@ CMainWindow::CMainWindow()
     DetachedPanels = FALSE;
     CreatingDetachedChrome = FALSE;
     DetachedPanelsSwapFixNeeded = FALSE;
+    WindowPosSizeUpdatePending = FALSE;
     //  DrivesControlHWnd = NULL;
     HDisabledKeyboard = NULL;
     CmdShow = SW_SHOWNORMAL;

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -9201,19 +9201,20 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         // Some detach/reattach paths move tab HWNDs between top-level hosts while Windows
         // is also changing activation/z-order.  If the following maximize/resize does not
         // deliver a usable WM_SIZE, the chrome and panel children keep their old rectangle
-        // and the newly exposed part of the main window remains empty.  Treat a changed
-        // client size observed in WM_WINDOWPOSCHANGED as authoritative and run the same
-        // sizing path after the current position-change notification unwinds.  Running the
-        // layout synchronously from WM_WINDOWPOSCHANGED can re-enter the rebar/control
-        // notification path (WM_SIZE -> WM_NOTIFY -> WM_SIZE -> WM_WINDOWPOSCHANGED) until
-        // the stack overflows on startup with current Windows common controls.
-        if (Created && !DetachedPanels && !WindowPosSizeUpdatePending)
+        // and the newly exposed part of the main window remains empty.  Treat a changed,
+        // visible client size observed in WM_WINDOWPOSCHANGED as authoritative and run the
+        // same sizing path after the current position-change notification unwinds.  Do not
+        // synthesize restored-size layout while minimized: Windows sends the real
+        // SIZE_MINIMIZED WM_SIZE for that state, and laying out a 0x0 restored client area
+        // can re-enter the rebar/control notification path until the stack overflows.
+        if (Created && !DetachedPanels && !WindowPosSizeUpdatePending && !IsIconic(HWindow))
         {
             RECT clientRect;
             GetClientRect(HWindow, &clientRect);
             int clientWidth = clientRect.right - clientRect.left;
             int clientHeight = clientRect.bottom - clientRect.top;
-            if (clientWidth != WindowWidth || clientHeight != WindowHeight)
+            if (clientWidth > 0 && clientHeight > 0 &&
+                (clientWidth != WindowWidth || clientHeight != WindowHeight))
             {
                 WindowPosSizeUpdatePending = TRUE;
                 PostMessage(HWindow, WM_SIZE, SIZE_RESTORED, MAKELPARAM(clientWidth, clientHeight));

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -9203,21 +9203,29 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         // deliver a usable WM_SIZE, the chrome and panel children keep their old rectangle
         // and the newly exposed part of the main window remains empty.  Treat a changed
         // client size observed in WM_WINDOWPOSCHANGED as authoritative and run the same
-        // sizing path immediately.
-        if (Created && !DetachedPanels)
+        // sizing path after the current position-change notification unwinds.  Running the
+        // layout synchronously from WM_WINDOWPOSCHANGED can re-enter the rebar/control
+        // notification path (WM_SIZE -> WM_NOTIFY -> WM_SIZE -> WM_WINDOWPOSCHANGED) until
+        // the stack overflows on startup with current Windows common controls.
+        if (Created && !DetachedPanels && !WindowPosSizeUpdatePending)
         {
             RECT clientRect;
             GetClientRect(HWindow, &clientRect);
             int clientWidth = clientRect.right - clientRect.left;
             int clientHeight = clientRect.bottom - clientRect.top;
             if (clientWidth != WindowWidth || clientHeight != WindowHeight)
-                SendMessage(HWindow, WM_SIZE, SIZE_RESTORED, MAKELPARAM(clientWidth, clientHeight));
+            {
+                WindowPosSizeUpdatePending = TRUE;
+                PostMessage(HWindow, WM_SIZE, SIZE_RESTORED, MAKELPARAM(clientWidth, clientHeight));
+            }
         }
         break;
     }
 
     case WM_SIZE: // panel size adjustment
     {
+        WindowPosSizeUpdatePending = FALSE;
+
         // at Tonda's, WM_SIZE arrives before WM_CREATE finishes
         // (bug report execution address = 0x004743C3)
         if (!Created)


### PR DESCRIPTION
### Motivation
- A synchronous fallback resize triggered from `WM_WINDOWPOSCHANGED` can re-enter the control/rebar notification path (`WM_SIZE` -> `WM_NOTIFY` -> `WM_SIZE` -> `WM_WINDOWPOSCHANGED`) and cause a stack overflow on startup. 
- The change defers the fallback layout so the position-change notification can unwind before running the expensive sizing path.

### Description
- Added a coalescing flag `WindowPosSizeUpdatePending` to `CMainWindow` (`src/mainwnd.h`) to track a deferred resize. 
- Initialized `WindowPosSizeUpdatePending` in the main window constructor (`src/mainwnd1.cpp`). 
- Replaced the synchronous `SendMessage(HWindow, WM_SIZE, ...)` call in the `WM_WINDOWPOSCHANGED` handler with a deferred `PostMessage(WM_SIZE, ...)` and set `WindowPosSizeUpdatePending` when a fallback resize is posted (`src/mainwnd3.cpp`). 
- Cleared `WindowPosSizeUpdatePending` at the start of the `WM_SIZE` handler so subsequent real size changes can post a new deferred resize if needed (`src/mainwnd3.cpp`).

### Testing
- Ran `git diff --check` to catch whitespace/patch problems and it passed. 
- Executed a small Python static check that verified `WindowPosSizeUpdatePending` is present in the three modified source files and it succeeded. 
- Searched relevant handlers and message paths to ensure the deferred-post logic and clear-path are wired correctly. 
- A full Windows/MSBuild build and runtime verification could not be run in this Linux container because MSBuild was not available, so an MSVC build and startup smoke test on Windows is still recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61644ad8008329aae945daf6a3e3d2)