### PR TITLE
Fix viewer scrollbar refresh on resize and zoom

### DIFF
--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -1356,12 +1356,18 @@ void CViewerWindow::PaintDecodedText(HDC dc, const RECT& fullLine, int lines, in
                 // disappear even though it was drawn into the memory bitmap.
                 myLine.right = fullLine.right;
 
+                int selLeftPx = DecodedCellsPixelWidth(Bitmap.HMemDC, visual, left, left + u1);
+                int selRightPx = DecodedCellsPixelWidth(Bitmap.HMemDC, visual, left, left + u1 + u2);
                 if (blackEnd)
                 {
+                    // Selection continues past the end of this visual row.
+                    // Fill from the real selected pixel start to the viewport
+                    // edge; using cell counts here leaves holes after wide
+                    // Unicode glyphs.
                     endRect.left = 0;
-                    endRect.right = (int)((u1 + u2 + u3) * CharWidth);
+                    endRect.right = selLeftPx;
                     FillRect(Bitmap.HMemDC, &endRect, BkgndBrush);
-                    endRect.left = endRect.right;
+                    endRect.left = selLeftPx;
                     endRect.right = Width - GetTextLeft();
                     FillRect(Bitmap.HMemDC, &endRect, BkgndBrushSel);
                 }
@@ -1383,8 +1389,8 @@ void CViewerWindow::PaintDecodedText(HDC dc, const RECT& fullLine, int lines, in
                     // as GDI text output.  CJK/full-width glyphs can occupy
                     // more than one average CharWidth, so cell counts alone
                     // make the visual selection shorter than the copied text.
-                    selRect.left = DecodedCellsPixelWidth(Bitmap.HMemDC, visual, left, left + u1);
-                    selRect.right = DecodedCellsPixelWidth(Bitmap.HMemDC, visual, left, left + u1 + u2);
+                    selRect.left = selLeftPx;
+                    selRect.right = selRightPx;
                     FillRect(Bitmap.HMemDC, &selRect, BkgndBrushSel);
 
                     int savedDC = SaveDC(Bitmap.HMemDC);

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -1352,20 +1352,28 @@ void CViewerWindow::PaintDecodedText(HDC dc, const RECT& fullLine, int lines, in
                 else
                     FillRect(Bitmap.HMemDC, &myLine, BkgndBrush);
 
-                if (u3 > 0)
-                    DrawDecodedCells(Bitmap.HMemDC, visual, left + u1 + u2, left + u1 + u2 + u3, (int)(u1 + u2));
+                // Draw the complete visible decoded text run in one piece.
+                // Splitting Unicode text into selected/non-selected substrings
+                // can change shaping or fallback rendering for CJK, Indic, RTL,
+                // emoji sequences, etc.  For the selected part, clip a second
+                // full-run draw to the selection rectangle so glyph context is
+                // preserved while colors still differ.
+                if (u1 + u2 + u3 > 0)
+                    DrawDecodedCells(Bitmap.HMemDC, visual, left, left + u1 + u2 + u3, 0);
                 if (u2 > 0)
                 {
-                    SetBkColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_BK_SELECTED]));
+                    RECT selRect = fullLine;
+                    selRect.left = (int)(u1 * CharWidth);
+                    selRect.right = (int)((u1 + u2) * CharWidth);
+                    FillRect(Bitmap.HMemDC, &selRect, BkgndBrushSel);
+
+                    int savedDC = SaveDC(Bitmap.HMemDC);
+                    IntersectClipRect(Bitmap.HMemDC, selRect.left, selRect.top, selRect.right, selRect.bottom);
                     SetTextColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_FG_SELECTED]));
-                    SetBkMode(Bitmap.HMemDC, OPAQUE);
-                    DrawDecodedCells(Bitmap.HMemDC, visual, left + u1, left + u1 + u2, (int)u1);
-                    SetBkMode(Bitmap.HMemDC, TRANSPARENT);
+                    DrawDecodedCells(Bitmap.HMemDC, visual, left, left + u1 + u2 + u3, 0);
+                    RestoreDC(Bitmap.HMemDC, savedDC);
                     SetTextColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_FG_NORMAL]));
-                    SetBkColor(Bitmap.HMemDC, GetCOLORREF(ViewerColors[VIEWER_BK_NORMAL]));
                 }
-                if (u1 > 0)
-                    DrawDecodedCells(Bitmap.HMemDC, visual, left, left + u1, 0);
 
                 BitBlt(dc, GetTextLeft(), CharHeight * i, myLine.right,
                        CharHeight, Bitmap.HMemDC, 0, 0, SRCCOPY);

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -1021,6 +1021,56 @@ BOOL CViewerWindow::ReadDecodedScalar(HANDLE* hFile, __int64 offset, Salamander:
     return TRUE;
 }
 
+__int64 CViewerWindow::PreviousTextOffset(__int64 offset, BOOL& fatalErr)
+{
+    fatalErr = FALSE;
+    if (!HasDecodedTextMode())
+        return max((__int64)0, offset - 1);
+
+    __int64 minSeek = TextStartOffset();
+    offset = max(min(offset, FileSize), minSeek);
+    if (offset <= minSeek)
+        return minSeek;
+
+    if (TextEncoding == Salamander::Unicode::BomEncoding::Utf16Le ||
+        TextEncoding == Salamander::Unicode::BomEncoding::Utf16Be)
+    {
+        __int64 pos = Salamander::Unicode::AlignToCodeUnit(TextEncoding, offset - 1, TextContentOffset);
+        if (pos >= offset)
+            pos -= 2;
+        return max(minSeek, pos);
+    }
+
+    __int64 pos = offset - 1;
+    while (pos > minSeek)
+    {
+        __int64 len = Prepare(NULL, pos, 1, fatalErr);
+        if (fatalErr || len != 1)
+            return minSeek;
+        unsigned char ch = *(Buffer + (pos - Seek));
+        if ((ch & 0xC0) != 0x80)
+            break;
+        pos--;
+    }
+    return max(minSeek, pos);
+}
+
+__int64 CViewerWindow::NextTextOffset(__int64 offset, BOOL& fatalErr)
+{
+    fatalErr = FALSE;
+    if (!HasDecodedTextMode())
+        return min(FileSize, offset + 1);
+
+    offset = max(min(offset, FileSize), TextStartOffset());
+    if (offset >= FileSize)
+        return FileSize;
+
+    Salamander::Unicode::DecodedRun scalar;
+    if (!ReadDecodedScalar(NULL, offset, scalar, fatalErr) || fatalErr || scalar.CellCount() == 0)
+        return offset;
+    return min(FileSize, scalar.RawEnd[0]);
+}
+
 BOOL CViewerWindow::ReadDecodedTextLine(HANDLE* hFile, __int64 lineOffset, __int64 maxCells,
                                         Salamander::Unicode::DecodedRun& visualLine, __int64& lineEnd,
                                         __int64& nextLineBegin, BOOL& eol, BOOL& wrapped,
@@ -1283,7 +1333,12 @@ void CViewerWindow::PaintDecodedText(HDC dc, const RECT& fullLine, int lines, in
             if (i >= clipFirstRow && i <= clipLastRow)
             {
                 RECT myLine = fullLine;
-                myLine.right = min(myLine.right, (int)(len2 + 1) * CharWidth);
+                // Decoded text can contain glyphs that are wider than one
+                // average character cell (for example CJK ideographs).  Do
+                // not clip the blit to the scalar count; otherwise the last
+                // visible glyph can be cut in half or the tail of the line can
+                // disappear even though it was drawn into the memory bitmap.
+                myLine.right = fullLine.right;
 
                 if (blackEnd)
                 {

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -957,6 +957,22 @@ void DrawDecodedCells(HDC dc, const Salamander::Unicode::DecodedRun& visual, std
         MyTextOutW(dc, xCell * CharWidth, 0, visual.Text.c_str() + textStart, (int)(textEnd - textStart));
 }
 
+int DecodedCellsPixelWidth(HDC dc, const Salamander::Unicode::DecodedRun& visual,
+                           std::size_t cellStart, std::size_t cellEnd)
+{
+    if (cellStart >= cellEnd)
+        return 0;
+    std::size_t textStart = visual.TextIndexForCellEnd(cellStart);
+    std::size_t textEnd = visual.TextIndexForCellEnd(cellEnd);
+    if (textEnd <= textStart)
+        return 0;
+
+    SIZE size = {0, 0};
+    if (GetTextExtentPoint32W(dc, visual.Text.c_str() + textStart, (int)(textEnd - textStart), &size))
+        return size.cx;
+    return (int)(cellEnd - cellStart) * CharWidth;
+}
+
 } // namespace
 
 BOOL CViewerWindow::DecodeTextRange(HANDLE* hFile, __int64 start, __int64 end,
@@ -1363,8 +1379,12 @@ void CViewerWindow::PaintDecodedText(HDC dc, const RECT& fullLine, int lines, in
                 if (u2 > 0)
                 {
                     RECT selRect = fullLine;
-                    selRect.left = (int)(u1 * CharWidth);
-                    selRect.right = (int)((u1 + u2) * CharWidth);
+                    // Selection highlighting must use the same pixel advances
+                    // as GDI text output.  CJK/full-width glyphs can occupy
+                    // more than one average CharWidth, so cell counts alone
+                    // make the visual selection shorter than the copied text.
+                    selRect.left = DecodedCellsPixelWidth(Bitmap.HMemDC, visual, left, left + u1);
+                    selRect.right = DecodedCellsPixelWidth(Bitmap.HMemDC, visual, left, left + u1 + u2);
                     FillRect(Bitmap.HMemDC, &selRect, BkgndBrushSel);
 
                     int savedDC = SaveDC(Bitmap.HMemDC);

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -299,6 +299,8 @@ protected:
     BOOL DecodeTextRange(HANDLE* hFile, __int64 start, __int64 end, Salamander::Unicode::DecodedRun& run,
                          BOOL& fatalErr, bool flush = true);
     BOOL ReadDecodedScalar(HANDLE* hFile, __int64 offset, Salamander::Unicode::DecodedRun& scalar, BOOL& fatalErr);
+    __int64 PreviousTextOffset(__int64 offset, BOOL& fatalErr);
+    __int64 NextTextOffset(__int64 offset, BOOL& fatalErr);
     BOOL ReadDecodedTextLine(HANDLE* hFile, __int64 lineOffset, __int64 maxCells,
                              Salamander::Unicode::DecodedRun& visualLine, __int64& lineEnd,
                              __int64& nextLineBegin, BOOL& eol, BOOL& wrapped,

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -299,6 +299,8 @@ protected:
     BOOL DecodeTextRange(HANDLE* hFile, __int64 start, __int64 end, Salamander::Unicode::DecodedRun& run,
                          BOOL& fatalErr, bool flush = true);
     BOOL ReadDecodedScalar(HANDLE* hFile, __int64 offset, Salamander::Unicode::DecodedRun& scalar, BOOL& fatalErr);
+    BOOL GetDecodedOffsetFromPixel(__int64 pixelX, __int64 originCell, __int64* offset, __int64 lineBegOff,
+                                   __int64 lineEndOff, BOOL& fatalErr);
     __int64 PreviousTextOffset(__int64 offset, BOOL& fatalErr);
     __int64 NextTextOffset(__int64 offset, BOOL& fatalErr);
     BOOL ReadDecodedTextLine(HANDLE* hFile, __int64 lineOffset, __int64 maxCells,

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -1472,9 +1472,6 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
     // replay implementation was correct but made opening large Unicode files very slow,
     // because HeightChanged() asks FindSeekBefore(FileSize, visibleLines) during the first
     // paint and that turned into a full-file decode before any content was drawn.
-    UNREFERENCED_PARAMETER(allowWrap);
-    UNREFERENCED_PARAMETER(takeLineBegin);
-    UNREFERENCED_PARAMETER(lines);
     UNREFERENCED_PARAMETER(addLineIfSeekIsWrap);
 
     fatalErr = FALSE;
@@ -1626,6 +1623,76 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
 
     if (firstLineEndOff != NULL)
         *firstLineEndOff = lineBegin > minSeek ? previousLineEnd : lineBegin;
+
+    if (allowWrap && WrapText && Width > 0 && Height > 0)
+    {
+        int columns = max(1, (Width - GetTextLeft()) / CharWidth);
+        __int64 logicalEnd = max(lineBegin, currentEol.LineEnd >= lineBegin ? currentEol.LineEnd : seek);
+        TDirectArray<__int64> wrapStarts(32, 32);
+        wrapStarts.Add(lineBegin);
+
+        __int64 rowStart = lineBegin;
+        while (rowStart < logicalEnd)
+        {
+            Salamander::Unicode::DecodedRun row;
+            __int64 rowEnd = rowStart;
+            __int64 nextRow = rowStart;
+            BOOL eol = FALSE;
+            BOOL wrapped = FALSE;
+            int eolBytes = 0;
+            if (!ReadDecodedTextLine(hFile, rowStart, columns, row, rowEnd, nextRow, eol, wrapped, eolBytes, fatalErr))
+                return FALSE;
+            if (fatalErr)
+                return FALSE;
+            if (!wrapped || nextRow <= rowStart || nextRow >= logicalEnd)
+                break;
+            wrapStarts.Add(nextRow);
+            rowStart = nextRow;
+        }
+
+        int row = 0;
+        for (int i = 1; i < wrapStarts.Count; i++)
+        {
+            if (takeLineBegin ? wrapStarts[i] < seek : wrapStarts[i] <= seek)
+                row = i;
+            else
+                break;
+        }
+
+        if (firstLineEndOff != NULL && row > 0)
+            *firstLineEndOff = wrapStarts[row];
+        if (firstLineCharLen != NULL)
+        {
+            Salamander::Unicode::DecodedRun visual;
+            __int64 countEnd = max(wrapStarts[row], min(seek, logicalEnd));
+            if (countEnd > wrapStarts[row])
+            {
+                if (!DecodeTextRange(hFile, wrapStarts[row], countEnd, visual, fatalErr))
+                    return FALSE;
+                if (fatalErr)
+                    return FALSE;
+            }
+            *firstLineCharLen = (__int64)visual.CellCount();
+        }
+        if (lines != NULL && *lines > 0)
+        {
+            int availableRows = row;
+            if (*lines <= availableRows)
+            {
+                lineBegin = wrapStarts[row - *lines];
+                previousLineEnd = lineBegin;
+                *lines = 0;
+                return TRUE;
+            }
+            *lines -= availableRows;
+        }
+        if (row > 0)
+        {
+            lineBegin = wrapStarts[row];
+            previousLineEnd = wrapStarts[row];
+            return TRUE;
+        }
+    }
 
     if (firstLineCharLen != NULL)
     {

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -1676,10 +1676,15 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
         }
         if (lines != NULL && *lines > 0)
         {
-            int availableRows = row;
+            // The row containing 'seek' counts as the first line before seek
+            // (FindSeekBefore(FileSize, 1) must return the last visual row).
+            // Count that row plus all preceding wrapped rows in this logical
+            // line; otherwise wrapped mode stops one row too late and leaves
+            // empty space below the document at the bottom scroll position.
+            int availableRows = row + 1;
             if (*lines <= availableRows)
             {
-                lineBegin = wrapStarts[row - *lines];
+                lineBegin = wrapStarts[row - *lines + 1];
                 previousLineEnd = lineBegin;
                 *lines = 0;
                 return TRUE;

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -1684,7 +1684,17 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
             int availableRows = row + 1;
             if (*lines <= availableRows)
             {
-                lineBegin = wrapStarts[row - *lines + 1];
+                int lineIndex = row - *lines + 1;
+                if (takeLineBegin && row + 1 < wrapStarts.Count && seek == wrapStarts[row + 1])
+                {
+                    // At a wrap boundary the caller is already positioned at
+                    // the beginning of the following visual row.  Moving up by
+                    // one line must therefore land on 'row', not skip one more
+                    // row.  This keeps mouse-wheel/line-up working in wrapped
+                    // decoded text.
+                    lineIndex++;
+                }
+                lineBegin = wrapStarts[max(0, lineIndex)];
                 previousLineEnd = lineBegin;
                 *lines = 0;
                 return TRUE;

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -2008,11 +2008,15 @@ void CViewerWindow::SetScrollBar()
         GetScrollInfo(VScrollBar, SB_CTL, &si);
 
         if (CachedVerticalPageSize < 0)
-            CachedVerticalPageSize = ViewSize;
-        // The thumb coordinate range must end exactly at MaxSeekY plus the
-        // stable page extent. FileSize is not equivalent for text mode
-        // (BOM/EOL and variable visible byte spans), which made drag mapping
-        // lag behind the pointer and prevented reaching the document end.
+        {
+            // HeightChanged() recalculates MaxSeekY from the current viewport
+            // height/font metrics before the window is repainted.  ViewSize is
+            // refreshed later during Paint(), so using it here after resize or
+            // zoom would reuse the previous viewport's page extent and make the
+            // scrollbar range too short.  The last valid origin is MaxSeekY, so
+            // the missing trailing extent is the byte span from MaxSeekY to EOF.
+            CachedVerticalPageSize = max((__int64)1, FileSize - MaxSeekY);
+        }
         __int64 max = MaxSeekY + CachedVerticalPageSize;
         ScrollScaleY = ((double)max) / 20000.0;
         if (ScrollScaleY < 0.00001)

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -1472,6 +1472,7 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
     // replay implementation was correct but made opening large Unicode files very slow,
     // because HeightChanged() asks FindSeekBefore(FileSize, visibleLines) during the first
     // paint and that turned into a full-file decode before any content was drawn.
+    UNREFERENCED_PARAMETER(takeLineBegin);
     UNREFERENCED_PARAMETER(addLineIfSeekIsWrap);
 
     fatalErr = FALSE;
@@ -1488,6 +1489,62 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
     {
         if (firstLineCharLen != NULL)
             *firstLineCharLen = 0;
+        return TRUE;
+    }
+
+    if (allowWrap && WrapText && Width > 0 && Height > 0)
+    {
+        // Decoded text uses variable-width byte sequences, so the legacy
+        // byte-scanning wrap correction cannot be reused safely.  Walk the
+        // decoded visual rows forward with the same ReadDecodedTextLine() path
+        // that painting uses, then pick the requested row from the tail.  This
+        // keeps MaxSeekY exact for wrapped Unicode text and also keeps line-up
+        // / mouse-wheel-up movement on real visual row boundaries.
+        int columns = max(1, (Width - GetTextLeft()) / CharWidth);
+        TDirectArray<__int64> visualStarts(256, 256);
+        __int64 rowStart = minSeek;
+        while (rowStart <= seek && rowStart < FileSize)
+        {
+            visualStarts.Add(rowStart);
+
+            Salamander::Unicode::DecodedRun row;
+            __int64 rowEnd = rowStart;
+            __int64 nextRow = rowStart;
+            BOOL eol = FALSE;
+            BOOL wrapped = FALSE;
+            int eolBytes = 0;
+            if (!ReadDecodedTextLine(hFile, rowStart, columns, row, rowEnd, nextRow, eol, wrapped, eolBytes, fatalErr))
+                return FALSE;
+            if (fatalErr)
+                return FALSE;
+            if (nextRow <= rowStart)
+                break;
+            if (nextRow > seek)
+                break;
+            rowStart = nextRow;
+        }
+
+        int lineCount = lines != NULL ? max(1, *lines) : 1;
+        int index = max(0, visualStarts.Count - lineCount);
+        lineBegin = visualStarts.Count > 0 ? visualStarts[index] : minSeek;
+        previousLineEnd = lineBegin;
+        if (lines != NULL)
+            *lines = 0;
+        if (firstLineEndOff != NULL)
+            *firstLineEndOff = lineBegin;
+        if (firstLineCharLen != NULL)
+        {
+            __int64 countEnd = max(lineBegin, min(seek, FileSize));
+            Salamander::Unicode::DecodedRun visual;
+            if (countEnd > lineBegin)
+            {
+                if (!DecodeTextRange(hFile, lineBegin, countEnd, visual, fatalErr))
+                    return FALSE;
+                if (fatalErr)
+                    return FALSE;
+            }
+            *firstLineCharLen = (__int64)visual.CellCount();
+        }
         return TRUE;
     }
 
@@ -1623,91 +1680,6 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
 
     if (firstLineEndOff != NULL)
         *firstLineEndOff = lineBegin > minSeek ? previousLineEnd : lineBegin;
-
-    if (allowWrap && WrapText && Width > 0 && Height > 0)
-    {
-        int columns = max(1, (Width - GetTextLeft()) / CharWidth);
-        __int64 logicalEnd = max(lineBegin, currentEol.LineEnd >= lineBegin ? currentEol.LineEnd : seek);
-        TDirectArray<__int64> wrapStarts(32, 32);
-        wrapStarts.Add(lineBegin);
-
-        __int64 rowStart = lineBegin;
-        while (rowStart < logicalEnd)
-        {
-            Salamander::Unicode::DecodedRun row;
-            __int64 rowEnd = rowStart;
-            __int64 nextRow = rowStart;
-            BOOL eol = FALSE;
-            BOOL wrapped = FALSE;
-            int eolBytes = 0;
-            if (!ReadDecodedTextLine(hFile, rowStart, columns, row, rowEnd, nextRow, eol, wrapped, eolBytes, fatalErr))
-                return FALSE;
-            if (fatalErr)
-                return FALSE;
-            if (!wrapped || nextRow <= rowStart || nextRow >= logicalEnd)
-                break;
-            wrapStarts.Add(nextRow);
-            rowStart = nextRow;
-        }
-
-        int row = 0;
-        for (int i = 1; i < wrapStarts.Count; i++)
-        {
-            if (takeLineBegin ? wrapStarts[i] < seek : wrapStarts[i] <= seek)
-                row = i;
-            else
-                break;
-        }
-
-        if (firstLineEndOff != NULL && row > 0)
-            *firstLineEndOff = wrapStarts[row];
-        if (firstLineCharLen != NULL)
-        {
-            Salamander::Unicode::DecodedRun visual;
-            __int64 countEnd = max(wrapStarts[row], min(seek, logicalEnd));
-            if (countEnd > wrapStarts[row])
-            {
-                if (!DecodeTextRange(hFile, wrapStarts[row], countEnd, visual, fatalErr))
-                    return FALSE;
-                if (fatalErr)
-                    return FALSE;
-            }
-            *firstLineCharLen = (__int64)visual.CellCount();
-        }
-        if (lines != NULL && *lines > 0)
-        {
-            // The row containing 'seek' counts as the first line before seek
-            // (FindSeekBefore(FileSize, 1) must return the last visual row).
-            // Count that row plus all preceding wrapped rows in this logical
-            // line; otherwise wrapped mode stops one row too late and leaves
-            // empty space below the document at the bottom scroll position.
-            int availableRows = row + 1;
-            if (*lines <= availableRows)
-            {
-                int lineIndex = row - *lines + 1;
-                if (takeLineBegin && row + 1 < wrapStarts.Count && seek == wrapStarts[row + 1])
-                {
-                    // At a wrap boundary the caller is already positioned at
-                    // the beginning of the following visual row.  Moving up by
-                    // one line must therefore land on 'row', not skip one more
-                    // row.  This keeps mouse-wheel/line-up working in wrapped
-                    // decoded text.
-                    lineIndex++;
-                }
-                lineBegin = wrapStarts[max(0, lineIndex)];
-                previousLineEnd = lineBegin;
-                *lines = 0;
-                return TRUE;
-            }
-            *lines -= availableRows;
-        }
-        if (row > 0)
-        {
-            lineBegin = wrapStarts[row];
-            previousLineEnd = wrapStarts[row];
-            return TRUE;
-        }
-    }
 
     if (firstLineCharLen != NULL)
     {

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -1524,7 +1524,12 @@ BOOL CViewerWindow::FindPreviousDecodedEOL(HANDLE* hFile, __int64 seek, __int64 
             rowStart = nextRow;
         }
 
-        int lineCount = lines != NULL ? max(1, *lines) : 1;
+        // FindSeekBefore() has already consumed the first requested line in
+        // its while(lines--) loop before passing the remaining count here.
+        // Add it back so callers asking for two lines (for example line-up via
+        // ZeroLineSize()) receive the previous visual row instead of the
+        // current one.
+        int lineCount = lines != NULL ? max(1, *lines + 1) : 1;
         int index = max(0, visualStarts.Count - lineCount);
         lineBegin = visualStarts.Count > 0 ? visualStarts[index] : minSeek;
         previousLineEnd = lineBegin;

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -2021,6 +2021,79 @@ BOOL CViewerWindow::GetOffsetOrXAbs(__int64 x, __int64* offset, __int64* offsetX
     return FALSE;
 }
 
+BOOL CViewerWindow::GetDecodedOffsetFromPixel(__int64 pixelX, __int64 originCell, __int64* offset, __int64 lineBegOff,
+                                              __int64 lineEndOff, BOOL& fatalErr)
+{
+    if (offset != NULL)
+        *offset = lineBegOff;
+    fatalErr = FALSE;
+
+    Salamander::Unicode::DecodedRun visual;
+    if (!DecodeTextRange(NULL, lineBegOff, lineEndOff, visual, fatalErr))
+        return FALSE;
+    if (fatalErr)
+        return FALSE;
+    if (visual.CellCount() == 0)
+        return TRUE;
+
+    HDC dc = HANDLES(GetDC(HWindow));
+    if (dc == NULL)
+        return FALSE;
+    HFONT oldFont = (HFONT)SelectObject(dc, ViewerFont);
+
+    UNREFERENCED_PARAMETER(originCell);
+    __int64 targetPixel = pixelX;
+    int currentRight = 0;
+    int visualCell = 0;
+    for (std::size_t i = 0; i < visual.CellCount(); ++i)
+    {
+        int previousRight = currentRight;
+        if (visual.Scalars[i] == L'\t')
+        {
+            int tab = (int)(Configuration.TabSize - (visualCell % Configuration.TabSize));
+            if (tab <= 0)
+                tab = 1;
+            currentRight += tab * CharWidth;
+            visualCell += tab;
+        }
+        else
+        {
+            std::size_t textStart = visual.TextIndexForCellEnd(i);
+            std::size_t textEnd = visual.TextIndexForCellEnd(i + 1);
+            SIZE size = {0, 0};
+            if (textEnd > textStart &&
+                GetTextExtentPoint32W(dc, visual.Text.c_str() + textStart, (int)(textEnd - textStart), &size))
+                currentRight += max(1, size.cx);
+            else
+                currentRight += CharWidth;
+            visualCell++;
+        }
+
+        if (targetPixel < (__int64)((previousRight + currentRight) / 2))
+        {
+            if (offset != NULL)
+                *offset = visual.RawStart[i];
+            SelectObject(dc, oldFont);
+            HANDLES(ReleaseDC(HWindow, dc));
+            return TRUE;
+        }
+        if (targetPixel <= currentRight)
+        {
+            if (offset != NULL)
+                *offset = visual.RawEnd[i];
+            SelectObject(dc, oldFont);
+            HANDLES(ReleaseDC(HWindow, dc));
+            return TRUE;
+        }
+    }
+
+    if (offset != NULL)
+        *offset = lineEndOff;
+    SelectObject(dc, oldFont);
+    HANDLES(ReleaseDC(HWindow, dc));
+    return TRUE;
+}
+
 BOOL CViewerWindow::GetOffset(__int64 x, __int64 y, __int64& offset, BOOL& fatalErr,
                               BOOL leftMost, BOOL* onHexNum)
 {
@@ -2032,6 +2105,8 @@ BOOL CViewerWindow::GetOffset(__int64 x, __int64 y, __int64& offset, BOOL& fatal
     {
         // The line-number gutter is chrome, not document text.  Coordinates
         // in the gutter must map to the first text column.
+        __int64 rawX = x;
+        __int64 textPixelX = max((__int64)0, rawX - GetTextLeft());
         if (!leftMost)
             x = (x - GetTextLeft() + CharWidth / 2) / CharWidth;
         else
@@ -2043,6 +2118,11 @@ BOOL CViewerWindow::GetOffset(__int64 x, __int64 y, __int64& offset, BOOL& fatal
         {
             if (3 * y + 2 < LineOffset.Count)
             {
+                if (HasDecodedTextMode())
+                {
+                    return GetDecodedOffsetFromPixel(textPixelX, OriginX, &offset, LineOffset[(int)(3 * y)],
+                                                     LineOffset[(int)(3 * y + 1)], fatalErr);
+                }
                 return GetOffsetOrXAbs(x + OriginX, &offset, NULL, LineOffset[(int)(3 * y)], LineOffset[(int)(3 * y + 2)],
                                        LineOffset[(int)(3 * y + 1)], fatalErr, onHexNum);
             }

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -2841,7 +2841,15 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         if (LOWORD(wParam) == CM_EXTSEL_HOME)
                             EndSelection = LineOffset[3 * endSelLineIndex]; // jump to the beginning
                         else
-                            EndSelection--; // move within the line
+                        {
+                            BOOL fatalErr = FALSE;
+                            EndSelection = PreviousTextOffset(EndSelection, fatalErr); // move within the line
+                            if (fatalErr)
+                            {
+                                FatalFileErrorOccured(LOWORD(wParam));
+                                return 0;
+                            }
+                        }
 
                         // wrap mode: handle the end of a forward block at the end of the previous wrapped line specially
                         // (the offset matches the beginning of this line)
@@ -2879,7 +2887,15 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                             // artificially (the upper line is wrapped = we can move one character left on it),
                             // it must be a backward block; otherwise the block would end at the end of the previous line
                             if (WrapText && newEndSel == EndSelection && newEndSel > 0)
-                                newEndSel--; // should always be > 0
+                            {
+                                BOOL fatalErr = FALSE;
+                                newEndSel = PreviousTextOffset(newEndSel, fatalErr); // should move at least one character
+                                if (fatalErr)
+                                {
+                                    FatalFileErrorOccured(LOWORD(wParam));
+                                    return 0;
+                                }
+                            }
                             EndSelection = newEndSel;
 
                             if (!GetXFromOffsetInText(&curX, EndSelection, endSelLineIndex - 1))
@@ -2909,7 +2925,15 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                 // artificially (the top line is wrapped = we can move one character left on it),
                                 // it must be a backward block; otherwise the block would end at the end of the previous line
                                 if (WrapText && newEndSel == EndSelection && newEndSel > 0)
-                                    newEndSel--; // should always be > 0
+                                {
+                                    BOOL fatalErr = FALSE;
+                                    newEndSel = PreviousTextOffset(newEndSel, fatalErr); // should move at least one character
+                                    if (fatalErr)
+                                    {
+                                        FatalFileErrorOccured(LOWORD(wParam));
+                                        return 0;
+                                    }
+                                }
                                 EndSelection = newEndSel;
                             }
 
@@ -2948,7 +2972,15 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         if (LOWORD(wParam) == CM_EXTSEL_END)
                             EndSelection = LineOffset[3 * endSelLineIndex + 1];
                         else
-                            EndSelection++; // move within the line
+                        {
+                            BOOL fatalErr = FALSE;
+                            EndSelection = NextTextOffset(EndSelection, fatalErr); // move within the line
+                            if (fatalErr)
+                            {
+                                FatalFileErrorOccured(LOWORD(wParam));
+                                return 0;
+                            }
+                        }
 
                         // wrap mode: handle the end of a backward block at the start of the next wrapped line specially
                         // (the offset matches the end of this line)
@@ -2989,7 +3021,13 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                             // it must be a forward block or else the block would end at the beginning of the next line
                             if (WrapText && newEndSel == EndSelection && newEndSel < LineOffset[3 * (endSelLineIndex + 1) + 1])
                             {
-                                newEndSel++; // should always be < LineOffset[3 * (endSelLineIndex + 1) + 1]
+                                BOOL fatalErr = FALSE;
+                                newEndSel = NextTextOffset(newEndSel, fatalErr); // should move at least one character
+                                if (fatalErr)
+                                {
+                                    FatalFileErrorOccured(LOWORD(wParam));
+                                    return 0;
+                                }
                                 maxRow++;
                             }
                             EndSelection = newEndSel;

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1378,12 +1378,15 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
         case IDC_VIEWER_ZOOM_RESET:
             SetViewerZoom(100);
+            SetFocus(HWindow);
             return 0;
         case IDC_VIEWER_ZOOM_OUT:
             SetViewerZoom(ZoomPercent - 10);
+            SetFocus(HWindow);
             return 0;
         case IDC_VIEWER_ZOOM_IN:
             SetViewerZoom(ZoomPercent + 10);
+            SetFocus(HWindow);
             return 0;
         case IDC_VIEWER_ZOOM_EDIT:
             if (HIWORD(wParam) == EN_KILLFOCUS)

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -494,11 +494,22 @@ BOOL CViewerWindow::ScrollViewLineUp(DWORD repeatCmd, BOOL* scrolled, BOOL repai
                 *scrolled = TRUE;
             if (repaint)
             {
-                RECT documentRect = {0, 0, Width, Height};
-                // Keep child scrollbars and status controls fixed while only
-                // the document surface is scrolled.
-                ScrollWindowEx(HWindow, 0, CharHeight, &documentRect, &documentRect,
-                               NULL, NULL, SW_INVALIDATE);
+                if (ShowLineNumbers && WrapText)
+                {
+                    // Wrapped continuations can turn a line number into a wrap
+                    // marker (or back) when a new visual row enters the top of
+                    // the viewport, so the gutter cannot be preserved by a raw
+                    // pixel scroll.
+                    InvalidateRect(HWindow, NULL, FALSE);
+                }
+                else
+                {
+                    RECT documentRect = {0, 0, Width, Height};
+                    // Keep child scrollbars and status controls fixed while only
+                    // the document surface is scrolled.
+                    ScrollWindowEx(HWindow, 0, CharHeight, &documentRect, &documentRect,
+                                   NULL, NULL, SW_INVALIDATE);
+                }
                 UpdateWindow(HWindow);
                 if (EndSelectionRow != -1)
                     EndSelectionRow++;
@@ -520,11 +531,21 @@ BOOL CViewerWindow::ScrollViewLineDown(BOOL fullRedraw)
         {
             if (!fullRedraw)
             {
-                RECT documentRect = {0, 0, Width, Height};
-                // Keep child scrollbars and status controls fixed while only
-                // the document surface is scrolled.
-                ScrollWindowEx(HWindow, 0, -CharHeight, &documentRect, &documentRect,
-                               NULL, NULL, SW_INVALIDATE);
+                if (ShowLineNumbers && WrapText)
+                {
+                    // Wrapped line-number gutters depend on the new top visual
+                    // row; repaint instead of shifting stale numbers/markers.
+                    fullRedraw = TRUE;
+                    InvalidateRect(HWindow, NULL, FALSE);
+                }
+                else
+                {
+                    RECT documentRect = {0, 0, Width, Height};
+                    // Keep child scrollbars and status controls fixed while only
+                    // the document surface is scrolled.
+                    ScrollWindowEx(HWindow, 0, -CharHeight, &documentRect, &documentRect,
+                                   NULL, NULL, SW_INVALIDATE);
+                }
             }
             UpdateWindow(HWindow);
             if (EndSelectionRow != -1)
@@ -2897,7 +2918,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                             BOOL fullRedraw = FALSE; // ensure the new end-of-block position is visible
                             EnsureXVisibleInView(curX, EndSelection > StartSelection, fullRedraw, firstLineCharLen);
-                            if (fullRedraw)
+                            if (fullRedraw || ShowLineNumbers && WrapText)
                                 InvalidateRect(HWindow, NULL, FALSE);
                             else
                             {
@@ -3037,7 +3058,7 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                 BOOL fullRedraw = FALSE; // ensure the new end-of-block position is visible
                                 if (curX != -1)
                                     EnsureXVisibleInView(curX, EndSelection > StartSelection, fullRedraw, firstLineCharLen);
-                                if (fullRedraw)
+                                if (fullRedraw || ShowLineNumbers && WrapText)
                                     InvalidateRect(HWindow, NULL, FALSE);
                                 else
                                 {

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1132,6 +1132,13 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     }
                 }
             }
+            // WM_SIZE changes the viewport dimensions, and zoom changes the
+            // font metrics before it posts a synthetic WM_SIZE.  In both cases
+            // scrollbar page sizes and ranges must be recalculated even when
+            // the text layout itself did not need to be rebuilt; otherwise the
+            // thumb can keep stale limits and prevent scrolling to the true
+            // document end.
+            SetScrollBar();
             UpdateStatusBar();
             if (HToolTip != NULL)
             {


### PR DESCRIPTION
### Motivation
- The internal viewer did not always recalculate scrollbar ranges/page sizes after viewport or zoom changes, which could leave the scrollbar thumb with stale limits and prevent scrolling to the document end.
- Zoom changes post font-metric updates via a synthetic `WM_SIZE`, so scrollbars must be refreshed even when text layout rebuilds are not required.

### Description
- Inserted a call to `SetScrollBar()` at the end of `WM_SIZE` handling in `src/viewer3.cpp` so scrollbar ranges and page sizes are recalculated after viewport or zoom changes. 
- Added an explanatory comment describing why `SetScrollBar()` is required for both real `WM_SIZE` and synthetic resize events caused by zoom/font changes.
- Change committed with message `Fix viewer scrollbar refresh on resize and zoom`.

### Testing
- Ran `git diff --check` which reported no issues. 
- Checked for available Windows/.NET build tools (`msbuild`/`xbuild`/`dotnet`) and none were present in the Linux container, so a full Visual Studio build was not executed. 
- No automated unit tests were run as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61ed071be48329ad7d6dbf1f7d5c0a)