### PR TITLE
Prevent Python demo UI during lifecycle activation

### DIFF
--- a/src/extensions/demos/python/extension.json
+++ b/src/extensions/demos/python/extension.json
@@ -2,7 +2,7 @@
   "schema": 2,
   "id": "Salamatrix.Demo.Python",
   "name": "Salamatrix Python Demo",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Demonstrates commands, Viewer and a simple panel file system in a CPython Salamatrix extension package.",
   "runtime": "Python.CPython",
   "entryPoint": "main.py",

--- a/src/extensions/demos/python/main.py
+++ b/src/extensions/demos/python/main.py
@@ -53,74 +53,75 @@ if handler in ("inspectDemoMachine", "toggleDemoMachine"):
             "Salamatrix FS demo", 2500)
     raise SystemExit(0)
 
-Salamander.ui.notify("CPython extension package is running through Salamatrix.", "Salamatrix Python Demo", 2500)
-progress = Salamander.ui.progress("Salamatrix Python Progress Demo", 5)
-try:
-    for step in range(1, 6):
-        progress.update(step, text=f"Step {step} of 5")
-        time.sleep(0.15)
-        if progress.is_cancelled():
-            break
-finally:
-    progress.close()
-Salamander.storage.set("lastRun", "Python.CPython")
+if handler == "run":
+    Salamander.ui.notify("CPython extension package is running through Salamatrix.", "Salamatrix Python Demo", 2500)
+    progress = Salamander.ui.progress("Salamatrix Python Progress Demo", 5)
+    try:
+        for step in range(1, 6):
+            progress.update(step, text=f"Step {step} of 5")
+            time.sleep(0.15)
+            if progress.is_cancelled():
+                break
+    finally:
+        progress.close()
+    Salamander.storage.set("lastRun", "Python.CPython")
 
-# Build the complete gallery here, through the public runtime-neutral API.
-dialog = Salamander.ui.dialog("Salamatrix UI capabilities", 463, 236)
-def add(kind, control_id, text, x, y, width, height, **options):
-    dialog.add_control(kind, control_id, text,
-                       layout={"x": x, "y": y, "width": width, "height": height},
-                       options=options)
+    # Build the complete gallery here, through the public runtime-neutral API.
+    dialog = Salamander.ui.dialog("Salamatrix UI capabilities", 463, 236)
+    def add(kind, control_id, text, x, y, width, height, **options):
+        dialog.add_control(kind, control_id, text,
+                           layout={"x": x, "y": y, "width": width, "height": height},
+                           options=options)
 
-uptime = f"System was started {Salamander.ui.uptime()} ms ago."
-add("groupbox", "static-group", "CGUIStaticTextAbstract", 6, 4, 254, 108)
-add("label", "not-attached-label", "Not attached static text", 14, 17, 80, 8)
-add("label", "uptime-plain", uptime, 102, 17, 152, 8)
-rows = [
-    ("static-none", "0 (no flags)", uptime, 27, 0),
-    ("static-cache", "STF_CACHED_PAINT", uptime, 37, 1),
-    ("static-bold", "STF_BOLD", "Bold &text", 47, 0x10082),
-    ("static-underline", "STF_UNDERLINE", "Underlined text", 56, 0x20004),
-    ("static-end", "STF_END_ELLIPSIS", "Long long long long long long long long long string.", 66, 0x20),
-    ("static-path", "STF_PATH_ELLIPSIS", r"C:\Program Files\Some Application With Long Path\example.exe", 76, 0x40),
-    ("static-path-url", "STF_PATH_ELLIPSIS", "ftp://ftp.altap.cz/pub/salamander/example.exe", 87, 0x40),
-]
-for control_id, caption, value, y, flags in rows:
-    add("label", control_id + "-label", caption, 14, y, 75, 8)
-    extra = {"styleFlags": flags}
-    if control_id == "static-path-url": extra["pathSeparator"] = "/"
-    add("statictext", control_id, value, 102, y, 152, 8, **extra)
-add("label", "drag-hint", "Drag texts to change their size.", 151, 97, 103, 8)
-add("groupbox", "progress-group", "CGUIProgressBarAbstract", 6, 118, 254, 66)
-add("label", "progress-label", "Progress label", 15, 129, 60, 8)
-add("progressbar", "progress", "", 15, 138, 235, 12, progress=120)
-add("label", "unknown-label", "Unknown progress", 15, 154, 67, 8)
-add("progressbar", "unknown-progress", "", 15, 163, 235, 12, progress=-1, indeterminateDuration=-1, indeterminateInterval=100)
-add("groupbox", "buttons-group", "Button, CGUITextArrowButtonAbstract, CGUIColorArrowButtonAbstract", 6, 188, 254, 40)
-add("button", "more", "...", 15, 204, 15, 14, keepOpen=True)
-add("arrowbutton", "arrow", "", 37, 204, 15, 14)
-add("textarrowbutton", "choose", "&Choose", 60, 204, 50, 14, styleFlags=8)
-add("textarrowbutton", "drop", "&Drop", 117, 204, 50, 14, styleFlags=2)
-add("colorarrowbutton", "color", "", 174, 204, 33, 14, textColor=0xff8000, backgroundColor=0xff8000)
-add("colorarrowbutton", "color-text", "ABC", 215, 204, 33, 14, textColor=0, backgroundColor=0xffff)
-add("groupbox", "hyperlink-group", "CGUIHyperLinkAbstract", 269, 4, 185, 48)
-add("label", "open-label", "SetActionOpen", 277, 17, 75, 8)
-add("hyperlink", "open-link", "www.altap.cz", 365, 17, 47, 8, styleFlags=0x14, actionOpen="https://www.altap.cz")
-add("label", "command-label", "SetActionPostCommand", 277, 27, 81, 8)
-add("hyperlink", "command-link", "Say something!", 365, 27, 55, 8, styleFlags=0x14, actionCommand=0x7f01)
-add("label", "hint-label", "SetActionShowHint", 277, 37, 81, 8)
-add("hyperlink", "hint-link", "mask hints", 365, 37, 40, 8, styleFlags=8, actionHint="text 1 text 1 text 1 text 1\ntext 2 text 2 text 2")
-add("groupbox", "tooltip-group", "SetCurrentToolTip", 269, 59, 185, 31)
-add("statictext", "tooltip", "Pause the mouse pointer over this text.", 278, 73, 130, 8, styleFlags=0x40000, toolTip="ToolTip")
-add("listview", "header-list", "", 269, 113, 185, 50, styleFlags=0x01e00000)
-add("toolbarheader", "toolbar-header", "CGUIToolbarHeaderAbstract", 269, 102, 96, 8, alignControlId="header-list", buttonMask=0x31)
-add("groupbox", "origin-group", "Created by", 269, 169, 185, 38)
-add("label", "runtime-label", "Runtime:", 277, 181, 42, 8)
-add("statictext", "runtime-value", "Python.CPython", 323, 181, 122, 8, styleFlags=2)
-add("label", "extension-label", "Extension:", 277, 192, 42, 8)
-add("statictext", "extension-value", "Salamatrix Python Demo", 323, 192, 122, 8, styleFlags=2)
-add("button", "close", "Close", 403, 213, 50, 14, dialogResult=1, styleFlags=0x100000)
-try:
-    dialog.show()
-finally:
-    dialog.close()
+    uptime = f"System was started {Salamander.ui.uptime()} ms ago."
+    add("groupbox", "static-group", "CGUIStaticTextAbstract", 6, 4, 254, 108)
+    add("label", "not-attached-label", "Not attached static text", 14, 17, 80, 8)
+    add("label", "uptime-plain", uptime, 102, 17, 152, 8)
+    rows = [
+        ("static-none", "0 (no flags)", uptime, 27, 0),
+        ("static-cache", "STF_CACHED_PAINT", uptime, 37, 1),
+        ("static-bold", "STF_BOLD", "Bold &text", 47, 0x10082),
+        ("static-underline", "STF_UNDERLINE", "Underlined text", 56, 0x20004),
+        ("static-end", "STF_END_ELLIPSIS", "Long long long long long long long long long string.", 66, 0x20),
+        ("static-path", "STF_PATH_ELLIPSIS", r"C:\Program Files\Some Application With Long Path\example.exe", 76, 0x40),
+        ("static-path-url", "STF_PATH_ELLIPSIS", "ftp://ftp.altap.cz/pub/salamander/example.exe", 87, 0x40),
+    ]
+    for control_id, caption, value, y, flags in rows:
+        add("label", control_id + "-label", caption, 14, y, 75, 8)
+        extra = {"styleFlags": flags}
+        if control_id == "static-path-url": extra["pathSeparator"] = "/"
+        add("statictext", control_id, value, 102, y, 152, 8, **extra)
+    add("label", "drag-hint", "Drag texts to change their size.", 151, 97, 103, 8)
+    add("groupbox", "progress-group", "CGUIProgressBarAbstract", 6, 118, 254, 66)
+    add("label", "progress-label", "Progress label", 15, 129, 60, 8)
+    add("progressbar", "progress", "", 15, 138, 235, 12, progress=120)
+    add("label", "unknown-label", "Unknown progress", 15, 154, 67, 8)
+    add("progressbar", "unknown-progress", "", 15, 163, 235, 12, progress=-1, indeterminateDuration=-1, indeterminateInterval=100)
+    add("groupbox", "buttons-group", "Button, CGUITextArrowButtonAbstract, CGUIColorArrowButtonAbstract", 6, 188, 254, 40)
+    add("button", "more", "...", 15, 204, 15, 14, keepOpen=True)
+    add("arrowbutton", "arrow", "", 37, 204, 15, 14)
+    add("textarrowbutton", "choose", "&Choose", 60, 204, 50, 14, styleFlags=8)
+    add("textarrowbutton", "drop", "&Drop", 117, 204, 50, 14, styleFlags=2)
+    add("colorarrowbutton", "color", "", 174, 204, 33, 14, textColor=0xff8000, backgroundColor=0xff8000)
+    add("colorarrowbutton", "color-text", "ABC", 215, 204, 33, 14, textColor=0, backgroundColor=0xffff)
+    add("groupbox", "hyperlink-group", "CGUIHyperLinkAbstract", 269, 4, 185, 48)
+    add("label", "open-label", "SetActionOpen", 277, 17, 75, 8)
+    add("hyperlink", "open-link", "www.altap.cz", 365, 17, 47, 8, styleFlags=0x14, actionOpen="https://www.altap.cz")
+    add("label", "command-label", "SetActionPostCommand", 277, 27, 81, 8)
+    add("hyperlink", "command-link", "Say something!", 365, 27, 55, 8, styleFlags=0x14, actionCommand=0x7f01)
+    add("label", "hint-label", "SetActionShowHint", 277, 37, 81, 8)
+    add("hyperlink", "hint-link", "mask hints", 365, 37, 40, 8, styleFlags=8, actionHint="text 1 text 1 text 1 text 1\ntext 2 text 2 text 2")
+    add("groupbox", "tooltip-group", "SetCurrentToolTip", 269, 59, 185, 31)
+    add("statictext", "tooltip", "Pause the mouse pointer over this text.", 278, 73, 130, 8, styleFlags=0x40000, toolTip="ToolTip")
+    add("listview", "header-list", "", 269, 113, 185, 50, styleFlags=0x01e00000)
+    add("toolbarheader", "toolbar-header", "CGUIToolbarHeaderAbstract", 269, 102, 96, 8, alignControlId="header-list", buttonMask=0x31)
+    add("groupbox", "origin-group", "Created by", 269, 169, 185, 38)
+    add("label", "runtime-label", "Runtime:", 277, 181, 42, 8)
+    add("statictext", "runtime-value", "Python.CPython", 323, 181, 122, 8, styleFlags=2)
+    add("label", "extension-label", "Extension:", 277, 192, 42, 8)
+    add("statictext", "extension-value", "Salamatrix Python Demo", 323, 192, 122, 8, styleFlags=2)
+    add("button", "close", "Close", 403, 213, 50, 14, dialogResult=1, styleFlags=0x100000)
+    try:
+        dialog.show()
+    finally:
+        dialog.close()

--- a/src/plugins/automation/tests/processruntime_tests.cpp
+++ b/src/plugins/automation/tests/processruntime_tests.cpp
@@ -695,6 +695,66 @@ void RunPythonOneShotBootstrapTest()
     DeleteFileW(&script[0]);
 }
 
+void RunPythonDemoLifecycleTest()
+{
+    std::vector<wchar_t> workerRoot(SAL_MAX_PATH);
+    DWORD rootLength = GetEnvironmentVariableW(
+        L"SALAMATRIX_WORKER_ROOT", &workerRoot[0],
+        static_cast<DWORD>(workerRoot.size()));
+    if (rootLength == 0 || rootLength >= workerRoot.size())
+        return;
+    std::vector<wchar_t> interpreter(SAL_MAX_PATH);
+    if (!FindProgram(
+            L"python.exe", &interpreter[0],
+            static_cast<int>(interpreter.size())))
+        return;
+    SetEnvironmentVariableW(L"SALAMATRIX_PYTHON", &interpreter[0]);
+
+    std::vector<wchar_t> entryPoint(SAL_MAX_PATH);
+    DWORD entryLength = GetFullPathNameW(
+        L"src\\extensions\\demos\\python\\main.py",
+        static_cast<DWORD>(entryPoint.size()), &entryPoint[0], NULL);
+    Check(entryLength != 0 && entryLength < entryPoint.size(),
+          "resolve Python demo lifecycle entry point");
+    if (entryLength == 0 || entryLength >= entryPoint.size())
+        return;
+
+    CAutomationProcessRuntimeAdapter adapter(
+        "Python.CPython", "CPython", "python", ".py",
+        L"SALAMATRIX_PYTHON", L"python.exe", L"python3.exe",
+        CAutomationProcessRuntimeAdapter::ProcessKindPython);
+    Salamatrix::Runtime::RuntimeExecutionRequest request;
+    request.EntryPoint = &entryPoint[0];
+    request.Flags =
+        Salamatrix::Runtime::RuntimeExecutionFlagPersistentWorker |
+        Salamatrix::Runtime::RuntimeExecutionFlagUseWorkerBootstrap;
+    request.TimeoutMs = 5000;
+    BootstrapDispatchState state;
+    request.HostDispatch = WorkerHostDispatch;
+    request.HostDispatchContext = &state;
+    Salamatrix::Runtime::IRuntimeSession* session = NULL;
+    Check(adapter.StartPersistent(&request, &session) != FALSE && session != NULL,
+          "start Python demo lifecycle worker");
+    if (session != NULL)
+    {
+        Check(session->Pump(1000) != FALSE,
+              "Python demo lifecycle worker handshake");
+        // Once the entry point has returned, a quiet persistent worker waits
+        // for events. The unfixed demo instead sends its Run notification here.
+        (void)session->Pump(500);
+        Check(session->IsAlive() != FALSE,
+              "Python demo lifecycle worker remains available for events");
+        Check(state.NotificationCalls == 0,
+              "Python demo lifecycle activation has no notification side effect");
+        Check(state.StorageCalls == 0,
+              "Python demo lifecycle activation has no storage side effect");
+        Check(state.DialogCalls == 0 && state.MessageBoxCalls == 0,
+              "Python demo lifecycle activation has no modal UI side effect");
+        session->Stop();
+        session->Release();
+    }
+}
+
 void RunPythonBootstrapTest()
 {
     std::vector<wchar_t> workerRoot(SAL_MAX_PATH);
@@ -1194,6 +1254,7 @@ int main()
     RunPythonTests();
     RunPythonFailureDiagnosticTest();
     RunPythonOneShotBootstrapTest();
+    RunPythonDemoLifecycleTest();
     RunPythonBootstrapTest();
     RunPowerShellBootstrapTest();
     RunPhpBootstrapTest();

--- a/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
+++ b/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
@@ -1034,12 +1034,19 @@ def main() -> int:
         "PHP": (php_demo_manifest, php_demo),
         "Lua": (lua_demo_manifest, lua_demo),
     }
+    demo_versions = {
+        "Node": "1.4.1",
+        "Python": "1.4.2",
+        "PowerShell": "1.4.1",
+        "PHP": "1.4.1",
+        "Lua": "1.4.1",
+    }
     viewer_patterns = set()
     for runtime_name, (demo_manifest, demo_source) in demo_roles.items():
         viewers = demo_manifest.get("viewers", [])
         file_systems = demo_manifest.get("fileSystems", [])
         if (demo_manifest.get("schema") != 2 or not viewers or
-                demo_manifest.get("version") != "1.4.1" or
+                demo_manifest.get("version") != demo_versions[runtime_name] or
                 not viewers[0].get("name") or
                 viewers[0].get("handler") != "viewDemo" or
                 not file_systems or
@@ -1358,6 +1365,10 @@ def main() -> int:
         r"ImageList_Add\(hotImageList",
         "Extension Bar SVG alpha is not flattened onto its light/dark background")
     require(python_demo, r"Salamander\.ui\.notify", "Python demo does not show a non-blocking result")
+    require(
+        python_demo,
+        r'if handler == "run":.*?CPython extension package is running',
+        "Python demo executes its Run UI during lifecycle activation")
     require(python_demo, r'handler == "viewDemo".*?message_box.*?SystemExit',
             "Python Viewer demo does not isolate its modal preview from ordinary commands")
     require(powershell_demo, r"\$Salamander\.ui\.Notify", "PowerShell demo does not show a non-blocking result")


### PR DESCRIPTION
## Summary
- run the Python demo notification, progress and UI gallery only for the explicit `run` handler
- keep empty-handler persistent lifecycle activation quiet and available for events
- bump Salamatrix Python Demo to 1.4.2
- add a real process-runtime regression using the shipped Python demo entry point

## Root cause
Unlike the Node, PowerShell, PHP and Lua demos, the Python demo fell through into its Run body whenever the handler was not Viewer/FS-specific. Salamatrix activates persistent extension sessions with an empty handler and recreates them during catalog/runtime refreshes, so startup, configuration changes and shutdown-related refreshes repeatedly executed the complete demo UI.

## Validation
- new real-worker lifecycle regression verifies zero notification, storage, dialog and message-box calls while the persistent worker remains alive
- full `tools/run_native_tests.ps1` suite: 14/14 groups passed
- Salamatrix Debug x64 build: passed, 0 warnings, 0 errors
- staged Python demo SHA-256 matches source and manifest reports 1.4.2
- Python syntax, source contracts and `git diff --check`: passed