### PR TITLE
Fix main window dragging and initial tab tooltip DPI font

### DIFF
--- a/src/common/winlibdpi.h
+++ b/src/common/winlibdpi.h
@@ -235,11 +235,14 @@ inline HFONT WinLibDPICreateMessageFontForDPI(UINT dpi)
     return CreateFontIndirect(&metrics.lfMessageFont);
 }
 
-inline HFONT WinLibDPICreateStatusFontForDPI(UINT dpi)
+inline BOOL WinLibDPIGetStatusLogFontForDPI(UINT dpi, LOGFONT* font)
 {
+    if (font == NULL)
+        return FALSE;
+
     NONCLIENTMETRICS metrics;
     if (!WinLibDPIGetNonClientMetricsForDPI(dpi, &metrics))
-        return NULL;
+        return FALSE;
 
     if (dpi != 0 && metrics.lfStatusFont.lfHeight != 0)
     {
@@ -251,7 +254,8 @@ inline HFONT WinLibDPICreateStatusFontForDPI(UINT dpi)
                 metrics.lfStatusFont.lfHeight < 0 ? -expectedHeight : expectedHeight;
         }
     }
-    return CreateFontIndirect(&metrics.lfStatusFont);
+    *font = metrics.lfStatusFont;
+    return TRUE;
 }
 
 inline void WinLibDPIScaleLogFont(HWND hwnd, LOGFONT* font)

--- a/src/common/winlibdpi.h
+++ b/src/common/winlibdpi.h
@@ -235,6 +235,25 @@ inline HFONT WinLibDPICreateMessageFontForDPI(UINT dpi)
     return CreateFontIndirect(&metrics.lfMessageFont);
 }
 
+inline HFONT WinLibDPICreateStatusFontForDPI(UINT dpi)
+{
+    NONCLIENTMETRICS metrics;
+    if (!WinLibDPIGetNonClientMetricsForDPI(dpi, &metrics))
+        return NULL;
+
+    if (dpi != 0 && metrics.lfStatusFont.lfHeight != 0)
+    {
+        int height = abs(metrics.lfStatusFont.lfHeight);
+        int expectedHeight = MulDiv(12, (int)dpi, USER_DEFAULT_SCREEN_DPI);
+        if (height < expectedHeight - 1 || height > expectedHeight + 2)
+        {
+            metrics.lfStatusFont.lfHeight =
+                metrics.lfStatusFont.lfHeight < 0 ? -expectedHeight : expectedHeight;
+        }
+    }
+    return CreateFontIndirect(&metrics.lfStatusFont);
+}
+
 inline void WinLibDPIScaleLogFont(HWND hwnd, LOGFONT* font)
 {
     if (font == NULL)

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -909,6 +909,9 @@ public:
 
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
     LRESULT WindowProcImpl(UINT uMsg, WPARAM wParam, LPARAM lParam);
+    LRESULT OnSetCursor(WPARAM wParam, LPARAM lParam);
+    LRESULT OnEraseBkgnd(WPARAM wParam);
+    LRESULT OnPaint();
 
     void SafeHandleMenuNewMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT* plResult);
 

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -908,6 +908,7 @@ public:
     }
 
     virtual LRESULT WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
+    LRESULT WindowProcImpl(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
     void SafeHandleMenuNewMsg2(UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT* plResult);
 

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -4138,10 +4138,24 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     // pointer step, so keep them on this small, allocation-free path.
     switch (uMsg)
     {
+    case WM_GETMINMAXINFO:
+    case WM_NCHITTEST:
+    case WM_NCMOUSEMOVE:
+    case WM_NCPAINT:
+    case WM_SYNCPAINT:
     case WM_MOVE:
     case WM_MOVING:
     case WM_WINDOWPOSCHANGING:
         return CWindow::WindowProc(uMsg, wParam, lParam);
+
+    case WM_SETCURSOR:
+        return OnSetCursor(wParam, lParam);
+
+    case WM_ERASEBKGND:
+        return OnEraseBkgnd(wParam);
+
+    case WM_PAINT:
+        return OnPaint();
 
     case WM_WINDOWPOSCHANGED:
     {
@@ -4174,6 +4188,120 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
 
     return WindowProcImpl(uMsg, wParam, lParam);
+}
+
+LRESULT
+CMainWindow::OnSetCursor(WPARAM wParam, LPARAM lParam)
+{
+    if (!HasLockedUI())
+    {
+        if (HelpMode)
+        {
+            SetCursor(HHelpCursor);
+            return TRUE;
+        }
+        POINT p, p2;
+        GetCursorPos(&p);
+        p2 = p;
+        ScreenToClient(HWindow, &p);
+        RECT r;
+        GetSplitRect(r);
+        if (IsWindowEnabled(HWindow) && PtInRect(&r, p) && GetCapture() == NULL)
+        {
+            BOOL aboveMiddle = FALSE;
+            if (MiddleToolBar != NULL && MiddleToolBar->HWindow != NULL)
+            {
+                GetWindowRect(MiddleToolBar->HWindow, &r);
+                aboveMiddle = PtInRect(&r, p2);
+            }
+            if (!aboveMiddle)
+            {
+                SetCursor(LoadCursor(NULL, IDC_SIZEWE));
+                return TRUE;
+            }
+        }
+    }
+    return CWindow::WindowProc(WM_SETCURSOR, wParam, lParam);
+}
+
+LRESULT
+CMainWindow::OnEraseBkgnd(WPARAM wParam)
+{
+    if (DarkModeIsWindowsDarkSchemeSelected())
+    {
+        HDC dc = (HDC)wParam;
+        RECT clientRect;
+        GetClientRect(HWindow, &clientRect);
+        COLORREF oldColor = SetDCBrushColor(dc, DarkModeGetColors().background);
+        FillRect(dc, &clientRect, (HBRUSH)GetStockObject(DC_BRUSH));
+        SetDCBrushColor(dc, oldColor);
+    }
+    return TRUE;
+}
+
+LRESULT
+CMainWindow::OnPaint()
+{
+    PAINTSTRUCT ps;
+
+    HDC dc = HANDLES(BeginPaint(HWindow, &ps));
+    RECT paintRect = ps.rcPaint;
+    if (DarkModeIsWindowsDarkSchemeSelected())
+    {
+        COLORREF oldColor = SetDCBrushColor(dc, DarkModeGetColors().background);
+        FillRect(dc, &paintRect, (HBRUSH)GetStockObject(DC_BRUSH));
+        SetDCBrushColor(dc, oldColor);
+    }
+    else
+        FillRect(dc, &paintRect, HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
+    HPEN oldPen = (HPEN)SelectObject(dc, BtnShadowPen);
+
+    RECT r;
+    if (TopToolBar->HWindow != NULL)
+    {
+        MoveToEx(dc, 0, 0, NULL);
+        LineTo(dc, WindowWidth + 1, 0);
+        SelectObject(dc, BtnHilightPen);
+        MoveToEx(dc, 0, 1, NULL);
+        LineTo(dc, WindowWidth + 1, 1);
+    }
+
+    if (PanelsHeight > 0)
+    {
+        r.left = SplitPositionPix;
+        r.top = TopRebarHeight;
+        r.right = SplitPositionPix + MainWindow->GetSplitBarWidth();
+        r.bottom = r.top + PanelsHeight;
+        FillRect(dc, &r, HDialogBrush);
+
+        SelectObject(dc, BtnFacePen);
+        MoveToEx(dc, 0, 0, NULL);
+        LineTo(dc, 0, WindowHeight - 1);
+        LineTo(dc, WindowWidth - 1, WindowHeight - 1);
+        LineTo(dc, WindowWidth - 1, 0);
+    }
+
+    if (EditWindow->HWindow != NULL)
+    {
+        r.left = 0;
+        r.top = TopRebarHeight + PanelsHeight;
+        r.right = WindowWidth;
+        r.bottom = r.top + 2;
+        FillRect(dc, &r, HDialogBrush);
+    }
+
+    if (BottomToolBar->HWindow != NULL)
+    {
+        r.left = 0;
+        r.top = TopRebarHeight + PanelsHeight + EditHeight;
+        r.right = WindowWidth;
+        r.bottom = r.top + 2;
+        FillRect(dc, &r, HDialogBrush);
+    }
+
+    SelectObject(dc, oldPen);
+    HANDLES(EndPaint(HWindow, &ps));
+    return 0;
 }
 
 LRESULT
@@ -9198,38 +9326,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         return plResult;
     }
 
-    case WM_SETCURSOR:
-    {
-        if (HasLockedUI())
-            break;
-        if (HelpMode)
-        {
-            SetCursor(HHelpCursor);
-            return TRUE;
-        }
-        POINT p, p2;
-        GetCursorPos(&p);
-        p2 = p;
-        ScreenToClient(HWindow, &p);
-        RECT r;
-        GetSplitRect(r);
-        if (IsWindowEnabled(HWindow) && PtInRect(&r, p) && GetCapture() == NULL)
-        {
-            BOOL aboveMiddle = FALSE;
-            if (MiddleToolBar != NULL && MiddleToolBar->HWindow != NULL)
-            {
-                GetWindowRect(MiddleToolBar->HWindow, &r);
-                aboveMiddle = PtInRect(&r, p2);
-            }
-            if (!aboveMiddle)
-            {
-                SetCursor(LoadCursor(NULL, IDC_SIZEWE));
-                return TRUE;
-            }
-        }
-        break;
-    }
-
     case WM_CONTEXTMENU:
     {
         if (HasLockedUI())
@@ -11467,99 +11563,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             return TRUE; // if it gets this far, allow the shutdown
         }
         return 0; // return value for WM_USER_CLOSE_MAINWND, WM_USER_FORCECLOSE_MAINWND and WM_ENDSESSION
-    }
-
-    case WM_ERASEBKGND:
-    {
-        if (DarkModeIsWindowsDarkSchemeSelected())
-        {
-            HDC dc = (HDC)wParam;
-            RECT clientRect;
-            GetClientRect(HWindow, &clientRect);
-            COLORREF oldColor = SetDCBrushColor(dc, DarkModeGetColors().background);
-            FillRect(dc, &clientRect, (HBRUSH)GetStockObject(DC_BRUSH));
-            SetDCBrushColor(dc, oldColor);
-        }
-        /*
-      HDC dc = (HDC)wParam;
-      HPEN oldPen = (HPEN)SelectObject(dc, BtnFacePen);
-      MoveToEx(dc, 0, 0, NULL);
-      LineTo(dc, 0, WindowHeight - 1);
-      LineTo(dc, WindowWidth - 1, WindowHeight - 1);
-      LineTo(dc, WindowWidth - 1, 0);
-      SelectObject(dc, oldPen);
-*/
-        return TRUE;
-    }
-
-    case WM_PAINT:
-    {
-        PAINTSTRUCT ps;
-
-        HDC dc = HANDLES(BeginPaint(HWindow, &ps));
-        RECT paintRect = ps.rcPaint;
-        if (DarkModeIsWindowsDarkSchemeSelected())
-        {
-            COLORREF oldColor = SetDCBrushColor(dc, DarkModeGetColors().background);
-            FillRect(dc, &paintRect, (HBRUSH)GetStockObject(DC_BRUSH));
-            SetDCBrushColor(dc, oldColor);
-        }
-        else
-            FillRect(dc, &paintRect, HDialogBrush != NULL ? HDialogBrush : GetSysColorBrush(COLOR_BTNFACE));
-        HPEN oldPen = (HPEN)SelectObject(dc, BtnShadowPen);
-
-        RECT r;
-        if (TopToolBar->HWindow != NULL)
-        {
-            MoveToEx(dc, 0, 0, NULL);
-            LineTo(dc, WindowWidth + 1, 0);
-            SelectObject(dc, BtnHilightPen);
-            MoveToEx(dc, 0, 1, NULL);
-            LineTo(dc, WindowWidth + 1, 1);
-        }
-
-        if (PanelsHeight > 0)
-        {
-            r.left = SplitPositionPix;
-            r.top = TopRebarHeight;
-            r.right = SplitPositionPix + MainWindow->GetSplitBarWidth();
-            //        SelectObject(dc, shadowPen);
-            //        MoveToEx(dc, r.left, r.top, NULL);
-            //        LineTo(dc, r.right, r.top);
-            //        SelectObject(dc, lightPen);
-            //        MoveToEx(dc, r.left, r.top + 1, NULL);
-            //        LineTo(dc, r.right, r.top + 1);
-            r.bottom = r.top + PanelsHeight;
-            FillRect(dc, &r, HDialogBrush);
-
-            SelectObject(dc, BtnFacePen);
-            MoveToEx(dc, 0, 0, NULL);
-            LineTo(dc, 0, WindowHeight - 1);
-            LineTo(dc, WindowWidth - 1, WindowHeight - 1);
-            LineTo(dc, WindowWidth - 1, 0);
-        }
-
-        if (EditWindow->HWindow != NULL)
-        {
-            r.left = 0;
-            r.top = TopRebarHeight + PanelsHeight;
-            r.right = WindowWidth;
-            r.bottom = r.top + 2;
-            FillRect(dc, &r, HDialogBrush);
-        }
-
-        if (BottomToolBar->HWindow != NULL)
-        {
-            r.left = 0;
-            r.top = TopRebarHeight + PanelsHeight + EditHeight;
-            r.right = WindowWidth;
-            r.bottom = r.top + 2;
-            FillRect(dc, &r, HDialogBrush);
-        }
-
-        SelectObject(dc, oldPen);
-        HANDLES(EndPaint(HWindow, &ps));
-        return 0;
     }
 
     case WM_DESTROY:

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -4133,6 +4133,52 @@ void CMainWindow::OnConfiguration(int mode, int param)
 LRESULT
 CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    // WindowProcImpl handles many commands and therefore has a large stack
+    // frame.  Interactive window dragging sends these messages for every
+    // pointer step, so keep them on this small, allocation-free path.
+    switch (uMsg)
+    {
+    case WM_MOVE:
+    case WM_MOVING:
+    case WM_WINDOWPOSCHANGING:
+        return CWindow::WindowProc(uMsg, wParam, lParam);
+
+    case WM_WINDOWPOSCHANGED:
+    {
+        GetWindowRect(HWindow, &WindowRect);
+
+        // Some detach/reattach paths move tab HWNDs between top-level hosts while Windows
+        // is also changing activation/z-order.  If the following maximize/resize does not
+        // deliver a usable WM_SIZE, the chrome and panel children keep their old rectangle
+        // and the newly exposed part of the main window remains empty.  Treat a changed,
+        // visible client size observed in WM_WINDOWPOSCHANGED as authoritative and run the
+        // same sizing path after the current position-change notification unwinds.  Do not
+        // synthesize restored-size layout while minimized: Windows sends the real
+        // SIZE_MINIMIZED WM_SIZE for that state, and laying out a 0x0 restored client area
+        // can re-enter the rebar/control notification path until the stack overflows.
+        if (Created && !DetachedPanels && !WindowPosSizeUpdatePending && !IsIconic(HWindow))
+        {
+            RECT clientRect;
+            GetClientRect(HWindow, &clientRect);
+            int clientWidth = clientRect.right - clientRect.left;
+            int clientHeight = clientRect.bottom - clientRect.top;
+            if (clientWidth > 0 && clientHeight > 0 &&
+                (clientWidth != WindowWidth || clientHeight != WindowHeight))
+            {
+                WindowPosSizeUpdatePending = TRUE;
+                PostMessage(HWindow, WM_SIZE, SIZE_RESTORED, MAKELPARAM(clientWidth, clientHeight));
+            }
+        }
+        return CWindow::WindowProc(uMsg, wParam, lParam);
+    }
+    }
+
+    return WindowProcImpl(uMsg, wParam, lParam);
+}
+
+LRESULT
+CMainWindow::WindowProcImpl(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
     SLOW_CALL_STACK_MESSAGE4("CMainWindow::WindowProc(0x%X, 0x%IX, 0x%IX)", uMsg, wParam, lParam);
     switch (uMsg)
     {
@@ -9710,35 +9756,6 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             return 0;
         }
 
-        break;
-    }
-
-    case WM_WINDOWPOSCHANGED:
-    {
-        GetWindowRect(HWindow, &WindowRect);
-
-        // Some detach/reattach paths move tab HWNDs between top-level hosts while Windows
-        // is also changing activation/z-order.  If the following maximize/resize does not
-        // deliver a usable WM_SIZE, the chrome and panel children keep their old rectangle
-        // and the newly exposed part of the main window remains empty.  Treat a changed,
-        // visible client size observed in WM_WINDOWPOSCHANGED as authoritative and run the
-        // same sizing path after the current position-change notification unwinds.  Do not
-        // synthesize restored-size layout while minimized: Windows sends the real
-        // SIZE_MINIMIZED WM_SIZE for that state, and laying out a 0x0 restored client area
-        // can re-enter the rebar/control notification path until the stack overflows.
-        if (Created && !DetachedPanels && !WindowPosSizeUpdatePending && !IsIconic(HWindow))
-        {
-            RECT clientRect;
-            GetClientRect(HWindow, &clientRect);
-            int clientWidth = clientRect.right - clientRect.left;
-            int clientHeight = clientRect.bottom - clientRect.top;
-            if (clientWidth > 0 && clientHeight > 0 &&
-                (clientWidth != WindowWidth || clientHeight != WindowHeight))
-            {
-                WindowPosSizeUpdatePending = TRUE;
-                PostMessage(HWindow, WM_SIZE, SIZE_RESTORED, MAKELPARAM(clientWidth, clientHeight));
-            }
-        }
         break;
     }
 

--- a/src/plugins/automation/tests/processruntime_tests.cpp
+++ b/src/plugins/automation/tests/processruntime_tests.cpp
@@ -89,6 +89,22 @@ struct BootstrapDispatchState
     }
 };
 
+void PumpBootstrapUntilComplete(
+    Salamatrix::Runtime::IRuntimeSession* session,
+    BootstrapDispatchState* state)
+{
+    const ULONGLONG deadline = GetTickCount64() + 30000;
+    while (state->CommandCalls < 2 && session->IsAlive())
+    {
+        ULONGLONG now = GetTickCount64();
+        if (now >= deadline)
+            break;
+        ULONGLONG remaining = deadline - now;
+        DWORD timeout = remaining < 250 ? static_cast<DWORD>(remaining) : 250;
+        (void)session->Pump(timeout);
+    }
+}
+
 void Check(bool condition, const char* message)
 {
     if (!condition)
@@ -912,8 +928,7 @@ void RunPythonBootstrapTest()
         // A persistent worker can issue many calls after the subscription call;
         // stopping at SubscribeCalls would race the script and send shutdown
         // while it is still waiting for the next response.
-        for (int attempt = 0; attempt < 60 && state.CommandCalls < 2 && session->IsAlive(); ++attempt)
-            (void)session->Pump(250);
+        PumpBootstrapUntilComplete(session, &state);
         Check(state.CommandCalls == 2, "bootstrap command and completion calls reached host");
         Check(state.NotificationCalls == 1, "bootstrap notification call reached host");
         Check(state.MessageBoxCalls == 1, "bootstrap message box call reached host");
@@ -1057,8 +1072,7 @@ void RunPowerShellBootstrapTest()
           "start powershell bootstrap worker");
     if (session != NULL)
     {
-        for (int attempt = 0; attempt < 60 && state.CommandCalls < 2 && session->IsAlive(); ++attempt)
-            (void)session->Pump(250);
+        PumpBootstrapUntilComplete(session, &state);
         Check(state.CommandCalls == 2, "powershell bootstrap command and completion calls");
         Check(state.MessageBoxCalls == 1, "powershell message box call");
         Check(state.FilePropertiesCalls == 1, "powershell file properties call");
@@ -1194,8 +1208,7 @@ void RunPhpBootstrapTest()
           "start php bootstrap worker");
     if (session != NULL)
     {
-        for (int attempt = 0; attempt < 60 && state.CommandCalls < 2 && session->IsAlive(); ++attempt)
-            (void)session->Pump(250);
+        PumpBootstrapUntilComplete(session, &state);
         Check(state.CommandCalls == 2, "php bootstrap command and completion calls");
         Check(state.MessageBoxCalls == 1, "php message box call");
         Check(state.FilePropertiesCalls == 1, "php file properties call");

--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -216,6 +216,15 @@ static LRESULT CALLBACK TabTipWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 {
     switch (uMsg)
     {
+    case WM_SETFONT:
+        SetWindowLongPtr(hWnd, GWLP_USERDATA, (LONG_PTR)wParam);
+        if (lParam != 0)
+            InvalidateRect(hWnd, NULL, TRUE);
+        return 0;
+
+    case WM_GETFONT:
+        return GetWindowLongPtr(hWnd, GWLP_USERDATA);
+
     case WM_PAINT:
     {
         PAINTSTRUCT ps;
@@ -225,7 +234,10 @@ static LRESULT CALLBACK TabTipWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
         FillRect(hdc, &rc, (HBRUSH)(COLOR_INFOBK + 1));
         SetBkMode(hdc, TRANSPARENT);
         SetTextColor(hdc, GetSysColor(COLOR_INFOTEXT));
-        HFONT hOldFont = (HFONT)SelectObject(hdc, GetStockObject(DEFAULT_GUI_FONT));
+        HFONT font = (HFONT)GetWindowLongPtr(hWnd, GWLP_USERDATA);
+        if (font == NULL)
+            font = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
+        HFONT hOldFont = (HFONT)SelectObject(hdc, font);
         DrawText(hdc, g_TabTipText, -1, &rc, DT_CENTER | DT_VCENTER | DT_NOPREFIX | DT_SINGLELINE);
         SelectObject(hdc, hOldFont);
         EndPaint(hWnd, &ps);
@@ -265,6 +277,8 @@ CTabWindow::CTabWindow(CMainWindow* mainWindow, CPanelSide side)
     MouseWheelAccumulator = 0;
     InitialEnsureSelectedTabVisiblePending = true;
     HTabTipWnd = NULL;
+    HTabTipFont = NULL;
+    TabTipDPI = 0;
     TabTipTabIndex = -1;
     TabTipHoverIndex = -1;
     TabTipTracking = false;
@@ -282,6 +296,8 @@ CTabWindow::~CTabWindow()
         HANDLES(DeleteObject(HDPIFont));
     if (HDPIFontBold != NULL)
         HANDLES(DeleteObject(HDPIFontBold));
+    if (HTabTipFont != NULL)
+        HANDLES(DeleteObject(HTabTipFont));
 }
 
 BOOL CTabWindow::Create(HWND parent, int controlID)
@@ -335,6 +351,8 @@ int CTabWindow::GetNeededHeight() const
 
 void CTabWindow::RefreshDPIResources()
 {
+    RefreshTabToolTipFont();
+
     LOGFONT lf;
     HFONT font = WinLibDPIGetIconTitleLogFont(HWindow, &lf)
                      ? HANDLES(CreateFontIndirect(&lf))
@@ -905,6 +923,26 @@ void CTabWindow::EnsureTabTipWnd()
                                 WS_POPUP | WS_EX_TOPMOST | WS_EX_TOOLWINDOW,
                                 0, 0, 0, 0,
                                 HWindow, NULL, HInstance, NULL);
+    if (HTabTipWnd != NULL && HTabTipFont != NULL)
+        SendMessage(HTabTipWnd, WM_SETFONT, (WPARAM)HTabTipFont, FALSE);
+}
+
+void CTabWindow::RefreshTabToolTipFont()
+{
+    UINT dpi = WinLibDPIGetWindowDPI(HWindow);
+    if (HTabTipFont != NULL && TabTipDPI == dpi)
+        return;
+
+    HFONT font = HANDLES(WinLibDPICreateStatusFontForDPI(dpi));
+    if (font == NULL)
+        return;
+
+    if (HTabTipWnd != NULL)
+        SendMessage(HTabTipWnd, WM_SETFONT, (WPARAM)font, FALSE);
+    if (HTabTipFont != NULL)
+        HANDLES(DeleteObject(HTabTipFont));
+    HTabTipFont = font;
+    TabTipDPI = dpi;
 }
 
 void CTabWindow::ShowTabToolTip(int tabIndex)
@@ -935,13 +973,17 @@ void CTabWindow::ShowTabToolTip(int tabIndex)
     if (HTabTipWnd == NULL)
         return;
 
+    RefreshTabToolTipFont();
     HDC hdc = GetDC(HTabTipWnd);
-    SelectObject(hdc, (HFONT)GetStockObject(DEFAULT_GUI_FONT));
+    HFONT oldFont = (HFONT)SelectObject(
+        hdc, HTabTipFont != NULL ? HTabTipFont : (HFONT)GetStockObject(DEFAULT_GUI_FONT));
     SIZE sz;
     GetTextExtentPoint32(hdc, path, (int)strlen(path), &sz);
+    SelectObject(hdc, oldFont);
     ReleaseDC(HTabTipWnd, hdc);
-    int w = sz.cx + 6;
-    int h = sz.cy + 4;
+    UINT dpi = TabTipDPI != 0 ? TabTipDPI : USER_DEFAULT_SCREEN_DPI;
+    int w = sz.cx + MulDiv(6, (int)dpi, USER_DEFAULT_SCREEN_DPI);
+    int h = sz.cy + MulDiv(4, (int)dpi, USER_DEFAULT_SCREEN_DPI);
 
     RECT tabRect;
     SendMessage(HWindow, TCM_GETITEMRECT, tabIndex, (LPARAM)&tabRect);

--- a/src/tabwnd.cpp
+++ b/src/tabwnd.cpp
@@ -933,7 +933,10 @@ void CTabWindow::RefreshTabToolTipFont()
     if (HTabTipFont != NULL && TabTipDPI == dpi)
         return;
 
-    HFONT font = HANDLES(WinLibDPICreateStatusFontForDPI(dpi));
+    LOGFONT lf;
+    HFONT font = WinLibDPIGetStatusLogFontForDPI(dpi, &lf)
+                     ? HANDLES(CreateFontIndirect(&lf))
+                     : NULL;
     if (font == NULL)
         return;
 

--- a/src/tabwnd.h
+++ b/src/tabwnd.h
@@ -80,6 +80,7 @@ private:
     void ShowTabToolTip(int tabIndex);
     void HideTabToolTip();
     void EnsureTabTipWnd();
+    void RefreshTabToolTipFont();
 
     struct STabColor
     {
@@ -124,6 +125,8 @@ private:
     std::vector<STabColor> TabColors;
 
     HWND HTabTipWnd;
+    HFONT HTabTipFont;
+    UINT TabTipDPI;
     int TabTipTabIndex;
     int TabTipHoverIndex;
     bool TabTipTracking;

--- a/src/tests/detached_tab_contract_tests.py
+++ b/src/tests/detached_tab_contract_tests.py
@@ -133,8 +133,10 @@ def main() -> None:
         "dark menu-bar background before suppressing erase",
     )
     require(mainwnd1, "case WM_DPICHANGED:", "per-monitor DPI handling")
-    require(tabwnd, "WinLibDPICreateStatusFontForDPI(dpi)",
-            "tab tooltip font created for its host-window DPI")
+    require(tabwnd, "WinLibDPIGetStatusLogFontForDPI(dpi, &lf)",
+            "tab tooltip font selected for its host-window DPI")
+    require(tabwnd, "HANDLES(CreateFontIndirect(&lf))",
+            "tab tooltip font creation remains visible to debug handle tracking")
     require(tabwnd, "SendMessage(HTabTipWnd, WM_SETFONT, (WPARAM)font, FALSE)",
             "visible tab tooltip receives the refreshed per-monitor font")
     require(tabwnd, "HTabTipFont != NULL ? HTabTipFont",

--- a/src/tests/detached_tab_contract_tests.py
+++ b/src/tests/detached_tab_contract_tests.py
@@ -133,6 +133,14 @@ def main() -> None:
         "dark menu-bar background before suppressing erase",
     )
     require(mainwnd1, "case WM_DPICHANGED:", "per-monitor DPI handling")
+    require(tabwnd, "WinLibDPICreateStatusFontForDPI(dpi)",
+            "tab tooltip font created for its host-window DPI")
+    require(tabwnd, "SendMessage(HTabTipWnd, WM_SETFONT, (WPARAM)font, FALSE)",
+            "visible tab tooltip receives the refreshed per-monitor font")
+    require(tabwnd, "HTabTipFont != NULL ? HTabTipFont",
+            "tab tooltip measurement uses the same DPI font as painting")
+    require(tabwnd, "MulDiv(6, (int)dpi, USER_DEFAULT_SCREEN_DPI)",
+            "tab tooltip horizontal padding scales with per-monitor DPI")
     require(mainwnd1, "RebuildDetachedTabToolbarImageLists",
             "per-window directory-line toolbar images")
     require(mainwnd1, "BuildWindowTitleForPanel(info.Panel, prefix, wideAppSuffix)",

--- a/src/tests/main_window_move_contract_tests.py
+++ b/src/tests/main_window_move_contract_tests.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def require(text: str, needle: str, description: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"Missing {description}: {needle}")
+
+
+def main() -> None:
+    mainwnd3 = (ROOT / "src/mainwnd3.cpp").read_text(encoding="utf-8")
+
+    fast_start = mainwnd3.index("CMainWindow::WindowProc(UINT uMsg")
+    impl_start = mainwnd3.index("CMainWindow::WindowProcImpl(UINT uMsg")
+    fast_path = mainwnd3[fast_start:impl_start]
+    implementation = mainwnd3[impl_start:]
+
+    for message in (
+        "case WM_MOVE:",
+        "case WM_MOVING:",
+        "case WM_WINDOWPOSCHANGING:",
+        "case WM_WINDOWPOSCHANGED:",
+    ):
+        require(fast_path, message, "interactive main-window move fast path")
+        if message in implementation:
+            raise AssertionError(
+                f"Heavy WindowProcImpl must not handle drag message: {message}"
+            )
+
+    require(
+        fast_path,
+        "return CWindow::WindowProc(uMsg, wParam, lParam);",
+        "default Windows processing for drag messages",
+    )
+    require(
+        fast_path,
+        "return WindowProcImpl(uMsg, wParam, lParam);",
+        "non-drag dispatch to the complete message handler",
+    )
+    require(
+        fast_path,
+        "PostMessage(HWindow, WM_SIZE, SIZE_RESTORED",
+        "deferred size recovery retained on the fast path",
+    )
+
+    print("Main-window move contract tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tests/main_window_move_contract_tests.py
+++ b/src/tests/main_window_move_contract_tests.py
@@ -21,10 +21,18 @@ def main() -> None:
     implementation = mainwnd3[impl_start:]
 
     for message in (
+        "case WM_GETMINMAXINFO:",
+        "case WM_NCHITTEST:",
+        "case WM_NCMOUSEMOVE:",
+        "case WM_NCPAINT:",
+        "case WM_SYNCPAINT:",
         "case WM_MOVE:",
         "case WM_MOVING:",
         "case WM_WINDOWPOSCHANGING:",
         "case WM_WINDOWPOSCHANGED:",
+        "case WM_SETCURSOR:",
+        "case WM_ERASEBKGND:",
+        "case WM_PAINT:",
     ):
         require(fast_path, message, "interactive main-window move fast path")
         if message in implementation:

--- a/src/tooltip.cpp
+++ b/src/tooltip.cpp
@@ -343,20 +343,7 @@ BOOL CToolTip::UpdateFontForDPI(UINT dpi)
     if (WindowFont != NULL && WindowDPI == dpi)
         return TRUE;
 
-    NONCLIENTMETRICS metrics;
-    if (!WinLibDPIGetNonClientMetricsForDPI(dpi, &metrics))
-        return FALSE;
-
-    LOGFONT lf = metrics.lfStatusFont;
-    if (lf.lfHeight != 0)
-    {
-        int height = abs(lf.lfHeight);
-        int expectedHeight = MulDiv(12, (int)dpi, USER_DEFAULT_SCREEN_DPI);
-        if (height < expectedHeight - 1 || height > expectedHeight + 2)
-            lf.lfHeight = lf.lfHeight < 0 ? -expectedHeight : expectedHeight;
-    }
-
-    HFONT font = HANDLES(CreateFontIndirect(&lf));
+    HFONT font = HANDLES(WinLibDPICreateStatusFontForDPI(dpi));
     if (font == NULL)
         return FALSE;
     if (WindowFont != NULL)

--- a/src/tooltip.cpp
+++ b/src/tooltip.cpp
@@ -343,7 +343,10 @@ BOOL CToolTip::UpdateFontForDPI(UINT dpi)
     if (WindowFont != NULL && WindowDPI == dpi)
         return TRUE;
 
-    HFONT font = HANDLES(WinLibDPICreateStatusFontForDPI(dpi));
+    LOGFONT lf;
+    HFONT font = WinLibDPIGetStatusLogFontForDPI(dpi, &lf)
+                     ? HANDLES(CreateFontIndirect(&lf))
+                     : NULL;
     if (font == NULL)
         return FALSE;
     if (WindowFont != NULL)

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -229,6 +229,14 @@ try {
                 (Join-Path $repositoryRoot `
                     'src\tests\detached_tab_contract_tests.py')
             )
+        },
+        @{
+            Name = 'main_window_move_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\main_window_move_contract_tests.py')
+            )
         }
     )) {
         Write-Host "Running $($contractTest.Name)..."


### PR DESCRIPTION
## Summary
- keep high-frequency main-window drag, non-client, cursor, and paint messages on a small fast path
- preserve existing position and paint behavior while avoiding the large general `WindowProc` stack frame
- initialize panel-tab tooltip fonts and padding from the owning window's per-monitor DPI
- add source-contract coverage to the existing PR test runner

## Root cause
The main window's monolithic message handler has a very large stack frame, and several messages emitted repeatedly during interactive dragging still entered it. The custom panel-tab tooltip also measured and rendered with `DEFAULT_GUI_FONT`, so its initial font followed the wrong scale until a DPI transition rebuilt the state.

## Impact
Main-window interaction avoids the heavyweight handler for drag-related messages. Tab tooltips use the correct font and dimensions on first display and refresh when the owning tab window changes DPI.

## Validation
- Release x64 Salamander build
- Debug x64 Salamander build
- `main_window_move_contract_tests`
- `detached_tab_contract_tests`
- `git diff --check`

## Runtime validation
Live drag smoothness and tooltip appearance still require confirmation in the newly built application.