### PR TITLE
Match file icons with Windows Explorer

### DIFF
--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -2277,11 +2277,19 @@ void CFilesWindow::RepaintIconsForExtension(const char* extension)
     // A newly resolved association changes only files with this extension.
     // Repainting every icon in both panels for each association makes the
     // persistent-DC list visibly sweep across the window during startup.
+    BOOL repaint = FALSE;
+    RECT itemRect;
     for (int i = 0; i < Files->Count; i++)
     {
-        if (StrICmp(Files->At(i).Ext, extension) == 0)
-            ListBox->PaintItem(Dirs->Count + i, DRAWFLAG_ICON_ONLY);
+        if (StrICmp(Files->At(i).Ext, extension) == 0 &&
+            ListBox->GetItemRect(Dirs->Count + i, &itemRect))
+        {
+            InvalidateRect(ListBox->HWindow, &itemRect, FALSE);
+            repaint = TRUE;
+        }
     }
+    if (repaint)
+        UpdateWindow(ListBox->HWindow);
 }
 
 void CFilesWindow::CompletePendingStartupRefreshes()

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -798,25 +798,26 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (file != NULL && !isDir &&                                   // jde o soubor
                 (!Is(ptPluginFS) || GetPluginIconsType() != pitFromPlugin)) // nejde o ikonu z plug-inu
             {
-                char buf[MAX_PATH + 4]; // pripona malymi pismeny
-                char *s1 = buf, *s2 = file->Ext;
+                char extension[MAX_PATH + 4]; // pripona malymi pismeny
+                char *s1 = extension, *s2 = file->Ext;
                 while (*s2 != 0)
                     *s1++ = LowerCase[*s2++];
                 *((DWORD*)s1) = 0;
                 int index;
                 CIconSizeEnum iconSize = IconCache->GetIconSize();
-                BOOL icoFileIcon = iconSize == ICONSIZE_16 && *(DWORD*)buf == *(DWORD*)"ico";
+                BOOL icoFileIcon = iconSize == ICONSIZE_16 && *(DWORD*)extension == *(DWORD*)"ico";
                 if (!icoFileIcon &&
-                    Associations.GetIndex(buf, index) &&             // pripona ma ikonku (asociaci)
+                    Associations.GetIndex(extension, index) &&       // pripona ma ikonku (asociaci)
                     (Associations[index].GetIndex(iconSize) == -1 || // jde o ikonku, ktera se nacita
                      Associations[index].GetIndex(iconSize) == -3))
                 {
                     int icon;
                     CIconList* srcIconList;
                     int srcIconListIndex;
-                    memmove(buf, file->Name, file->NameLen);
-                    *(DWORD*)(buf + file->NameLen) = 0;
-                    if (IconCache->GetIndex(buf, icon, NULL, NULL) &&                                 // icon-thread ji nacita
+                    char fileName[MAX_PATH + 4];
+                    memmove(fileName, file->Name, file->NameLen);
+                    *(DWORD*)(fileName + file->NameLen) = 0;
+                    if (IconCache->GetIndex(fileName, icon, NULL, NULL) &&                            // icon-thread ji nacita
                         (IconCache->At(icon).GetFlag() == 1 || IconCache->At(icon).GetFlag() == 2) && // ikona je nactena nova nebo stara
                         IconCache->GetIcon(IconCache->At(icon).GetIndex(),
                                            &srcIconList, &srcIconListIndex)) // povede se ziskat nactenou ikonku
@@ -848,11 +849,11 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                             {
                                 // panely prekreslime pouze pokud odpovidaji velikosti ikon
                                 if (iconSize == GetIconSizeForCurrentViewMode())
-                                    RepaintIconsForExtension(buf);
+                                    RepaintIconsForExtension(extension);
 
                                 CFilesWindow* otherPanel = MainWindow->GetOtherPanel(this);
                                 if (otherPanel != NULL && iconSize == otherPanel->GetIconSizeForCurrentViewMode())
-                                    otherPanel->RepaintIconsForExtension(buf);
+                                    otherPanel->RepaintIconsForExtension(extension);
                             }
                             else
                                 PostAllIconsRepaint = TRUE;

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -250,6 +250,39 @@ static std::wstring PanelPathToWide(const char* path)
     return std::wstring(wide.data());
 }
 
+static HICON GetExplorerFileIcon(const char* path, int pixelSize)
+{
+    if (path == NULL || pixelSize <= 0)
+        return NULL;
+
+    std::wstring widePath = PanelPathToWide(path);
+    if (widePath.empty())
+        return NULL;
+
+    SHFILEINFOW fileInfo;
+    ZeroMemory(&fileInfo, sizeof(fileInfo));
+    if (SHGetFileInfoW(widePath.c_str(), 0, &fileInfo, sizeof(fileInfo),
+                       SHGFI_ICON | SHGFI_SMALLICON) == 0 ||
+        fileInfo.hIcon == NULL)
+        return NULL;
+
+    HICON icon = fileInfo.hIcon;
+    if (GetIconPixelWidth(icon) != pixelSize)
+    {
+        HICON resized = (HICON)CopyImage(icon, IMAGE_ICON, pixelSize, pixelSize, 0);
+        if (resized == NULL)
+        {
+            HANDLES(DestroyIcon(icon));
+            return NULL;
+        }
+        HANDLES(DestroyIcon(icon));
+        icon = resized;
+    }
+
+    DiscardSolidBlackIcon(&icon, pixelSize);
+    return icon;
+}
+
 static HICON GetDefaultAssociationIcon(const char* path, int pixelSize)
 {
     if (path == NULL || pixelSize <= 0)
@@ -771,6 +804,16 @@ BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum 
 */
     if (!pathIsPIDL && iconSize == ICONSIZE_16 && LoadIcoFileSmallIcon(path, hIcon))
         return TRUE;
+
+    // For ordinary small file icons use the same path-based shell result that
+    // Explorer displays. IExtractIcon resource locations and registered
+    // DefaultIcon values can both be valid yet select different artwork.
+    if (!pathIsPIDL && iconSize == ICONSIZE_16)
+    {
+        *hIcon = GetExplorerFileIcon(path, IconSizes[ICONSIZE_16]);
+        if (*hIcon != NULL)
+            return TRUE;
+    }
 
     if (!pathIsPIDL)
         pidlFull = SHILCreateFromPath(path);

--- a/src/icncache.cpp
+++ b/src/icncache.cpp
@@ -10,6 +10,11 @@
 #include "geticon.h"
 #include "logo.h"
 
+#include <shlwapi.h>
+
+#include <string>
+#include <vector>
+
 // melo by byt nasobkem hodnoty IL_ITEMS_IN_ROW
 // aby se plne vyuzil prostor v bitmape
 #define ICONS_IN_LIST 100
@@ -1449,10 +1454,91 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
     }
 }
 
+static std::wstring AssociationExtensionToWide(const char* ext)
+{
+    if (ext == NULL || ext[0] == 0)
+        return std::wstring();
+
+    UINT codePage = CP_UTF8;
+    DWORD flags = MB_ERR_INVALID_CHARS;
+    int length = MultiByteToWideChar(codePage, flags, ext, -1, NULL, 0);
+    if (length == 0)
+    {
+        codePage = CP_ACP;
+        flags = 0;
+        length = MultiByteToWideChar(codePage, flags, ext, -1, NULL, 0);
+    }
+    if (length <= 1)
+        return std::wstring();
+
+    std::vector<wchar_t> wide(length);
+    if (MultiByteToWideChar(codePage, flags, ext, -1, wide.data(), length) == 0)
+        return std::wstring();
+
+    std::wstring result(L".");
+    result.append(wide.data());
+    return result;
+}
+
+static BOOL QueryShellAssociation(const char* ext, BOOL& canOpen)
+{
+    canOpen = FALSE;
+    std::wstring wideExtension = AssociationExtensionToWide(ext);
+    if (wideExtension.empty())
+        return FALSE;
+
+    DWORD commandLength = 0;
+    HRESULT commandResult = AssocQueryStringW(ASSOCF_NONE, ASSOCSTR_COMMAND,
+                                               wideExtension.c_str(), NULL,
+                                               NULL, &commandLength);
+    canOpen = SUCCEEDED(commandResult) && commandLength > 1;
+
+    std::wstring probeName(L"__opensalamander_file");
+    probeName.append(wideExtension);
+    SHFILEINFOW associatedInfo;
+    ZeroMemory(&associatedInfo, sizeof(associatedInfo));
+    if (SHGetFileInfoW(probeName.c_str(), FILE_ATTRIBUTE_NORMAL, &associatedInfo,
+                       sizeof(associatedInfo), SHGFI_USEFILEATTRIBUTES |
+                                                   SHGFI_SYSICONINDEX |
+                                                   SHGFI_SMALLICON) == 0)
+        return canOpen;
+
+    SHFILEINFOW genericInfo;
+    ZeroMemory(&genericInfo, sizeof(genericInfo));
+    if (SHGetFileInfoW(L"__opensalamander_file.__opensalamander_unknown__",
+                       FILE_ATTRIBUTE_NORMAL, &genericInfo, sizeof(genericInfo),
+                       SHGFI_USEFILEATTRIBUTES | SHGFI_SYSICONINDEX |
+                           SHGFI_SMALLICON) == 0)
+        return canOpen;
+
+    return canOpen || associatedInfo.iIcon != genericInfo.iIcon;
+}
+
 BOOL CAssociations::IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum iconSize)
 {
     int index;
-    if (GetIndex(ext, index))
+    BOOL found = GetIndex(ext, index);
+    if (!found)
+    {
+        // The registry layout parsed by ReadAssociations predates per-user and
+        // application-managed associations. Explorer can still resolve those
+        // through the shell (for example PDF and torrent handlers), so add a
+        // lazy cache entry and let the normal icon thread read the real file.
+        BOOL canOpen;
+        if (QueryShellAssociation(ext, canOpen))
+        {
+            CAssociationData data;
+            data.SetFlag(canOpen ? 1 : 0);
+            data.SetIndexAll(-1);
+            LONG size;
+            char* end = ext + strlen(ext);
+            InsertData("shell: ", index, FALSE, ext, end, data, size, "", "");
+            found = IsGood();
+            if (!found)
+                ResetState();
+        }
+    }
+    if (found)
     {
         int i = At(index).GetIndex(iconSize);
         if (i == -1)

--- a/src/tests/panel_rendering_contract_tests.py
+++ b/src/tests/panel_rendering_contract_tests.py
@@ -16,6 +16,7 @@ def main() -> int:
     fileswnd = (ROOT / "fileswn1.cpp").read_text(encoding="utf-8")
     fileswnd2 = (ROOT / "fileswn2.cpp").read_text(encoding="utf-8")
     fileswndb = (ROOT / "fileswnb.cpp").read_text(encoding="utf-8")
+    icon_cache = (ROOT / "icncache.cpp").read_text(encoding="utf-8")
     mainwnd1 = (ROOT / "mainwnd1.cpp").read_text(encoding="utf-8")
     mainwnd2 = (ROOT / "mainwnd2.cpp").read_text(encoding="utf-8")
     mainwnd3 = (ROOT / "mainwnd3.cpp").read_text(encoding="utf-8")
@@ -96,6 +97,23 @@ def main() -> int:
     if "SHDefExtractIconW(iconPath.c_str(), iconIndex" not in geticon:
         print("registered DefaultIcon must be extracted at the panel pixel size")
         return 1
+    explorer_icon = re.search(
+        r"static HICON GetExplorerFileIcon\(.*?\n\}", geticon, re.DOTALL
+    )
+    get_file_icon = re.search(
+        r"BOOL GetFileIcon\(.*?\n\}", geticon, re.DOTALL
+    )
+    if (
+        explorer_icon is None
+        or "PanelPathToWide(path)" not in explorer_icon.group(0)
+        or "SHGetFileInfoW" not in explorer_icon.group(0)
+        or "SHGFI_ICON | SHGFI_SMALLICON" not in explorer_icon.group(0)
+        or get_file_icon is None
+        or get_file_icon.group(0).find("GetExplorerFileIcon(")
+        > get_file_icon.group(0).find("SHILCreateFromPath(")
+    ):
+        print("ordinary small file icons must prefer Explorer's wide shell result")
+        return 1
     if "useExplorerFileTypeIcon" in fileswnd or "GetExplorerFileTypeIcon" in fileswnd:
         print("ordinary disk icon loading must not bypass GetFileIcon")
         return 1
@@ -123,6 +141,45 @@ def main() -> int:
         print(
             "association icon delivery must preserve the extension while looking up the source file"
         )
+        return 1
+    targeted_repaint = re.search(
+        r"void CFilesWindow::RepaintIconsForExtension\(.*?\n\}",
+        fileswnd0,
+        re.DOTALL,
+    )
+    if (
+        targeted_repaint is None
+        or "GetItemRect" not in targeted_repaint.group(0)
+        or "InvalidateRect(ListBox->HWindow" not in targeted_repaint.group(0)
+        or "UpdateWindow(ListBox->HWindow);" not in targeted_repaint.group(0)
+        or "PaintItem(" in targeted_repaint.group(0)
+    ):
+        print("association updates must be published through one synchronous paint")
+        return 1
+    modern_association = re.search(
+        r"static BOOL QueryShellAssociation\(.*?\n\}",
+        icon_cache,
+        re.DOTALL,
+    )
+    association_lookup = re.search(
+        r"BOOL CAssociations::IsAssociated\(char\* ext, BOOL& addtoIconCache,"
+        r".*?\n\}",
+        icon_cache,
+        re.DOTALL,
+    )
+    if (
+        modern_association is None
+        or "AssocQueryStringW" not in modern_association.group(0)
+        or "SHGFI_USEFILEATTRIBUTES" not in modern_association.group(0)
+        or "associatedInfo.iIcon != genericInfo.iIcon"
+        not in modern_association.group(0)
+        or association_lookup is None
+        or "QueryShellAssociation(ext, canOpen)"
+        not in association_lookup.group(0)
+        or "InsertData(\"shell: \"" not in association_lookup.group(0)
+        or "data.SetIndexAll(-1);" not in association_lookup.group(0)
+    ):
+        print("modern shell-only associations must enter the normal icon cache")
         return 1
 
     if "!TreeViewAutoHide || TreeViewAutoHideExpanded" not in fileswnd2:

--- a/src/tests/panel_rendering_contract_tests.py
+++ b/src/tests/panel_rendering_contract_tests.py
@@ -106,10 +106,23 @@ def main() -> int:
     )
     if (
         association_refresh is None
-        or "RepaintIconsForExtension(buf);" not in association_refresh.group(0)
+        or "RepaintIconsForExtension(extension);"
+        not in association_refresh.group(0)
         or "RepaintIconOnly(-1)" in association_refresh.group(0)
     ):
         print("association icon delivery must not repaint every icon in both panels")
+        return 1
+    if (
+        "Associations.GetIndex(extension, index)" not in association_refresh.group(0)
+        or "IconCache->GetIndex(fileName, icon" not in association_refresh.group(0)
+        or association_refresh.group(0).count(
+            "RepaintIconsForExtension(extension);"
+        )
+        != 2
+    ):
+        print(
+            "association icon delivery must preserve the extension while looking up the source file"
+        )
         return 1
 
     if "!TreeViewAutoHide || TreeViewAutoHideExpanded" not in fileswnd2:


### PR DESCRIPTION
## What changed

- preserve the file extension while resolving and repainting a shared association icon
- prefer the wide path-based shell icon returned by `SHGetFileInfoW` for ordinary small file icons
- publish association icon updates through a targeted synchronous paint instead of direct persistent-DC drawing
- lazily add modern per-user/application-managed shell associations that the legacy registry parser does not discover
- extend the existing PR-run panel rendering contract test for all repaired paths

## Why

Some associated files displayed Salamander's generic icon or a different resource icon than Windows Explorer. Other icons, such as `.torrent`, appeared only after clicking the item.

There were multiple root causes:

1. the extension buffer was overwritten with the source file name before repainting all files of that type
2. direct `IExtractIcon`/resource and `DefaultIcon` extraction could legitimately select artwork different from Explorer
3. direct item painting did not always publish the updated association cache to the compositor
4. the legacy registry enumeration missed modern per-user associations, so PDF and torrent files could be excluded from icon loading entirely

The shell fallback now compares the extension's system image-list index with the generic-file index and feeds distinct associations through the normal icon thread. Path conversion prefers UTF-8 and falls back to ACP.

## User impact

PDF, torrent, MP3, DOC/DOCX, and other associated file types now use the same shell icon source as Explorer and update without requiring selection or another incidental repaint.

## Validation

- user visually confirmed the corrected icons on the affected machine
- `python src/tests/panel_rendering_contract_tests.py`
- Debug x64 `salamand.vcxproj` build
- Release x64 `salamand.vcxproj` build
- isolated shell probes: PDF index 437, torrent index 238, generic file index 0
- `git diff --check`
