### PR TITLE
Make Salamatrix language examples collapsible

### DIFF
--- a/js/language-examples.js
+++ b/js/language-examples.js
@@ -1,0 +1,10 @@
+const openTargetedLanguageExample = () => {
+  const target = document.getElementById(decodeURIComponent(location.hash.slice(1)));
+
+  if (target?.matches("details.language-example")) {
+    target.open = true;
+  }
+};
+
+openTargetedLanguageExample();
+window.addEventListener("hashchange", openTargetedLanguageExample);

--- a/salamatrix/salamatrix-ui.html
+++ b/salamatrix/salamatrix-ui.html
@@ -104,8 +104,8 @@
       <h2 id="languages">Build it in every supported language</h2>
       <p>The examples below show the same origin group and Close button. The complete demo files add the static-text, hyperlink, progress, toolbar-header, and color-arrow portions using the same pattern.</p>
 
-      <article class="language-example" id="javascript">
-        <header><span class="language-badge">JS</span><div><h3>JavaScript / Node</h3><p>Async facade; create first, then await every host operation.</p></div></header>
+      <details class="language-example" id="javascript">
+        <summary><span class="language-badge">JS</span><div><h3>JavaScript / Node</h3><p>Async facade; create first, then await every host operation.</p></div></summary>
         <pre><code>if (Salamander.command_handler === "run") {
   await Salamander.ui.notify(
     "Node.js extension package is running through Salamatrix.",
@@ -186,10 +186,10 @@
         <div class="language-example__visual">
           <img src="../images/salamatrix_preview_jsnode.png" alt="JavaScript/Node preview">
         </div>
-      </article>
+      </details>
 
-      <article class="language-example" id="python">
-        <header><span class="language-badge">PY</span><div><h3>Python</h3><p>Synchronous facade with a Python options dictionary.</p></div></header>
+      <details class="language-example" id="python">
+        <summary><span class="language-badge">PY</span><div><h3>Python</h3><p>Synchronous facade with a Python options dictionary.</p></div></summary>
         <pre><code>import time
 
 Salamander.ui.notify("CPython extension package is running through Salamatrix.", "Salamatrix Python Demo", 2500)
@@ -266,10 +266,10 @@ finally:
         <div class="language-example__visual">
           <img src="../images/salamatrix_preview_python.png" alt="Python preview">
         </div>
-      </article>
+      </details>
 
-      <article class="language-example" id="powershell">
-        <header><span class="language-badge">PS</span><div><h3>PowerShell</h3><p>Layout and extended properties are ordinary hashtables.</p></div></header>
+      <details class="language-example" id="powershell">
+        <summary><span class="language-badge">PS</span><div><h3>PowerShell</h3><p>Layout and extended properties are ordinary hashtables.</p></div></summary>
         <pre><code>if ($Salamander.command_handler -eq 'run') {
     $Salamander.ui.Notify('PowerShell extension package is running through Salamatrix.', 'Salamatrix PowerShell Demo', 2500)
     $progress = $Salamander.ui.Progress('Salamatrix PowerShell Progress Demo', 5)
@@ -343,10 +343,10 @@ finally:
         <div class="language-example__visual">
           <img src="../images/salamatrix_preview_powershell.png" alt="PowerShell preview">
         </div>
-      </article>
+      </details>
 
-      <article class="language-example" id="php">
-        <header><span class="language-badge">PHP</span><div><h3>PHP</h3><p>The last argument is the common extended option map.</p></div></header>
+      <details class="language-example" id="php">
+        <summary><span class="language-badge">PHP</span><div><h3>PHP</h3><p>The last argument is the common extended option map.</p></div></summary>
         <pre><code>&lt;?php
 if ($Salamander->command_handler === 'run') {
     $Salamander->ui->notify('PHP CLI extension package is running through Salamatrix.', 'Salamatrix PHP Demo', 2500);
@@ -423,10 +423,10 @@ if ($Salamander->command_handler === 'run') {
         <div class="language-example__visual">
           <img src="../images/salamatrix_preview_php.png" alt="PHP preview">
         </div>
-      </article>
+      </details>
 
-      <article class="language-example" id="lua">
-        <header><span class="language-badge">LUA</span><div><h3>Lua</h3><p>Snake-case options map to the same SMX1 payload.</p></div></header>
+      <details class="language-example" id="lua">
+        <summary><span class="language-badge">LUA</span><div><h3>Lua</h3><p>Snake-case options map to the same SMX1 payload.</p></div></summary>
         <pre><code>if Salamander.command_handler == "run" then
     Salamander.ui.notify(
         "Lua extension package is running through Salamatrix.",
@@ -514,10 +514,10 @@ end
         <div class="language-example__visual">
           <img src="../images/salamatrix_preview_lua.png" alt="Lua preview">
         </div>
-      </article>
+      </details>
 
-      <article class="language-example" id="automation">
-        <header><span class="language-badge">COM</span><div><h3>Automation JScript</h3><p>A thin COM adapter over the same native service.</p></div></header>
+      <details class="language-example" id="automation">
+        <summary><span class="language-badge">COM</span><div><h3>Automation JScript</h3><p>A thin COM adapter over the same native service.</p></div></summary>
         <pre><code>// Demonstrates the Salamatrix-backed Automation API.
 // Requires the Salamatrix Framework plugin to be installed and loaded.
 
@@ -620,10 +620,10 @@ try { dialog.show(); } finally { dialog.close(); }</code></pre>
         <div class="language-example__visual">
           <img src="../images/salamatrix_preview_automation.png" alt="Automation JScript preview">
         </div>
-      </article>
+      </details>
 
-      <article class="language-example" id="native">
-        <header><span class="language-badge">C++</span><div><h3>Native plugin</h3><p>Version negotiation and direct <code>IDialog</code>/<code>IControl</code> use.</p></div></header>
+      <details class="language-example" id="native">
+        <summary><span class="language-badge">C++</span><div><h3>Native plugin</h3><p>Version negotiation and direct <code>IDialog</code>/<code>IControl</code> use.</p></div></summary>
         <pre><code>static Salamatrix::UI::IControl* AddSalamatrixDemoControl(
     Salamatrix::UI::IDialog* dialog, Salamatrix::UI::ControlKind kind,
     const char* id, const char* text, int x, int y, int width, int height)
@@ -717,7 +717,7 @@ static BOOL ShowDemoPlugSalamatrixControls(
         <div class="language-example__visual">
           <img src="../images/salamatrix_preview_native.png" alt="Native plugin preview">
         </div>
-      </article>
+      </details>
 
       <h2 id="appearance">Dark mode, DPI, keyboard, accessibility</h2>
       <div class="card-grid">
@@ -754,5 +754,6 @@ static BOOL ShowDemoPlugSalamatrixControls(
 
   <a class="back-to-top" href="#content" aria-label="Back to top" title="Back to top" data-back-to-top>↑</a>
   <script src="../js/back-to-top.js" defer></script>
+  <script src="../js/language-examples.js" defer></script>
 </body>
 </html>

--- a/salamatrix/salamatrix-ui.html
+++ b/salamatrix/salamatrix-ui.html
@@ -106,6 +106,10 @@
 
       <details class="language-example" id="javascript">
         <summary><span class="language-badge">JS</span><div><h3>JavaScript / Node</h3><p>Async facade; create first, then await every host operation.</p></div></summary>
+        <div class="language-example__visual">
+          <img src="../images/salamatrix_preview_jsnode.png" alt="JavaScript/Node preview">
+        </div>
+        <h4>Node.js script source code example:</h4>
         <pre><code>if (Salamander.command_handler === "run") {
   await Salamander.ui.notify(
     "Node.js extension package is running through Salamatrix.",
@@ -183,13 +187,14 @@
   try { await dialog.show(); } finally { await dialog.close(); }
 }
 </code></pre>
-        <div class="language-example__visual">
-          <img src="../images/salamatrix_preview_jsnode.png" alt="JavaScript/Node preview">
-        </div>
       </details>
 
       <details class="language-example" id="python">
         <summary><span class="language-badge">PY</span><div><h3>Python</h3><p>Synchronous facade with a Python options dictionary.</p></div></summary>
+        <div class="language-example__visual">
+          <img src="../images/salamatrix_preview_python.png" alt="Python preview">
+        </div>
+        <h4>Python script source code example:</h4>
         <pre><code>import time
 
 Salamander.ui.notify("CPython extension package is running through Salamatrix.", "Salamatrix Python Demo", 2500)
@@ -263,13 +268,14 @@ try:
     dialog.show()
 finally:
     dialog.close()</code></pre>
-        <div class="language-example__visual">
-          <img src="../images/salamatrix_preview_python.png" alt="Python preview">
-        </div>
       </details>
 
       <details class="language-example" id="powershell">
         <summary><span class="language-badge">PS</span><div><h3>PowerShell</h3><p>Layout and extended properties are ordinary hashtables.</p></div></summary>
+        <div class="language-example__visual">
+          <img src="../images/salamatrix_preview_powershell.png" alt="PowerShell preview">
+        </div>
+        <h4>PowerShell script source code example:</h4>
         <pre><code>if ($Salamander.command_handler -eq 'run') {
     $Salamander.ui.Notify('PowerShell extension package is running through Salamatrix.', 'Salamatrix PowerShell Demo', 2500)
     $progress = $Salamander.ui.Progress('Salamatrix PowerShell Progress Demo', 5)
@@ -340,13 +346,14 @@ finally:
     Add-CapabilityControl button close Close 403 213 50 14 @{dialogResult=1;styleFlags=0x100000}
     try { [void]$dialog.Show() } finally { $dialog.Close() }
 }</code></pre>
-        <div class="language-example__visual">
-          <img src="../images/salamatrix_preview_powershell.png" alt="PowerShell preview">
-        </div>
       </details>
 
       <details class="language-example" id="php">
         <summary><span class="language-badge">PHP</span><div><h3>PHP</h3><p>The last argument is the common extended option map.</p></div></summary>
+        <div class="language-example__visual">
+          <img src="../images/salamatrix_preview_php.png" alt="PHP preview">
+        </div>
+        <h4>PHP script source code example:</h4>
         <pre><code>&lt;?php
 if ($Salamander->command_handler === 'run') {
     $Salamander->ui->notify('PHP CLI extension package is running through Salamatrix.', 'Salamatrix PHP Demo', 2500);
@@ -420,13 +427,14 @@ if ($Salamander->command_handler === 'run') {
     $add('button','close','Close',403,213,50,14,array('dialogResult'=>1,'styleFlags'=>0x100000));
     try { $dialog->show(); } finally { $dialog->close(); }
 }</code></pre>
-        <div class="language-example__visual">
-          <img src="../images/salamatrix_preview_php.png" alt="PHP preview">
-        </div>
       </details>
 
       <details class="language-example" id="lua">
         <summary><span class="language-badge">LUA</span><div><h3>Lua</h3><p>Snake-case options map to the same SMX1 payload.</p></div></summary>
+        <div class="language-example__visual">
+          <img src="../images/salamatrix_preview_lua.png" alt="Lua preview">
+        </div>
+        <h4>LUA script source code example:</h4>
         <pre><code>if Salamander.command_handler == "run" then
     Salamander.ui.notify(
         "Lua extension package is running through Salamatrix.",
@@ -511,13 +519,14 @@ if ($Salamander->command_handler === 'run') {
     if not shown then error(show_error) end
 end
 </code></pre>
-        <div class="language-example__visual">
-          <img src="../images/salamatrix_preview_lua.png" alt="Lua preview">
-        </div>
       </details>
 
       <details class="language-example" id="automation">
         <summary><span class="language-badge">COM</span><div><h3>Automation JScript</h3><p>A thin COM adapter over the same native service.</p></div></summary>
+        <div class="language-example__visual">
+          <img src="../images/salamatrix_preview_automation.png" alt="Automation JScript preview">
+        </div>
+        <h4>JavaScript source code example:</h4>
         <pre><code>// Demonstrates the Salamatrix-backed Automation API.
 // Requires the Salamatrix Framework plugin to be installed and loaded.
 
@@ -617,13 +626,14 @@ add("label","runtime-label","Runtime:",277,181,42,8); add("statictext","runtime-
 add("label","extension-label","Extension:",277,192,42,8); add("statictext","extension-value","Salamatrix Progress Demo",323,192,122,8,2);
 add("button","close","Close",403,213,50,14,0x100000,1);
 try { dialog.show(); } finally { dialog.close(); }</code></pre>
-        <div class="language-example__visual">
-          <img src="../images/salamatrix_preview_automation.png" alt="Automation JScript preview">
-        </div>
       </details>
 
       <details class="language-example" id="native">
         <summary><span class="language-badge">C++</span><div><h3>Native plugin</h3><p>Version negotiation and direct <code>IDialog</code>/<code>IControl</code> use.</p></div></summary>
+        <div class="language-example__visual">
+          <img src="../images/salamatrix_preview_native.png" alt="Native plugin preview">
+        </div>
+        <h4>Native C++ source code example:</h4>
         <pre><code>static Salamatrix::UI::IControl* AddSalamatrixDemoControl(
     Salamatrix::UI::IDialog* dialog, Salamatrix::UI::ControlKind kind,
     const char* id, const char* text, int x, int y, int width, int height)
@@ -714,9 +724,6 @@ static BOOL ShowDemoPlugSalamatrixControls(
     ui->DestroyDialog(dialog);
     return complete;
 }</code></pre>
-        <div class="language-example__visual">
-          <img src="../images/salamatrix_preview_native.png" alt="Native plugin preview">
-        </div>
       </details>
 
       <h2 id="appearance">Dark mode, DPI, keyboard, accessibility</h2>

--- a/salamatrix/style.css
+++ b/salamatrix/style.css
@@ -205,12 +205,24 @@ a:hover .runtime-pill span, a:hover .runtime-pill strong { text-decoration: none
 .identity-grid article { display: flex; flex-direction: column; gap: 5px; padding: 13px; background: linear-gradient(145deg, #303030, #242424); border: 1px solid #4a4a4a; border-radius: 4px; }
 .identity-grid b { color: #f35353; font-size: .86rem; }
 .identity-grid span { color: var(--sam-muted); font-size: .78rem; }
-.language-example { margin: 18px 0 28px; background: #252525; border: 1px solid #474747; border-radius: 6px; overflow: hidden; }
-.language-example > header { display: flex; align-items: center; gap: 13px; padding: 14px 17px; background: linear-gradient(#303030, #292929); border-bottom: 1px solid #474747; }
+.language-example { margin: 18px 0 28px; background: #252525; border: 1px solid #474747; border-radius: 6px; overflow: hidden; interpolate-size: allow-keywords; }
+.language-example::details-content { block-size: 0; overflow: hidden; transition: block-size .35s ease-in-out, content-visibility .35s allow-discrete; }
+.language-example[open]::details-content { block-size: auto; }
+.language-example > summary { display: flex; align-items: center; gap: 13px; padding: 14px 52px 14px 17px; background: linear-gradient(#303030, #292929); cursor: pointer; list-style: none; position: relative; transition: background .2s ease-in-out; }
+.language-example > summary::-webkit-details-marker { display: none; }
+.language-example > summary::after { content: ""; position: absolute; right: 21px; width: 10px; height: 10px; border-right: 2px solid var(--sam-muted); border-bottom: 2px solid var(--sam-muted); transform: rotate(45deg) translateY(-3px); transition: transform .25s ease-in-out, border-color .2s ease-in-out; }
+.language-example[open] > summary { border-bottom: 1px solid #474747; }
+.language-example[open] > summary::after { transform: rotate(225deg) translate(-2px, -2px); }
+.language-example > summary:hover,
+.language-example > summary:focus-visible { background: linear-gradient(#393939, #303030); }
+.language-example > summary:hover::after,
+.language-example > summary:focus-visible::after { border-color: #fff; }
+.language-example > summary:focus-visible { outline: 2px solid var(--sam-link); outline-offset: -2px; }
 .language-example h3 { margin: 0 0 3px; color: #fff; }
-.language-example header p { margin: 0; color: var(--sam-muted); font-size: .82rem; }
+.language-example summary p { margin: 0; color: var(--sam-muted); font-size: .82rem; }
 .language-example pre { margin: 0; border: 0; border-radius: 0; }
 .language-badge { display: grid; place-items: center; min-width: 48px; height: 38px; padding: 0 7px; color: #fff; background: #e02e2e; border-radius: 4px; font: 700 .75rem var(--sam-mono); }
+@media (prefers-reduced-motion: reduce) { .language-example::details-content, .language-example > summary, .language-example > summary::after { transition: none; } }
 .protocol-grid { display: grid; grid-template-columns: minmax(190px, .3fr) 1fr; gap: 1px; margin: 18px 0 26px; background: #494949; border: 1px solid #494949; }
 .protocol-grid code, .protocol-grid span { padding: 10px 12px; border: 0; border-radius: 0; background: #272727; }
 .protocol-grid code { color: #f35353; }


### PR DESCRIPTION
### Motivation
- Improve page scannability by collapsing long language examples so only their headers are visible by default.
- Provide an accessible, keyboard-navigable disclosure UI with a smooth expand/collapse animation and respect for reduced-motion preferences.

### Description
- Replace each language example container from an `<article>` with a native `<details class="language-example">` and its header with `<summary>` in `salamatrix/salamatrix-ui.html` for seven language examples. 
- Add animated expand/collapse styling, a visual chevron, hover and keyboard focus states, and `prefers-reduced-motion` support in `salamatrix/style.css`.
- Add `js/language-examples.js` to automatically open a targeted language example when the URL fragment/hash matches the example `id` and to listen for `hashchange` updates.
- Include the new script in the page and adjust markup so examples start collapsed and can be toggled via mouse or keyboard.

### Testing
- Ran `git diff --check` to validate whitespace and patch issues and it completed without errors.
- Ran `node --check js/language-examples.js` and the script syntax check passed.
- Parsed `salamatrix/salamatrix-ui.html` with Python's `html.parser` and parsing completed successfully.
- Verified there are seven opening and seven closing `<details class="language-example">` elements via automated counts, and confirmed the new script is referenced in the page HTML; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fb1efb7808329aaf86aea709883fc)