### PR TITLE
Fix shell icons and startup panel rendering

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -1795,6 +1795,7 @@ DWORD CfgSkillLevelToMenu(BYTE cfgSkillLevel);
 #define IDT_THROBBER 949
 #define IDT_DELAYEDTHROBBER 950
 #define IDT_UPDATETASKLIST 951
+#define IDT_FINISHSTARTUPREVEAL 952
 
 // POZOR: skoro vsechny funkce v teto sekci pri chybe zobrazuji hlaseni o LOAD / SAVE
 //        konfigurace, coz z nich dela nevhodne pro bezny pristup do Registry,

--- a/src/darkmode.cpp
+++ b/src/darkmode.cpp
@@ -2421,6 +2421,16 @@ bool DarkModeIsSupported()
     return gSupported;
 }
 
+bool DarkModeSetWindowCloaked(HWND hwnd, bool cloaked)
+{
+    EnsureInitialized();
+    if (gDwmSetWindowAttribute == nullptr)
+        return false;
+
+    BOOL value = cloaked ? TRUE : FALSE;
+    return SUCCEEDED(gDwmSetWindowAttribute(hwnd, 13 /* DWMWA_CLOAK */, &value, sizeof(value)));
+}
+
 void DarkModeDetectAndEnableSystemDarkMode()
 {
     EnsureInitialized();

--- a/src/darkmode.h
+++ b/src/darkmode.h
@@ -24,6 +24,10 @@ void DarkModeShutdown();
 // Returns true if native dark mode APIs are available on this system.
 bool DarkModeIsSupported();
 
+// Hides or reveals a window at the DWM compositor without changing its Win32
+// visibility. Returns false when the DWM API is unavailable or rejects it.
+bool DarkModeSetWindowCloaked(HWND hwnd, bool cloaked);
+
 // Enables or disables native dark mode integration for the process.
 void DarkModeSetEnabled(bool enabled);
 

--- a/src/filesbx1.cpp
+++ b/src/filesbx1.cpp
@@ -1418,6 +1418,11 @@ CFilesBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_SIZE:
     {
         LayoutChilds();
+        // HPrivateDC is persistent and is also used by direct item paints. In
+        // brief view a resize can otherwise leave an old column-sized area
+        // outside the regions invalidated by LayoutChilds(), which then covers
+        // the panel until another full repaint happens.
+        InvalidateRect(HWindow, NULL, FALSE);
         break;
     }
 
@@ -1439,8 +1444,41 @@ CFilesBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_PAINT:
     {
         PAINTSTRUCT ps;
-        HANDLES(BeginPaint(HWindow, &ps));
-        PaintAllItems(NULL, 0);
+        HDC paintDC = HANDLES(BeginPaint(HWindow, &ps));
+        RECT clientRect;
+        GetClientRect(HWindow, &clientRect);
+        int width = clientRect.right - clientRect.left;
+        int height = clientRect.bottom - clientRect.top;
+        HDC memoryDC = width > 0 && height > 0 ? HANDLES(CreateCompatibleDC(paintDC)) : NULL;
+        HBITMAP memoryBitmap = memoryDC != NULL ? HANDLES(CreateCompatibleBitmap(paintDC, width, height)) : NULL;
+        if (memoryBitmap != NULL)
+        {
+            HBITMAP oldBitmap = (HBITMAP)SelectObject(memoryDC, memoryBitmap);
+            BitBlt(memoryDC, 0, 0, width, height, HPrivateDC, 0, 0, SRCCOPY);
+
+            // PaintAllItems can touch hundreds of cells. Drawing them directly
+            // into the persistent window DC exposes a visible erase/draw sweep
+            // to DWM. Build the complete frame off-screen and publish it once.
+            HDC windowDC = HPrivateDC;
+            HPrivateDC = memoryDC;
+            PaintAllItems(NULL, 0);
+            HPrivateDC = windowDC;
+
+            BitBlt(paintDC,
+                   ps.rcPaint.left, ps.rcPaint.top,
+                   ps.rcPaint.right - ps.rcPaint.left,
+                   ps.rcPaint.bottom - ps.rcPaint.top,
+                   memoryDC, ps.rcPaint.left, ps.rcPaint.top, SRCCOPY);
+            SelectObject(memoryDC, oldBitmap);
+            HANDLES(DeleteObject(memoryBitmap));
+            HANDLES(DeleteDC(memoryDC));
+        }
+        else
+        {
+            if (memoryDC != NULL)
+                HANDLES(DeleteDC(memoryDC));
+            PaintAllItems(NULL, 0);
+        }
         HANDLES(EndPaint(HWindow, &ps));
         SelectClipRgn(HPrivateDC, NULL);
         return 0;

--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -2268,6 +2268,53 @@ void CFilesWindow::RepaintIconOnly(int index)
         ListBox->PaintItem(index, DRAWFLAG_ICON_ONLY);
 }
 
+void CFilesWindow::RepaintIconsForExtension(const char* extension)
+{
+    CALL_STACK_MESSAGE_NONE
+    if (extension == NULL)
+        return;
+
+    // A newly resolved association changes only files with this extension.
+    // Repainting every icon in both panels for each association makes the
+    // persistent-DC list visibly sweep across the window during startup.
+    for (int i = 0; i < Files->Count; i++)
+    {
+        if (StrICmp(Files->At(i).Ext, extension) == 0)
+            ListBox->PaintItem(Dirs->Count + i, DRAWFLAG_ICON_ONLY);
+    }
+}
+
+void CFilesWindow::CompletePendingStartupRefreshes()
+{
+    // CFilesWindow::Activate posts this deliberately conservative refresh and
+    // its handler delays the actual directory read by 200 ms. During startup
+    // the directory has just been read, so allowing the pending work to run
+    // after the first frame was presented visibly clears and rebuilds the
+    // panel. Cancel both stages; a WM_TIMER already in the queue is harmless
+    // once RefreshDirExTimerSet is FALSE.
+    KillTimer(HWindow, IDT_REFRESH_DIR_EX);
+    RefreshDirExTimerSet = FALSE;
+    RefreshDirExLParam = 0;
+
+    MSG msg;
+    while (PeekMessage(&msg, HWindow, WM_USER_REFRESH_DIR_EX,
+                       WM_USER_REFRESH_DIR_EX, PM_REMOVE))
+        ;
+    while (PeekMessage(&msg, HWindow, WM_USER_REFRESH_DIR_EX_DELAYED,
+                       WM_USER_REFRESH_DIR_EX_DELAYED, PM_REMOVE))
+        ;
+
+    // WM_DPICHANGED_AFTERPARENT can invalidate the icon cache while the saved
+    // startup placement is applied. Its ordinary refresh is required, but it
+    // must finish while the top-level window is still cloaked. Otherwise the
+    // message loop clears and rebuilds each already-visible panel in turn.
+    while (PeekMessage(&msg, HWindow, WM_USER_REFRESH_DIR,
+                       WM_USER_REFRESH_DIR, PM_REMOVE))
+    {
+        SendMessage(HWindow, msg.message, msg.wParam, msg.lParam);
+    }
+}
+
 void ReleaseListingBody(CPanelType oldPanelType, CSalamanderDirectory*& oldArchiveDir,
                         CSalamanderDirectory*& oldPluginFSDir,
                         CPluginDataInterfaceEncapsulation& oldPluginData,

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -781,6 +781,10 @@ void CFilesWindow::ExpandTreeViewAutoHide()
         return;
     TreeViewAutoHideExpanded = TRUE;
     TreeViewAutoHideCollapseStart = 0;
+    // A collapsed auto-hide tree is deliberately not populated during startup.
+    // Populate it only when the user actually expands the panel.
+    RefreshTreeViewDPI();
+    RefreshTreeView();
     if (HTreeHeader != NULL)
         InvalidateRect(HTreeHeader, NULL, TRUE);
     if (MainWindow != NULL)
@@ -2240,7 +2244,10 @@ void CFilesWindow::CreateTreeView()
         DarkModeApplyWindow(HTreeView);
         DarkModePreserveCustomTreeView(HTreeView);
 
-        RefreshTreeViewDPI();
+        // Copying every shell image-list entry is expensive and pointless while
+        // an auto-hide tree is collapsed.  It is initialized on first expand.
+        if (!TreeViewAutoHide || TreeViewAutoHideExpanded)
+            RefreshTreeViewDPI();
         UpdateTreeViewColors();
     }
 
@@ -2465,7 +2472,7 @@ void CFilesWindow::UpdateTreeView(BOOL active)
     if (HTreeView != NULL)
     {
         ShowWindow(HTreeView, TreeViewActive && (!TreeViewAutoHide || TreeViewAutoHideExpanded) ? SW_SHOW : SW_HIDE);
-        if (TreeViewActive)
+        if (TreeViewActive && (!TreeViewAutoHide || TreeViewAutoHideExpanded))
             RefreshTreeView();
     }
     if (HTreeHeader != NULL)

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "precomp.h"
+
 #include "common/winlibdpi.h"
 
 #include "cfgdlg.h"
@@ -847,11 +848,11 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                             {
                                 // panely prekreslime pouze pokud odpovidaji velikosti ikon
                                 if (iconSize == GetIconSizeForCurrentViewMode())
-                                    RepaintIconOnly(-1); // u nas vsechny
+                                    RepaintIconsForExtension(buf);
 
                                 CFilesWindow* otherPanel = MainWindow->GetOtherPanel(this);
-                                if (iconSize == otherPanel->GetIconSizeForCurrentViewMode())
-                                    otherPanel->RepaintIconOnly(-1); // a u sousedu vsechny
+                                if (otherPanel != NULL && iconSize == otherPanel->GetIconSizeForCurrentViewMode())
+                                    otherPanel->RepaintIconsForExtension(buf);
                             }
                             else
                                 PostAllIconsRepaint = TRUE;
@@ -1150,7 +1151,13 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         SelectViewTemplate(index, FALSE, FALSE);
         ShowWindow(ListBox->HWindow, SW_SHOW);
-        UpdateTreeView(IsActiveTreeViewHost());
+        // LoadConfig creates all tab windows while RestoringPanelPaths is set.
+        // Building the shared Tree View here enumerates the same shell tree for
+        // every transiently active tab (over a second for the first tab on a
+        // normal local path). FocusPanel performs the single required rebuild
+        // after RestoringPanelPaths is cleared.
+        if (MainWindow == NULL || !MainWindow->RestoringPanelPaths)
+            UpdateTreeView(IsActiveTreeViewHost());
 
         // srovname nastaveni promenne AutomaticRefresh a directory-liny
         SetAutomaticRefresh(AutomaticRefresh, TRUE);

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1744,6 +1744,8 @@ public:
     void LayoutListBoxChilds(); // after a font change layout must be updated
     void RepaintListBox(DWORD drawFlags);
     void RepaintIconOnly(int index);   // for index == -1 redraws icons of all items
+    void RepaintIconsForExtension(const char* extension);
+    void CompletePendingStartupRefreshes();
     void EnsureItemVisible(int index); // ensures the item is visible
     void SetQuickSearchCaretPos();     // sets caret position within FocusedIndex
 

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -4,6 +4,10 @@
 
 #include "precomp.h"
 #include "commoncontrols.h"
+#include <shlwapi.h>
+
+#include <string>
+#include <vector>
 
 static UINT PrivateExtractSingleIcon(LPCTSTR fileName, int iconIndex, int iconSize, HICON* hIcon, UINT* iconID, UINT flags)
 {
@@ -214,6 +218,99 @@ static BOOL IsSolidBlackIcon(HICON icon, int pixelSize)
     return solidBlack;
 }
 
+static void DiscardSolidBlackIcon(HICON* icon, int pixelSize)
+{
+    if (icon != NULL && *icon != NULL && IsSolidBlackIcon(*icon, pixelSize))
+    {
+        HANDLES(DestroyIcon(*icon));
+        *icon = NULL;
+    }
+}
+
+static std::wstring PanelPathToWide(const char* path)
+{
+    if (path == NULL || path[0] == 0)
+        return std::wstring();
+
+    UINT codePage = CP_UTF8;
+    DWORD flags = MB_ERR_INVALID_CHARS;
+    int length = MultiByteToWideChar(codePage, flags, path, -1, NULL, 0);
+    if (length == 0)
+    {
+        codePage = CP_ACP;
+        flags = 0;
+        length = MultiByteToWideChar(codePage, flags, path, -1, NULL, 0);
+    }
+    if (length <= 1)
+        return std::wstring();
+
+    std::vector<wchar_t> wide(length);
+    if (MultiByteToWideChar(codePage, flags, path, -1, wide.data(), length) == 0)
+        return std::wstring();
+    return std::wstring(wide.data());
+}
+
+static HICON GetDefaultAssociationIcon(const char* path, int pixelSize)
+{
+    if (path == NULL || pixelSize <= 0)
+        return NULL;
+
+    const char* name = path;
+    for (const char* p = path; *p != 0; ++p)
+    {
+        if (*p == '\\' || *p == '/')
+            name = p + 1;
+    }
+    const char* extension = strrchr(name, '.');
+    if (extension == NULL || extension[1] == 0)
+        return NULL;
+
+    std::wstring wideExtension = PanelPathToWide(extension);
+    if (wideExtension.empty())
+        return NULL;
+
+    DWORD length = 0;
+    AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_DEFAULTICON, wideExtension.c_str(), NULL, NULL, &length);
+    if (length <= 1)
+        return NULL;
+
+    std::vector<wchar_t> location(length);
+    if (FAILED(AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_DEFAULTICON, wideExtension.c_str(),
+                                 NULL, location.data(), &length)))
+        return NULL;
+
+    int iconIndex = PathParseIconLocationW(location.data());
+    std::wstring iconPath;
+    if (_wcsicmp(location.data(), L"%1") == 0)
+        iconPath = PanelPathToWide(path);
+    else
+    {
+        DWORD expandedLength = ExpandEnvironmentStringsW(location.data(), NULL, 0);
+        if (expandedLength == 0)
+            return NULL;
+        std::vector<wchar_t> expanded(expandedLength);
+        if (ExpandEnvironmentStringsW(location.data(), expanded.data(), expandedLength) == 0)
+            return NULL;
+        iconPath.assign(expanded.data());
+    }
+    if (iconPath.empty())
+        return NULL;
+
+    HICON largeIcon = NULL;
+    HICON smallIcon = NULL;
+    HRESULT result = SHDefExtractIconW(iconPath.c_str(), iconIndex, 0, &largeIcon, &smallIcon,
+                                       MAKELONG(pixelSize, pixelSize));
+    if (FAILED(result))
+        return NULL;
+
+    HICON icon = smallIcon != NULL ? smallIcon : largeIcon;
+    if (largeIcon != NULL && largeIcon != icon)
+        HANDLES(DestroyIcon(largeIcon));
+    if (smallIcon != NULL && smallIcon != icon)
+        HANDLES(DestroyIcon(smallIcon));
+    return icon;
+}
+
 BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl, HICON* hIcon,
                         CIconSizeEnum iconSize, BOOL fallbackToDefIcon, BOOL defIconIsDir)
 {
@@ -264,8 +361,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         // another way to get 48x48 icons is LoadImage, but we would need the file path and icon number
         // a "*" in the file name means iconIndex already refers to a system icon index
         //TRACE_I("  SalGetIconFromPIDL() wFlags="<<wFlags<<" iconFile='"<<iconFile<<"' TryObtainGetImageList="<<TryObtainGetImageList);
-        if ((wFlags & GIL_NOTFILENAME) && iconFile[0] == '*' && iconFile[1] == 0 &&
-            !preferExtractorSmallIcon)
+        if ((wFlags & GIL_NOTFILENAME) && iconFile[0] == '*' && iconFile[1] == 0)
         {
             // multiple attempts helped JIS, but if icon extraction keeps failing
             // we would waste 50 ms on each icon retrieval for no reason
@@ -287,6 +383,11 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             {
                 if (imageListSmall->GetIcon(iconIndex, ILD_NORMAL, &hIconSmall) != S_OK)
                     hIconSmall = NULL;
+                // A successful image-list call can still return an all-black
+                // icon.  Treat that as extraction failure here so the direct
+                // SHGFI_ICON fallback below gets a chance to supply the same
+                // usable HICON that Explorer draws.
+                DiscardSolidBlackIcon(&hIconSmall, IconSizes[ICONSIZE_16]);
                 //TRACE_I("  SalGetIconFromPIDL() SHIL_SMALL IID_IImageList, hIconSmall="<<hIconSmall);
                 imageListSmall->Release();
             }
@@ -303,6 +404,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
                     if (hSysImageList != NULL)
                     {
                         hIconSmall = ImageList_GetIcon(hSysImageList, sfi.iIcon, ILD_NORMAL);
+                        DiscardSolidBlackIcon(&hIconSmall, IconSizes[ICONSIZE_16]);
                         //TRACE_I("  SalGetIconFromPIDL() ImageList_GetIcon for SHGFI_SMALLICON hIconSmall="<<hIconSmall<<" sfi.iIcon="<<sfi.iIcon<<" hSysImageList="<<hSysImageList);
                     }
                     if (hIconSmall == NULL)
@@ -312,6 +414,19 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
                         if (SHGetFileInfo(path, 0, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_SMALLICON) != 0)
                             hIconSmall = sfi.hIcon;
                         //TRACE_I("  SalGetIconFromPIDL() SHGetFileInfo for SHGFI_ICON | SHGFI_SMALLICON hIconSmall="<<hIconSmall);
+                    }
+                    if (hIconSmall == NULL || IsSolidBlackIcon(hIconSmall, IconSizes[ICONSIZE_16]))
+                    {
+                        HICON associationIcon = GetDefaultAssociationIcon(path, IconSizes[ICONSIZE_16]);
+                        if (associationIcon != NULL &&
+                            !IsSolidBlackIcon(associationIcon, IconSizes[ICONSIZE_16]))
+                        {
+                            if (hIconSmall != NULL)
+                                HANDLES(DestroyIcon(hIconSmall));
+                            hIconSmall = associationIcon;
+                        }
+                        else if (associationIcon != NULL)
+                            HANDLES(DestroyIcon(associationIcon));
                     }
                 }
                 //else TRACE_I("  SalGetIconFromPIDL() path == NULL");
@@ -421,11 +536,6 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             //TRACE_I("  SalGetIconFromPIDL() ExtractIcons hIconLarge="<<hIconLarge<<" hIconSmall="<<hIconSmall);
         }
 
-        if (preferExtractorSmallIcon && hIconSmall == NULL && hIconLarge == NULL &&
-            (wFlags & GIL_NOTFILENAME) && iconFile[0] == '*' && iconFile[1] == 0)
-        {
-            hIconSmall = GetShellImageListIcon(SHIL_SMALL, iconIndex);
-        }
     }
     if (iconSize == ICONSIZE_16 && hIconSmall != NULL &&
         GetIconPixelWidth(hIconSmall) != IconSizes[ICONSIZE_16] && pxi != NULL)

--- a/src/logo.cpp
+++ b/src/logo.cpp
@@ -221,8 +221,16 @@ void CSplashScreen::SetText(const char* text)
 {
     if (Bitmap != NULL && OriginalBitmap != NULL)
     {
-        // restore the background
-        BitBlt(Bitmap->HMemDC, StatusR.left, StatusR.top, StatusR.right - StatusR.left, StatusR.bottom - StatusR.top, OriginalBitmap->HMemDC, StatusR.left, StatusR.top, SRCCOPY);
+        // DrawText with DT_NOCLIP can antialias an overhanging glyph one pixel
+        // outside its logical origin. Restore and publish a padded dirty area;
+        // otherwise the first glyph of the previous status remains beside the
+        // new one (most visibly Reading... -> Initializing...).
+        RECT dirtyR = StatusR;
+        dirtyR.left = max(0, dirtyR.left - 2);
+        dirtyR.right = min(Width, dirtyR.right + 2);
+        BitBlt(Bitmap->HMemDC, dirtyR.left, dirtyR.top,
+               dirtyR.right - dirtyR.left, dirtyR.bottom - dirtyR.top,
+               OriginalBitmap->HMemDC, dirtyR.left, dirtyR.top, SRCCOPY);
         PaintText(text,
                   StatusR.left, StatusR.top,
                    FALSE, RGB(255, 255, 255));
@@ -231,7 +239,9 @@ void CSplashScreen::SetText(const char* text)
         if (HWindow != NULL)
         {
             HDC hDC = HANDLES(GetDC(HWindow));
-            BitBlt(hDC, StatusR.left, StatusR.top, StatusR.right - StatusR.left, StatusR.bottom - StatusR.top, Bitmap->HMemDC, StatusR.left, StatusR.top, SRCCOPY);
+            BitBlt(hDC, dirtyR.left, dirtyR.top,
+                   dirtyR.right - dirtyR.left, dirtyR.bottom - dirtyR.top,
+                   Bitmap->HMemDC, dirtyR.left, dirtyR.top, SRCCOPY);
             HANDLES(ReleaseDC(HWindow, hDC));
         }
     }

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -456,6 +456,7 @@ public:
 
     BOOL Created;
     BOOL RestoringPanelPaths; // suppress repeated Tree View rebuilds while LoadConfig restores panels
+    BOOL StartupWindowCloaked; // TRUE while the fully initialized startup UI is hidden behind the splash
     BOOL DetachedPanels;      // TRUE = left and right sides are hosted in separate top-level windows
     BOOL CreatingDetachedChrome; // suppress detached-window activation while its child chrome is being built
     BOOL DetachedPanelsSwapFixNeeded; // TRUE after Swap Sides while detached; reattach replays a double swap to refresh layout state
@@ -745,6 +746,8 @@ public:
 
     void SaveConfig(HWND parent = NULL, BOOL showConfigFileSaveError = TRUE); // parent: NULL = MainWindow->HWindow
     BOOL LoadConfig(BOOL importingOldConfig, const CCommandLineParams* cmdLineParams);
+    void RevealStartupWindow();
+    void FinishStartupWindowReveal();
     void SavePanelConfig(CPanelSide side, HKEY hSalamander, const char* reg);
     void LoadPanelConfig(char* panelPath, CPanelSide side, HKEY hSalamander, const char* reg);
     void SaveDetachedTabConfig(HKEY hSalamander);

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -381,6 +381,7 @@ CMainWindow::CMainWindow()
     strcpy(SelectionMask, "*.*");
     Created = FALSE;
     RestoringPanelPaths = FALSE;
+    StartupWindowCloaked = FALSE;
     DetachedPanels = FALSE;
     CreatingDetachedChrome = FALSE;
     DetachedPanelsSwapFixNeeded = FALSE;
@@ -637,7 +638,9 @@ BOOL CMainWindow::ToggleTopToolBar(BOOL storePos)
     if (TopToolBar == NULL)
         return FALSE;
 
-    LockWindowUpdate(HWindow);
+    const BOOL lockWindowUpdate = IsWindowVisible(HWindow) && !StartupWindowCloaked;
+    if (lockWindowUpdate)
+        LockWindowUpdate(HWindow);
 
     if (TopToolBar->HWindow != NULL)
     {
@@ -665,7 +668,8 @@ BOOL CMainWindow::ToggleTopToolBar(BOOL storePos)
             StoreBandsPos();
     }
 
-    LockWindowUpdate(NULL);
+    if (lockWindowUpdate)
+        LockWindowUpdate(NULL);
 
     if (DetachedPanels)
     {
@@ -696,7 +700,9 @@ BOOL CMainWindow::ToggleExtensionBar(BOOL storePos)
     if (ExtensionBar == NULL)
         return FALSE;
 
-    LockWindowUpdate(HWindow);
+    const BOOL lockWindowUpdate = IsWindowVisible(HWindow) && !StartupWindowCloaked;
+    if (lockWindowUpdate)
+        LockWindowUpdate(HWindow);
     if (ExtensionBar->HWindow != NULL)
     {
         int index = (int)SendMessage(HTopRebar, RB_IDTOINDEX,
@@ -719,7 +725,8 @@ BOOL CMainWindow::ToggleExtensionBar(BOOL storePos)
         if (storePos)
             StoreBandsPos();
     }
-    LockWindowUpdate(NULL);
+    if (lockWindowUpdate)
+        LockWindowUpdate(NULL);
 
     if (DetachedPanels)
     {
@@ -736,7 +743,9 @@ BOOL CMainWindow::TogglePluginsBar(BOOL storePos)
     if (PluginsBar == NULL)
         return FALSE;
 
-    LockWindowUpdate(HWindow);
+    const BOOL lockWindowUpdate = IsWindowVisible(HWindow) && !StartupWindowCloaked;
+    if (lockWindowUpdate)
+        LockWindowUpdate(HWindow);
 
     if (PluginsBar->HWindow != NULL)
     {
@@ -761,7 +770,8 @@ BOOL CMainWindow::TogglePluginsBar(BOOL storePos)
             StoreBandsPos();
     }
 
-    LockWindowUpdate(NULL);
+    if (lockWindowUpdate)
+        LockWindowUpdate(NULL);
 
     if (DetachedPanels)
     {
@@ -779,7 +789,9 @@ BOOL CMainWindow::ToggleMiddleToolBar()
     if (MiddleToolBar == NULL)
         return FALSE;
 
-    LockWindowUpdate(HWindow);
+    const BOOL lockWindowUpdate = IsWindowVisible(HWindow) && !StartupWindowCloaked;
+    if (lockWindowUpdate)
+        LockWindowUpdate(HWindow);
 
     if (MiddleToolBar->HWindow != NULL)
     {
@@ -798,7 +810,8 @@ BOOL CMainWindow::ToggleMiddleToolBar()
         Configuration.MiddleToolBarVisible = TRUE;
     }
 
-    LockWindowUpdate(NULL);
+    if (lockWindowUpdate)
+        LockWindowUpdate(NULL);
 
     return TRUE;
 }
@@ -809,7 +822,9 @@ BOOL CMainWindow::ToggleUserMenuToolBar(BOOL storePos)
     if (UMToolBar == NULL)
         return FALSE;
 
-    LockWindowUpdate(HWindow);
+    const BOOL lockWindowUpdate = IsWindowVisible(HWindow) && !StartupWindowCloaked;
+    if (lockWindowUpdate)
+        LockWindowUpdate(HWindow);
 
     if (UMToolBar->HWindow != NULL)
     {
@@ -835,7 +850,8 @@ BOOL CMainWindow::ToggleUserMenuToolBar(BOOL storePos)
             StoreBandsPos();
     }
 
-    LockWindowUpdate(NULL);
+    if (lockWindowUpdate)
+        LockWindowUpdate(NULL);
 
     if (DetachedPanels)
     {
@@ -853,7 +869,9 @@ BOOL CMainWindow::ToggleHotPathsBar(BOOL storePos)
     if (HPToolBar == NULL)
         return FALSE;
 
-    LockWindowUpdate(HWindow);
+    const BOOL lockWindowUpdate = IsWindowVisible(HWindow) && !StartupWindowCloaked;
+    if (lockWindowUpdate)
+        LockWindowUpdate(HWindow);
 
     if (HPToolBar->HWindow != NULL)
     {
@@ -877,7 +895,8 @@ BOOL CMainWindow::ToggleHotPathsBar(BOOL storePos)
             StoreBandsPos();
     }
 
-    LockWindowUpdate(NULL);
+    if (lockWindowUpdate)
+        LockWindowUpdate(NULL);
 
     if (DetachedPanels)
     {
@@ -895,7 +914,9 @@ BOOL CMainWindow::ToggleDriveBar(BOOL twoDriveBars, BOOL storePos)
     if (DriveBar == NULL || DriveBar2 == NULL)
         return FALSE;
 
-    LockWindowUpdate(HWindow);
+    const BOOL lockWindowUpdate = IsWindowVisible(HWindow) && !StartupWindowCloaked;
+    if (lockWindowUpdate)
+        LockWindowUpdate(HWindow);
 
     BOOL forceShow = TRUE;
     BOOL twoBarsVisible = (DriveBar2->HWindow != NULL);
@@ -949,7 +970,8 @@ BOOL CMainWindow::ToggleDriveBar(BOOL twoDriveBars, BOOL storePos)
             StoreBandsPos();
     }
 
-    LockWindowUpdate(NULL);
+    if (lockWindowUpdate)
+        LockWindowUpdate(NULL);
     //  InvalidateRect(HTopRebar, NULL, TRUE);
     //  UpdateWindow(HTopRebar);
     if (DetachedPanels)
@@ -3403,29 +3425,43 @@ BOOL CMainWindow::ReattachDetachedTab(CFilesWindow* panel, CPanelSide targetSide
     BOOL wasGloballyActive = GetActivePanel() == panel;
     HWND detachedWindow = info->HWindow;
 
+    const BOOL suppressDetachedRedraw = detachedWindow != NULL && IsWindowVisible(detachedWindow);
     if (detachedWindow != NULL)
     {
         info->Placement.length = sizeof(WINDOWPLACEMENT);
         GetWindowPlacement(detachedWindow, &info->Placement);
-        ShowWindow(detachedWindow, SW_HIDE);
+        if (suppressDetachedRedraw)
+            SendMessage(detachedWindow, WM_SETREDRAW, FALSE, 0);
     }
 
     HWND targetHost = DetachedPanels && targetSide == cpsRight && HRightDetachedWindow != NULL
                           ? HRightDetachedWindow
                           : HWindow;
+    const BOOL suppressTargetRedraw = IsWindowVisible(targetHost);
+    if (suppressTargetRedraw)
+        SendMessage(targetHost, WM_SETREDRAW, FALSE, 0);
     SetParent(panel->HWindow, targetHost);
     if (!InsertPanelTabInstance(targetSide, insertIndex, panel, true))
     {
         SetParent(panel->HWindow, detachedWindow);
-        ShowWindow(detachedWindow, SW_SHOW);
+        if (suppressTargetRedraw)
+        {
+            SendMessage(targetHost, WM_SETREDRAW, TRUE, 0);
+            RedrawWindow(targetHost, NULL, NULL,
+                         RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+        }
+        if (suppressDetachedRedraw)
+        {
+            SendMessage(detachedWindow, WM_SETREDRAW, TRUE, 0);
+            RedrawWindow(detachedWindow, NULL, NULL,
+                         RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+        }
         return FALSE;
     }
 
     SendMessage(panel->HWindow, WM_DPICHANGED_AFTERPARENT, 0, 0);
     EnsurePanelRefreshAndRequest(panel, false, true);
     size_t detachedIndex = (size_t)(info - &DetachedTabs[0]);
-    if (detachedWindow != NULL)
-        DestroyWindow(detachedWindow);
     if (info->HHotToolBarImageList != NULL)
         ImageList_Destroy(info->HHotToolBarImageList);
     if (info->HGrayToolBarImageList != NULL)
@@ -3473,6 +3509,21 @@ BOOL CMainWindow::ReattachDetachedTab(CFilesWindow* panel, CPanelSide targetSide
     LayoutWindows();
     RefreshCommandStates();
     Plugins.Event(PLUGINEVENT_TABCHANGED, targetSide == cpsRight ? PANEL_RIGHT : PANEL_LEFT);
+    if (suppressTargetRedraw)
+    {
+        SendMessage(targetHost, WM_SETREDRAW, TRUE, 0);
+        RedrawWindow(targetHost, NULL, NULL,
+                     RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+    }
+    // Keep the old detached surface visible and frozen until the complete
+    // target-host frame exists behind it. Destroying it earlier exposes a hole
+    // followed by the target panel being assembled in several visible steps.
+    if (detachedWindow != NULL)
+    {
+        if (suppressDetachedRedraw)
+            DarkModeSetWindowCloaked(detachedWindow, true);
+        DestroyWindow(detachedWindow);
+    }
     return TRUE;
 }
 
@@ -3576,6 +3627,15 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
         if (HRightDetachedWindow == NULL)
             return FALSE;
 
+        // Build the detached host as one compositor transaction. Reparenting
+        // the right panel first used to expose an empty half of the main window
+        // while its duplicate chrome and DPI resources were still being made.
+        const BOOL suppressMainRedraw = IsWindowVisible(HWindow);
+        if (suppressMainRedraw)
+            SendMessage(HWindow, WM_SETREDRAW, FALSE, 0);
+        SendMessage(HRightDetachedWindow, WM_SETREDRAW, FALSE, 0);
+        const BOOL detachedWindowCloaked = DarkModeSetWindowCloaked(HRightDetachedWindow, true);
+
         if (RightTabWindow != NULL && RightTabWindow->HWindow != NULL)
         {
             SetParent(RightTabWindow->HWindow, HRightDetachedWindow);
@@ -3599,7 +3659,19 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
         DetachedPanelsSwapFixNeeded = FALSE;
         UpdateDetachedMenuLabels();
         if (!EnsureDetachedChrome())
+        {
+            SendMessage(HRightDetachedWindow, WM_SETREDRAW, TRUE, 0);
+            if (detachedWindowCloaked)
+                DarkModeSetWindowCloaked(HRightDetachedWindow, false);
+            if (suppressMainRedraw)
+            {
+                SendMessage(HWindow, WM_SETREDRAW, TRUE, 0);
+                RedrawWindow(HWindow, NULL, NULL,
+                             RDW_INVALIDATE | RDW_ERASE | RDW_FRAME |
+                                 RDW_ALLCHILDREN | RDW_UPDATENOW);
+            }
             return FALSE;
+        }
         CreatingDetachedChrome = TRUE;
         RightPanel->TreeViewWidth = Configuration.DetachedTreeViewWidth;
         RightPanel->TreeViewAutoHide = Configuration.DetachedTreeViewAutoHide;
@@ -3614,10 +3686,39 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
         LayoutWindows();
         LayoutDetachedPanels();
         SetWindowTitle();
+        SetActivePanel(RightPanel);
+        Plugins.Event(PLUGINEVENT_TABCHANGED, PANEL_RIGHT);
         CreatingDetachedChrome = FALSE;
+
+        SendMessage(HRightDetachedWindow, WM_SETREDRAW, TRUE, 0);
+        RedrawWindow(HRightDetachedWindow, NULL, NULL,
+                     RDW_INVALIDATE | RDW_ERASE | RDW_FRAME |
+                         RDW_ALLCHILDREN | RDW_UPDATENOW);
+        if (suppressMainRedraw)
+        {
+            SendMessage(HWindow, WM_SETREDRAW, TRUE, 0);
+            RedrawWindow(HWindow, NULL, NULL,
+                         RDW_INVALIDATE | RDW_ERASE | RDW_FRAME |
+                             RDW_ALLCHILDREN | RDW_UPDATENOW);
+        }
+        if (detachedWindowCloaked)
+            DarkModeSetWindowCloaked(HRightDetachedWindow, false);
+        return TRUE;
     }
     else
     {
+        // Reparenting the right-side tab strip and every panel, rebuilding the
+        // shared chrome, resizing the main window, and replaying swap state are
+        // one visual transaction. Keep both currently visible hosts frozen so
+        // none of those intermediate rectangles is presented.
+        const BOOL suppressMainRedraw = IsWindowVisible(HWindow);
+        const BOOL suppressDetachedRedraw = HRightDetachedWindow != NULL &&
+                                             IsWindowVisible(HRightDetachedWindow);
+        if (suppressMainRedraw)
+            SendMessage(HWindow, WM_SETREDRAW, FALSE, 0);
+        if (suppressDetachedRedraw)
+            SendMessage(HRightDetachedWindow, WM_SETREDRAW, FALSE, 0);
+
         RECT mainRectBeforeReattach;
         RECT mainClientBeforeReattach;
         RECT detachedRectBeforeReattach;
@@ -3670,8 +3771,6 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
         }
         CreatingDetachedChrome = FALSE;
         DestroyDetachedChrome();
-        if (HRightDetachedWindow != NULL)
-            ShowWindow(HRightDetachedWindow, SW_HIDE);
         // The detached menu used a different DPI and shared menu item metrics.
         // Re-measure the main menu before the rebar negotiates its bands again;
         // otherwise the old cxMinChild clips item captions on their right edge.
@@ -3785,8 +3884,6 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
 
         UpdatePanelTabVisibility(cpsLeft);
         UpdatePanelTabVisibility(cpsRight);
-        RedrawWindow(HWindow, NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_FRAME | RDW_UPDATENOW);
-
         if (DetachedPanelsSwapFixNeeded)
         {
             DetachedPanelsSwapFixNeeded = FALSE;
@@ -3798,14 +3895,28 @@ BOOL CMainWindow::SetPanelsDetached(BOOL detached)
             SendMessage(HWindow, WM_COMMAND, CM_SWAPPANELS, 0);
         }
 
-    }
-
-    if (DetachedPanels)
-        SetActivePanel(RightPanel);
-    else
         FocusPanel(GetActivePanel());
-    Plugins.Event(PLUGINEVENT_TABCHANGED, PANEL_RIGHT);
-    return TRUE;
+        Plugins.Event(PLUGINEVENT_TABCHANGED, PANEL_RIGHT);
+
+        if (suppressMainRedraw)
+        {
+            SendMessage(HWindow, WM_SETREDRAW, TRUE, 0);
+            RedrawWindow(HWindow, NULL, NULL,
+                         RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+        }
+        // The detached window is the visual cover over the area by which the
+        // main window grows. Leave its last complete surface in place until
+        // the expanded main surface has been fully drawn behind it.
+        const BOOL detachedWindowCloaked = suppressDetachedRedraw &&
+                                           DarkModeSetWindowCloaked(HRightDetachedWindow, true);
+        if (suppressDetachedRedraw)
+            SendMessage(HRightDetachedWindow, WM_SETREDRAW, TRUE, 0);
+        if (HRightDetachedWindow != NULL)
+            ShowWindow(HRightDetachedWindow, SW_HIDE);
+        if (detachedWindowCloaked)
+            DarkModeSetWindowCloaked(HRightDetachedWindow, false);
+        return TRUE;
+    }
 }
 
 BOOL CMainWindow::TogglePanelsDetached()

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -36,7 +36,6 @@ static const char* DetectProductName(const char* root);
 static BOOL MCDIsGeneratedConfigDisplayName(const char* root, const char* version, const char* displayName);
 static BOOL MCDGetCurrentInstancePath(char* path, int pathSize);
 
-
 static void SaveInstalledPluginVersionsToBootstrap()
 {
     char fileName[SAL_MAX_PATH];
@@ -4604,6 +4603,7 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
 
         WINDOWPLACEMENT place;
         BOOL useWinPlacement = FALSE;
+        BOOL deferMainWindowReveal = FALSE;
         if (OpenKey(salamander, SALAMANDER_WINDOW_REG, actKey))
         {
             place.length = sizeof(WINDOWPLACEMENT);
@@ -5715,6 +5715,14 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
             GetValue(actKey, CONFIG_PANELTOOLTIPS_REG, REG_DWORD,
                      &Configuration.PanelTooltips, sizeof(DWORD));
 
+            // Every RB_INSERTBAND synchronously sends RBN_AUTOSIZE. Laying out the whole
+            // hidden main window after each individual band is wasted work and used to
+            // dominate configuration loading. Batch those notifications and perform one
+            // complete layout after all configured bars exist.
+            BOOL batchToolbarLayout = ret && !LayoutWindowsInProgress;
+            if (batchToolbarLayout)
+                LayoutWindowsInProgress = TRUE;
+
             if (ret) // if we return FALSE, everything will be inserted later
             {
                 // bands must be inserted in the correct order according to their index
@@ -5729,17 +5737,29 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                         menuInserted = TRUE;
                     }
                     if (idx == Configuration.TopToolbarIndex && Configuration.TopToolBarVisible)
+                    {
                         ToggleTopToolBar(FALSE);
+                    }
                     if (idx == Configuration.PluginsBarIndex && Configuration.PluginsBarVisible)
+                    {
                         TogglePluginsBar(FALSE);
+                    }
                     if (idx == Configuration.ExtensionBarIndex && Configuration.ExtensionBarVisible)
+                    {
                         ToggleExtensionBar(FALSE);
+                    }
                     if (idx == Configuration.UserMenuToolbarIndex && Configuration.UserMenuToolBarVisible)
+                    {
                         ToggleUserMenuToolBar(FALSE);
+                    }
                     if (idx == Configuration.HotPathsBarIndex && Configuration.HotPathsBarVisible)
+                    {
                         ToggleHotPathsBar(FALSE);
+                    }
                     if (idx == Configuration.DriveBarIndex && Configuration.DriveBarVisible)
+                    {
                         ToggleDriveBar(Configuration.DriveBar2Visible, FALSE);
+                    }
                 }
                 if (!menuInserted)
                 {
@@ -5748,7 +5768,9 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                     InsertMenuBand();
                 }
                 if (Configuration.MiddleToolBarVisible)
+                {
                     ToggleMiddleToolBar();
+                }
                 CreateAndInsertWorkerBand(); // insert the worker band at the end
             }
 
@@ -5758,7 +5780,15 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
             // builds the default UI. Do not create the bottom toolbar here too, otherwise
             // the caller's default pass toggles it back off.
             if (ret && Configuration.BottomToolBarVisible)
+            {
                 ToggleBottomToolBar();
+            }
+
+            if (batchToolbarLayout)
+            {
+                LayoutWindowsInProgress = FALSE;
+                LayoutWindows();
+            }
 
             //      GetValue(actKey, CONFIG_SPACESELCALCSPACE, REG_DWORD,
             //               &Configuration.SpaceSelCalcSpace, sizeof(DWORD));
@@ -5944,6 +5974,9 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
             CloseKey(actKey);
         }
 
+        // Registry/configuration loading is complete. Panel objects and their
+        // active directory listings are initialized in the next phase.
+        IfExistSetSplashScreenText(LoadStr(IDS_STARTUP_DATA));
         //---  left and right panel
 
         char leftPanelPath[MAX_PATH];
@@ -5972,17 +6005,6 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
 
         if (cmdLine && !SystemPolicies.GetNoRun())
             PostMessage(HWindow, WM_COMMAND, CM_TOGGLEEDITLINE, TRUE);
-
-        // Finish messages queued while the hidden main window and its controls were being
-        // initialized. In particular, toolbar/rebar layout and panel paints must settle before
-        // SetWindowPlacement reveals the window below; otherwise their intermediate state flashes
-        // on screen and panel contents can visibly change immediately after startup.
-        MSG msg;
-        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
-        }
 
         // set the active panel according to command line parameters
         if (ret && cmdLineParams != NULL)
@@ -6028,7 +6050,6 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
             SetMenuItemInfo(h, SC_MAXIMIZE, FALSE, &mii);
         }
 
-        SplashScreenCloseIfExist();
         if (Configuration.StatusArea)
             AddTrayIcon();
 
@@ -6103,7 +6124,14 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                 }
                 }
             }
-            SetWindowPlacement(HWindow, &place);
+            // Keep the ordinary two-panel window hidden until both panel paths
+            // and their list boxes are fully initialized.  Showing it here
+            // exposes the saved panel contents first and the final directory
+            // refresh a moment later, which makes both panels visibly blink.
+            if (Configuration.DetachedPanels)
+                SetWindowPlacement(HWindow, &place);
+            else
+                deferMainWindowReveal = TRUE;
         }
         if (Configuration.DetachedPanels)
         {
@@ -6215,10 +6243,82 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
         // restore DefaultDir
         MainWindow->UpdateDefaultDir(TRUE);
 
+        // Publish the first main-window frame only after all panel state is
+        // final.  The splash remains visible during preparation, and the
+        // synchronous redraw prevents DWM from presenting an empty interim
+        // client area after SetWindowPlacement makes the window visible.
+        if (deferMainWindowReveal)
+        {
+            const BOOL revealWindow = place.showCmd != SW_HIDE;
+            const BOOL windowCloaked = revealWindow && DarkModeSetWindowCloaked(HWindow, true);
+            SetWindowPlacement(HWindow, &place);
+            RedrawWindow(HWindow, NULL, NULL,
+                         RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+            StartupWindowCloaked = windowCloaked;
+        }
+
         return ret;
     }
 
     LoadSaveToRegistryMutex.Leave();
 
     return FALSE;
+}
+
+void CMainWindow::RevealStartupWindow()
+{
+    // Plugin load-on-start and command-line processing still run after
+    // LoadConfig. Keep their owned wait windows and all resulting panel
+    // layouts behind the splash, then publish exactly one final frame.
+    // Closing the splash/startup wait owner causes one synthetic activation
+    // transition. The panels were read only moments ago, so letting that
+    // transition enter CFilesWindow::Activate queues a second complete
+    // directory/icon pass and visibly clears and repaints both panels.
+    FirstActivateApp = FALSE;
+    SkipOneActivateRefresh = TRUE;
+    PostMessage(HWindow, WM_USER_SKIPONEREFRESH, 0, 0);
+
+    MSG msg;
+    while (PeekMessage(&msg, HWindow, WM_USER_END_SUSPMODE, WM_USER_END_SUSPMODE, PM_REMOVE))
+        ;
+    ActivateSuspMode = 0;
+
+    // SetFont posts a WM_SIZE after the startup DPI transition. Complete that
+    // one deferred whole-window layout before processing the panel refreshes
+    // it generated; otherwise the message loop rebuilds all chrome during the
+    // first visible frames.
+    while (PeekMessage(&msg, HWindow, WM_SIZE, WM_SIZE, PM_REMOVE))
+        SendMessage(HWindow, msg.message, msg.wParam, msg.lParam);
+
+    // Do not uncloak here. Child DPI/rebar notifications processed during the
+    // first message-loop turn can still post another top-level layout and panel
+    // refresh. Publishing the window now exposes those intermediate frames.
+    // Queue the final barrier behind messages already posted by startup. A
+    // real timer is a low-priority message and was observed to leave the
+    // completed, cloaked window behind the splash for hundreds of milliseconds.
+    if (!PostMessage(HWindow, WM_TIMER, IDT_FINISHSTARTUPREVEAL, 0))
+    {
+        // Only an exhausted message queue leaves no asynchronous barrier.
+        // Keep the old synchronous fallback so startup can still complete.
+        FinishStartupWindowReveal();
+    }
+}
+
+void CMainWindow::FinishStartupWindowReveal()
+{
+    // The first message-loop turn may have generated fresh delayed activation
+    // or DPI refreshes. Finish or cancel them while the DWM surface is still
+    // cloaked, draw the one final frame, and only then publish the window.
+    LeftPanel->CompletePendingStartupRefreshes();
+    RightPanel->CompletePendingStartupRefreshes();
+
+    RedrawWindow(HWindow, NULL, NULL,
+                 RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+
+    if (StartupWindowCloaked)
+    {
+        DarkModeSetWindowCloaked(HWindow, false);
+        StartupWindowCloaked = FALSE;
+    }
+    SplashScreenCloseIfExist();
 }

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -4161,6 +4161,12 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         GetWindowRect(HWindow, &WindowRect);
 
+        // DefWindowProc synchronously sends the authoritative WM_SIZE for a
+        // real size change. Let it update WindowWidth/WindowHeight before
+        // deciding whether the detach/reattach fallback is needed; checking
+        // first posted a redundant second full-window layout at startup.
+        LRESULT result = CWindow::WindowProc(uMsg, wParam, lParam);
+
         // Some detach/reattach paths move tab HWNDs between top-level hosts while Windows
         // is also changing activation/z-order.  If the following maximize/resize does not
         // deliver a usable WM_SIZE, the chrome and panel children keep their old rectangle
@@ -4183,7 +4189,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 PostMessage(HWindow, WM_SIZE, SIZE_RESTORED, MAKELPARAM(clientWidth, clientHeight));
             }
         }
-        return CWindow::WindowProc(uMsg, wParam, lParam);
+        return result;
     }
     }
 
@@ -10576,6 +10582,13 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         {
             KillTimer(HWindow, IDT_ASSOCIATIONSCHNG);
             OnAssociationsChangedNotification(FALSE);
+            break;
+        }
+
+        case IDT_FINISHSTARTUPREVEAL:
+        {
+            KillTimer(HWindow, IDT_FINISHSTARTUPREVEAL);
+            FinishStartupWindowReveal();
             break;
         }
 

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -1641,7 +1641,13 @@ void CMainWindow::FocusPanel(CFilesWindow* focus, BOOL testIfMainWndActive)
 
     CFilesWindow* old = GetActivePanel();
     SetActivePanel(focus);
-    if (DetachedPanels && focus == RightPanel)
+    if (RestoringPanelPaths)
+    {
+        // LoadPanelConfig temporarily activates each side while all tab paths
+        // are restored.  The final FocusPanel call after restoration updates
+        // the shared Tree View once for the real active panel.
+    }
+    else if (DetachedPanels && focus == RightPanel)
     {
         // The detached window owns an independent tree-view host. Updating the
         // main-window tree while focus only moves inside the detached window

--- a/src/plugins/samandarin/managed_bridge.cpp
+++ b/src/plugins/samandarin/managed_bridge.cpp
@@ -20,6 +20,10 @@ ICLRRuntimeHost* gRuntimeHost = nullptr;
 std::wstring gAssemblyPath;
 std::wstring gCurrentVersion;
 bool gIsInitialized = false;
+SRWLOCK gRuntimeLock = SRWLOCK_INIT;
+HANDLE gInitializationThread = nullptr;
+DWORD gInitializationThreadId = 0;
+LONG gInitializationResult = 0;
 const wchar_t* const kManagedType = L"OpenSalamander.Samandarin.EntryPoint";
 const wchar_t* const kManagedMethod = L"Dispatch";
 const wchar_t* const kPluginCaption = L"Samandarin Update Notifier";
@@ -123,9 +127,24 @@ std::wstring BuildCurrentVersion()
     return result;
 }
 
-} // namespace
+void ResetRuntimeLocked()
+{
+    if (gRuntimeHost != nullptr)
+    {
+        if (gIsInitialized)
+        {
+            ExecuteCommand(L"Shutdown", nullptr, nullptr);
+            gIsInitialized = false;
+        }
+        gRuntimeHost->Stop();
+        gRuntimeHost->Release();
+        gRuntimeHost = nullptr;
+    }
+    gAssemblyPath.clear();
+    gCurrentVersion.clear();
+}
 
-bool ManagedBridge_EnsureInitialized(HWND parent)
+bool InitializeRuntimeLocked(HWND parent)
 {
     if (gRuntimeHost != nullptr)
     {
@@ -170,7 +189,7 @@ bool ManagedBridge_EnsureInitialized(HWND parent)
     if (GetModuleFileNameW(DLLInstance, modulePath, _countof(modulePath)) == 0)
     {
         ShowLoadError(parent, L"Failed to determine plugin path.");
-        ManagedBridge_Shutdown();
+        ResetRuntimeLocked();
         return false;
     }
 
@@ -190,7 +209,7 @@ bool ManagedBridge_EnsureInitialized(HWND parent)
         gIsInitialized = ExecuteCommand(L"Initialize", parent, gCurrentVersion.c_str());
         if (!gIsInitialized)
         {
-            ManagedBridge_Shutdown();
+            ResetRuntimeLocked();
             return false;
         }
     }
@@ -198,21 +217,74 @@ bool ManagedBridge_EnsureInitialized(HWND parent)
     return true;
 }
 
+DWORD WINAPI InitializeRuntimeThread(void* parameter)
+{
+    AcquireSRWLockExclusive(&gRuntimeLock);
+    const bool initialized = InitializeRuntimeLocked(static_cast<HWND>(parameter));
+    InterlockedExchange(&gInitializationResult, initialized ? 1 : -1);
+    ReleaseSRWLockExclusive(&gRuntimeLock);
+    return initialized ? 0 : 1;
+}
+
+void WaitForBackgroundInitialization()
+{
+    HANDLE thread = nullptr;
+    DWORD threadId = 0;
+    AcquireSRWLockShared(&gRuntimeLock);
+    thread = gInitializationThread;
+    threadId = gInitializationThreadId;
+    ReleaseSRWLockShared(&gRuntimeLock);
+    if (thread != nullptr && threadId != GetCurrentThreadId())
+        WaitForSingleObject(thread, INFINITE);
+}
+} // namespace
+
+bool ManagedBridge_BeginInitialize(HWND parent)
+{
+    AcquireSRWLockExclusive(&gRuntimeLock);
+    if (gIsInitialized || gInitializationThread != nullptr)
+    {
+        ReleaseSRWLockExclusive(&gRuntimeLock);
+        return true;
+    }
+    InterlockedExchange(&gInitializationResult, 0);
+    gInitializationThread = CreateThread(nullptr, 0, InitializeRuntimeThread, parent, 0,
+                                         &gInitializationThreadId);
+    const bool started = gInitializationThread != nullptr;
+    ReleaseSRWLockExclusive(&gRuntimeLock);
+    return started;
+}
+
+bool ManagedBridge_EnsureInitialized(HWND parent)
+{
+    WaitForBackgroundInitialization();
+    AcquireSRWLockExclusive(&gRuntimeLock);
+    if (gInitializationThread != nullptr)
+    {
+        CloseHandle(gInitializationThread);
+        gInitializationThread = nullptr;
+        gInitializationThreadId = 0;
+    }
+    bool initialized = gIsInitialized;
+    if (!initialized && InterlockedCompareExchange(&gInitializationResult, 0, 0) >= 0)
+        initialized = InitializeRuntimeLocked(parent);
+    ReleaseSRWLockExclusive(&gRuntimeLock);
+    return initialized;
+}
+
 void ManagedBridge_Shutdown()
 {
-    if (gRuntimeHost != nullptr)
+    WaitForBackgroundInitialization();
+    AcquireSRWLockExclusive(&gRuntimeLock);
+    if (gInitializationThread != nullptr)
     {
-        if (gIsInitialized)
-        {
-            ExecuteCommand(L"Shutdown", nullptr, nullptr);
-            gIsInitialized = false;
-        }
-        gRuntimeHost->Stop();
-        gRuntimeHost->Release();
-        gRuntimeHost = nullptr;
-        gAssemblyPath.clear();
-        gCurrentVersion.clear();
+        CloseHandle(gInitializationThread);
+        gInitializationThread = nullptr;
+        gInitializationThreadId = 0;
     }
+    ResetRuntimeLocked();
+    InterlockedExchange(&gInitializationResult, 0);
+    ReleaseSRWLockExclusive(&gRuntimeLock);
 }
 
 bool ManagedBridge_ShowConfiguration(HWND parent)

--- a/src/plugins/samandarin/managed_bridge.h
+++ b/src/plugins/samandarin/managed_bridge.h
@@ -6,6 +6,7 @@
 #include <string>
 
 bool ManagedBridge_EnsureInitialized(HWND parent);
+bool ManagedBridge_BeginInitialize(HWND parent);
 void ManagedBridge_Shutdown();
 bool ManagedBridge_ShowConfiguration(HWND parent);
 void ManagedBridge_NotifyColorsChanged();

--- a/src/plugins/samandarin/samandarin.cpp
+++ b/src/plugins/samandarin/samandarin.cpp
@@ -309,7 +309,13 @@ void WINAPI CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* s
     salamander->AddMenuItem(-1, LoadStr(IDS_MENU_PLUGIN_UPDATES), 0, MENUCMD_PLUGIN_UPDATES, FALSE,
                             MENU_EVENT_TRUE, MENU_EVENT_TRUE, MENU_SKILLLEVEL_ALL);
 
-    if (!ManagedBridge_EnsureInitialized(parent))
+    // Loading and starting the CLR costs hundreds of milliseconds on a cold
+    // launch. The managed Initialize command already schedules the update
+    // check asynchronously, so prewarm the bridge without blocking the host's
+    // first window. Interactive entry points wait for this worker through
+    // ManagedBridge_EnsureInitialized, and Release joins it before unloading.
+    if (!ManagedBridge_BeginInitialize(parent) &&
+        !ManagedBridge_EnsureInitialized(parent))
     {
         ShowInitializationError(parent);
     }

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -5466,7 +5466,7 @@ FIND_NEW_SLG_FILE:
                         SendMessage(MainWindow->HWindow, WM_COMMAND, CM_TOGGLEEDITLINE, TRUE);
                     MainWindow->SetWindowIcon();
                     MainWindow->SetWindowTitle();
-                    SplashScreenCloseIfExist();
+                    MainWindow->StartupWindowCloaked = DarkModeSetWindowCloaked(MainWindow->HWindow, true);
                     ShowWindow(MainWindow->HWindow, cmdShow);
                     UpdateWindow(MainWindow->HWindow);
                     MainWindow->RefreshDirs();
@@ -5651,6 +5651,13 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
 
                     if (IsSLGIncomplete[0] != 0 && Configuration.ShowSLGIncomplete)
                         PostMessage(MainWindow->HWindow, WM_USER_SLGINCOMPLETE, 0, 0);
+
+                    // LoadConfig is not the end of startup: command-line
+                    // handling and load-on-start plug-ins can still relayout
+                    // both panels. Replace the splash only after all of that
+                    // work is complete, so no intermediate main-window frame
+                    // is ever presented.
+                    MainWindow->RevealStartupWindow();
 
                     //--- aplikacni smycka
                     CALL_STACK_MESSAGE1("WinMainBody::message_loop");

--- a/src/tests/panel_rendering_contract_tests.py
+++ b/src/tests/panel_rendering_contract_tests.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    geticon = (ROOT / "geticon.cpp").read_text(encoding="utf-8")
+    filesbox = (ROOT / "filesbx1.cpp").read_text(encoding="utf-8")
+    fileswnd0 = (ROOT / "fileswn0.cpp").read_text(encoding="utf-8")
+    fileswnd = (ROOT / "fileswn1.cpp").read_text(encoding="utf-8")
+    fileswnd2 = (ROOT / "fileswn2.cpp").read_text(encoding="utf-8")
+    fileswndb = (ROOT / "fileswnb.cpp").read_text(encoding="utf-8")
+    mainwnd1 = (ROOT / "mainwnd1.cpp").read_text(encoding="utf-8")
+    mainwnd2 = (ROOT / "mainwnd2.cpp").read_text(encoding="utf-8")
+    mainwnd3 = (ROOT / "mainwnd3.cpp").read_text(encoding="utf-8")
+    mainwnd4 = (ROOT / "mainwnd4.cpp").read_text(encoding="utf-8")
+    logo = (ROOT / "logo.cpp").read_text(encoding="utf-8")
+    plugins2 = (ROOT / "plugins2.cpp").read_text(encoding="utf-8")
+    salamdr1 = (ROOT / "salamdr1.cpp").read_text(encoding="utf-8")
+    samandarin = (ROOT / "plugins/samandarin/samandarin.cpp").read_text(encoding="utf-8")
+    managed_bridge = (ROOT / "plugins/samandarin/managed_bridge.cpp").read_text(encoding="utf-8")
+
+    if "IsSolidBlackIcon" not in geticon or "IsInvalidShellIcon" in geticon:
+        print("shell icon validation must reject only the proven solid-black corruption")
+        return 1
+
+    resize = re.search(
+        r"case WM_SIZE:\s*\{(.*?)break;\s*\}", filesbox, re.DOTALL
+    )
+    if resize is None or "LayoutChilds();" not in resize.group(1):
+        print("files box no longer lays out children during WM_SIZE")
+        return 1
+    if "InvalidateRect(HWindow, NULL, FALSE);" not in resize.group(1):
+        print("files box resize must invalidate stale persistent-DC content")
+        return 1
+    buffered_paint = re.search(r"case WM_PAINT:.*?case WM_HELP:", filesbox, re.DOTALL)
+    if (
+        buffered_paint is None
+        or "CreateCompatibleBitmap" not in buffered_paint.group(0)
+        or "HPrivateDC = memoryDC;" not in buffered_paint.group(0)
+        or "BitBlt(paintDC" not in buffered_paint.group(0)
+    ):
+        print("full files-box WM_PAINT must publish one buffered frame")
+        return 1
+
+    production = geticon + fileswnd + fileswndb + mainwnd2 + plugins2 + salamdr1
+    if (
+        "OpenSalamander-icon-state.log" in production
+        or "OpenSalamander-startup-timing.log" in production
+        or "OpenSalamander-startup-timing2.log" in production
+        or "OpenSalamander-startup-refresh.log" in production
+        or "StartupPerfMark" in production
+        or "StartupPerfFlush" in production
+        or "StartupProbeMark" in production
+        or "StartupProbeFlush" in production
+    ):
+        print("temporary runtime diagnostics remain in production sources")
+        return 1
+    if "CStartupTimingTrace" in mainwnd2 or "panel WM_CREATE total=" in fileswndb:
+        print("startup timing instrumentation must not ship in production")
+        return 1
+    connect = re.search(
+        r"void WINAPI CPluginInterface::Connect\(.*?\n\}", samandarin, re.DOTALL
+    )
+    if (
+        connect is None
+        or "ManagedBridge_BeginInitialize(parent)" not in connect.group(0)
+        or "ManagedBridge_EnsureInitialized(parent)" not in connect.group(0)
+        or "CreateThread(nullptr, 0, InitializeRuntimeThread" not in managed_bridge
+        or managed_bridge.count("WaitForBackgroundInitialization();") < 2
+        or "ResetRuntimeLocked();" not in managed_bridge
+    ):
+        print("Samandarin CLR prewarm must not block startup and must join before shutdown")
+        return 1
+
+    if "DiscardSolidBlackIcon(&hIconSmall" not in geticon:
+        print("corrupt image-list icons must be discarded before direct shell fallback")
+        return 1
+    direct_fallback = re.search(
+        r"DiscardSolidBlackIcon\(&hIconSmall.*?SHGFI_ICON\s*\|\s*SHGFI_SMALLICON",
+        geticon,
+        re.DOTALL,
+    )
+    if direct_fallback is None:
+        print("solid-black image-list result must fall through to direct SHGFI_ICON")
+        return 1
+    if "AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_DEFAULTICON" not in geticon:
+        print("failed shell image-list extraction must use the registered DefaultIcon")
+        return 1
+    if "SHDefExtractIconW(iconPath.c_str(), iconIndex" not in geticon:
+        print("registered DefaultIcon must be extracted at the panel pixel size")
+        return 1
+    if "useExplorerFileTypeIcon" in fileswnd or "GetExplorerFileTypeIcon" in fileswnd:
+        print("ordinary disk icon loading must not bypass GetFileIcon")
+        return 1
+    association_refresh = re.search(
+        r"case WM_USER_REFRESHINDEX:.*?case WM_USER_DROPCOPYMOVE:",
+        fileswndb,
+        re.DOTALL,
+    )
+    if (
+        association_refresh is None
+        or "RepaintIconsForExtension(buf);" not in association_refresh.group(0)
+        or "RepaintIconOnly(-1)" in association_refresh.group(0)
+    ):
+        print("association icon delivery must not repaint every icon in both panels")
+        return 1
+
+    if "!TreeViewAutoHide || TreeViewAutoHideExpanded" not in fileswnd2:
+        print("collapsed auto-hide Tree View must not be populated during startup")
+        return 1
+    if "RefreshTreeViewDPI();\n    RefreshTreeView();" not in fileswnd2:
+        print("deferred auto-hide Tree View must be initialized when expanded")
+        return 1
+    if "!MainWindow->RestoringPanelPaths" not in fileswndb or "if (RestoringPanelPaths)" not in mainwnd4:
+        print("panel restoration must suppress transient Tree View rebuilds")
+        return 1
+    if "batchToolbarLayout" not in mainwnd2:
+        print("configured rebar bands must use one batched startup layout")
+        return 1
+    startup_lock_guard = (
+        "const BOOL lockWindowUpdate = IsWindowVisible(HWindow) && "
+        "!StartupWindowCloaked;"
+    )
+    if mainwnd1.count(startup_lock_guard) != 7:
+        print("hidden startup must skip global LockWindowUpdate in all toolbar toggles")
+        return 1
+    config_done = mainwnd2.find("IfExistSetSplashScreenText(LoadStr(IDS_STARTUP_DATA));")
+    panel_restore = mainwnd2.find("RestoringPanelPaths = TRUE;")
+    if config_done < 0 or panel_restore < 0 or config_done > panel_restore:
+        print("Reading configuration status must end before panel initialization")
+        return 1
+    panel_final = mainwnd2.find("MainWindow->UpdateDefaultDir(TRUE);")
+    deferred_reveal = mainwnd2.find("if (deferMainWindowReveal)", panel_final)
+    if (
+        "deferMainWindowReveal = TRUE;" not in mainwnd2
+        or panel_final < 0
+        or deferred_reveal < panel_final
+    ):
+        print("main window must remain hidden until both panels are fully initialized")
+        return 1
+    if "RDW_ALLCHILDREN | RDW_UPDATENOW" not in mainwnd2[deferred_reveal:]:
+        print("the first visible main-window frame must synchronously draw all panels")
+        return 1
+    if (
+        "DarkModeSetWindowCloaked(HWindow, true)" not in mainwnd2
+        or "void CMainWindow::RevealStartupWindow()" not in mainwnd2
+        or "DarkModeSetWindowCloaked(HWindow, false)" not in mainwnd2
+        or "MainWindow->RevealStartupWindow();" not in salamdr1
+    ):
+        print("the main window must stay cloaked through post-config plug-in startup")
+        return 1
+    plugin_startup = salamdr1.find("Plugins.HandleLoadOnStartFlag(MainWindow->HWindow);")
+    final_reveal = salamdr1.find("MainWindow->RevealStartupWindow();")
+    message_loop = salamdr1.find('CALL_STACK_MESSAGE1("WinMainBody::message_loop")')
+    if plugin_startup < 0 or final_reveal < plugin_startup or message_loop < final_reveal:
+        print("the first main-window frame must be revealed after plug-ins and before the message loop")
+        return 1
+    reveal_body = re.search(
+        r"void CMainWindow::RevealStartupWindow\(\).*?\n\}",
+        mainwnd2,
+        re.DOTALL,
+    )
+    if (
+        reveal_body is None
+        or "WM_USER_END_SUSPMODE" not in reveal_body.group(0)
+        or "SkipOneActivateRefresh = TRUE;" not in reveal_body.group(0)
+        or "WM_USER_SKIPONEREFRESH" not in reveal_body.group(0)
+    ):
+        print("splash teardown must suppress its redundant first activation refresh")
+        return 1
+    startup_size = reveal_body.group(0).find(
+        "PeekMessage(&msg, HWindow, WM_SIZE, WM_SIZE, PM_REMOVE)"
+    )
+    reveal_barrier = reveal_body.group(0).find(
+        "PostMessage(HWindow, WM_TIMER, IDT_FINISHSTARTUPREVEAL, 0)"
+    )
+    if startup_size < 0 or reveal_barrier < startup_size:
+        print("startup DPI layout must enter the message loop before final reveal")
+        return 1
+    if "SetTimer(HWindow, IDT_FINISHSTARTUPREVEAL" in reveal_body.group(0):
+        print("startup reveal must not wait for a low-priority timer")
+        return 1
+    finish_body = re.search(
+        r"void CMainWindow::FinishStartupWindowReveal\(\).*?\n\}",
+        mainwnd2,
+        re.DOTALL,
+    )
+    if (
+        "DarkModeSetWindowCloaked(HWindow, false)" in reveal_body.group(0)
+        or "CompletePendingStartupRefreshes();" in reveal_body.group(0)
+        or finish_body is None
+        or finish_body.group(0).count("CompletePendingStartupRefreshes();") != 2
+    ):
+        print("startup window must remain cloaked through the first message-loop turn")
+        return 1
+    final_refresh = finish_body.group(0).find("LeftPanel->CompletePendingStartupRefreshes();")
+    final_redraw = finish_body.group(0).find("RedrawWindow(HWindow")
+    final_uncloak = finish_body.group(0).find("DarkModeSetWindowCloaked(HWindow, false)")
+    splash_close = finish_body.group(0).find("SplashScreenCloseIfExist();")
+    if (
+        final_refresh < 0
+        or final_redraw < final_refresh
+        or final_uncloak < final_redraw
+        or splash_close < final_uncloak
+        or "case IDT_FINISHSTARTUPREVEAL:" not in mainwnd3
+    ):
+        print("final refresh and redraw must complete before uncloak and splash close")
+        return 1
+    cancel_refresh = re.search(
+        r"void CFilesWindow::CompletePendingStartupRefreshes\(\).*?\n\}",
+        fileswnd0,
+        re.DOTALL,
+    )
+    if (
+        cancel_refresh is None
+        or "KillTimer(HWindow, IDT_REFRESH_DIR_EX);" not in cancel_refresh.group(0)
+        or "RefreshDirExTimerSet = FALSE;" not in cancel_refresh.group(0)
+        or "WM_USER_REFRESH_DIR_EX_DELAYED" not in cancel_refresh.group(0)
+        or "WM_USER_REFRESH_DIR," not in cancel_refresh.group(0)
+        or "SendMessage(HWindow, msg.message, msg.wParam, msg.lParam);"
+        not in cancel_refresh.group(0)
+    ):
+        print("startup reveal must finish required refreshes while still cloaked")
+        return 1
+    window_pos_changed = re.search(
+        r"case WM_WINDOWPOSCHANGED:.*?LRESULT result = CWindow::WindowProc\(uMsg, wParam, lParam\);"
+        r".*?clientWidth != WindowWidth.*?PostMessage\(HWindow, WM_SIZE",
+        mainwnd3,
+        re.DOTALL,
+    )
+    if window_pos_changed is None:
+        print("WM_WINDOWPOSCHANGED must run the real WM_SIZE before considering its fallback")
+        return 1
+
+    reattach_tab = re.search(
+        r"BOOL CMainWindow::ReattachDetachedTab\(CFilesWindow\* panel.*?\n\}",
+        mainwnd1,
+        re.DOTALL,
+    )
+    if (
+        reattach_tab is None
+        or "WM_SETREDRAW, FALSE" not in reattach_tab.group(0)
+        or reattach_tab.group(0).count("WM_SETREDRAW, TRUE") < 3
+        or "RDW_ALLCHILDREN | RDW_UPDATENOW" not in reattach_tab.group(0)
+        or reattach_tab.group(0).rfind("DestroyWindow(detachedWindow)")
+        < reattach_tab.group(0).rfind("RedrawWindow(targetHost")
+        or reattach_tab.group(0).rfind("DarkModeSetWindowCloaked(detachedWindow, true)")
+        < reattach_tab.group(0).rfind("RedrawWindow(targetHost")
+    ):
+        print("detached-tab reattach must publish one final target-host frame")
+        return 1
+    reattach_panels = re.search(
+        r"BOOL CMainWindow::SetPanelsDetached\(BOOL detached\).*?"
+        r"BOOL CMainWindow::TogglePanelsDetached",
+        mainwnd1,
+        re.DOTALL,
+    )
+    panels_body = reattach_panels.group(0) if reattach_panels is not None else ""
+    detach_start = panels_body.find("if (detached)")
+    reattach_start = panels_body.find("\n    else", detach_start)
+    detach_panels = panels_body[detach_start:reattach_start]
+    reattach_only = panels_body[reattach_start:]
+    if (
+        reattach_panels is None
+        or detach_start < 0
+        or reattach_start < 0
+        or reattach_only.count("WM_SETREDRAW, FALSE") != 2
+        or reattach_only.count("WM_SETREDRAW, TRUE") != 2
+        or reattach_only.rfind("RedrawWindow(HWindow") < reattach_only.rfind("CM_SWAPPANELS")
+        or reattach_only.rfind("ShowWindow(HRightDetachedWindow, SW_HIDE)")
+        < reattach_only.rfind("RedrawWindow(HWindow")
+        or "DarkModeSetWindowCloaked(HRightDetachedWindow, true)" not in reattach_only
+    ):
+        print("detached-panel reattach must freeze both hosts and publish one final frame")
+        return 1
+    if (
+        detach_panels.count("WM_SETREDRAW, FALSE") != 2
+        or detach_panels.count("WM_SETREDRAW, TRUE") != 4
+        or "DarkModeSetWindowCloaked(HRightDetachedWindow, true)" not in detach_panels
+        or detach_panels.rfind("RedrawWindow(HRightDetachedWindow")
+        < detach_panels.rfind("Plugins.Event(PLUGINEVENT_TABCHANGED")
+        or detach_panels.rfind("DarkModeSetWindowCloaked(HRightDetachedWindow, false)")
+        < detach_panels.rfind("RedrawWindow(HWindow")
+    ):
+        print("panel detach must build both complete frames before compositor reveal")
+        return 1
+    splash_status = re.search(
+        r"void CSplashScreen::SetText\(const char\* text\).*?\n\}", logo, re.DOTALL
+    )
+    if (
+        splash_status is None
+        or "dirtyR.left = max(0, dirtyR.left - 2);" not in splash_status.group(0)
+        or splash_status.group(0).count("dirtyR.right - dirtyR.left") != 2
+    ):
+        print("splash status repaint must clear and publish glyph overhang pixels")
+        return 1
+    if re.search(r"while\s*\(PeekMessage\(&msg, NULL, 0, 0, PM_REMOVE\)\)", mainwnd2):
+        print("configuration loading must not synchronously drain the UI message queue")
+        return 1
+
+    print("panel repaint and Explorer association icon contracts hold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -247,6 +247,14 @@ try {
             )
         },
         @{
+            Name = 'panel_rendering_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\panel_rendering_contract_tests.py')
+            )
+        },
+        @{
             Name = 'webview2_render_viewer_contract_tests'
             Arguments = @(
                 '-B',


### PR DESCRIPTION
## What changed

- resolve file-type icons through the same Windows shell associations used by Explorer, with guarded fallbacks for corrupt solid-black icon results
- keep startup panel initialization behind the splash and publish only one completed main-window frame
- make panel detach and reattach operations a single redraw transaction so intermediate empty or partially laid-out panels are not presented
- restore the complete splash status dirty rectangle so glyph overhang from the previous status cannot corrupt the first letter
- prewarm the Samandarin managed bridge asynchronously instead of blocking the startup path
- add source-contract regression coverage for icon extraction, startup reveal, detach/reattach, splash painting, and managed bridge lifecycle

## Why

Clean configurations displayed generic or corrupt icons instead of Explorer's registered file-type icons. Startup and panel detach/reattach also exposed intermediate layout and refresh states, causing blank panels, repeated repainting, and visible flicker. Splash status replacement left antialiased pixels outside the logical text rectangle, corrupting the first character of the next status. Managed runtime initialization added avoidable blocking work to application startup.

## User impact

Files receive their registered shell icons, including in a clean configuration. Startup, detach, and reattach present completed panel layouts without exposing intermediate blank frames. Splash status text is rendered cleanly, and managed initialization blocks the startup path for less time.

## Validation

- `Release clean|x64` main application build
- `Release clean|x64` Samandarin plug-in build
- panel rendering contract regression tests
- isolated startup, detach, and reattach visual probe in `H:\temp\test`
- isolated graceful-shutdown probe with exit code 0
- verified the test copy did not modify `configstorage.ini` or `config.reg`
