### PR TITLE
Preserve main window size after sleep

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -1811,6 +1811,7 @@ DWORD CfgSkillLevelToMenu(BYTE cfgSkillLevel);
 #define IDT_DELAYEDTHROBBER 950
 #define IDT_UPDATETASKLIST 951
 #define IDT_FINISHSTARTUPREVEAL 952
+#define IDT_RESTOREWINDOWPLACEMENT 953
 
 // POZOR: skoro vsechny funkce v teto sekci pri chybe zobrazuji hlaseni o LOAD / SAVE
 //        konfigurace, coz z nich dela nevhodne pro bezny pristup do Registry,

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3829,6 +3829,32 @@ static BOOL DPIWindowRectAlreadyApplied = FALSE;
 static int MainWindowContentDPI = 0;
 static int InitialSessionDPI = 0;
 static BOOL DPIChangePromptShown = FALSE;
+static WINDOWPLACEMENT PreSuspendWindowPlacement = {sizeof(WINDOWPLACEMENT)};
+static BOOL PreSuspendWindowPlacementValid = FALSE;
+static BOOL ResumeWindowPlacementPending = FALSE;
+
+static void ScheduleResumeWindowPlacementRestore(HWND hWindow)
+{
+    if (!PreSuspendWindowPlacementValid)
+        return;
+
+    ResumeWindowPlacementPending = TRUE;
+    KillTimer(hWindow, IDT_RESTOREWINDOWPLACEMENT);
+    SetTimer(hWindow, IDT_RESTOREWINDOWPLACEMENT, 1000, NULL);
+}
+
+static void RestorePreSuspendWindowPlacement(HWND hWindow)
+{
+    KillTimer(hWindow, IDT_RESTOREWINDOWPLACEMENT);
+    ResumeWindowPlacementPending = FALSE;
+    if (!PreSuspendWindowPlacementValid)
+        return;
+
+    WINDOWPLACEMENT placement = PreSuspendWindowPlacement;
+    PreSuspendWindowPlacementValid = FALSE;
+    MultiMonEnsureRectVisible(&placement.rcNormalPosition, FALSE);
+    SetWindowPlacement(hWindow, &placement);
+}
 
 static BOOL DWMInteractiveMoveActive = FALSE;
 
@@ -4713,6 +4739,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         PendingDPIWindowRectApplied = FALSE;
         DPIWindowRectAlreadyApplied = FALSE;
         RefreshDPI(TRUE, dpi, suggestedRect);
+        if (ResumeWindowPlacementPending)
+            ScheduleResumeWindowPlacementRestore(HWindow);
         return 0;
     }
 
@@ -4737,7 +4765,26 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
+        if (ResumeWindowPlacementPending)
+            ScheduleResumeWindowPlacementRestore(HWindow);
         break;
+    }
+
+    case WM_POWERBROADCAST:
+    {
+        if (wParam == PBT_APMSUSPEND)
+        {
+            KillTimer(HWindow, IDT_RESTOREWINDOWPLACEMENT);
+            ResumeWindowPlacementPending = FALSE;
+            PreSuspendWindowPlacement.length = sizeof(WINDOWPLACEMENT);
+            PreSuspendWindowPlacementValid = GetWindowPlacement(HWindow, &PreSuspendWindowPlacement);
+        }
+        else if (wParam == PBT_APMRESUMEAUTOMATIC || wParam == PBT_APMRESUMECRITICAL ||
+                 wParam == PBT_APMRESUMESUSPEND)
+        {
+            ScheduleResumeWindowPlacementRestore(HWindow);
+        }
+        return TRUE;
     }
 
     case WM_WTSSESSION_CHANGE:
@@ -10668,6 +10715,12 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             break;
         }
 
+        case IDT_RESTOREWINDOWPLACEMENT:
+        {
+            RestorePreSuspendWindowPlacement(HWindow);
+            break;
+        }
+
         default:
         {
             TRACE_E("Unknown WM_TIMER wParam=" << wParam);
@@ -11679,6 +11732,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         }
 
         UnregisterSessionNotification(HWindow);
+        KillTimer(HWindow, IDT_RESTOREWINDOWPLACEMENT);
 
         // notify the task list that we are exiting
         TaskList.SetProcessState(PROCESS_STATE_ENDING, NULL);

--- a/src/tests/main_window_move_contract_tests.py
+++ b/src/tests/main_window_move_contract_tests.py
@@ -107,6 +107,31 @@ def main() -> None:
         "RightTabWindow->RefreshDPIResources();",
         "attached right tab resources rebuilt by the complete main-window DPI refresh",
     )
+    require(
+        implementation,
+        "case WM_POWERBROADCAST:",
+        "power suspend and resume handling",
+    )
+    require(
+        implementation,
+        "GetWindowPlacement(HWindow, &PreSuspendWindowPlacement)",
+        "main-window placement captured before suspend",
+    )
+    require(
+        implementation,
+        "ScheduleResumeWindowPlacementRestore(HWindow);",
+        "placement restore deferred until resume display changes settle",
+    )
+    require(
+        mainwnd3,
+        "MultiMonEnsureRectVisible(&placement.rcNormalPosition, FALSE);",
+        "pre-suspend placement constrained to the resumed monitor topology",
+    )
+    require(
+        mainwnd3,
+        "SetWindowPlacement(hWindow, &placement);",
+        "complete pre-suspend placement restored after resume",
+    )
 
     print("Main-window move contract tests passed.")
 


### PR DESCRIPTION
Fixes #641.

## What changed

- capture the main window `WINDOWPLACEMENT` before system suspend
- defer restoring it until resume-time DPI and display-change notifications settle
- constrain the restored rectangle to the available monitor work area when the monitor topology changed
- add a contract regression test for suspend/resume placement handling

## Root cause

During wake-up Windows can temporarily report a different display geometry or DPI. The main window accepted the corresponding `WM_DPICHANGED` suggested rectangle, but Salamander did not retain a stable pre-suspend placement to restore once the display configuration settled. This left the upper-left corner intact while the lower-right corner—and therefore the window size—remained reduced.

## Validation

- `python -B src/tests/main_window_move_contract_tests.py`
- `git diff --check`
- Release x64 compiled and linked successfully to `salamand.exe`; the overall MSBuild invocation subsequently failed in the existing post-build staging script because its PowerShell environment did not provide `Get-FileHash`

The exact Windows 11 sleep/wake scenario at 3840×2160 and 150% scaling still requires manual GUI validation.