### PR TITLE
Fix Plugin Updates dialog rendering, flicker and slow loading

### DIFF
--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -1025,6 +1025,54 @@ internal sealed class ConfigurationDialog : Form
 }
 
 
+internal sealed class ThemedBorderPanel : Panel
+{
+    private static readonly Color DarkBorder = Color.FromArgb(56, 56, 56);
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        base.OnPaint(e);
+        using var pen = new Pen(IsDarkBackColor ? DarkBorder : SystemColors.ControlDark);
+        e.Graphics.DrawRectangle(pen, 0, 0, Width - 1, Height - 1);
+    }
+
+    protected override void OnBackColorChanged(EventArgs e)
+    {
+        base.OnBackColorChanged(e);
+        Invalidate();
+    }
+
+    private bool IsDarkBackColor => BackColor.GetBrightness() < 0.5f;
+}
+
+internal sealed class ThemedGroupBox : GroupBox
+{
+    private static readonly Color DarkBorder = Color.FromArgb(56, 56, 56);
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        e.Graphics.Clear(BackColor);
+
+        TextRenderer.DrawText(
+            e.Graphics,
+            Text,
+            Font,
+            new Point(8, 0),
+            ForeColor,
+            TextFormatFlags.Left | TextFormatFlags.NoPrefix);
+
+        var textSize = TextRenderer.MeasureText(Text, Font);
+        var borderTop = Math.Max(Font.Height / 2, 1);
+        using var pen = new Pen(BackColor.GetBrightness() < 0.5f ? DarkBorder : SystemColors.ControlLight);
+
+        e.Graphics.DrawLine(pen, 0, borderTop, 6, borderTop);
+        e.Graphics.DrawLine(pen, 10 + textSize.Width, borderTop, Width - 1, borderTop);
+        e.Graphics.DrawLine(pen, 0, borderTop, 0, Height - 1);
+        e.Graphics.DrawLine(pen, Width - 1, borderTop, Width - 1, Height - 1);
+        e.Graphics.DrawLine(pen, 0, Height - 1, Width - 1, Height - 1);
+    }
+}
+
 internal sealed class PluginUpdatesDialog : Form
 {
     private readonly ListView _listView;
@@ -1089,6 +1137,7 @@ internal sealed class PluginUpdatesDialog : Form
             Scrollable = true,
             View = View.Details,
             OwnerDraw = true,
+            BorderStyle = BorderStyle.None,
         };
         EnableSmoothListViewPainting(_listView);
         _pluginImages = new ImageList { ColorDepth = ColorDepth.Depth32Bit, ImageSize = new System.Drawing.Size(16, 16) };
@@ -1112,13 +1161,15 @@ internal sealed class PluginUpdatesDialog : Form
         _listContextMenu.Items.Add(NativeStrings.Get(NativeStringId.PluginCopyValue), null, (_, _) => CopyContextCellValue());
         _listContextMenu.Items.Add(NativeStrings.Get(NativeStringId.PluginCopyRowWithHeaders), null, (_, _) => CopyContextRowWithHeaders());
         _listView.ContextMenuStrip = _listContextMenu;
-        layout.Controls.Add(_listView, 0, 1);
+        var listFrame = new ThemedBorderPanel { Dock = DockStyle.Fill, Padding = new Padding(1) };
+        listFrame.Controls.Add(_listView);
+        layout.Controls.Add(listFrame, 0, 1);
 
         _showOnlyUpdates = new CheckBox { Text = NativeStrings.Get(NativeStringId.PluginUpdatesShowOnly), AutoSize = true, Anchor = AnchorStyles.Left, Padding = new Padding(0, 6, 0, 6) };
         _showOnlyUpdates.CheckedChanged += (_, _) => BindRows();
         layout.Controls.Add(_showOnlyUpdates, 0, 2);
 
-        var detailGroup = new GroupBox { Text = NativeStrings.Get(NativeStringId.PluginDetails), Dock = DockStyle.Fill, Padding = new Padding(10) };
+        var detailGroup = new ThemedGroupBox { Text = NativeStrings.Get(NativeStringId.PluginDetails), Dock = DockStyle.Fill, Padding = new Padding(10) };
         var detailLayout = new TableLayoutPanel { Dock = DockStyle.Fill, ColumnCount = 4, RowCount = 5 };
         detailLayout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
         detailLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
@@ -1308,7 +1359,6 @@ internal sealed class PluginUpdatesDialog : Form
 
     private void SetLoadingState(bool isLoading)
     {
-        _listView.Enabled = !isLoading;
         _showOnlyUpdates.Enabled = !isLoading;
         _refreshButton.Enabled = !isLoading;
         _sourcesButton.Enabled = !isLoading;
@@ -1365,7 +1415,17 @@ internal sealed class PluginUpdatesDialog : Form
         AdjustListViewColumns();
         NativeListView.SetSortArrow(_listView, _sortColumn, _sortOrder);
         ThemeHelper.ApplyNativeDarkMode(_listView);
+        EnsureListViewLightModeBackground();
         UpdateDetails();
+    }
+
+    private void EnsureListViewLightModeBackground()
+    {
+        if (BackColor.GetBrightness() >= 0.5f)
+        {
+            _listView.BackColor = Color.White;
+            _listView.ForeColor = SystemColors.WindowText;
+        }
     }
 
     private void RefreshCatalogImages()

--- a/src/plugins/samandarin/managed/EntryPoint.cs
+++ b/src/plugins/samandarin/managed/EntryPoint.cs
@@ -1030,6 +1030,8 @@ internal sealed class PluginUpdatesDialog : Form
     private readonly ListView _listView;
     private readonly CheckBox _showOnlyUpdates;
     private readonly Label _statusLabel;
+    private readonly Button _refreshButton;
+    private readonly Button _sourcesButton;
     private readonly ContextMenuStrip _listContextMenu;
     private readonly ImageList _pluginImages;
     private readonly Dictionary<string, string> _catalogImageKeys = new(StringComparer.OrdinalIgnoreCase);
@@ -1088,6 +1090,7 @@ internal sealed class PluginUpdatesDialog : Form
             View = View.Details,
             OwnerDraw = true,
         };
+        EnableSmoothListViewPainting(_listView);
         _pluginImages = new ImageList { ColorDepth = ColorDepth.Depth32Bit, ImageSize = new System.Drawing.Size(16, 16) };
         _listView.SmallImageList = _pluginImages;
         _listView.Columns.Add(string.Empty, 46);
@@ -1149,13 +1152,13 @@ internal sealed class PluginUpdatesDialog : Form
 
         var buttons = new FlowLayoutPanel { Dock = DockStyle.Fill, AutoSize = true, WrapContents = false, FlowDirection = FlowDirection.RightToLeft, Margin = new Padding(0) };
         var closeButton = new Button { Text = NativeStrings.Get(NativeStringId.PluginUpdatesClose), DialogResult = DialogResult.Cancel, AutoSize = true };
-        var refreshButton = new Button { Text = NativeStrings.Get(NativeStringId.PluginUpdatesRefresh), AutoSize = true };
-        var sourcesButton = new Button { Text = NativeStrings.Get(NativeStringId.PluginUpdatesConfigureSources), AutoSize = true };
-        refreshButton.Click += async (_, _) => await RefreshAsync().ConfigureAwait(true);
-        sourcesButton.Click += (_, _) => ShowSourcesDialog();
+        _refreshButton = new Button { Text = NativeStrings.Get(NativeStringId.PluginUpdatesRefresh), AutoSize = true };
+        _sourcesButton = new Button { Text = NativeStrings.Get(NativeStringId.PluginUpdatesConfigureSources), AutoSize = true };
+        _refreshButton.Click += async (_, _) => await RefreshAsync().ConfigureAwait(true);
+        _sourcesButton.Click += (_, _) => ShowSourcesDialog();
         buttons.Controls.Add(closeButton);
-        buttons.Controls.Add(refreshButton);
-        buttons.Controls.Add(sourcesButton);
+        buttons.Controls.Add(_refreshButton);
+        buttons.Controls.Add(_sourcesButton);
         bottomPanel.Controls.Add(buttons, 1, 0);
         layout.Controls.Add(bottomPanel, 0, 4);
 
@@ -1277,17 +1280,20 @@ internal sealed class PluginUpdatesDialog : Form
 
     private async Task RefreshAsync()
     {
+        SetLoadingState(true);
         _statusLabel.Text = NativeStrings.Get(NativeStringId.PluginUpdatesLoading);
         try
         {
             var result = await PluginCatalogService.CheckAsync().ConfigureAwait(true);
             _rows.Clear();
             _rows.AddRange(result);
-            await EnsureCatalogImagesAsync(_rows).ConfigureAwait(true);
             BindRows();
             _statusLabel.Text = PluginCatalogService.LastErrors.Count == 0
                 ? NativeStrings.Get(NativeStringId.PluginUpdatesReady)
                 : $"{NativeStrings.Get(NativeStringId.PluginUpdatesReady)} {string.Join(" | ", PluginCatalogService.LastErrors)}";
+            SetLoadingState(false);
+            await EnsureCatalogImagesAsync(_rows).ConfigureAwait(true);
+            RefreshCatalogImages();
         }
         catch (Exception ex)
         {
@@ -1295,8 +1301,18 @@ internal sealed class PluginUpdatesDialog : Form
         }
         finally
         {
+            SetLoadingState(false);
             UpdateDetails();
         }
+    }
+
+    private void SetLoadingState(bool isLoading)
+    {
+        _listView.Enabled = !isLoading;
+        _showOnlyUpdates.Enabled = !isLoading;
+        _refreshButton.Enabled = !isLoading;
+        _sourcesButton.Enabled = !isLoading;
+        UseWaitCursor = isLoading;
     }
 
     private void ShowSourcesDialog()
@@ -1308,6 +1324,11 @@ internal sealed class PluginUpdatesDialog : Form
         {
             _ = RefreshAsync();
         }
+    }
+
+    private static void EnableSmoothListViewPainting(ListView listView)
+    {
+        listView.GetType().GetProperty("DoubleBuffered", BindingFlags.Instance | BindingFlags.NonPublic)?.SetValue(listView, true, null);
     }
 
     private void BindRows()
@@ -1345,6 +1366,25 @@ internal sealed class PluginUpdatesDialog : Form
         NativeListView.SetSortArrow(_listView, _sortColumn, _sortOrder);
         ThemeHelper.ApplyNativeDarkMode(_listView);
         UpdateDetails();
+    }
+
+    private void RefreshCatalogImages()
+    {
+        _listView.BeginUpdate();
+        try
+        {
+            foreach (ListViewItem item in _listView.Items)
+            {
+                if (item.Tag is PluginUpdateRow row)
+                {
+                    item.ImageKey = EnsurePluginImage(row);
+                }
+            }
+        }
+        finally
+        {
+            _listView.EndUpdate();
+        }
     }
 
     private string EnsurePluginImage(PluginUpdateRow row)
@@ -1948,27 +1988,13 @@ internal static class PluginCatalogService
         var catalog = new List<PluginCatalogEntry>();
         var sourceErrors = new List<string>();
 
-        foreach (var source in PluginCatalogSources.LoadEnabledUrls())
+        var sourceResults = await Task.WhenAll(PluginCatalogSources.LoadEnabledUrls().Select(FetchCatalogSourceAsync)).ConfigureAwait(false);
+        foreach (var sourceResult in sourceResults)
         {
-            try
+            catalog.AddRange(sourceResult.Entries);
+            if (!string.IsNullOrEmpty(sourceResult.Error))
             {
-                var json = await FetchStringAsync(source).ConfigureAwait(false);
-                var manifest = Serializer.Deserialize<PluginCatalogManifest>(json);
-                if (manifest?.plugins is null)
-                {
-                    continue;
-                }
-
-                foreach (var entry in manifest.plugins.Where(entry => !string.IsNullOrWhiteSpace(entry.id)))
-                {
-                    entry.sourceUrl = source;
-                    entry.source = string.IsNullOrWhiteSpace(manifest.catalogName) ? source : manifest.catalogName;
-                    catalog.Add(entry);
-                }
-            }
-            catch (Exception ex)
-            {
-                sourceErrors.Add($"{source}: {ex.Message}");
+                sourceErrors.Add(sourceResult.Error);
             }
         }
 
@@ -1987,6 +2013,32 @@ internal static class PluginCatalogService
             .Select(BuildCatalogOnlyRow));
         LastErrors = sourceErrors;
         return rows.OrderBy(row => row.Name, StringComparer.CurrentCultureIgnoreCase).ToList();
+    }
+
+
+    private static async Task<(List<PluginCatalogEntry> Entries, string Error)> FetchCatalogSourceAsync(string source)
+    {
+        try
+        {
+            var json = await FetchStringAsync(source).ConfigureAwait(false);
+            var manifest = Serializer.Deserialize<PluginCatalogManifest>(json);
+            var entries = new List<PluginCatalogEntry>();
+            if (manifest?.plugins is not null)
+            {
+                foreach (var entry in manifest.plugins.Where(entry => !string.IsNullOrWhiteSpace(entry.id)))
+                {
+                    entry.sourceUrl = source;
+                    entry.source = string.IsNullOrWhiteSpace(manifest.catalogName) ? source : manifest.catalogName;
+                    entries.Add(entry);
+                }
+            }
+
+            return (entries, string.Empty);
+        }
+        catch (Exception ex)
+        {
+            return (new List<PluginCatalogEntry>(), $"{source}: {ex.Message}");
+        }
     }
 
     private static async Task<string> FetchStringAsync(string source)

--- a/src/plugins/samandarin/managed/ThemeHelper.cs
+++ b/src/plugins/samandarin/managed/ThemeHelper.cs
@@ -436,13 +436,13 @@ internal static class ThemeHelper
     {
         public ThemePalette(Color background, Color foreground, Color highlightBackground, Color highlightForeground, Color accent)
         {
-            Background = background;
-            Foreground = foreground;
+            IsDark = ComputeLuminance(background) < 128;
+            Background = IsDark ? background : SystemColors.Control;
+            Foreground = IsDark ? foreground : SystemColors.ControlText;
             HighlightBackground = highlightBackground;
             HighlightForeground = highlightForeground;
             Accent = accent;
 
-            IsDark = ComputeLuminance(background) < 128;
             ControlBackground = IsDark ? Lighten(background, 0.08) : SystemColors.Control;
             ControlBorder = IsDark ? Lighten(background, 0.16) : SystemColors.ControlDark;
             InputBackground = IsDark ? Lighten(background, 0.12) : SystemColors.Window;


### PR DESCRIPTION
### Motivation
- Restore correct light-mode chrome while keeping the ListView/input background white, eliminate hover repaint flicker in the Plugin Updates list, and improve perceived loading responsiveness when fetching plugin catalogs.

### Description
- Update `ThemeHelper` so dialog chrome uses `SystemColors.Control`/`ControlText` in light mode while `InputBackground` remains the explicit window/input color.
- Enable double-buffering for the owner-drawn ListView via `EnableSmoothListViewPainting` and call it for the updates `_listView` to reduce hover flicker.
- Improve `PluginUpdatesDialog.RefreshAsync` by adding `SetLoadingState` to disable the ListView/filter/buttons and show the wait cursor during loading, call `BindRows()` early to display rows quickly, and defer image fetching using `EnsureCatalogImagesAsync` plus `RefreshCatalogImages` to update icons after rows are visible.
- Parallelize catalog manifest loading in `PluginCatalogService.CheckAsync` by adding `FetchCatalogSourceAsync` and using `Task.WhenAll` to fetch multiple catalog sources concurrently.

### Testing
- Ran `git diff --check` which reported no problems.
- Attempted `dotnet build src/plugins/samandarin/managed/Samandarin.Managed.csproj` but the build could not be run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a619367b86883299f9d96280524a05f)