### PR TITLE
Fix UTF-8 USB directory enumeration

### DIFF
--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -656,7 +656,14 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
         }
         UseThumbnails = readThumbnails;
 
-        const bool useWideDiskPath = GetPathW() != NULL && GetPathW()[0] != 0 && strlen(GetPath()) >= MAX_PATH;
+        // FindFirstFileA converts names through the active code page into the
+        // fixed WIN32_FIND_DATAA::cFileName buffer.  With the UTF-8 manifest a
+        // valid 255-character FAT/exFAT name can require more than MAX_PATH
+        // bytes, making FindNextFileA stop a partial listing with
+        // ERROR_MORE_DATA.  Enumerate wide whenever PathW is authoritative so
+        // the full on-disk name never passes through that fixed UTF-8 buffer.
+        const bool useWideDiskPath = GetPathW() != NULL && GetPathW()[0] != 0 &&
+                                     (GetACP() == CP_UTF8 || strlen(GetPath()) >= MAX_PATH);
         if (useWideDiskPath)
         {
             std::wstring currentDirW = SalPathAddExtendedPrefixW(GetPathW());

--- a/src/tests/directory_listing_contract_tests.py
+++ b/src/tests/directory_listing_contract_tests.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+import re
+import sys
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "fileswn3.cpp"
+
+
+def main() -> int:
+    text = SOURCE.read_text(encoding="utf-8")
+
+    selection = re.search(
+        r"const bool useWideDiskPath\s*=\s*(.*?);", text, re.DOTALL
+    )
+    if selection is None:
+        print("fileswn3.cpp no longer selects a wide directory enumeration path")
+        return 1
+
+    expression = selection.group(1)
+    required = ("GetPathW()", "GetACP() == CP_UTF8", "strlen(GetPath()) >= MAX_PATH")
+    missing = [token for token in required if token not in expression]
+    if missing:
+        print("wide directory enumeration selection is missing: " + ", ".join(missing))
+        return 1
+
+    if "FindFirstFileW" not in text or "FindNextFileW" not in text:
+        print("wide directory enumeration must use both FindFirstFileW and FindNextFileW")
+        return 1
+
+    print("UTF-8 and long panel paths use wide directory enumeration")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -239,6 +239,14 @@ try {
             )
         },
         @{
+            Name = 'directory_listing_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\directory_listing_contract_tests.py')
+            )
+        },
+        @{
             Name = 'webview2_render_viewer_contract_tests'
             Arguments = @(
                 '-B',


### PR DESCRIPTION
## What changed

- use wide Win32 directory enumeration for all local panel paths when Salamander runs with the UTF-8 active code page
- retain the existing wide enumeration behavior for long paths
- add a source-contract regression test to the PR-running native test suite

## Why

Salamander 5 declares UTF-8 as its active ANSI code page, but short panel paths were still enumerated through `FindFirstFileA` and `FindNextFileA`. A valid FAT/exFAT filename can fit the 255-character filesystem limit while its UTF-8 representation exceeds the fixed `WIN32_FIND_DATAA::cFileName` buffer. Windows then stops enumeration with `ERROR_MORE_DATA` (234), leaving a partial directory listing and displaying an error. Salamander 4 did not hit this because its legacy ANSI code page used fewer bytes for the same names.

Using `FindFirstFileW` and `FindNextFileW` avoids the lossy fixed-size UTF-8 conversion and preserves the complete UTF-16 filename already supported by the panel data model.

## User impact

USB flash drives and other FAT/exFAT volumes containing long multibyte filenames should load completely without the error 234 dialog.

## Validation

- `python -B src/tests/directory_listing_contract_tests.py`
- Release x64 build of `src/vcxproj/salamand.vcxproj`
- `git diff --check`

The exact reporter USB drive was not available for live GUI validation.