### PR TITLE
Fix Python demo file-system listing

### DIFF
--- a/src/plugins/automation/runtime/salamatrix_worker.py
+++ b/src/plugins/automation/runtime/salamatrix_worker.py
@@ -181,7 +181,7 @@ class _FileSystem:
     def add_item(self, item_id: str, name: str, **options: Any) -> bool:
         payload = {"id": item_id, "name": name, **options}
         return bool(self._transport.call(
-            "salamander.fileSystem.addItem", payload).get("added"))
+            "salamander.fileSystem.addItem", **payload).get("added"))
 
 
 class _FileOperations:

--- a/src/plugins/automation/tests/processruntime_tests.cpp
+++ b/src/plugins/automation/tests/processruntime_tests.cpp
@@ -19,6 +19,7 @@ struct BootstrapDispatchState
     int CommandCalls;
     int StorageCalls;
     int StorageKeysCalls;
+    int FileSystemCalls;
     int SubscribeCalls;
     int FileOperationCalls;
     int DialogCalls;
@@ -54,6 +55,7 @@ struct BootstrapDispatchState
           CommandCalls(0),
           StorageCalls(0),
           StorageKeysCalls(0),
+          FileSystemCalls(0),
           SubscribeCalls(0),
           FileOperationCalls(0),
           DialogCalls(0),
@@ -122,6 +124,12 @@ BOOL WINAPI WorkerHostDispatch(
         if (state != NULL)
             ++state->CommandCalls;
         response = "{\"ok\":true,\"result\":\"ok\"}";
+    }
+    else if (strstr(payloadJson, "salamander.fileSystem.addItem") != NULL)
+    {
+        if (state != NULL)
+            ++state->FileSystemCalls;
+        response = "{\"ok\":true,\"added\":true}";
     }
     else if (strstr(payloadJson, "salamander.ui.notify") != NULL)
     {
@@ -632,7 +640,11 @@ void RunPythonOneShotBootstrapTest()
               "if Salamander.invocation.get('path') != 'C:/test/readme.md':\n"
               "    raise RuntimeError('invocation path was not propagated')\n"
               "if Salamander.commands.execute('Copy') != 'ok':\n"
-              "    raise RuntimeError('one-shot host call failed')\n"),
+              "    raise RuntimeError('one-shot host call failed')\n"
+              "if not Salamander.file_system.add_item(\n"
+              "        'development', 'Development VM — Running',\n"
+              "        icon='icon.svg', directory=False, enabled=True):\n"
+              "    raise RuntimeError('file-system item call failed')\n"),
           "write one-shot python worker");
 
     CAutomationProcessRuntimeAdapter adapter(
@@ -675,6 +687,8 @@ void RunPythonOneShotBootstrapTest()
         Check(diagnostic.ExitCode == 0,
               "exited worker diagnostic preserves exit code");
         Check(state.CommandCalls == 1, "one-shot worker host call reached host");
+        Check(state.FileSystemCalls == 1,
+              "one-shot Python file-system item call reached host");
         session->Stop();
         session->Release();
     }

--- a/src/plugins/automation/versinfo.rh2
+++ b/src/plugins/automation/versinfo.rh2
@@ -17,7 +17,7 @@
 #endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
 
 #define VERSINFO_MAJOR       2
-#define VERSINFO_MINORA      5
+#define VERSINFO_MINORA      6
 #define VERSINFO_MINORB      0  // POZOR: tady musi byt 0, jinak vyleti assert pri buildu
 
 #include "spl_vers.h" // get version and build numbers

--- a/src/plugins/pythonruntime/runtime/salamatrix_worker.py
+++ b/src/plugins/pythonruntime/runtime/salamatrix_worker.py
@@ -181,7 +181,7 @@ class _FileSystem:
     def add_item(self, item_id: str, name: str, **options: Any) -> bool:
         payload = {"id": item_id, "name": name, **options}
         return bool(self._transport.call(
-            "salamander.fileSystem.addItem", payload).get("added"))
+            "salamander.fileSystem.addItem", **payload).get("added"))
 
 
 class _FileOperations:

--- a/src/plugins/pythonruntime/versinfo.rh2
+++ b/src/plugins/pythonruntime/versinfo.rh2
@@ -6,7 +6,7 @@
 
 #define VERSINFO_MAJOR       0
 #define VERSINFO_MINORA      3
-#define VERSINFO_MINORB      0
+#define VERSINFO_MINORB      1
 
 #include "../shared/spl_vers.h"
 


### PR DESCRIPTION
## Summary
- fix the Python worker file-system item dispatch argument forwarding
- keep the Automation compatibility worker copy aligned
- add process-runtime regression coverage for `Salamander.file_system.add_item`
- bump Python Runtime to 0.3.1 and Automation to 2.6.0

## Validation
- full `tools/run_native_tests.ps1` suite: 14/14 groups passed
- Python Runtime Debug x64 build: passed, 0 warnings, 0 errors
- Automation Debug x64 build: passed with `/m:1`, 0 warnings, 0 errors
- `git diff --check`: passed