### PR TITLE
Make the Local Llama configuration Close button dismiss its dialog

### DIFF
--- a/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
+++ b/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
@@ -1148,6 +1148,11 @@ def main() -> int:
         r'control->KeepOpen \|\| control->DialogResult == 0',
         "zero-result action buttons do not remain open for the legacy Automation facade")
     require(
+        local_llama,
+        r'closeOptions\.Id = "close";.*?'
+        r'closeOptions\.DialogResult = IDCANCEL;',
+        "Local Llama configuration Close button does not close its modal dialog")
+    require(
         packages,
         r'interactiveModalCall.*?salamander\.ui\.dialog\.show.*?'
         r'salamander\.ui\.controls.*?salamander\.ui\.messageBox.*?'

--- a/src/plugins/salamatrixailocalllama/local_llama.cpp
+++ b/src/plugins/salamatrixailocalllama/local_llama.cpp
@@ -327,6 +327,7 @@ static void ShowConfiguration(HWND parent)
     Salamatrix::UI::ControlOptions closeOptions;
     closeOptions.Id = "close";
     closeOptions.Text = LoadLocalLlamaString(IDS_LLAMA_CLOSE);
+    closeOptions.DialogResult = IDCANCEL;
     Salamatrix::UI::ControlLayout closeLayout;
     closeLayout.HasBounds = TRUE;
     closeLayout.X = 290; closeLayout.Y = 98; closeLayout.Width = 62; closeLayout.Height = 16;


### PR DESCRIPTION
## Summary

- Set the Local Llama configuration Close button’s dialog result to `IDCANCEL`.
- Add a regression check ensuring the button closes its modal dialog.

## Testing

- Added coverage to `salamatrix_regression_tests.py`.