### PR TITLE
Exclude SFTP projects from CodeQL solution build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,9 @@ jobs:
 
     env:
       BUILD_CONFIGURATION: Release
+      # SFTP is not part of CodeQL coverage; keep this off so the workflow does
+      # not prepare the SFTP plugin or install its vcpkg dependencies.
+      BUILD_SFTP_PLUGIN: 'false'
       PROJECT_PATH: '.\\src\\vcxproj\\salamand.vcxproj'
       SOLUTION_PATH: '.\\src\\vcxproj\\salamand.sln'
       LOG_DIRECTORY: build_logs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -123,25 +123,51 @@ jobs:
           if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
             $solutionPath = Join-Path (Get-Location) $env:SOLUTION_PATH
             $solutionDir = Split-Path -Parent $solutionPath
-            $solutionFilterPath = Join-Path $solutionDir 'salamand-without-sftp.slnf'
-            $projects = Select-String -LiteralPath $solutionPath -Pattern '^Project\("\{[^}]+\}"\) = "([^"]+)", "([^"]+)", "\{[^}]+\}"' |
-              ForEach-Object {
-                [pscustomobject]@{
-                  Name = $_.Matches[0].Groups[1].Value
-                  Path = $_.Matches[0].Groups[2].Value
+            $solutionBuildPath = Join-Path $solutionDir 'salamand-codeql-without-sftp.sln'
+            $excludedProjects = @{
+              '514DA5DF-C9D5-4A39-9BE6-CBCFA6CE0D5A' = 'sftp'
+              '2D3A2ADD-498B-4420-8E08-6A9FC9C09D5E' = 'lang_sftp'
+            }
+            $excludedProjectGuids = $excludedProjects.Keys | ForEach-Object { $_.ToUpperInvariant() }
+            $projectHeaderPattern = '^Project\("\{[^}]+\}"\) = "([^"]+)", "([^"]+)", "\{([^}]+)\}"'
+            $lines = Get-Content -LiteralPath $solutionPath
+            $filteredLines = New-Object System.Collections.Generic.List[string]
+            $skipProjectBlock = $false
+
+            foreach ($line in $lines) {
+              if ($line -match $projectHeaderPattern) {
+                $projectName = $Matches[1]
+                $projectGuid = $Matches[3].ToUpperInvariant()
+                $skipProjectBlock = $excludedProjectGuids -contains $projectGuid
+
+                if ($skipProjectBlock) {
+                  Write-Host "Excluding CodeQL project from solution build: $projectName ($($excludedProjects[$projectGuid]))"
+                  continue
                 }
-              } |
-              Where-Object { $_.Path -match '\.(?:vcxproj|csproj)$' -and $_.Name -notin @('sftp', 'lang_sftp') } |
-              ForEach-Object { $_.Path }
-
-            @{
-              solution = @{
-                path = Split-Path -Leaf $solutionPath
-                projects = @($projects)
               }
-            } | ConvertTo-Json -Depth 4 | Set-Content -Path $solutionFilterPath -Encoding UTF8
 
-            $buildPath = $solutionFilterPath
+              if ($skipProjectBlock) {
+                if ($line -eq 'EndProject') {
+                  $skipProjectBlock = $false
+                }
+                continue
+              }
+
+              $referencesExcludedProject = $false
+              foreach ($projectGuid in $excludedProjectGuids) {
+                if ($line -match [regex]::Escape("{$projectGuid}")) {
+                  $referencesExcludedProject = $true
+                  break
+                }
+              }
+
+              if (-not $referencesExcludedProject) {
+                $filteredLines.Add($line)
+              }
+            }
+
+            $filteredLines | Set-Content -Path $solutionBuildPath -Encoding UTF8
+            $buildPath = $solutionBuildPath
             Write-Host "Building full solution without SFTP projects via $buildPath"
           } else {
             Write-Host "Building $buildPath"


### PR DESCRIPTION
### Motivation
- CodeQL workflow MSBuild was failing because the solution references SFTP projects (`sftp`, `lang_sftp`) whose .vcxproj files are missing, causing analysis runs to error. 
- The goal is to avoid building SFTP-related projects during CodeQL runs so the scan can complete successfully for the rest of the solution.

### Description
- For `workflow_dispatch` builds the workflow now generates a temporary sanitized solution file `salamand-codeql-without-sftp.sln` instead of creating a `.slnf`. 
- The workflow adds an explicit list of excluded SFTP project GUIDs and filters the original `.sln` by removing entire `Project(...) ... EndProject` blocks whose GUIDs match the excluded set. 
- The filter also drops any lines that reference the excluded GUIDs so the resulting `.sln` contains no residual references to the SFTP projects. 
- MSBuild is invoked on the sanitized solution file so missing `sftp.vcxproj` / `lang_sftp.vcxproj` no longer cause CodeQL build failures.

### Testing
- A `python3` assertion script verified the updated workflow contains the temporary solution filename and the two excluded SFTP GUIDs and it passed. 
- A local diff and `nl` output were inspected to confirm the inserted PowerShell filtering code appears at the expected lines and was written to the workflow file. 
- PowerShell validation could not be executed locally because `pwsh` is not installed in this environment, so runtime execution of the PowerShell logic was not tested here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62cc473b508329aae575e384424e3f)