### PR TITLE
Fix ZIP filename diacritics under UTF-8 ACP

### DIFF
--- a/src/plugins/7zip/7za/cpp/7zip/Archive/Zip/ZipItem.cpp
+++ b/src/plugins/7zip/7za/cpp/7zip/Archive/Zip/ZipItem.cpp
@@ -15,11 +15,40 @@
 
 #include "ZipItem.h"
 
+#include <stdlib.h>
+
 namespace NArchive {
 namespace NZip {
 
 using namespace NFileHeader;
 
+static UINT ZipLocaleInteger(LCTYPE type, UINT fallback)
+{
+  wchar_t buf[16] = {};
+  if (::GetLocaleInfoW(LOCALE_SYSTEM_DEFAULT, type, buf, 16) <= 0 &&
+      ::GetLocaleInfoW(LOCALE_USER_DEFAULT, type, buf, 16) <= 0)
+    return fallback;
+  UINT parsed = (UINT)_wtoi(buf);
+  return (parsed != 0 && parsed != CP_UTF8) ? parsed : fallback;
+}
+
+UINT GetZipLegacyOemCodePage()
+{
+  // salamand.exe declares UTF-8 activeCodePage, so GetOEMCP()/CP_OEMCP are 65001.
+  // Traditional ZIP names without the UTF-8 flag are still DOS OEM (CP852 on Czech Windows).
+  UINT oem = ::GetOEMCP();
+  if (oem != 0 && oem != CP_UTF8)
+    return oem;
+  return ZipLocaleInteger(LOCALE_IDEFAULTCODEPAGE, 852);
+}
+
+UINT GetZipLegacyAnsiCodePage()
+{
+  UINT acp = ::GetACP();
+  if (acp != 0 && acp != CP_UTF8)
+    return acp;
+  return ZipLocaleInteger(LOCALE_IDEFAULTANSICODEPAGE, 1250);
+}
 
 /*
 const char *k_SpecName_NTFS_STREAM = "@@NTFS@STREAM@";

--- a/src/plugins/7zip/7za/cpp/7zip/Archive/Zip/ZipItem.h
+++ b/src/plugins/7zip/7za/cpp/7zip/Archive/Zip/ZipItem.h
@@ -14,6 +14,9 @@
 namespace NArchive {
 namespace NZip {
 
+UINT GetZipLegacyOemCodePage();
+UINT GetZipLegacyAnsiCodePage();
+
 /*
 extern const char *k_SpecName_NTFS_STREAM;
 extern const char *k_SpecName_MAC_RESOURCE_FORK;
@@ -275,7 +278,7 @@ public:
   {
     if (IsUtf8())
       return CP_UTF8;
-    return CP_OEMCP;
+    return GetZipLegacyOemCodePage();
   }
 };
 
@@ -341,13 +344,13 @@ public:
     if (IsUtf8())
       return CP_UTF8;
     if (!FromCentral)
-      return CP_OEMCP;
+      return GetZipLegacyOemCodePage();
     Byte hostOS = MadeByVersion.HostOS;
     return (UINT)((
            hostOS == NFileHeader::NHostOS::kFAT
         || hostOS == NFileHeader::NHostOS::kNTFS
         || hostOS == NFileHeader::NHostOS::kUnix // do we need it?
-        ) ? CP_OEMCP : CP_ACP);
+        ) ? GetZipLegacyOemCodePage() : GetZipLegacyAnsiCodePage());
   }
 };
 

--- a/src/plugins/7zip/7zclient.cpp
+++ b/src/plugins/7zip/7zclient.cpp
@@ -16,6 +16,8 @@
 #include "7zip.rh2"
 #include "lang\lang.rh"
 
+#include <stdlib.h>
+
 // ****************************************************************************
 //
 // C7zClient
@@ -299,14 +301,52 @@ BOOL C7zClient::FillItemData(IInArchive* archive, UINT32 index, C7zClient::CItem
     return TRUE;
 }
 
+static wchar_t* DupUtf8NameW(const char* name, int nameLen)
+{
+    if (name == NULL || nameLen <= 0)
+        return NULL;
+
+    int wideLen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, name, nameLen, NULL, 0);
+    if (wideLen <= 0)
+        return NULL;
+
+    wchar_t* nameW = (wchar_t*)malloc((wideLen + 1) * sizeof(wchar_t));
+    if (nameW == NULL)
+        return NULL;
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, name, nameLen, nameW, wideLen) != wideLen)
+    {
+        free(nameW);
+        return NULL;
+    }
+    nameW[wideLen] = 0;
+    return nameW;
+}
+
+static void FreeListedFileDataName(CFileData& fd)
+{
+    if (fd.NameW != NULL)
+    {
+        free(fd.NameW);
+        fd.NameW = NULL;
+    }
+    if (fd.Name != NULL)
+    {
+        SalamanderGeneral->Free(fd.Name);
+        fd.Name = NULL;
+    }
+}
+
 BOOL C7zClient::AddFileDir(IInArchive* archive, UINT32 idx,
                            CSalamanderDirectoryAbstract* dir, CPluginDataInterface*& pluginData,
                            BOOL* reportTooLongPathErr, const char* archiveName)
 {
     NWindows::NCOM::CPropVariant propVariant;
-    // path
+    // path: 7-Zip already decoded the archive name to Unicode (OEM vs UTF-8 flag).
+    // Convert to UTF-8 for CFileData::Name; do not use GetAnsiString/CP_ACP.
     archive->GetProperty(idx, kpidPath, &propVariant);
-    CSysString path = GetAnsiString(propVariant.bstrVal);
+    AString path;
+    if (propVariant.vt == VT_BSTR && propVariant.bstrVal != NULL && propVariant.bstrVal[0] != 0)
+        path = UnicodeStringToMultiByte(UString(propVariant.bstrVal), CP_UTF8);
 
     BOOL ret = FALSE;
     LPTSTR p = NULL;
@@ -347,6 +387,7 @@ BOOL C7zClient::AddFileDir(IInArchive* archive, UINT32 idx,
         } // if
 
         fd.NameLen = _tcslen(fd.Name);
+        fd.NameW = DupUtf8NameW(fd.Name, (int)fd.NameLen);
         LPTSTR s = _tcsrchr(fd.Name, '.');
         if (s != NULL)
             fd.Ext = s + 1; // ".cvspass" is treated as an extension on Windows ...
@@ -356,14 +397,14 @@ BOOL C7zClient::AddFileDir(IInArchive* archive, UINT32 idx,
         itemData = new C7zClient::CItemData;
         if (!itemData)
         {
-            SalamanderGeneral->Free(fd.Name);
+            FreeListedFileDataName(fd);
             Error(IDS_INSUFFICIENT_MEMORY);
             throw FALSE;
         }
 
         if (!FillItemData(archive, idx, itemData))
         {
-            SalamanderGeneral->Free(fd.Name);
+            FreeListedFileDataName(fd);
             delete itemData;
             throw FALSE;
         }
@@ -410,7 +451,7 @@ BOOL C7zClient::AddFileDir(IInArchive* archive, UINT32 idx,
 
             if (dir && !dir->AddDir(filePath, fd, pluginData))
             {
-                SalamanderGeneral->Free(fd.Name);
+                FreeListedFileDataName(fd);
                 delete itemData; // already stored in fd.PluginData
                 // dir->Clear(pluginData);  // Petr: no reason to throw the rest away
                 if (_tcslen(filePath) > SAL_MAX_PATH - 5) // Petr: too-long-path test copied from Salamander
@@ -437,7 +478,7 @@ BOOL C7zClient::AddFileDir(IInArchive* archive, UINT32 idx,
             // file
             if (dir && !dir->AddFile(filePath, fd, pluginData))
             {
-                SalamanderGeneral->Free(fd.Name);
+                FreeListedFileDataName(fd);
                 delete itemData; // already stored in fd.PluginData
                 // dir->Clear(pluginData);  // Petr: no reason to throw the rest away
                 if (_tcslen(filePath) > SAL_MAX_PATH - 5) // Petr: too-long-path test copied from Salamander

--- a/src/plugins/zip/add.cpp
+++ b/src/plugins/zip/add.cpp
@@ -270,7 +270,7 @@ int CZipPack::PackMultiVol(SalEnumSelection2 next, void* param)
             char archName[MAX_PATH];
             MakeFileName(1, Options.SeqNames, SalamanderGeneral->SalPathFindFileName(ZipName), archName,
                          false);
-            CharToOem(archName, archName);
+            ZipUtf8ToOemBuffer(archName, MAX_PATH);
             if (!WriteSFXHeader(archName, 0, 0) ||
                 Write(TempFile, &EONewCentrDir, sizeof(CEOCentrDirRecord), NULL) || // just as a placeholder, we update it later
                 Flush(TempFile, TempFile->OutputBuffer, TempFile->BufferPosition, NULL))
@@ -661,6 +661,7 @@ int CZipPack::ExportLocalHeader(CFileInfo* fileInfo, char* buffer)
         Zip64Size = 8 + 8; // In Local Header, both Size and CompSize must be present, if any
     }
     localHeader->NameLen = ExportName(buffer + sizeof(CLocalFileHeader), fileInfo);
+    localHeader->Flag = fileInfo->Flag;
     localHeader->ExtraLen = 0;
     if (Zip64Size)
     {
@@ -781,6 +782,7 @@ int CZipPack::WriteCentralHeader(CFileInfo* fileInfo, char* buffer, BOOL first, 
     }
 
     centralHeader->NameLen = ExportName(buffer + sizeof(CFileHeader), fileInfo);
+    centralHeader->Flag = fileInfo->Flag;
     centralHeader->ExtraLen = 0;
     centralHeader->CommentLen = 0;
     if (fileInfo->StartDisk < 0xFFFF)
@@ -859,25 +861,14 @@ int CZipPack::ExportName(char* name, CFileInfo* fileInfo)
 {
     CALL_STACK_MESSAGE1("CZipPack::ExportName(, )");
 
-    char* sour = fileInfo->Name;
-    char* dest = name;
-
-    while (*sour)
-        if (*sour == '\\')
-        {
-            *dest++ = '/';
-            sour++;
-        }
-        else
-            *dest++ = *sour++;
-    if (fileInfo->IsDir)
-        *dest++ = '/';
-    *dest = 0;
-
-    CharToOem(name, name);
-
-    //*dest = NULL;
-    return (int)(dest - name);
+    bool usedUtf8 = false;
+    int nameLen = ZipEncodeEntryName(fileInfo->Name, fileInfo->IsDir != 0, name,
+                                     MAX_HEADER_SIZE - (int)sizeof(CFileHeader), &usedUtf8);
+    if (usedUtf8)
+        fileInfo->Flag |= GPF_UTF8;
+    else
+        fileInfo->Flag &= ~GPF_UTF8;
+    return nameLen;
 }
 
 int CZipPack::CreateTempFile()

--- a/src/plugins/zip/common.cpp
+++ b/src/plugins/zip/common.cpp
@@ -6,6 +6,8 @@
 #include <ostream>
 #include <stdio.h>
 #include <string>
+#include <cstring>
+#include <string.h>
 #include <commctrl.h>
 #include <tchar.h>
 
@@ -36,27 +38,209 @@ static std::wstring ZipPathAddExtendedPrefix(const std::wstring& path)
     return std::wstring(L"\\\\?\\") + path;
 }
 
+static bool ZipBytesToWide(UINT codePage, const char* src, int srcLen, std::wstring& wide)
+{
+    wide.clear();
+    if (src == NULL)
+        return false;
+    if (srcLen < 0)
+        srcLen = (int)strlen(src);
+    if (srcLen == 0)
+        return true;
+
+    DWORD flags = (codePage == CP_UTF8) ? MB_ERR_INVALID_CHARS : 0;
+    int n = MultiByteToWideChar(codePage, flags, src, srcLen, NULL, 0);
+    if (n <= 0)
+        return false;
+    wide.assign((size_t)n, L'\0');
+    if (MultiByteToWideChar(codePage, flags, src, srcLen, &wide[0], n) != n)
+    {
+        wide.clear();
+        return false;
+    }
+    return true;
+}
+
+static bool ZipWideToUtf8(const wchar_t* src, int srcChars, std::string& utf8)
+{
+    utf8.clear();
+    if (src == NULL)
+        return false;
+    if (srcChars < 0)
+        srcChars = (int)wcslen(src);
+    if (srcChars == 0)
+        return true;
+
+    int n = WideCharToMultiByte(CP_UTF8, 0, src, srcChars, NULL, 0, NULL, NULL);
+    if (n <= 0)
+        return false;
+    utf8.assign((size_t)n, '\0');
+    if (WideCharToMultiByte(CP_UTF8, 0, src, srcChars, &utf8[0], n, NULL, NULL) != n)
+    {
+        utf8.clear();
+        return false;
+    }
+    return true;
+}
+
+static bool ZipWideIsAscii(const wchar_t* src, int srcChars)
+{
+    if (src == NULL)
+        return true;
+    for (int i = 0; i < srcChars; i++)
+    {
+        if ((unsigned)src[i] >= 0x80)
+            return false;
+    }
+    return true;
+}
+
+static UINT ZipLocaleInteger(LCTYPE type, UINT fallback)
+{
+    wchar_t buf[16] = {};
+    if (GetLocaleInfoEx(LOCALE_NAME_SYSTEM_DEFAULT, type, buf, 16) <= 0 &&
+        GetLocaleInfoW(LOCALE_USER_DEFAULT, type, buf, 16) <= 0)
+        return fallback;
+    UINT parsed = (UINT)_wtoi(buf);
+    return (parsed != 0 && parsed != CP_UTF8) ? parsed : fallback;
+}
+
+static UINT ZipLegacyOemCodePage()
+{
+    // salamand.exe declares UTF-8 activeCodePage, so GetOEMCP()/CP_OEMCP are 65001.
+    // Traditional ZIP names without GPF_UTF8 are still DOS OEM (CP852 on Czech Windows).
+    UINT oem = GetOEMCP();
+    if (oem != 0 && oem != CP_UTF8)
+        return oem;
+    return ZipLocaleInteger(LOCALE_IDEFAULTCODEPAGE, 852);
+}
+
+static UINT ZipLegacyAnsiCodePage()
+{
+    UINT acp = GetACP();
+    if (acp != 0 && acp != CP_UTF8)
+        return acp;
+    return ZipLocaleInteger(LOCALE_IDEFAULTANSICODEPAGE, 1250);
+}
+
+static size_t ZipUtf8PrefixBytes(const char* s, size_t len, size_t maxBytes)
+{
+    if (s == NULL || maxBytes == 0)
+        return 0;
+    if (len <= maxBytes)
+        return len;
+    size_t n = maxBytes;
+    while (n > 0 && (((unsigned char)s[n]) & 0xC0) == 0x80)
+        n--;
+    return n;
+}
+
+static bool ZipIsOemCodedName(const CFileHeader* fileHeader)
+{
+    if (fileHeader == NULL || (fileHeader->Flag & GPF_UTF8))
+        return false;
+    unsigned host = fileHeader->Version >> 8;
+    unsigned ver = fileHeader->Version & 0xFF;
+    // ZIP built-in to WinXP writes Version 0x0b14 and uses OEM.
+    // Altap Salamander writes version 0x0016 and uses OEM.
+    return host == HS_FAT || host == HS_HPFS ||
+           (host == HS_NTFS && (ver <= 20 || ver >= 25));
+}
+
+static bool ZipDecodeZipNameToUtf8(const CFileHeader* fileHeader, std::string& utf8)
+{
+    utf8.clear();
+    if (fileHeader == NULL)
+        return false;
+
+    const char* sour = (const char*)fileHeader + sizeof(CFileHeader);
+    int len = fileHeader->NameLen;
+    const void* zero = memchr(sour, 0, (size_t)len);
+    if (zero)
+        len = (int)((const char*)zero - sour);
+    if (len < 0)
+        return false;
+
+    const bool utf8Flag = (fileHeader->Flag & GPF_UTF8) != 0;
+    const bool unixOrigin = ((fileHeader->Version >> 8) == HS_UNIX);
+    const bool looksUtf8 = IsUTF8Encoded(sour, len);
+    std::wstring wide;
+    bool decoded = false;
+
+    if (utf8Flag || looksUtf8)
+        decoded = ZipBytesToWide(CP_UTF8, sour, len, wide);
+    if (!decoded && ZipIsOemCodedName(fileHeader))
+        decoded = ZipBytesToWide(ZipLegacyOemCodePage(), sour, len, wide);
+    if (!decoded && !unixOrigin)
+        decoded = ZipBytesToWide(ZipLegacyAnsiCodePage(), sour, len, wide);
+    if (!decoded)
+        return false;
+    return ZipWideToUtf8(wide.data(), (int)wide.size(), utf8);
+}
+
 static std::wstring ZipPathToWide(const char* path)
 {
     if (path == NULL || *path == 0)
         return std::wstring();
 
-    UINT codePage = CP_UTF8;
-    int len = MultiByteToWideChar(codePage, 0, path, -1, NULL, 0);
-    if (len <= 0)
-    {
-        codePage = CP_ACP;
-        len = MultiByteToWideChar(codePage, 0, path, -1, NULL, 0);
-    }
-    if (len <= 0)
-        return std::wstring();
-
-    std::wstring widePath(len, L'\0');
-    MultiByteToWideChar(codePage, 0, path, -1, &widePath[0], len);
-    widePath.resize(len - 1);
+    std::wstring widePath;
+    if (!ZipBytesToWide(CP_UTF8, path, -1, widePath))
+        ZipBytesToWide(CP_ACP, path, -1, widePath);
+    if (widePath.empty())
+        return widePath;
     if (widePath.length() >= MAX_PATH)
         widePath = ZipPathAddExtendedPrefix(widePath);
     return widePath;
+}
+
+int ZipEncodeEntryName(const char* utf8Path, bool isDir, char* dest, int destMax, bool* usedUtf8)
+{
+    if (usedUtf8)
+        *usedUtf8 = false;
+    if (dest == NULL || destMax <= 1)
+        return 0;
+    if (utf8Path == NULL)
+        utf8Path = "";
+
+    std::string unixPath;
+    unixPath.reserve(strlen(utf8Path) + 2);
+    for (const char* s = utf8Path; *s != 0; s++)
+        unixPath.push_back(*s == '\\' ? '/' : *s);
+    if (isDir && (unixPath.empty() || unixPath[unixPath.size() - 1] != '/'))
+        unixPath.push_back('/');
+
+    std::wstring wide;
+    if (!ZipBytesToWide(CP_UTF8, unixPath.data(), (int)unixPath.size(), wide))
+        ZipBytesToWide(CP_ACP, unixPath.data(), (int)unixPath.size(), wide);
+
+    // The 7-Zip plugin lists *.zip in the panel. Store non-ASCII names as UTF-8
+    // with GPF_UTF8 so listing does not depend on OEM code pages. Legacy OEM
+    // archives without that flag are decoded on listing (ZIP plugin and 7za).
+    const bool storeUtf8 = !ZipWideIsAscii(wide.c_str(), (int)wide.size());
+
+    size_t copyLen = ZipUtf8PrefixBytes(unixPath.data(), unixPath.size(), (size_t)destMax - 1);
+    memcpy(dest, unixPath.data(), copyLen);
+    dest[copyLen] = 0;
+    if (usedUtf8)
+        *usedUtf8 = storeUtf8;
+    return (int)copyLen;
+}
+
+void ZipUtf8ToOemBuffer(char* name, int nameMax)
+{
+    if (name == NULL || nameMax <= 1 || *name == 0)
+        return;
+
+    std::wstring wide;
+    if (!ZipBytesToWide(CP_UTF8, name, -1, wide) && !ZipBytesToWide(CP_ACP, name, -1, wide))
+        return;
+
+    const UINT oemCp = ZipLegacyOemCodePage();
+    BOOL usedDefault = FALSE;
+    int n = WideCharToMultiByte(oemCp, 0, wide.c_str(), -1, NULL, 0, NULL, &usedDefault);
+    if (n <= 0 || n > nameMax)
+        return;
+    WideCharToMultiByte(oemCp, 0, wide.c_str(), -1, name, nameMax, NULL, NULL);
 }
 
 #ifndef SSZIP
@@ -1445,91 +1629,40 @@ int CZipCommon::ProcessName(CFileHeader* fileHeader, char* outputName)
 {
     CALL_STACK_MESSAGE_NONE // time-critical method
                             //  CALL_STACK_MESSAGE1("CZipCommon::ProcessName");
-        char* sour;
+        const char* sour;
     char* dest;
     sour = (char*)fileHeader + sizeof(CFileHeader);
     size_t len = fileHeader->NameLen;
 
-    char* sourLocEnc = NULL;
-    // If the file is originating on Unix (or Mac), we check if it is a true UTF8 string
-    // if yes, then we convert it to local encoding
-    if (((fileHeader->Version >> 8 == HS_UNIX) || (fileHeader->Flag & GPF_UTF8)))
+    std::string utf8Name;
+    // Panel paths are UTF-8. Decode ZIP OEM / UTF-8 entry names into UTF-8 instead of
+    // ACP, otherwise Czech diacritics become U+FFFD replacement characters.
+    if (ZipDecodeZipNameToUtf8(fileHeader, utf8Name))
     {
-        void* zero = memchr(sour, 0, len);
+        sour = utf8Name.c_str();
+        len = utf8Name.size();
+    }
+    else
+    {
+        const void* zero = memchr(sour, 0, len);
         if (zero)
-        {
-            len = (char*)zero - sour + 1;
-        }
-        if (IsUTF8Encoded(sour, (int)len))
-        {
-            LPWSTR wsour = (LPWSTR)malloc(len * sizeof(WCHAR));
-            if (wsour)
-            {
-                // CodePage 65001 is UTF8 and is supported since W2K (or WNT4?)
-                int wlen = (int)MultiByteToWideChar(CP_UTF8, 0, sour, (int)len, wsour, (int)len);
-
-                if (wlen > 0)
-                {
-                    // Convert ZIP UTF-8 names to the local encoding used by the archive panel tree.
-                    // If a character cannot be represented there (for example supplementary Unicode
-                    // characters), use an ASCII-safe replacement instead of feeding raw UTF-8
-                    // into the legacy multibyte panel path code.
-                    BOOL usedDefaultChar = FALSE;
-                    int lenLocEnc = WideCharToMultiByte(CP_ACP, WC_COMPOSITECHECK | WC_NO_BEST_FIT_CHARS,
-                                                        wsour, wlen, NULL, 0, NULL, &usedDefaultChar);
-                    if (lenLocEnc > 0 && !usedDefaultChar)
-                    {
-                        sourLocEnc = (char*)malloc(lenLocEnc);
-                        if (sourLocEnc)
-                        {
-                            len = WideCharToMultiByte(CP_ACP, WC_COMPOSITECHECK | WC_NO_BEST_FIT_CHARS,
-                                                      wsour, wlen, sourLocEnc, lenLocEnc, NULL, NULL);
-                            sour = sourLocEnc;
-                        }
-                    }
-                    else
-                    {
-                        sourLocEnc = (char*)malloc(len * 3 + 1);
-                        if (sourLocEnc)
-                        {
-                            char* encoded = sourLocEnc;
-                            static const char hex[] = "0123456789ABCDEF";
-                            for (size_t i = 0; i < len && sour[i] != 0; i++)
-                            {
-                                unsigned char ch = (unsigned char)sour[i];
-                                if (ch < 0x80)
-                                    *encoded++ = (char)ch;
-                                else
-                                {
-                                    *encoded++ = '%';
-                                    *encoded++ = hex[ch >> 4];
-                                    *encoded++ = hex[ch & 0x0f];
-                                }
-                            }
-                            *encoded = 0;
-                            len = encoded - sourLocEnc;
-                            sour = sourLocEnc;
-                        }
-                    }
-                }
-                free(wsour);
-            }
-        }
+            len = (size_t)((const char*)zero - sour);
     }
 
-    char* end = sour + len;
+    const char* end = sour + len;
     dest = outputName;
+    char* destEnd = outputName + MAX_HEADER_SIZE - 1;
 
     // remove leading slashes
     while ((sour < end) && (*sour == '/' || *sour == '\\'))
         sour++;
     // replace leading spaces with underscores
-    while ((sour < end) && *sour == ' ')
+    while ((sour < end) && *sour == ' ' && dest < destEnd)
     {
         *dest++ = '_';
         sour++;
     }
-    while ((sour < end) && *sour != 0)
+    while ((sour < end) && *sour != 0 && dest < destEnd)
     {
         if (*sour == '/' || *sour == '\\')
         {
@@ -1543,7 +1676,7 @@ int CZipCommon::ProcessName(CFileHeader* fileHeader, char* outputName)
                 *iter-- = '_';
             *dest++ = '\\';
             // replace leading spaces in the current filename component with underscores
-            while ((sour < end) && *sour == ' ')
+            while ((sour < end) && *sour == ' ' && dest < destEnd)
             {
                 *dest++ = '_';
                 sour++;
@@ -1571,18 +1704,7 @@ int CZipCommon::ProcessName(CFileHeader* fileHeader, char* outputName)
     while ((iter >= outputName) && *iter == ' ')
         *iter-- = '_';
 
-    if (sourLocEnc)
-        free(sourLocEnc);
-
     *dest = 0;
-    if (!(fileHeader->Flag & GPF_UTF8) && ((fileHeader->Version >> 8 == HS_FAT /*0*/) ||
-                                           (fileHeader->Version >> 8 == HS_HPFS /*6*/) ||
-                                           //       ((fileHeader->Version >> 8 == HS_NTFS/*11*/) && ((fileHeader->Version & 0x0F) == 0x50)) // Patera 2010.03.30: This doesn't make sense -> disabled
-                                           // The following line got inspiration in MultiArc plugin of FAR
-                                           ((fileHeader->Version >> 8 == HS_NTFS /*11*/) && (((fileHeader->Version & 0xFF) <= 20) || ((fileHeader->Version & 0xFF) >= 25)))))
-        // ZIP built-in to WinXP writes Version 0x0b14 and uses OEM
-        // AS writes version 0x0016 and uses OEM
-        OemToChar(outputName, outputName);
     //  TRACE_I("Processed name " << outputName);
     return (int)(dest - outputName);
 }

--- a/src/plugins/zip/common.h
+++ b/src/plugins/zip/common.h
@@ -296,6 +296,8 @@ extern CConfiguration Config;
 char* LoadStr(int resID);
 WCHAR* LoadStrW(int resID);
 bool IsUTF8Encoded(const char* s, int len);
+int ZipEncodeEntryName(const char* utf8Path, bool isDir, char* dest, int destMax, bool* usedUtf8);
+void ZipUtf8ToOemBuffer(char* name, int nameMax);
 
 int InflateBuffer(char* sour, int sourSize, char* dest, int* destSize);
 int LoadSfxFileData(char* fileName, CSfxLang** lang);

--- a/src/plugins/zip/list.cpp
+++ b/src/plugins/zip/list.cpp
@@ -25,47 +25,24 @@
 #include "common.h"
 #include "list.h"
 
-static wchar_t* DupZipLeafNameW(CFileHeader* header)
+static wchar_t* DupZipUtf8NameW(const char* name, int nameLen)
 {
-    if ((header->Flag & GPF_UTF8) == 0 && (header->Version >> 8) != HS_UNIX)
+    if (name == NULL || nameLen <= 0)
         return NULL;
 
-    const char* rawName = (const char*)header + sizeof(CFileHeader);
-    int rawLen = header->NameLen;
-    if (rawLen <= 0 || !IsUTF8Encoded(rawName, rawLen))
-        return NULL;
-
-    while (rawLen > 0 && (rawName[rawLen - 1] == '/' || rawName[rawLen - 1] == '\\' || rawName[rawLen - 1] == 0))
-        rawLen--;
-    const char* leaf = rawName;
-    for (int i = 0; i < rawLen; i++)
-        if (rawName[i] == '/' || rawName[i] == '\\')
-            leaf = rawName + i + 1;
-    int leafLen = rawLen - (int)(leaf - rawName);
-    if (leafLen <= 0)
-        return NULL;
-
-    int wideLen = MultiByteToWideChar(CP_UTF8, 0, leaf, leafLen, NULL, 0);
-    if (wideLen <= 0 || wideLen > 511)
+    int wideLen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, name, nameLen, NULL, 0);
+    if (wideLen <= 0)
         return NULL;
 
     wchar_t* nameW = (wchar_t*)malloc((wideLen + 1) * sizeof(wchar_t));
     if (nameW == NULL)
         return NULL;
-    if (MultiByteToWideChar(CP_UTF8, 0, leaf, leafLen, nameW, wideLen) != wideLen)
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, name, nameLen, nameW, wideLen) != wideLen)
     {
         free(nameW);
         return NULL;
     }
     nameW[wideLen] = 0;
-
-    for (wchar_t* s = nameW; *s != 0; s++)
-    {
-        if (*s < 32 || (wcschr(L"*?<>|\":\\/ ", *s) != NULL && (*s != L' ' || s == nameW)))
-            *s = L'_';
-    }
-    for (wchar_t* s = nameW + wideLen - 1; s >= nameW && *s == L' '; s--)
-        *s = L'_';
     return nameW;
 }
 
@@ -189,7 +166,7 @@ START_LIST:
                 break;
             }
             memcpy(file.Name, name, sizeof(TCHAR) * (file.NameLen + 1));
-            file.NameW = DupZipLeafNameW(centralHeader);
+            file.NameW = DupZipUtf8NameW(name, nameLen);
             //initialize remaining members of CFileData
             file.Size = CQuadWord().SetUI64(fileInfo.Size);
             file.Attr = fileInfo.FileAttr & FILE_ATTTRIBUTE_MASK;

--- a/src/tests/zip_filename_encoding_contract_tests.py
+++ b/src/tests/zip_filename_encoding_contract_tests.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ZIP = ROOT / "plugins" / "zip"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def function_body(text: str, signature: str) -> str:
+    start = text.index(signature)
+    brace = text.index("{", start)
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace : index + 1]
+    raise AssertionError("unterminated function: " + signature)
+
+
+def main() -> int:
+    common_cpp = (ZIP / "common.cpp").read_text(encoding="utf-8")
+    add_cpp = (ZIP / "add.cpp").read_text(encoding="utf-8")
+    list_cpp = (ZIP / "list.cpp").read_text(encoding="utf-8")
+
+    zip_bytes = function_body(common_cpp, "static bool ZipBytesToWide")
+    require(
+        "CP_UTF8" in zip_bytes and "MB_ERR_INVALID_CHARS" in zip_bytes,
+        "ZIP path/name UTF-8 decoding must reject invalid sequences before ACP fallback",
+    )
+
+    zip_path = function_body(common_cpp, "static std::wstring ZipPathToWide")
+    require(
+        "ZipBytesToWide(CP_UTF8" in zip_path and "ZipBytesToWide(CP_ACP" in zip_path,
+        "ZIP file I/O must try UTF-8 paths first and fall back to ACP only on error",
+    )
+
+    oem_page = function_body(common_cpp, "static UINT ZipLegacyOemCodePage")
+    require(
+        "GetOEMCP()" in oem_page
+        and "CP_UTF8" in oem_page
+        and "LOCALE_IDEFAULTCODEPAGE" in oem_page,
+        "ZIP OEM decoding must use the locale DOS code page when the process ACP is UTF-8",
+    )
+
+    decode = function_body(common_cpp, "static bool ZipDecodeZipNameToUtf8")
+    require(
+        "ZipLegacyOemCodePage" in decode and "GPF_UTF8" in decode and "ZipWideToUtf8" in decode,
+        "ZIP listing must decode OEM and UTF-8 entry names into UTF-8 for the panel",
+    )
+    require(
+        "CP_OEMCP" not in decode and "CP_ACP" not in decode,
+        "ZIP listing must not decode legacy names through CP_OEMCP/CP_ACP while the process is UTF-8",
+    )
+    require(
+        "WideCharToMultiByte(CP_ACP" not in decode,
+        "ZIP UTF-8 names must stay UTF-8 instead of being transcoded to ACP",
+    )
+
+    process = function_body(common_cpp, "int CZipCommon::ProcessName")
+    require(
+        "ZipDecodeZipNameToUtf8" in process,
+        "ProcessName must decode archive names through ZipDecodeZipNameToUtf8",
+    )
+    require(
+        "OemToChar" not in process,
+        "ProcessName must not finish by converting names with OemToChar into ACP",
+    )
+    require(
+        "WideCharToMultiByte(CP_ACP" not in process,
+        "ProcessName must not convert UTF-8 ZIP names to ACP for the panel",
+    )
+
+    encode = function_body(common_cpp, "int ZipEncodeEntryName")
+    require(
+        "ZipWideToOemLossless" not in encode and "ZipLegacyOemCodePage" not in encode,
+        "ZIP packing must store UTF-8 names instead of OEM while the process ACP is UTF-8",
+    )
+    require(
+        "storeUtf8" in encode and "ZipWideIsAscii" in encode and "unixPath" in encode,
+        "ZIP packing must store UTF-8 with the UTF-8 flag when the name is not ASCII",
+    )
+    require(
+        "CharToOem" not in encode,
+        "ZIP packing must not run CharToOem on UTF-8 panel names",
+    )
+
+    export_name = function_body(add_cpp, "int CZipPack::ExportName")
+    require(
+        "ZipEncodeEntryName" in export_name and "GPF_UTF8" in export_name,
+        "ExportName must encode panel UTF-8 names and set GPF_UTF8 when needed",
+    )
+    require(
+        "CharToOem" not in export_name,
+        "ExportName must not treat UTF-8 panel names as ACP via CharToOem",
+    )
+
+    local_header = function_body(add_cpp, "int CZipPack::ExportLocalHeader")
+    require(
+        local_header.index("ExportName") < local_header.rindex("localHeader->Flag = fileInfo->Flag"),
+        "local ZIP headers must copy GPF_UTF8 after the entry name is encoded",
+    )
+
+    central_header = function_body(add_cpp, "int CZipPack::WriteCentralHeader")
+    require(
+        central_header.index("ExportName") < central_header.rindex("centralHeader->Flag = fileInfo->Flag"),
+        "central ZIP headers must copy GPF_UTF8 after the entry name is encoded",
+    )
+
+    require("CharToOem" not in add_cpp, "the ZIP packer must not call CharToOem on file names")
+
+    require(
+        "DupZipUtf8NameW" in list_cpp and "file.NameW = DupZipUtf8NameW(name, nameLen)" in list_cpp,
+        "ZIP listing must expose decoded UTF-8 leaf names through CFileData::NameW",
+    )
+    dup = function_body(list_cpp, "static wchar_t* DupZipUtf8NameW")
+    require(
+        "CP_UTF8" in dup and "MB_ERR_INVALID_CHARS" in dup,
+        "ZIP NameW copies must decode the already converted UTF-8 panel name",
+    )
+
+    zip7 = ROOT / "plugins" / "7zip"
+    zip_item_h = (zip7 / "7za" / "cpp" / "7zip" / "Archive" / "Zip" / "ZipItem.h").read_text(
+        encoding="utf-8"
+    )
+    zip_item_cpp = (zip7 / "7za" / "cpp" / "7zip" / "Archive" / "Zip" / "ZipItem.cpp").read_text(
+        encoding="utf-8"
+    )
+    client_cpp = (zip7 / "7zclient.cpp").read_text(encoding="utf-8")
+
+    require(
+        "GetZipLegacyOemCodePage" in zip_item_h and "GetZipLegacyAnsiCodePage" in zip_item_h,
+        "7-Zip ZIP listing must declare locale OEM/ANSI helpers instead of CP_OEMCP/CP_ACP",
+    )
+    require(
+        "CP_OEMCP" not in zip_item_h and "CP_ACP" not in zip_item_h,
+        "7-Zip GetCodePage must not use CP_OEMCP/CP_ACP while the process is UTF-8",
+    )
+
+    oem_7z = function_body(zip_item_cpp, "UINT GetZipLegacyOemCodePage")
+    require(
+        "GetOEMCP()" in oem_7z
+        and "CP_UTF8" in oem_7z
+        and "LOCALE_IDEFAULTCODEPAGE" in oem_7z,
+        "7-Zip OEM decoding must use the locale DOS code page when the process OEMCP is UTF-8",
+    )
+
+    add_file_dir = function_body(client_cpp, "BOOL C7zClient::AddFileDir")
+    require(
+        "UnicodeStringToMultiByte" in add_file_dir and "CP_UTF8" in add_file_dir,
+        "7-Zip panel listing must convert archive paths to UTF-8",
+    )
+    require(
+        "GetAnsiString(propVariant.bstrVal)" not in add_file_dir,
+        "7-Zip panel listing must not convert kpidPath through ACP",
+    )
+    require(
+        "DupUtf8NameW" in add_file_dir,
+        "7-Zip listing must expose decoded UTF-8 leaf names through CFileData::NameW",
+    )
+
+    print("ZIP pack/list filename encoding preserves Unicode names")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -255,6 +255,14 @@ try {
             )
         },
         @{
+            Name = 'zip_filename_encoding_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\zip_filename_encoding_contract_tests.py')
+            )
+        },
+        @{
             Name = 'panel_rendering_contract_tests'
             Arguments = @(
                 '-B',


### PR DESCRIPTION
## Summary
- Pack Alt+F5 ZIP names as UTF-8 with the UTF-8 flag so Czech diacritics survive a UTF-8 process ACP.
- Decode legacy OEM ZIP names (including old Altap archives) with the locale DOS code page instead of `CP_OEMCP` (65001) when listing through the 7-Zip plugin.
- Keep panel names in UTF-8 (`CFileData::Name` / `NameW`) instead of round-tripping through ACP.

Fixes #700

## Test plan
- [x] Restart Salamander so `zip.spl`, `7zip.spl`, and `7za.dll` reload.
- [x] Pack a file with Czech diacritics via Alt+F5 ZIP; listing and unpack keep the original name.
- [x] Open a ZIP packed by old Altap Salamander (OEM CP852, no UTF-8 flag) and confirm the name is not `�`.
- [x] `python -B src/tests/zip_filename_encoding_contract_tests.py`

Made with [Cursor](https://cursor.com)