### PR TITLE
Skip SFTP projects in manual workflow builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -119,8 +119,33 @@ jobs:
 
           Add-Content -Path $env:GITHUB_ENV -Value "LOG_PATH=$txtLog"
 
-          $buildPath = if ('${{ github.event_name }}' -eq 'workflow_dispatch') { $env:SOLUTION_PATH } else { $env:PROJECT_PATH }
-          Write-Host "Building $buildPath"
+          $buildPath = $env:PROJECT_PATH
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
+            $solutionPath = Join-Path (Get-Location) $env:SOLUTION_PATH
+            $solutionDir = Split-Path -Parent $solutionPath
+            $solutionFilterPath = Join-Path $solutionDir 'salamand-without-sftp.slnf'
+            $projects = Select-String -LiteralPath $solutionPath -Pattern '^Project\("\{[^}]+\}"\) = "([^"]+)", "([^"]+)", "\{[^}]+\}"' |
+              ForEach-Object {
+                [pscustomobject]@{
+                  Name = $_.Matches[0].Groups[1].Value
+                  Path = $_.Matches[0].Groups[2].Value
+                }
+              } |
+              Where-Object { $_.Path -match '\.(?:vcxproj|csproj)$' -and $_.Name -notin @('sftp', 'lang_sftp') } |
+              ForEach-Object { $_.Path }
+
+            @{
+              solution = @{
+                path = Split-Path -Leaf $solutionPath
+                projects = @($projects)
+              }
+            } | ConvertTo-Json -Depth 4 | Set-Content -Path $solutionFilterPath -Encoding UTF8
+
+            $buildPath = $solutionFilterPath
+            Write-Host "Building full solution without SFTP projects via $buildPath"
+          } else {
+            Write-Host "Building $buildPath"
+          }
 
           $arguments = @(
             $buildPath

--- a/.github/workflows/pr-msbuild.yml
+++ b/.github/workflows/pr-msbuild.yml
@@ -248,8 +248,30 @@ jobs:
 
           Add-Content -Path $env:GITHUB_ENV -Value "LOG_PATH=$txtLog"
 
+          $solutionPath = Join-Path (Get-Location) $env:SOLUTION_PATH
+          $solutionDir = Split-Path -Parent $solutionPath
+          $solutionFilterPath = Join-Path $solutionDir 'salamand-without-sftp.slnf'
+          $projects = Select-String -LiteralPath $solutionPath -Pattern '^Project\("\{[^}]+\}"\) = "([^"]+)", "([^"]+)", "\{[^}]+\}"' |
+            ForEach-Object {
+              [pscustomobject]@{
+                Name = $_.Matches[0].Groups[1].Value
+                Path = $_.Matches[0].Groups[2].Value
+              }
+            } |
+            Where-Object { $_.Path -match '\.(?:vcxproj|csproj)$' -and $_.Name -notin @('sftp', 'lang_sftp') } |
+            ForEach-Object { $_.Path }
+
+          @{
+            solution = @{
+              path = Split-Path -Leaf $solutionPath
+              projects = @($projects)
+            }
+          } | ConvertTo-Json -Depth 4 | Set-Content -Path $solutionFilterPath -Encoding UTF8
+
+          Write-Host "Building full solution without SFTP projects via $solutionFilterPath"
+
           $arguments = @(
-            $env:SOLUTION_PATH
+            $solutionFilterPath
             '/m'
             '/t:Rebuild'
             "/p:Configuration=$($env:BUILD_CONFIGURATION)"


### PR DESCRIPTION
### Motivation
- Manual `workflow_dispatch` runs for PR Build and CodeQL pull in the SFTP plugin and its heavy vcpkg dependencies, slowing or blocking ad-hoc runs; the intent is to skip SFTP for manual full-solution builds to make them faster and more reliable.
- Keep PR-time and automated analysis behavior unchanged while only altering behavior for manually-triggered builds.

### Description
- Update `.github/workflows/pr-msbuild.yml` to generate a temporary solution filter `salamand-without-sftp.slnf` that excludes the `sftp` and `lang_sftp` projects and build that filter when `github.event_name == 'workflow_dispatch'` instead of the full `.sln`.
- Update `.github/workflows/codeql.yml` so `workflow_dispatch` CodeQL runs create and build the same SFTP-excluding `.slnf`, while non-manual runs continue to build `PROJECT_PATH` as before.
- The change uses PowerShell `Select-String` to enumerate `.sln` Project entries, filters out the SFTP projects, writes a solution filter JSON file, and points `msbuild` at the generated `.slnf`.

### Testing
- Parsed both workflow files with Ruby YAML loader using `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/pr-msbuild.yml .github/workflows/codeql.yml` and both files loaded OK.
- Ran `git diff --check` to ensure no whitespace or diff problems and it reported no issues.
- Attempted a Python YAML parse using `yaml.safe_load`, but the environment lacked `PyYAML` so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61d9591ec483298f0f0d9c89457371)