### PR TITLE
Fix Lua demo FS action dialog

### DIFF
--- a/src/plugins/luaruntime/luaruntime.cpp
+++ b/src/plugins/luaruntime/luaruntime.cpp
@@ -134,6 +134,38 @@ static bool AppendUtf8QuotedArgument(std::wstring& command, const char* value)
     return AppendQuotedArgument(command, &converted[0]);
 }
 
+static bool AppendBase64Utf8QuotedArgument(
+    std::wstring& command,
+    const char* value)
+{
+    if (value == NULL)
+        return false;
+    static const char alphabet[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const unsigned char* bytes =
+        reinterpret_cast<const unsigned char*>(value);
+    const size_t length = strlen(value);
+    std::wstring encoded;
+    encoded.reserve(((length + 2) / 3) * 4);
+    for (size_t offset = 0; offset < length; offset += 3)
+    {
+        const unsigned int first = bytes[offset];
+        const unsigned int second =
+            offset + 1 < length ? bytes[offset + 1] : 0;
+        const unsigned int third =
+            offset + 2 < length ? bytes[offset + 2] : 0;
+        encoded.push_back(alphabet[first >> 2]);
+        encoded.push_back(alphabet[((first & 0x03) << 4) | (second >> 4)]);
+        encoded.push_back(
+            offset + 1 < length
+                ? alphabet[((second & 0x0f) << 2) | (third >> 6)]
+                : '=');
+        encoded.push_back(
+            offset + 2 < length ? alphabet[third & 0x3f] : '=');
+    }
+    return AppendQuotedArgument(command, encoded.c_str());
+}
+
 static void SetRuntimeText(
     const std::string& value,
     wchar_t* output,
@@ -1082,8 +1114,11 @@ BOOL WINAPI CLuaRuntimeAdapter::StartPersistent(
     if ((request->Flags & Salamatrix::Runtime::RuntimeExecutionFlagUseWorkerBootstrap) != 0 &&
         request->InvocationJson != NULL && request->InvocationJson[0] != '\0')
     {
-        command.append(L" --invocation-json ");
-        if (!AppendUtf8QuotedArgument(command, request->InvocationJson))
+        // The upstream Windows Lua executable exposes narrow argv and converts
+        // the wide CreateProcess command line through the active ANSI code page.
+        // Keep arbitrary UTF-8 invocation data ASCII-only across that boundary.
+        command.append(L" --invocation-json-base64 ");
+        if (!AppendBase64Utf8QuotedArgument(command, request->InvocationJson))
             return FALSE;
     }
     if ((request->Flags &

--- a/src/plugins/luaruntime/runtime/salamatrix_worker.lua
+++ b/src/plugins/luaruntime/runtime/salamatrix_worker.lua
@@ -248,13 +248,15 @@ local options = {
     command_id = "",
     command_handler = "",
     invocation_json = "{}",
+    invocation_json_base64 = nil,
     one_shot = false
 }
 local index = 1
 while index <= #arg do
     local name = arg[index]
     if name == "--entry" or name == "--command-id" or
-       name == "--command-handler" or name == "--invocation-json" then
+       name == "--command-handler" or name == "--invocation-json" or
+       name == "--invocation-json-base64" then
         if index == #arg then error("Missing value for " .. name) end
         local key = name:sub(3):gsub("-", "_")
         options[key] = arg[index + 1]
@@ -268,6 +270,51 @@ while index <= #arg do
 end
 if not options.entry or options.entry == "" then
     error("The Lua worker requires --entry")
+end
+
+local function decode_base64(value)
+    if type(value) ~= "string" or #value % 4 ~= 0 then
+        error("Invalid Base64 invocation JSON")
+    end
+    local alphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    local decoded = {}
+    for offset = 1, #value, 4 do
+        local chunk = value:sub(offset, offset + 3)
+        local numbers = {}
+        local padding = 0
+        for index = 1, 4 do
+            local character = chunk:sub(index, index)
+            if character == "=" then
+                numbers[index] = 0
+                padding = padding + 1
+            else
+                local position = alphabet:find(character, 1, true)
+                if not position or padding ~= 0 then
+                    error("Invalid Base64 invocation JSON")
+                end
+                numbers[index] = position - 1
+            end
+        end
+        if padding > 2 or (padding ~= 0 and offset + 3 ~= #value) then
+            error("Invalid Base64 invocation JSON")
+        end
+        decoded[#decoded + 1] = string.char(
+            numbers[1] * 4 + math.floor(numbers[2] / 16))
+        if padding < 2 then
+            decoded[#decoded + 1] = string.char(
+                (numbers[2] % 16) * 16 + math.floor(numbers[3] / 4))
+        end
+        if padding == 0 then
+            decoded[#decoded + 1] = string.char(
+                (numbers[3] % 4) * 64 + numbers[4])
+        end
+    end
+    return table.concat(decoded)
+end
+
+if options.invocation_json_base64 then
+    options.invocation_json = decode_base64(options.invocation_json_base64)
 end
 
 local function send_frame(kind, id, payload)

--- a/src/plugins/luaruntime/versinfo.rh2
+++ b/src/plugins/luaruntime/versinfo.rh2
@@ -6,7 +6,7 @@
 
 #define VERSINFO_MAJOR       0
 #define VERSINFO_MINORA      3
-#define VERSINFO_MINORB      0
+#define VERSINFO_MINORB      1
 
 #include "../shared/spl_vers.h"
 

--- a/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
+++ b/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
@@ -152,6 +152,7 @@ def main() -> int:
         "src/plugins/powershellruntime/runtime/salamatrix_worker.ps1")
     php_worker = read(
         "src/plugins/phpruntime/runtime/salamatrix_worker.php")
+    lua_runtime = read("src/plugins/luaruntime/luaruntime.cpp")
     lua_worker = read(
         "src/plugins/luaruntime/runtime/salamatrix_worker.lua")
     navigator = read("src/extensions/git-worktree-navigator/main.ps1")
@@ -1073,6 +1074,15 @@ def main() -> int:
                 f"x64 installer does not package bundled Lua asset {bundled_asset}")
     require(setup, r"AddPluginDependency\('luaruntime',\s*'salamatrix'\)",
             "x64 installer does not select Salamatrix for Lua Runtime")
+    require(
+        lua_runtime,
+        r'AppendBase64Utf8QuotedArgument.*?'
+        r'--invocation-json-base64.*?request->InvocationJson',
+        "Lua runtime passes Unicode invocation JSON through narrow Windows argv")
+    require(
+        lua_worker,
+        r'function decode_base64.*?invocation_json_base64.*?decode_json',
+        "Lua worker does not restore Base64-protected Unicode invocation JSON")
     require(runtime_package_verifier,
             r"Name\s*=\s*'luaruntime'.*?extension-runtimes\\luaruntime.*?salamatrix_worker\.lua.*?lua\.exe.*?lua\.dll.*?LICENSE-LUA\.txt",
             "runtime package verifier does not validate the Lua provider layout")


### PR DESCRIPTION
## Summary
- preserve UTF-8 file-system action invocation data across the Windows Lua narrow-argv boundary using Base64 transport
- decode the ASCII-safe invocation payload in the Lua worker while retaining backward compatibility with `--invocation-json`
- bump Lua Runtime to 0.3.1
- add a PR-running Salamatrix source contract for the Unicode-safe transport

## Root cause
The demo item name contains an em dash. The upstream Windows Lua executable exposes narrow `argv`, which corrupted that UTF-8 character before the worker built the `salamander.ui.messageBox` host call. The host rejected the malformed JSON, so double-click appeared to do nothing.

## Validation
- isolated real-worker `inspectDemoMachine` invocation preserved `Development VM — Running` in the message-box wire call
- full `tools/run_native_tests.ps1` suite: 14/14 groups passed
- Lua Runtime Debug x64: passed, 0 warnings, 0 errors
- Lua Runtime Release x64: passed, 0 warnings, 0 errors
- staged Release worker SHA-256 matches source
- `git diff --check`: passed