### PR TITLE
Add Log View Mode to internal viewer

### DIFF
--- a/src/lang/lang.rc2
+++ b/src/lang/lang.rc2
@@ -33,6 +33,7 @@ IDM_VIEWERMENU MENU
  {
   MENUITEM "&Open...\tCtrl+O", CM_OPENFILE
   MENUITEM "&Refresh\tCtrl+R", CM_REREADFILE
+  MENUITEM "&Log View Mode", CM_LOGVIEWMODE
   MENUITEM SEPARATOR
   
 // POZOR: pokud se zmeni index tohoto submenu, je potreba zmenit VIEWER_FILE_MENU_OTHFILESINDEX

--- a/src/resource.rh2
+++ b/src/resource.rh2
@@ -691,11 +691,13 @@
 #define CM_EXTSEL_FILEEND     6100
 #define CM_VIEW_LINENUMBERS   6101
 #define CM_VIEW_STATUSBAR     6102
+#define CM_LOGVIEWMODE       6103
 
 
 // timers
 #define IDT_AUTOSCROLL        6200
 #define IDT_THUMBSCROLL       6201
+#define IDT_LOGVIEWREFRESH    6202
 
 //#define CM_TEXTS_MIN               10000    // interval vyhrazeny pro texty
 //#define CM_TEXTS_MAX               18000

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -721,6 +721,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     WrapText = Configuration.WrapText;
     ShowLineNumbers = Configuration.ViewerShowLineNumbers;
     ShowStatusBar = Configuration.ViewerShowStatusBar;
+    LogViewMode = FALSE;
     LineNumberDigits = 1;
     CodePageAutoSelect = Configuration.CodePageAutoSelect;
     strcpy(DefaultConvert, Configuration.DefaultConvert);

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -325,6 +325,8 @@ protected:
     void SetViewerZoom(int percent);
     void LayoutStatusBar();
     void UpdateStatusBar(__int64 offset = -1);
+    void SetLogViewMode(BOOL enable);
+    void RefreshLogView();
     int GetTextLeft() const;
     __int64 GetDocumentLineNumber(__int64 offset, __int64* lineStart = NULL);
 
@@ -398,6 +400,7 @@ protected:
     BOOL WrapText; // local copy of Configuration.WrapText
     BOOL ShowLineNumbers;
     BOOL ShowStatusBar;
+    BOOL LogViewMode;
     int LineNumberDigits;
 
     BOOL CodePageAutoSelect;  // local copy of Configuration.CodePageAutoSelect

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -328,6 +328,51 @@ void CViewerWindow::ConfigHasChanged()
     InvalidateRect(HWindow, NULL, FALSE);
 }
 
+void CViewerWindow::SetLogViewMode(BOOL enable)
+{
+    if (LogViewMode == enable)
+        return;
+
+    LogViewMode = enable;
+    if (LogViewMode)
+    {
+        SetTimer(HWindow, IDT_LOGVIEWREFRESH, 1000, NULL);
+        RefreshLogView();
+    }
+    else
+        KillTimer(HWindow, IDT_LOGVIEWREFRESH);
+}
+
+void CViewerWindow::RefreshLogView()
+{
+    if (MouseDrag || FileName == NULL)
+        return;
+
+    ExitTextMode = FALSE;
+    ForceTextMode = FALSE;
+
+    BOOL fatalErr = FALSE;
+    FileChanged(NULL, FALSE, fatalErr, FALSE);
+    if (fatalErr)
+        FatalFileErrorOccured();
+    if (fatalErr || ExitTextMode)
+        return;
+
+    GoToEnd();
+    if (Type == vtText)
+    {
+        SeekY = FindBegin(SeekY, fatalErr);
+        if (fatalErr)
+            FatalFileErrorOccured();
+        if (fatalErr || ExitTextMode)
+            return;
+    }
+
+    ResetFindOffsetOnNextPaint = TRUE;
+    InvalidateRect(HWindow, NULL, FALSE);
+    UpdateWindow(HWindow);
+}
+
 __int64
 CViewerWindow::Prepare(HANDLE* hFile, __int64 offset, __int64 bytes, BOOL& fatalErr)
 {

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -2500,6 +2500,12 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
 
+        case CM_LOGVIEWMODE:
+        {
+            SetLogViewMode(!LogViewMode);
+            return 0;
+        }
+
         case CM_VIEWERHLP_KEYBOARD:
         {
             OpenHtmlHelp(NULL, HWindow, HHCDisplayContext, IDH_VIEWERKEYBOARD, FALSE);
@@ -3567,6 +3573,12 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
 
+        if (wParam == IDT_LOGVIEWREFRESH)
+        {
+            RefreshLogView();
+            return 0;
+        }
+
         if (wParam != IDT_AUTOSCROLL)
             break;
         POINT p;
@@ -3841,6 +3853,8 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     EnableMenuItem(othFilesMenu, CM_FIRSTFILE, MF_BYCOMMAND | (firstLastFile ? MF_ENABLED : MF_GRAYED));
                     EnableMenuItem(othFilesMenu, CM_LASTFILE, MF_BYCOMMAND | (firstLastFile ? MF_ENABLED : MF_GRAYED));
                 }
+                CheckMenuItem(subMenu, CM_LOGVIEWMODE, MF_BYCOMMAND | (LogViewMode ? MF_CHECKED : MF_UNCHECKED));
+                EnableMenuItem(subMenu, CM_LOGVIEWMODE, MF_BYCOMMAND | (FileName != NULL ? MF_ENABLED : MF_GRAYED));
             }
             subMenu = GetSubMenu(main, VIEW_MENU_INDEX);
             if (subMenu != NULL)
@@ -4202,6 +4216,7 @@ MENU_TEMPLATE_ITEM ViewerCodingMenu[] =
 
     case WM_DESTROY:
     {
+        KillTimer(HWindow, IDT_LOGVIEWREFRESH);
         // The scrollbar hook stores HWNDs.  Remove this entry before Windows
         // can recycle the handle for an unrelated top-level dialog.
         DarkModeDisallowDarkScrollbars(HWindow);


### PR DESCRIPTION
### Motivation
- Provide a realtime/tail-like "Log View Mode" for the internal viewer so a viewed file can auto-refresh and scroll to the end for monitoring growing log files.

### Description
- Add a new menu item `"Log View Mode"` under File and reserve `CM_LOGVIEWMODE` and `IDT_LOGVIEWREFRESH` resource IDs in `src/lang/lang.rc2` and `src/resource.rh2`.
- Add `LogViewMode` state to `CViewerWindow` and initialize it in the constructor (`src/viewer.h`, `src/viewer.cpp`).
- Implement `SetLogViewMode(BOOL)` and `RefreshLogView()` in `src/viewer2.cpp` to toggle a 1s timer (`SetTimer`/`KillTimer`) and to refresh/jump to file end safely (honors `MouseDrag`, `FileName == NULL`, file errors, and text/hex mode transitions).
- Wire the command and timer handling in `src/viewer3.cpp` by handling `CM_LOGVIEWMODE`, responding to `WM_TIMER` with `IDT_LOGVIEWREFRESH`, updating the menu check/enabled state, and cleaning up the timer on `WM_DESTROY`.

### Testing
- Ran a static diff/format check with `git diff --check` and inspected the resulting diffs (no whitespace or merge markers reported).
- Verified resource ID uniqueness with a small Python check script that parsed `src/resource.rh2` for `#define` collisions (no conflicts reported). 
- Attempted a full build with `msbuild` (`src/vcxproj/salamand.sln`) but `msbuild` is not available in this container, so a local Windows build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62c1ac7cbc83298ad7c771c5e3beda)