### PR TITLE
Fix PR test reporting after reruns

### DIFF
--- a/.github/workflows/pr-test-report.yml
+++ b/.github/workflows/pr-test-report.yml
@@ -16,7 +16,8 @@ jobs:
     if: >-
       ${{
         github.event.workflow_run.event == 'pull_request' &&
-        github.event.workflow_run.pull_requests[0].head.repo.full_name != github.repository
+        github.event.workflow_run.pull_requests[0] != null &&
+        github.event.workflow_run.head_repository.full_name != github.repository
       }}
     runs-on: ubuntu-latest
 

--- a/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
+++ b/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
@@ -516,7 +516,8 @@ def main() -> int:
             r'ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\|\|\s*github\.sha\s*\}\}',
             "PR tests do not explicitly check out the selected source branch commit")
     require(pr_test_report_workflow,
-            r'pull_requests\[0\]\.head\.repo\.full_name != github\.repository.*?'
+            r'pull_requests\[0\] != null.*?'
+            r'workflow_run\.head_repository\.full_name != github\.repository.*?'
             r'dorny/test-reporter@v3.*?'
             r'use-actions-summary:\s*false.*?'
             r'dorny/test-reporter@v3.*?'


### PR DESCRIPTION
## What changed

- use `workflow_run.head_repository.full_name` to distinguish fork PRs from same-repository PRs
- require an associated pull request before running the privileged fallback reporter
- update the source-contract regression to enforce the valid `workflow_run` payload field

## Root cause

The fallback `PR Test Report` workflow read `pull_requests[0].head.repo.full_name`, but the abbreviated pull-request object in a `workflow_run` payload does not provide `repo.full_name`. The missing value made the fork-only condition true for same-repository PRs as well.

After a failed job was rerun successfully, the fallback reporter downloaded test artifacts from both attempts under the same name. It then combined the new passing `native.xml` with the stale failing one and published a false red check.

## Validation

- rerun of PR #665 `PR Tests` passed completely
- `salamatrix_regression_tests.py` passed with the updated workflow contract
- complete `tools/run_native_tests.ps1` suite passed: 14/14 groups
