### PR TITLE
Preserve curly-braced placeholders in Markdown viewer

### DIFF
--- a/src/plugins/webview2renderviewer/managed/ViewerHost.cs
+++ b/src/plugins/webview2renderviewer/managed/ViewerHost.cs
@@ -1503,9 +1503,22 @@ internal static class ViewerHost
         {
             try
             {
-                return new MarkdownPipelineBuilder()
-                    .UseAdvancedExtensions()
-                    .Build();
+                var builder = new MarkdownPipelineBuilder()
+                    .UseAdvancedExtensions();
+
+                // Generic attributes treat text such as "{name}" immediately
+                // following an inline HTML element as attribute syntax. This is
+                // surprising in a document viewer and makes placeholder text in
+                // constructs such as <code>{name} {type}</code> disappear.
+                for (int index = builder.Extensions.Count - 1; index >= 0; index--)
+                {
+                    if (builder.Extensions[index] is Markdig.Extensions.GenericAttributes.GenericAttributesExtension)
+                    {
+                        builder.Extensions.RemoveAt(index);
+                    }
+                }
+
+                return builder.Build();
             }
             catch (Exception ex)
             {

--- a/src/tests/webview2_render_viewer_contract_tests.py
+++ b/src/tests/webview2_render_viewer_contract_tests.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+import re
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+VIEWER_HOST = (
+    REPOSITORY_ROOT
+    / "src"
+    / "plugins"
+    / "webview2renderviewer"
+    / "managed"
+    / "ViewerHost.cs"
+)
+
+
+def main() -> None:
+    source = VIEWER_HOST.read_text(encoding="utf-8")
+
+    create_pipeline = re.search(
+        r"private static MarkdownPipeline CreatePipeline\(\).*?\n        }\n    }",
+        source,
+        re.DOTALL,
+    )
+    if create_pipeline is None:
+        raise AssertionError("MarkdownRenderer.CreatePipeline was not found")
+
+    pipeline_source = create_pipeline.group(0)
+    if ".UseAdvancedExtensions()" not in pipeline_source:
+        raise AssertionError("the Markdown viewer must retain advanced extensions")
+    if "GenericAttributesExtension" not in pipeline_source:
+        raise AssertionError(
+            "generic attributes must be disabled so curly-braced placeholders remain visible"
+        )
+    if "builder.Extensions.RemoveAt(index)" not in pipeline_source:
+        raise AssertionError("the generic attributes extension is detected but not removed")
+
+    advanced_call = pipeline_source.index(".UseAdvancedExtensions()")
+    removal = pipeline_source.index("builder.Extensions.RemoveAt(index)")
+    build_call = pipeline_source.index("return builder.Build()")
+    if not advanced_call < removal < build_call:
+        raise AssertionError(
+            "generic attributes must be removed after advanced setup and before pipeline build"
+        )
+
+    print("WebView2 render viewer source-contract tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -237,6 +237,14 @@ try {
                 (Join-Path $repositoryRoot `
                     'src\tests\main_window_move_contract_tests.py')
             )
+        },
+        @{
+            Name = 'webview2_render_viewer_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\webview2_render_viewer_contract_tests.py')
+            )
         }
     )) {
         Write-Host "Running $($contractTest.Name)..."


### PR DESCRIPTION
## What changed

- keep Markdig advanced Markdown support while disabling only `GenericAttributesExtension`
- preserve curly-braced placeholder text such as `<code>{name} {type}</code>`
- add a WebView2 render viewer source-contract regression to the PR test runner

## Root cause

`UseAdvancedExtensions()` enables Markdig generic attributes. In Markdown containing inline HTML, text such as `{name}` and `{type}` immediately after the `<code>` tag was interpreted as attribute syntax instead of visible content, so it disappeared from the rendered HTML.

## Impact

Markdown files rendered by WebView2RenderViewer now show curly-braced placeholders inside inline code elements correctly. Other advanced Markdown extensions remain enabled.

## Validation

- `dotnet build src/plugins/webview2renderviewer/managed/WebView2RenderViewer.Managed.csproj --configuration Release --no-restore`
- `python -B src/tests/webview2_render_viewer_contract_tests.py`
- functional reflection test against the built renderer confirmed `<code>{name} {type}</code>` remains in generated HTML
- `git diff --check`

Live GUI behavior was not exercised because the locally running Salamander was intentionally left untouched.