### PR TITLE
Support HTML-aware translations for Internal Viewer zoom hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       </ul>
     </li>
     <li>Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.</li>
-    <li data-i18n-html>Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.</li>
+    <li>Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.</li>
     <li>Optional line numbers for easier navigation in text files.</li>
   </ul>
   <img alt="Internal Viewer with Unicode text, status bar, zoom settings, and line numbers" src="https://github.com/user-attachments/assets/66a19715-e1c4-47bc-9613-b050575fa5e6">

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       </ul>
     </li>
     <li>Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.</li>
-    <li>Zoom text with <kbd>Ctrl</kbd> + mouse wheel or <kbd>Ctrl</kbd> + <kbd>Num +</kbd>/<kbd>Num -</kbd>. Zoom reset with <kbd>Ctrl</kbd> + <kbd>Num 0</kbd>.</li>
+    <li data-i18n-html>Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.</li>
     <li>Optional line numbers for easier navigation in text files.</li>
   </ul>
   <img alt="Internal Viewer with Unicode text, status bar, zoom settings, and line numbers" src="https://github.com/user-attachments/assets/66a19715-e1c4-47bc-9613-b050575fa5e6">

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1606,6 +1606,7 @@
       "Internal Viewer": "Interní prohlížeč",
       "Support for Unicode encoding in text files.": "Podpora Unicode kódování v textových souborech.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Volitelný stavový řádek s číslem řádku/sloupce, počítáním vybraných znaků a řádků a nastavením přiblížení.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Přibližování textu pomocí <code>Ctrl + kolečka myši</code> nebo <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Obnovení přiblížení pomocí <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Přibližování textu pomocí",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ kolečka myši.",
@@ -1623,6 +1624,7 @@
       "Internal Viewer": "Interne viewer",
       "Support for Unicode encoding in text files.": "Ondersteuning voor Unicode-codering in tekstbestanden.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Optionele statusbalk met regel-/kolomnummer, telling van geselecteerde tekens en regels en zoominstellingen.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Zoom tekst met <code>Ctrl + muiswiel</code> of <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom resetten met <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Zoom tekst met",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ muiswiel.",
@@ -1640,6 +1642,7 @@
       "Internal Viewer": "Visionneuse interne",
       "Support for Unicode encoding in text files.": "Prise en charge de l’encodage Unicode dans les fichiers texte.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Barre d’état facultative avec numéro de ligne/colonne, comptage des caractères et lignes sélectionnés, et réglages de zoom.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Zoom du texte avec <code>Ctrl + molette de la souris</code> ou <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Réinitialisation du zoom avec <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Zoom du texte avec",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ molette de la souris.",
@@ -1657,6 +1660,7 @@
       "Internal Viewer": "Interner Viewer",
       "Support for Unicode encoding in text files.": "Unterstützung für Unicode-Kodierung in Textdateien.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Optionale Statusleiste mit Zeilen-/Spaltennummer, Zählung ausgewählter Zeichen und Zeilen sowie Zoomeinstellungen.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Text zoomen mit <code>Strg + Mausrad</code> oder <code>Strg + Num +</code>/<code>Strg + Num -</code>. Zoom zurücksetzen mit <code>Strg + Num 0</code>.",
       "Zoom text with": "Text zoomen mit",
       "Ctrl": "Strg",
       "+ mouse wheel.": "+ Mausrad.",
@@ -1674,6 +1678,7 @@
       "Internal Viewer": "Belső megjelenítő",
       "Support for Unicode encoding in text files.": "Unicode kódolás támogatása szövegfájlokban.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Opcionális állapotsor sor-/oszlopszámmal, a kijelölt karakterek és sorok számával, valamint nagyítási beállításokkal.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Szöveg nagyítása <code>Ctrl + egérgörgővel</code> vagy <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Nagyítás visszaállítása <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Szöveg nagyítása",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ egérgörgő használatával.",
@@ -1691,6 +1696,7 @@
       "Internal Viewer": "内部查看器",
       "Support for Unicode encoding in text files.": "支持文本文件中的 Unicode 编码。",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "可选状态栏，可显示行/列编号、所选字符和行数以及缩放设置。",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "使用 <code>Ctrl + 鼠标滚轮</code> 或 <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code> 缩放文本。使用 <code>Ctrl + Num 0</code> 重置缩放。",
       "Zoom text with": "使用",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ 鼠标滚轮缩放文本。",
@@ -1708,6 +1714,7 @@
       "Internal Viewer": "Vizualizator intern",
       "Support for Unicode encoding in text files.": "Suport pentru codificarea Unicode în fișiere text.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Bară de stare opțională cu numărul liniei/coloanei, numărarea caracterelor și liniilor selectate și setări de zoom.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Mărește textul cu <code>Ctrl + rotița mouse-ului</code> sau <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Resetare zoom cu <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Mărește textul cu",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ rotița mouse-ului.",
@@ -1725,6 +1732,7 @@
       "Internal Viewer": "Внутренний просмотрщик",
       "Support for Unicode encoding in text files.": "Поддержка кодировки Unicode в текстовых файлах.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Необязательная строка состояния с номером строки/столбца, подсчетом выбранных символов и строк, а также настройками масштаба.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Масштабирование текста с помощью <code>Ctrl + колесика мыши</code> или <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Сброс масштаба с помощью <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Масштабирование текста с помощью",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ колесика мыши.",
@@ -1742,6 +1750,7 @@
       "Internal Viewer": "Interný prehliadač",
       "Support for Unicode encoding in text files.": "Podpora Unicode kódovania v textových súboroch.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Voliteľný stavový riadok s číslom riadka/stĺpca, počítaním vybraných znakov a riadkov a nastaveniami priblíženia.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Približovanie textu pomocou <code>Ctrl + kolieska myši</code> alebo <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Obnovenie priblíženia pomocou <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Približovanie textu pomocou",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ kolieska myši.",
@@ -1759,6 +1768,7 @@
       "Internal Viewer": "Visor interno",
       "Support for Unicode encoding in text files.": "Compatibilidad con codificación Unicode en archivos de texto.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Barra de estado opcional con número de línea/columna, recuento de caracteres y líneas seleccionados y ajustes de zoom.",
+      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Zoom del texto con <code>Ctrl + rueda del ratón</code> o <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Restablecer zoom con <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Zoom del texto con",
       "Ctrl": "Ctrl",
       "+ mouse wheel.": "+ rueda del ratón.",
@@ -1914,6 +1924,7 @@
 
   const translatableTextNodes = [];
   const translatableAttributes = [];
+  const translatableHtmlElements = [];
 
   const rememberOriginalAttributes = (root = document.body) => {
     for (const element of root.querySelectorAll("[alt], [title], [aria-label]")) {
@@ -1971,6 +1982,10 @@
       element.textContent = translateText(source, selected).trim();
     }
 
+    for (const element of translatableHtmlElements) {
+      element.innerHTML = translateText(element.dataset.i18nHtmlSource, selected).trim();
+    }
+
     for (const element of document.querySelectorAll("[data-i18n-attr]")) {
       for (const mapping of element.dataset.i18nAttr.split(",")) {
         const [attr, source] = mapping.split(":").map((part) => part.trim());
@@ -1985,6 +2000,11 @@
   const setupSelector = () => {
     for (const element of document.querySelectorAll("[data-i18n]")) {
       element.dataset.i18nSource = element.textContent.trim();
+    }
+
+    for (const element of document.querySelectorAll("[data-i18n-html]")) {
+      element.dataset.i18nHtmlSource = element.innerHTML.trim();
+      translatableHtmlElements.push(element);
     }
 
     const selector = document.getElementById("language-select");

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1606,11 +1606,9 @@
       "Internal Viewer": "Interní prohlížeč",
       "Support for Unicode encoding in text files.": "Podpora Unicode kódování v textových souborech.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Volitelný stavový řádek s číslem řádku/sloupce, počítáním vybraných znaků a řádků a nastavením přiblížení.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Přibližování textu pomocí <code>Ctrl + kolečka myši</code> nebo <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Obnovení přiblížení pomocí <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Přibližování textu pomocí",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ kolečka myši.",
-      "+ mouse wheel or": "+ kolečka myši nebo",
+      "or": "nebo",
       ". Zoom reset with": ". Obnovení přiblížení pomocí",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Interní prohlížeč s Unicode textem, stavovým řádkem, nastavením přiblížení a čísly řádků",
       "Optional line numbers for easier navigation in text files.": "Volitelné číslování řádků pro snazší orientaci v textových souborech.",
@@ -1624,11 +1622,9 @@
       "Internal Viewer": "Interne viewer",
       "Support for Unicode encoding in text files.": "Ondersteuning voor Unicode-codering in tekstbestanden.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Optionele statusbalk met regel-/kolomnummer, telling van geselecteerde tekens en regels en zoominstellingen.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Zoom tekst met <code>Ctrl + muiswiel</code> of <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom resetten met <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Zoom tekst met",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ muiswiel.",
-      "+ mouse wheel or": "+ muiswiel of",
+      "or": "of",
       ". Zoom reset with": ". Zoom resetten met",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Interne viewer met Unicode-tekst, statusbalk, zoominstellingen en regelnummers",
       "Optional line numbers for easier navigation in text files.": "Optionele regelnummers voor eenvoudiger navigeren in tekstbestanden.",
@@ -1642,11 +1638,9 @@
       "Internal Viewer": "Visionneuse interne",
       "Support for Unicode encoding in text files.": "Prise en charge de l’encodage Unicode dans les fichiers texte.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Barre d’état facultative avec numéro de ligne/colonne, comptage des caractères et lignes sélectionnés, et réglages de zoom.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Zoom du texte avec <code>Ctrl + molette de la souris</code> ou <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Réinitialisation du zoom avec <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Zoom du texte avec",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ molette de la souris.",
-      "+ mouse wheel or": "+ molette de la souris ou",
+      "or": "ou",
       ". Zoom reset with": ". Réinitialisation du zoom avec",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Visionneuse interne avec texte Unicode, barre d’état, réglages de zoom et numéros de ligne",
       "Optional line numbers for easier navigation in text files.": "Numéros de ligne facultatifs pour faciliter la navigation dans les fichiers texte.",
@@ -1660,11 +1654,9 @@
       "Internal Viewer": "Interner Viewer",
       "Support for Unicode encoding in text files.": "Unterstützung für Unicode-Kodierung in Textdateien.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Optionale Statusleiste mit Zeilen-/Spaltennummer, Zählung ausgewählter Zeichen und Zeilen sowie Zoomeinstellungen.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Text zoomen mit <code>Strg + Mausrad</code> oder <code>Strg + Num +</code>/<code>Strg + Num -</code>. Zoom zurücksetzen mit <code>Strg + Num 0</code>.",
       "Zoom text with": "Text zoomen mit",
       "Ctrl": "Strg",
-      "+ mouse wheel.": "+ Mausrad.",
-      "+ mouse wheel or": "+ Mausrad oder",
+      "or": "oder",
       ". Zoom reset with": ". Zoom zurücksetzen mit",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Interner Viewer mit Unicode-Text, Statusleiste, Zoomeinstellungen und Zeilennummern",
       "Optional line numbers for easier navigation in text files.": "Optionale Zeilennummern für eine einfachere Navigation in Textdateien.",
@@ -1678,11 +1670,9 @@
       "Internal Viewer": "Belső megjelenítő",
       "Support for Unicode encoding in text files.": "Unicode kódolás támogatása szövegfájlokban.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Opcionális állapotsor sor-/oszlopszámmal, a kijelölt karakterek és sorok számával, valamint nagyítási beállításokkal.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Szöveg nagyítása <code>Ctrl + egérgörgővel</code> vagy <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Nagyítás visszaállítása <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Szöveg nagyítása",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ egérgörgő használatával.",
-      "+ mouse wheel or": "+ egérgörgővel vagy",
+      "or": "vagy",
       ". Zoom reset with": ". Nagyítás visszaállítása",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Belső megjelenítő Unicode szöveggel, állapotsorral, nagyítási beállításokkal és sorszámokkal",
       "Optional line numbers for easier navigation in text files.": "Opcionális sorszámok a szövegfájlokban való könnyebb navigációhoz.",
@@ -1696,11 +1686,9 @@
       "Internal Viewer": "内部查看器",
       "Support for Unicode encoding in text files.": "支持文本文件中的 Unicode 编码。",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "可选状态栏，可显示行/列编号、所选字符和行数以及缩放设置。",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "使用 <code>Ctrl + 鼠标滚轮</code> 或 <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code> 缩放文本。使用 <code>Ctrl + Num 0</code> 重置缩放。",
       "Zoom text with": "使用",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ 鼠标滚轮缩放文本。",
-      "+ mouse wheel or": "+ 鼠标滚轮或",
+      "or": "或",
       ". Zoom reset with": "。使用以下组合重置缩放",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "带 Unicode 文本、状态栏、缩放设置和行号的内部查看器",
       "Optional line numbers for easier navigation in text files.": "可选行号，便于在文本文件中导航。",
@@ -1714,11 +1702,9 @@
       "Internal Viewer": "Vizualizator intern",
       "Support for Unicode encoding in text files.": "Suport pentru codificarea Unicode în fișiere text.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Bară de stare opțională cu numărul liniei/coloanei, numărarea caracterelor și liniilor selectate și setări de zoom.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Mărește textul cu <code>Ctrl + rotița mouse-ului</code> sau <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Resetare zoom cu <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Mărește textul cu",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ rotița mouse-ului.",
-      "+ mouse wheel or": "+ rotița mouse-ului sau",
+      "or": "sau",
       ". Zoom reset with": ". Resetare zoom cu",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Vizualizator intern cu text Unicode, bară de stare, setări de zoom și numere de linie",
       "Optional line numbers for easier navigation in text files.": "Numere de linie opționale pentru navigare mai ușoară în fișiere text.",
@@ -1732,11 +1718,9 @@
       "Internal Viewer": "Внутренний просмотрщик",
       "Support for Unicode encoding in text files.": "Поддержка кодировки Unicode в текстовых файлах.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Необязательная строка состояния с номером строки/столбца, подсчетом выбранных символов и строк, а также настройками масштаба.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Масштабирование текста с помощью <code>Ctrl + колесика мыши</code> или <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Сброс масштаба с помощью <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Масштабирование текста с помощью",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ колесика мыши.",
-      "+ mouse wheel or": "+ колесика мыши или",
+      "or": "или",
       ". Zoom reset with": ". Сброс масштаба с помощью",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Внутренний просмотрщик с Unicode-текстом, строкой состояния, настройками масштаба и номерами строк",
       "Optional line numbers for easier navigation in text files.": "Необязательные номера строк для более удобной навигации по текстовым файлам.",
@@ -1750,11 +1734,9 @@
       "Internal Viewer": "Interný prehliadač",
       "Support for Unicode encoding in text files.": "Podpora Unicode kódovania v textových súboroch.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Voliteľný stavový riadok s číslom riadka/stĺpca, počítaním vybraných znakov a riadkov a nastaveniami priblíženia.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Približovanie textu pomocou <code>Ctrl + kolieska myši</code> alebo <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Obnovenie priblíženia pomocou <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Približovanie textu pomocou",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ kolieska myši.",
-      "+ mouse wheel or": "+ kolieska myši alebo",
+      "or": "alebo",
       ". Zoom reset with": ". Obnovenie priblíženia pomocou",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Interný prehliadač s Unicode textom, stavovým riadkom, nastaveniami priblíženia a číslami riadkov",
       "Optional line numbers for easier navigation in text files.": "Voliteľné číslovanie riadkov pre jednoduchšiu orientáciu v textových súboroch.",
@@ -1768,11 +1750,9 @@
       "Internal Viewer": "Visor interno",
       "Support for Unicode encoding in text files.": "Compatibilidad con codificación Unicode en archivos de texto.",
       "Optional status bar with Line/Column number, counting selected characters and lines, zoom settings.": "Barra de estado opcional con número de línea/columna, recuento de caracteres y líneas seleccionados y ajustes de zoom.",
-      "Zoom text with <code>Ctrl + mouse wheel</code> or <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Zoom reset with <code>Ctrl + Num 0</code>.": "Zoom del texto con <code>Ctrl + rueda del ratón</code> o <code>Ctrl + Num +</code>/<code>Ctrl + Num -</code>. Restablecer zoom con <code>Ctrl + Num 0</code>.",
       "Zoom text with": "Zoom del texto con",
       "Ctrl": "Ctrl",
-      "+ mouse wheel.": "+ rueda del ratón.",
-      "+ mouse wheel or": "+ rueda del ratón o",
+      "or": "o",
       ". Zoom reset with": ". Restablecer zoom con",
       "Internal Viewer with Unicode text, status bar, zoom settings, and line numbers": "Visor interno con texto Unicode, barra de estado, ajustes de zoom y números de línea",
       "Optional line numbers for easier navigation in text files.": "Números de línea opcionales para navegar más fácilmente en archivos de texto.",
@@ -1924,7 +1904,6 @@
 
   const translatableTextNodes = [];
   const translatableAttributes = [];
-  const translatableHtmlElements = [];
 
   const rememberOriginalAttributes = (root = document.body) => {
     for (const element of root.querySelectorAll("[alt], [title], [aria-label]")) {
@@ -1982,10 +1961,6 @@
       element.textContent = translateText(source, selected).trim();
     }
 
-    for (const element of translatableHtmlElements) {
-      element.innerHTML = translateText(element.dataset.i18nHtmlSource, selected).trim();
-    }
-
     for (const element of document.querySelectorAll("[data-i18n-attr]")) {
       for (const mapping of element.dataset.i18nAttr.split(",")) {
         const [attr, source] = mapping.split(":").map((part) => part.trim());
@@ -2000,11 +1975,6 @@
   const setupSelector = () => {
     for (const element of document.querySelectorAll("[data-i18n]")) {
       element.dataset.i18nSource = element.textContent.trim();
-    }
-
-    for (const element of document.querySelectorAll("[data-i18n-html]")) {
-      element.dataset.i18nHtmlSource = element.innerHTML.trim();
-      translatableHtmlElements.push(element);
     }
 
     const selector = document.getElementById("language-select");


### PR DESCRIPTION
### Motivation
- Make the Internal Viewer zoom hint use inline `<code>` markup and ensure that localized translations can preserve that markup.  
- Prevent the localization pipeline from flattening inline code when applying translations.  
- Provide translated HTML-aware copies of the updated hint for all supported non-English locales so the UI remains correct in other languages.

### Description
- Replace the original `<kbd>`-based hint in `index.html` with an HTML-aware element by switching to `<code>` markup and adding `data-i18n-html` to the list item.  
- Add explicit full-HTML translation entries for the updated zoom hint to `js/i18n.js` for the supported locales.  
- Introduce `translatableHtmlElements` plus logic in the i18n setup to capture each element's `innerHTML` into `dataset.i18nHtmlSource` and restore translated `innerHTML` in `applyLocale`.  
- Wire the new HTML-aware translation flow into the existing `translateText`/`applyLocale` pipeline so translations preserve inline markup.

### Testing
- Ran `node --check js/i18n.js` which completed successfully.  
- Executed a Python validation script that asserted the new `data-i18n-html` line exists in `index.html` and that locale keys were added to `js/i18n.js`, and the checks passed.  
- Ran `git diff --check` to verify no whitespace/conflict issues, and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61f2c3babc832981616ad8f4ad26ad)