### PR TITLE
Unblock skipped PR Test Report and queued CodeQL skips

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,20 +29,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  analyze:
-    name: Analyze C++ (MSBuild)
-    runs-on: windows-2025
-
-    defaults:
-      run:
-        shell: pwsh
-
-    env:
-      BUILD_CONFIGURATION: Release
-      PROJECT_PATH: '.\\src\\vcxproj\\salamand.vcxproj'
-      SOLUTION_PATH: '.\\src\\vcxproj\\salamand.sln'
-      LOG_DIRECTORY: build_logs
-
+  # Keep this cheap: the required "Analyze C++" check must still succeed when
+  # analysis is not needed, but it must not sit in the windows-2025 queue just
+  # to skip every later step.
+  decide:
+    name: Decide whether to analyze
+    runs-on: ubuntu-latest
+    outputs:
+      should_analyze: ${{ steps.codeql_gate.outputs.should_analyze }}
     steps:
       - name: Check whether CodeQL should run
         id: codeql_gate
@@ -86,8 +80,29 @@ jobs:
             core.setOutput('should_analyze', 'true');
             core.info(`CodeQL analysis will run because these main-project .cpp/.h files changed: ${relevantFiles.join(', ')}`);
 
+  analyze:
+    name: Analyze C++ (MSBuild)
+    needs: decide
+    runs-on: ${{ needs.decide.outputs.should_analyze == 'true' && 'windows-2025' || 'ubuntu-latest' }}
+
+    defaults:
+      run:
+        shell: pwsh
+
+    env:
+      BUILD_CONFIGURATION: Release
+      PROJECT_PATH: '.\\src\\vcxproj\\salamand.vcxproj'
+      SOLUTION_PATH: '.\\src\\vcxproj\\salamand.sln'
+      LOG_DIRECTORY: build_logs
+
+    steps:
+      - name: Skip analysis when no main-project C++ changed
+        if: needs.decide.outputs.should_analyze != 'true'
+        shell: bash
+        run: echo "No main-project .cpp or .h files changed; CodeQL analysis is not required."
+
       - name: Checkout repository
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.target_ref || github.event.inputs['target-ref'] || github.ref }}
@@ -95,27 +110,27 @@ jobs:
           submodules: recursive
 
       - name: Setup MSBuild in PATH (VS2026)
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         uses: microsoft/setup-msbuild@v2
 
       - name: Setup MSVC Developer Command Prompt (x64 toolchain)
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
 
       - name: Register MSVC problem matcher
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         uses: ammaraskar/msvc-problem-matcher@master
 
       # The manual full-solution build includes luaruntime. Install only its
       # manifest feature; do not build the unshipped SFTP plug-in in CodeQL.
       - name: Install Lua runtime dependency
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         run: |
           .\tools\vcpkg\build-third-party-libs.ps1 -Triplet x64-windows -NoDefaultFeatures -ManifestFeature lua-runtime -SkipLegacyCopy
       - name: Initialize CodeQL
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         uses: github/codeql-action/init@v3
         with:
           languages: cpp
@@ -125,7 +140,7 @@ jobs:
 
 
       - name: Build with MSBuild (Release | x64)
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         run: |
           $logDir = Join-Path (Get-Location) $env:LOG_DIRECTORY
           New-Item -ItemType Directory -Force -Path $logDir | Out-Null
@@ -183,13 +198,13 @@ jobs:
           }
 
       - name: Setup Python
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Perform CodeQL Analysis
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:cpp"
@@ -202,7 +217,7 @@ jobs:
       # modified in this pull request using the paginated files API.
       - name: Keep CodeQL alerts on PR-changed lines
         if: >-
-          steps.codeql_gate.outputs.should_analyze == 'true' &&
+          needs.decide.outputs.should_analyze == 'true' &&
           github.event_name != 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -219,7 +234,7 @@ jobs:
           }
 
       - name: Upload CodeQL SARIF
-        if: steps.codeql_gate.outputs.should_analyze == 'true'
+        if: needs.decide.outputs.should_analyze == 'true'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ github.workspace }}/codeql-sarif
@@ -227,7 +242,7 @@ jobs:
           wait-for-processing: true
 
       - name: Upload build logs
-        if: always() && steps.codeql_gate.outputs.should_analyze == 'true'
+        if: always() && needs.decide.outputs.should_analyze == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: codeql-msbuild-logs

--- a/.github/workflows/pr-test-report.yml
+++ b/.github/workflows/pr-test-report.yml
@@ -16,14 +16,26 @@ jobs:
     if: >-
       ${{
         github.event.workflow_run.event == 'pull_request' &&
-        github.event.workflow_run.pull_requests[0] != null &&
-        github.event.workflow_run.head_repository.full_name != github.repository
+        github.event.workflow_run.pull_requests[0] != null
       }}
     runs-on: ubuntu-latest
 
     steps:
+      # Same-repository PRs already publish Check Runs from pr-tests.yml, which
+      # has a writable token. Skipping this whole job left the workflow red/grey
+      # as "skipped" on every in-repo PR. Succeed here instead; only forks need
+      # the workflow_run reporter (their PR Tests token cannot write checks).
+      - name: Same-repository reports already published
+        if: github.event.workflow_run.head_repository.full_name == github.repository
+        run: |
+          echo "Same-repository PR; Native and Python test reports were published by PR Tests."
+
       - name: Report native and source-contract tests
-        if: ${{ !cancelled() }}
+        if: >-
+          ${{
+            !cancelled() &&
+            github.event.workflow_run.head_repository.full_name != github.repository
+          }}
         uses: dorny/test-reporter@v3
         with:
           artifact: test-results
@@ -36,7 +48,11 @@ jobs:
           use-actions-summary: false
 
       - name: Report Python tests
-        if: ${{ !cancelled() }}
+        if: >-
+          ${{
+            !cancelled() &&
+            github.event.workflow_run.head_repository.full_name != github.repository
+          }}
         uses: dorny/test-reporter@v3
         with:
           artifact: test-results

--- a/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
+++ b/src/plugins/salamatrix/tests/salamatrix_regression_tests.py
@@ -699,9 +699,12 @@ def main() -> int:
             "PR tests do not explicitly check out the selected source branch commit")
     require(pr_test_report_workflow,
             r'pull_requests\[0\] != null.*?'
-            r'workflow_run\.head_repository\.full_name != github\.repository.*?'
+            r'Same-repository reports already published.*?'
+            r'head_repository\.full_name == github\.repository.*?'
+            r'head_repository\.full_name != github\.repository.*?'
             r'dorny/test-reporter@v3.*?'
             r'use-actions-summary:\s*false.*?'
+            r'head_repository\.full_name != github\.repository.*?'
             r'dorny/test-reporter@v3.*?'
             r'use-actions-summary:\s*false',
             "workflow_run Test Reporter fallback is not limited to fork PRs")
@@ -2783,6 +2786,17 @@ def main() -> int:
         r"'powershellruntime'\)",
         "x64 installer does not include File Lock Inspector dependencies")
 
+    require(
+        codeql_workflow,
+        r"name: Decide whether to analyze.*?runs-on: ubuntu-latest.*?id: codeql_gate",
+        "CodeQL still decides whether to analyze on a Windows runner")
+    require(
+        codeql_workflow,
+        r"name: Analyze C\+\+ \(MSBuild\).*?"
+        r"needs: decide.*?"
+        r"windows-2025.*?ubuntu-latest.*?"
+        r"Skip analysis when no main-project C\+\+ changed",
+        "CodeQL required analysis check does not succeed on Ubuntu when analysis is skipped")
     require(
         codeql_workflow,
         r"uses: actions/checkout@v4.*?submodules: recursive",


### PR DESCRIPTION
## Summary
- Same-repository PRs no longer skip the whole `PR Test Report` workflow. Forks still use `workflow_run` + Test Reporter; in-repo PRs already publish checks from `PR Tests` and now get a green no-op instead of Skipped.
- CodeQL decides whether analysis is needed on Ubuntu. When only plugins/docs change, the required `Analyze C++` check succeeds on Ubuntu instead of sitting pending in the `windows-2025` queue.

## Test plan
- [x] Open an in-repo PR that does not touch `src/*.cpp` outside plugins: `PR Test Report` should succeed (not skipped), CodeQL should go green in seconds.
- [x] Open a PR that changes `src/*.cpp` outside plugins: CodeQL should still run the Windows MSBuild analysis.
- [x] `python -B src/plugins/salamatrix/tests/salamatrix_regression_tests.py`

Made with [Cursor](https://cursor.com)