### PR TITLE
Make file tooltips more compact

### DIFF
--- a/.github/workflows/code-growth.yml
+++ b/.github/workflows/code-growth.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   report:
-    name: Source growth against latest Samandarin release
+    name: Source growth against latest release and PR base
     runs-on: windows-2022
     timeout-minutes: 10
 
@@ -39,6 +39,10 @@ jobs:
         run: |
           git remote add canonical "https://github.com/${{ github.repository }}.git"
           git fetch canonical 'refs/tags/5.0-samandarin-*:refs/tags/5.0-samandarin-*'
+
+      - name: Fetch canonical pull request base commit
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: git fetch canonical '${{ github.event.pull_request.base.sha }}'
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -62,17 +66,40 @@ jobs:
           $delta = [int]$report.comparison.summary.deltaNloc
           "title=$('{0:+#,#;-#,#;0} NLOC' -f $delta)" | Add-Content -Path $env:GITHUB_OUTPUT
 
+      - name: Generate pull request source code growth report
+        if: github.event_name == 'pull_request'
+        id: pr_report
+        run: |
+          New-Item -ItemType Directory -Force -Path code-growth-pr-report | Out-Null
+          python tools/code_metrics/report_code_growth.py `
+            --repository-root . `
+            --baseline-commit '${{ github.event.pull_request.base.sha }}' `
+            --baseline-label 'base branch: ${{ github.event.pull_request.base.ref }}' `
+            --current-label 'PR head: ${{ github.event.pull_request.head.sha }}' `
+            --output-json code-growth-pr-report/report.json `
+            --output-markdown code-growth-pr-report/report.md
+          "## Pull request source code growth" | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+          Get-Content code-growth-pr-report/report.md | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+          $report = Get-Content code-growth-pr-report/report.json -Raw | ConvertFrom-Json
+          $delta = [int]$report.comparison.summary.deltaNloc
+          "title=$('{0:+#,#;-#,#;0} NLOC in PR' -f $delta)" | Add-Content -Path $env:GITHUB_OUTPUT
+
       - name: Show source growth summary on the PR check
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           CHECK_RUN_ID: ${{ job.check_run_id }}
           REPORT_TITLE: ${{ steps.report.outputs.title }}
+          PR_REPORT_TITLE: ${{ steps.pr_report.outputs.title }}
         run: |
           $summary = Get-Content code-growth-report/report.md -Raw
+          if (Test-Path code-growth-pr-report/report.md) {
+            $summary += "`n`n---`n`n## Pull request source code growth`n`n"
+            $summary += Get-Content code-growth-pr-report/report.md -Raw
+          }
           @{
             output = @{
-              title = $env:REPORT_TITLE
+              title = if ($env:PR_REPORT_TITLE) { "$env:REPORT_TITLE; $env:PR_REPORT_TITLE" } else { $env:REPORT_TITLE }
               summary = $summary
             }
           } |
@@ -132,10 +159,69 @@ jobs:
               core.info(`Published source growth report: ${created.data.html_url}`);
             }
 
+      - name: Publish pull request source growth report
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPORT_PATH: code-growth-pr-report/report.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- source-code-growth-pr-report -->';
+            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8').trim();
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const footer = `\n\n---\n<sub>Compared with base branch \`${process.env.BASE_REF}\` at \`${process.env.BASE_SHA}\`; updated for \`${process.env.HEAD_SHA}\`. [Open workflow run](${runUrl}).</sub>`;
+            const body = `${marker}\n${report}${footer}`;
+
+            if (body.length > 65000) {
+              core.setFailed(`PR source growth report is too large for a PR comment (${body.length} characters).`);
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              const updated = await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated PR source growth report: ${updated.data.html_url}`);
+            } else {
+              const created = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info(`Published PR source growth report: ${created.data.html_url}`);
+            }
+
       - name: Upload source growth report
         uses: actions/upload-artifact@v4
         with:
           name: source-code-growth-report
           path: code-growth-report/*
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload pull request source growth report
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-code-growth-pr-report
+          path: code-growth-pr-report/*
           if-no-files-found: error
           retention-days: 14

--- a/src/consts.h
+++ b/src/consts.h
@@ -1020,6 +1020,7 @@ BOOL DirExists(const char* dirName);
 
 // tool tip
 void SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay = 0); // popis v tooltip.h
+void SetCurrentPanelToolTip(HWND hNotifyWindow, DWORD id, int showDelay = 0);
 void SuppressToolTipOnCurrentMousePos();                                 // popis v tooltip.h
 
 // zajisti skoky kurzoru pri Ctrl+Left/Right po zpetnych lomitkach a mezerach

--- a/src/fileswn9.cpp
+++ b/src/fileswn9.cpp
@@ -1706,7 +1706,7 @@ BOOL CFilesWindow::OnMouseMove(WPARAM wParam, LPARAM lParam, LRESULT* lResult)
                     index = -1;
             }
         }
-        SetCurrentToolTip(index >= 0 ? GetListBoxHWND() : NULL, index >= 0 ? (DWORD)index + 1 : 0);
+        SetCurrentPanelToolTip(index >= 0 ? GetListBoxHWND() : NULL, index >= 0 ? (DWORD)index + 1 : 0);
     }
 
     if (Configuration.SingleClick)

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -48,6 +48,12 @@ void SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
         MainWindow->ToolTip->SetCurrentToolTip(hNotifyWindow, id, showDelay);
 }
 
+void SetCurrentPanelToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
+{
+    if (MainWindow != NULL && MainWindow->ToolTip != NULL)
+        MainWindow->ToolTip->SetCurrentPanelToolTip(hNotifyWindow, id, showDelay);
+}
+
 void SuppressToolTipOnCurrentMousePos()
 {
     if (MainWindow != NULL && MainWindow->ToolTip != NULL)

--- a/src/tooltip.cpp
+++ b/src/tooltip.cpp
@@ -36,6 +36,7 @@ CToolTip::CToolTip(CObjectOrigin origin)
     TimerID = 0;
     WindowFont = NULL;
     WindowDPI = 0;
+    CompactPanelToolTip = FALSE;
 
     LastCursorPos.x = -1;
     LastCursorPos.y = -1;
@@ -321,12 +322,41 @@ void CToolTip::GetNeededWindowSize(SIZE* sz)
     HDC hDC = HANDLES(GetDC(HWindow));
     HFONT hFont = WindowFont != NULL ? WindowFont : TooltipFont;
     HFONT hOldFont = (HFONT)SelectObject(hDC, hFont);
-    RECT tR;
-    tR.left = 0;
-    tR.top = 0;
-    tR.right = 0;
-    tR.bottom = 0;
-    DrawText(hDC, Text, TextLen, &tR, DT_CALCRECT | DT_LEFT | DT_NOPREFIX | DT_EXPANDTABS);
+    RECT tR = {0, 0, 0, 0};
+    if (!CompactPanelToolTip)
+    {
+        DrawText(hDC, Text, TextLen, &tR, DT_CALCRECT | DT_LEFT | DT_NOPREFIX | DT_EXPANDTABS);
+    }
+    else
+    {
+        TEXTMETRIC tm;
+        GetTextMetrics(hDC, &tm);
+        UINT dpi = WindowDPI != 0 ? WindowDPI : USER_DEFAULT_SCREEN_DPI;
+        int lineStep = max(1, tm.tmHeight - MulDiv(1, (int)dpi, USER_DEFAULT_SCREEN_DPI));
+        int lineCount = 0;
+        int lineStart = 0;
+        while (lineStart <= TextLen)
+        {
+            int lineEnd = lineStart;
+            while (lineEnd < TextLen && Text[lineEnd] != '\n')
+                ++lineEnd;
+
+            int measuredEnd = lineEnd;
+            if (measuredEnd > lineStart && Text[measuredEnd - 1] == '\r')
+                --measuredEnd;
+
+            RECT lineRect = {0, 0, 0, 0};
+            DrawText(hDC, Text + lineStart, measuredEnd - lineStart, &lineRect,
+                     DT_CALCRECT | DT_SINGLELINE | DT_LEFT | DT_NOPREFIX | DT_EXPANDTABS);
+            tR.right = max(tR.right, lineRect.right);
+            ++lineCount;
+
+            if (lineEnd == TextLen)
+                break;
+            lineStart = lineEnd + 1;
+        }
+        tR.bottom = lineCount > 0 ? tm.tmHeight + (lineCount - 1) * lineStep : 0;
+    }
     SelectObject(hDC, hOldFont);
     HANDLES(ReleaseDC(HWindow, hDC));
     sz->cx = tR.right - tR.left;
@@ -336,29 +366,38 @@ void CToolTip::GetNeededWindowSize(SIZE* sz)
     sz->cy += MulDiv(2 + 2, (int)dpi, USER_DEFAULT_SCREEN_DPI);
 }
 
-BOOL CToolTip::UpdateFontForDPI(UINT dpi)
+BOOL CToolTip::UpdateFontForDPI(UINT dpi, BOOL compactPanelToolTip)
 {
     if (dpi == 0)
         dpi = USER_DEFAULT_SCREEN_DPI;
-    if (WindowFont != NULL && WindowDPI == dpi)
+    if (WindowFont != NULL && WindowDPI == dpi && CompactPanelToolTip == compactPanelToolTip)
         return TRUE;
 
     LOGFONT lf;
-    HFONT font = WinLibDPIGetStatusLogFontForDPI(dpi, &lf)
-                     ? HANDLES(CreateFontIndirect(&lf))
-                     : NULL;
+    HFONT font = NULL;
+    if (WinLibDPIGetStatusLogFontForDPI(dpi, &lf))
+    {
+        if (compactPanelToolTip && lf.lfHeight != 0)
+        {
+            int reduction = max(1, (int)((dpi + 36) / 72));
+            int height = max(1, abs(lf.lfHeight) - reduction);
+            lf.lfHeight = lf.lfHeight < 0 ? -height : height;
+        }
+        font = HANDLES(CreateFontIndirect(&lf));
+    }
     if (font == NULL)
         return FALSE;
     if (WindowFont != NULL)
         HANDLES(DeleteObject(WindowFont));
     WindowFont = font;
     WindowDPI = dpi;
+    CompactPanelToolTip = compactPanelToolTip;
     return TRUE;
 }
 
 BOOL CToolTip::UpdateFontForWindow(HWND hWindow)
 {
-    return UpdateFontForDPI(WinLibDPIGetWindowDPI(hWindow));
+    return UpdateFontForDPI(WinLibDPIGetWindowDPI(hWindow), CompactPanelToolTip);
 }
 
 BOOL CToolTip::Show(int x, int y, BOOL considerCursor, BOOL modal, HWND hParent)
@@ -456,9 +495,22 @@ void CToolTip::MyKillTimer()
 
 void CToolTip::SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
 {
+    SetCurrentToolTipInternal(hNotifyWindow, id, showDelay, FALSE);
+}
+
+void CToolTip::SetCurrentPanelToolTip(HWND hNotifyWindow, DWORD id, int showDelay)
+{
+    SetCurrentToolTipInternal(hNotifyWindow, id, showDelay, TRUE);
+}
+
+void CToolTip::SetCurrentToolTipInternal(HWND hNotifyWindow, DWORD id, int showDelay,
+                                         BOOL compactPanelToolTip)
+{
     CALL_STACK_MESSAGE2("CToolTip::SetCurrentToolTip(, 0x%X)", id);
     if (IsModal)
         return; // behem modalniho tooltipu nebereme toto volani
+
+    CompactPanelToolTip = compactPanelToolTip;
 
     HWND hOldNotifyWindow = HNotifyWindow;
     HNotifyWindow = hNotifyWindow;
@@ -649,7 +701,7 @@ CToolTip::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_DPICHANGED:
     {
         UINT dpi = HIWORD(wParam);
-        UpdateFontForDPI(dpi);
+        UpdateFontForDPI(dpi, CompactPanelToolTip);
         SIZE sz;
         GetNeededWindowSize(&sz);
         int x = 0;
@@ -702,7 +754,39 @@ CToolTip::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         UINT dpi = WindowDPI != 0 ? WindowDPI : USER_DEFAULT_SCREEN_DPI;
         r.left += MulDiv(2, (int)dpi, USER_DEFAULT_SCREEN_DPI);
         r.top += MulDiv(1, (int)dpi, USER_DEFAULT_SCREEN_DPI);
-        DrawText(hDC, Text, TextLen, &r, DT_LEFT | DT_NOPREFIX | DT_NOCLIP | DT_EXPANDTABS);
+        if (!CompactPanelToolTip)
+        {
+            DrawText(hDC, Text, TextLen, &r, DT_LEFT | DT_NOPREFIX | DT_NOCLIP | DT_EXPANDTABS);
+        }
+        else
+        {
+            TEXTMETRIC tm;
+            GetTextMetrics(hDC, &tm);
+            int lineStep = max(1, tm.tmHeight - MulDiv(1, (int)dpi, USER_DEFAULT_SCREEN_DPI));
+            int lineStart = 0;
+            int lineNumber = 0;
+            while (lineStart <= TextLen)
+            {
+                int lineEnd = lineStart;
+                while (lineEnd < TextLen && Text[lineEnd] != '\n')
+                    ++lineEnd;
+
+                int measuredEnd = lineEnd;
+                if (measuredEnd > lineStart && Text[measuredEnd - 1] == '\r')
+                    --measuredEnd;
+
+                RECT lineRect = r;
+                lineRect.top += lineNumber * lineStep;
+                lineRect.bottom = lineRect.top + tm.tmHeight;
+                DrawText(hDC, Text + lineStart, measuredEnd - lineStart, &lineRect,
+                         DT_SINGLELINE | DT_LEFT | DT_NOPREFIX | DT_NOCLIP | DT_EXPANDTABS);
+                ++lineNumber;
+
+                if (lineEnd == TextLen)
+                    break;
+                lineStart = lineEnd + 1;
+            }
+        }
         SetBkMode(hDC, oldBkMode);
         SetTextColor(hDC, oldTextColor);
         SelectObject(hDC, hOldFont);

--- a/src/tooltip.h
+++ b/src/tooltip.h
@@ -58,6 +58,7 @@ protected:
     UINT_PTR TimerID; // vracene ze SetTimer, potrebujeme pro KillTimer
     HFONT WindowFont; // font matching the monitor of the tooltip owner
     UINT WindowDPI;
+    BOOL CompactPanelToolTip;
 
 public:
     CToolTip(CObjectOrigin origin = ooStatic);
@@ -84,6 +85,7 @@ public:
     // pokud je roven 0, pouzije se implicitni prodleva
     // pokud je -1, casovac se vubec nenastartuje
     void SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay);
+    void SetCurrentPanelToolTip(HWND hNotifyWindow, DWORD id, int showDelay);
 
     // potlaci zobrazeni tooltipu na aktualnich souradnicich mysi
     // uzitecne volat pri aktivaci okna, ve kterem se tooltipy pouzivaji
@@ -105,8 +107,9 @@ protected:
 
     BOOL GetText();
     void GetNeededWindowSize(SIZE* sz);
-    BOOL UpdateFontForDPI(UINT dpi);
+    BOOL UpdateFontForDPI(UINT dpi, BOOL compactPanelToolTip);
     BOOL UpdateFontForWindow(HWND hWindow);
+    void SetCurrentToolTipInternal(HWND hNotifyWindow, DWORD id, int showDelay, BOOL compactPanelToolTip);
 
     void MessageLoop(); // pro modalni variantu tooltipu
 

--- a/tools/code_metrics/report_code_growth.py
+++ b/tools/code_metrics/report_code_growth.py
@@ -332,6 +332,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repository-root", type=Path, default=Path.cwd())
     parser.add_argument("--baseline-commit")
+    parser.add_argument("--baseline-label")
     parser.add_argument("--tag-prefix", default="5.0-samandarin-")
     parser.add_argument("--current-label", default="working tree")
     parser.add_argument("--output-json", type=Path)
@@ -340,9 +341,14 @@ def main() -> int:
     args = parser.parse_args()
 
     repository = args.repository_root.resolve()
-    baseline = resolve_baseline(repository, args.tag_prefix)
     if args.baseline_commit:
-        baseline["commit"] = str(git(repository, "rev-parse", args.baseline_commit)).strip().lower()
+        baseline = {
+            "tag": args.baseline_label or args.baseline_commit,
+            "version": "",
+            "commit": str(git(repository, "rev-parse", args.baseline_commit)).strip().lower(),
+        }
+    else:
+        baseline = resolve_baseline(repository, args.tag_prefix)
 
     if args.summary_only:
         summary = source_diff_summary(repository, baseline["commit"])

--- a/tools/code_metrics/tests/test_code_growth.py
+++ b/tools/code_metrics/tests/test_code_growth.py
@@ -144,6 +144,44 @@ def test_release_report_allows_explicit_initial_non_release_tag(tmp_path: Path) 
     assert "Current: **5.0-samandarin-0.1**" in rendered
 
 
+def test_report_compares_to_explicit_pull_request_base_without_release_tags(tmp_path: Path) -> None:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    create_repository(repository)
+    source = repository / "src" / "main.cpp"
+    source.parent.mkdir()
+    source.write_text("int Small() { return 1; }\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repository), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repository), "commit", "-q", "-m", "base"], check=True)
+    base_commit = git(repository, "rev-parse", "HEAD")
+
+    source.write_text("int Small() { return 1; }\nint Larger() { return 2; }\n", encoding="utf-8")
+    output_json = tmp_path / "report.json"
+    output_markdown = tmp_path / "report.md"
+    subprocess.run(
+        [
+            sys.executable,
+            str(REPORT),
+            "--repository-root", str(repository),
+            "--baseline-commit", base_commit,
+            "--baseline-label", "PR base branch",
+            "--current-label", "PR head",
+            "--output-json", str(output_json),
+            "--output-markdown", str(output_markdown),
+        ],
+        check=True,
+    )
+
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+    assert report["baseline"] == {
+        "tag": "PR base branch",
+        "version": "",
+        "commit": base_commit,
+    }
+    assert report["comparison"]["summary"]["deltaNloc"] > 0
+    assert "Baseline: **PR base branch**" in output_markdown.read_text(encoding="utf-8")
+
+
 def test_workflow_is_source_only_and_pr_build_calls_codeql_after_success() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     pr_build = PR_BUILD.read_text(encoding="utf-8")
@@ -151,6 +189,9 @@ def test_workflow_is_source_only_and_pr_build_calls_codeql_after_success() -> No
     assert "report_code_growth.py" in workflow
     assert "lizard==1.23.0" in workflow
     assert "<!-- source-code-growth-report -->" in workflow
+    assert "<!-- source-code-growth-pr-report -->" in workflow
+    assert "--baseline-commit" in workflow
+    assert "github.event.pull_request.base.sha" in workflow
     assert "github.rest.issues.createComment" in workflow
     assert "github.rest.issues.updateComment" in workflow
     assert "pull-requests: write" in workflow


### PR DESCRIPTION
## Summary

Makes rich file and folder panel tooltips more compact and keeps their existing instant update behavior when moving between items.

## Changes

- Uses a panel-tooltip-only font one point smaller than the regular tooltip font.
- Tightens line spacing by one DPI-scaled logical pixel and uses the same layout for measurement and drawing.
- Preserves per-monitor-per-window DPI font recreation and refresh behavior.
- Leaves regular control/tool bar tooltips and the plugin tooltip API unchanged.
- Keeps immediate tooltip content updates when moving between files.

## Validation

- `git diff --check` passed.
- Debug/x64 Salamander core build passed with 0 warnings and 0 errors.
- Full solution build was attempted; the unrelated SFTP project is blocked by missing `libssh2.h`.
- Visual runtime and cross-monitor DPI validation still require running the built application.