### PR TITLE
Use system theme when splash config is missing

### DIFF
--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -4895,10 +4895,17 @@ FIND_NEW_SLG_FILE:
                                          WasRestrictedFileStorageImported();
     Configuration.StorageType = storageType;
 
-    // Read UseWindowsDarkMode from configstorage.ini for splash screen theme
+    // Read UseWindowsDarkMode from configstorage.ini for splash screen theme.
+    // If the bootstrap value is missing, follow the current system dark-mode
+    // preference so the splash screen does not always fall back to light mode.
     BOOL useDarkFromConfig;
     if (ConfigurationStorage.LoadUseWindowsDarkMode(useDarkFromConfig))
         Configuration.UseWindowsDarkMode = useDarkFromConfig;
+    else
+    {
+        DarkModeDetectAndEnableSystemDarkMode();
+        Configuration.UseWindowsDarkMode = DarkModeShouldUseDarkColors() ? TRUE : FALSE;
+    }
 
     // Compute forceWelcomeDialog early so we can skip the splash screen on first run
     static char portableConfigPath[SAL_MAX_PATH];


### PR DESCRIPTION
### Motivation
- When `configstorage.ini` does not contain `SplashScreen/UseWindowsDarkMode`, the splash screen always fell back to light mode; the desired behavior is to follow the current system dark-mode preference instead.

### Description
- Update `src/salamdr1.cpp` so that if `ConfigurationStorage.LoadUseWindowsDarkMode(...)` fails, the code calls `DarkModeDetectAndEnableSystemDarkMode()` and sets `Configuration.UseWindowsDarkMode` based on `DarkModeShouldUseDarkColors()`, thereby using the system theme for the splash fallback.

### Testing
- Ran `git diff --check`, `git status --short`, and `git log -1 --oneline`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62368ad37c8329989a23baee127ccf)