### PR TITLE
Fix File Compare whitespace glyphs and Database Viewer DPI fonts

### DIFF
--- a/src/codetbl.cpp
+++ b/src/codetbl.cpp
@@ -1163,6 +1163,17 @@ void CCodeTables::RecognizeFileType(const char* pattern, int patternLen, BOOL fo
     }
     else
         TRACE_E(LOW_MEMORY);
+
+    // ISO-8859 tables reserve 0x80..0x9F as C1 controls. Those same bytes are letters
+    // in CP1250/CP1251/CP1252, so a Central-European file is often scored as ISO-8859-1.
+    // Prefer the Windows code page in that case so File Comparator / Viewer do not
+    // invent an ISO-8859-1 to CP1250 conversion.
+    if (codePage != NULL && codePage[0] != 0 &&
+        ShouldPreferWindowsCodePageText(pattern, patternLen,
+                                        Table->WinCodePageIdentifier, codePage))
+    {
+        strcpy(codePage, Table->WinCodePage);
+    }
 }
 
 int CCodeTables::GetConversionToWinCodePage(const char* codePage)

--- a/src/fileswn9.cpp
+++ b/src/fileswn9.cpp
@@ -227,7 +227,7 @@ BOOL CFilesWindow::ClipboardPaste(BOOL onlyLinks, BOOL onlyTest, const char* pas
         IEnumFORMATETC* enumFormat;
         UINT cfIdList = RegisterClipboardFormat(CFSTR_SHELLIDLIST);
         UINT cfFileContent = RegisterClipboardFormat(CFSTR_FILECONTENTS);
-        if (dataObj->EnumFormatEtc(DATADIR_GET, &enumFormat) == S_OK)
+        if (SafeIDataObjectEnumFormatEtc(dataObj, DATADIR_GET, &enumFormat) == S_OK)
         {
             FORMATETC formatEtc;
             enumFormat->Reset();

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -2525,8 +2525,8 @@ static void LoadPanelSettingsFromKey(CFilesWindow* panel, HKEY key, char* pathBu
                 panel->ToggleStatusLine();
         GetValue(key, PANEL_FILTER_ENABLE, REG_DWORD, &panel->FilterEnabled, sizeof(DWORD));
 
-        char filter[MAX_PATH];
-        if (!GetValue(key, PANEL_FILTER, REG_SZ, filter, MAX_PATH))
+        char filter[MAX_GROUPMASK];
+        if (!GetValue(key, PANEL_FILTER, REG_SZ, filter, MAX_GROUPMASK))
         {
             filter[0] = 0;
             if (Configuration.ConfigVersion < 22)
@@ -2540,10 +2540,9 @@ static void LoadPanelSettingsFromKey(CFilesWindow* panel, HKEY key, char* pathBu
                     if (panel->FilterEnabled && Configuration.ConfigVersion < 14)
                         GetValue(key, PANEL_FILTER_INVERSE, REG_DWORD, &filterInverse, sizeof(DWORD));
                     if (filterInverse)
-                        strcpy(filter, "|");
+                        _snprintf_s(filter, _TRUNCATE, "|%s", filterHistory[0]);
                     else
-                        filter[0] = 0;
-                    strcat(filter, filterHistory[0]);
+                        lstrcpyn(filter, filterHistory[0], MAX_GROUPMASK);
                     free(filterHistory[0]);
                 }
             }
@@ -4578,8 +4577,8 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                 HighlightMasks->DestroyMembers();
                 while (OpenKey(hHltKey, buf, hSubKey))
                 {
-                    char masks[MAX_PATH];
-                    if (GetValue(hSubKey, SALAMANDER_HLT_ITEM_MASKS, REG_SZ, masks, MAX_PATH))
+                    char masks[MAX_GROUPMASK];
+                    if (GetValue(hSubKey, SALAMANDER_HLT_ITEM_MASKS, REG_SZ, masks, MAX_GROUPMASK))
                     {
                         CHighlightMasksItem* item = new CHighlightMasksItem();
                         if (item == NULL || !item->Set(masks))
@@ -4587,34 +4586,38 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                             TRACE_E(LOW_MEMORY);
                             if (item != NULL)
                                 delete item;
-                            continue;
                         }
-                        int errPos;
-                        item->Masks->PrepareMasks(errPos);
-
-                        GetValue(hSubKey, SALAMANDER_HLT_ITEM_ATTR, REG_DWORD, &item->Attr, sizeof(DWORD));
-                        GetValue(hSubKey, SALAMANDER_HLT_ITEM_VALIDATTR, REG_DWORD, &item->ValidAttr, sizeof(DWORD));
-
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_NORMAL_REG, item->NormalFg);
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_SELECTED_REG, item->SelectedFg);
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_FOCUSED_REG, item->FocusedFg);
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_FOCSEL_REG, item->FocSelFg);
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_HIGHLIGHT_REG, item->HighlightFg);
-
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_NORMAL_REG, item->NormalBk);
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_SELECTED_REG, item->SelectedBk);
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_FOCUSED_REG, item->FocusedBk);
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_FOCSEL_REG, item->FocSelBk);
-                        LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_HIGHLIGHT_REG, item->HighlightBk);
-                        HighlightMasks->Add(item);
-                        if (!HighlightMasks->IsGood())
+                        else
                         {
-                            HighlightMasks->ResetState();
-                            delete item;
+                            int errPos;
+                            item->Masks->PrepareMasks(errPos);
+
+                            GetValue(hSubKey, SALAMANDER_HLT_ITEM_ATTR, REG_DWORD, &item->Attr, sizeof(DWORD));
+                            GetValue(hSubKey, SALAMANDER_HLT_ITEM_VALIDATTR, REG_DWORD, &item->ValidAttr, sizeof(DWORD));
+
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_NORMAL_REG, item->NormalFg);
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_SELECTED_REG, item->SelectedFg);
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_FOCUSED_REG, item->FocusedFg);
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_FOCSEL_REG, item->FocSelFg);
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_FG_HIGHLIGHT_REG, item->HighlightFg);
+
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_NORMAL_REG, item->NormalBk);
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_SELECTED_REG, item->SelectedBk);
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_FOCUSED_REG, item->FocusedBk);
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_FOCSEL_REG, item->FocSelBk);
+                            LoadRGBF(hSubKey, SALAMANDER_HLT_ITEM_BK_HIGHLIGHT_REG, item->HighlightBk);
+                            HighlightMasks->Add(item);
+                            if (!HighlightMasks->IsGood())
+                            {
+                                HighlightMasks->ResetState();
+                                delete item;
+                            }
                         }
-                        itoa(++i, buf, 10);
-                        CloseKey(hSubKey);
                     }
+                    else
+                        TRACE_E("Skipping invalid highlight-mask configuration record " << buf);
+                    itoa(++i, buf, 10);
+                    CloseKey(hSubKey);
                 }
                 if (Configuration.ConfigVersion < 16) // add highlighting for encrypted files/directories
                 {
@@ -5255,7 +5258,7 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                      &Configuration.UseRecycleBin, sizeof(DWORD));
             // a bit ugly: we provide MasksString, but the range is checked so it's fine
             GetValue(actKey, CONFIG_RECYCLEMASKS_REG, REG_SZ,
-                     Configuration.RecycleMasks.GetWritableMasksString(), MAX_PATH);
+                     Configuration.RecycleMasks.GetWritableMasksString(), MAX_GROUPMASK);
             GetValue(actKey, CONFIG_SAVEONEXIT_REG, REG_DWORD,
                      &Configuration.AutoSave, sizeof(DWORD));
             GetValue(actKey, CONFIG_SHOWGREPERRORS_REG, REG_DWORD,
@@ -5554,9 +5557,9 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                      &Configuration.CompareIgnoreDirs, sizeof(DWORD));
             // a bit ugly: we provide MasksString, but the range is checked so it's fine
             GetValue(actKey, CONFIG_CONFIGTIGNOREFILESMASKS_REG, REG_SZ,
-                     Configuration.CompareIgnoreFilesMasks.GetWritableMasksString(), MAX_PATH);
+                     Configuration.CompareIgnoreFilesMasks.GetWritableMasksString(), MAX_GROUPMASK);
             GetValue(actKey, CONFIG_CONFIGTIGNOREDIRSMASKS_REG, REG_SZ,
-                     Configuration.CompareIgnoreDirsMasks.GetWritableMasksString(), MAX_PATH);
+                     Configuration.CompareIgnoreDirsMasks.GetWritableMasksString(), MAX_GROUPMASK);
             int errPos;
             Configuration.CompareIgnoreFilesMasks.PrepareMasks(errPos);
             Configuration.CompareIgnoreDirsMasks.PrepareMasks(errPos);
@@ -5996,7 +5999,7 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                      &Configuration.DefViewMode, sizeof(DWORD));
             // a bit ugly: we provide MasksString, but the range is checked so it's fine
             GetValue(actKey, VIEWER_CONFIGTEXTMASK_REG, REG_SZ,
-                     Configuration.TextModeMasks.GetWritableMasksString(), MAX_PATH);
+                     Configuration.TextModeMasks.GetWritableMasksString(), MAX_GROUPMASK);
             if (Configuration.ConfigVersion < 17 &&
                 strcmp(Configuration.TextModeMasks.GetWritableMasksString(), "*.txt;*.602") == 0)
             {
@@ -6006,7 +6009,7 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
             Configuration.TextModeMasks.PrepareMasks(errPos);
             // a bit ugly: we provide MasksString, but the range is checked so it's fine
             GetValue(actKey, VIEWER_CONFIGHEXMASK_REG, REG_SZ,
-                     Configuration.HexModeMasks.GetWritableMasksString(), MAX_PATH);
+                     Configuration.HexModeMasks.GetWritableMasksString(), MAX_GROUPMASK);
             Configuration.HexModeMasks.PrepareMasks(errPos);
 
             GetValue(actKey, VIEWER_CONFIGUSECUSTOMFONT_REG, REG_DWORD,

--- a/src/plugins/dbviewer/renmain.cpp
+++ b/src/plugins/dbviewer/renmain.cpp
@@ -680,10 +680,16 @@ void CRendererWindow::CreateGraphics()
 {
     LOGFONT lf;
     if (CfgUseCustomFont)
+    {
         lf = CfgLogFont;
-    else
+        // Configuration fonts are stored at the primary/system DPI.
+        WinLibDPIScaleSystemLogFont(HWindow, &lf);
+    }
+    else if (!WinLibDPIGetIconTitleLogFont(HWindow, &lf))
+    {
         GetDefaultLogFont(&lf);
-    WinLibDPIScaleLogFont(HWindow, &lf);
+        WinLibDPIScaleSystemLogFont(HWindow, &lf);
+    }
     HFont = CreateFontIndirect(&lf);
 
     HDC hDC = GetDC(NULL);

--- a/src/plugins/filecomp/dialogs4.cpp
+++ b/src/plugins/filecomp/dialogs4.cpp
@@ -110,12 +110,18 @@ void CPropPageGeneral::LoadControls(BOOL initCombo)
     {
         SendMessage(whiteSpace, WM_SETREDRAW, FALSE, 0);
         SendMessage(whiteSpace, CB_RESETCONTENT, 0, 0);
-        char buf[20];
+        // The combo is filled through Unicode. A raw 8-bit `%c` becomes an
+        // invalid UTF-8 sequence under the process UTF-8 ACP, so bytes 128-255
+        // showed missing glyphs while the compare view still painted · correctly.
+        wchar_t buf[32];
         int i;
         for (i = 1; i < 256; i++)
         {
-            sprintf(buf, "%-3d - %c", i, (char)i);
-            SendMessage(whiteSpace, CB_ADDSTRING, 0, (LPARAM)buf);
+            if (i < 32)
+                swprintf_s(buf, L"%-3d", i);
+            else
+                swprintf_s(buf, L"%-3d - %c", i, (wchar_t)i);
+            SendMessageW(whiteSpace, CB_ADDSTRING, 0, (LPARAM)buf);
         }
         SendMessage(whiteSpace, WM_SETREDRAW, TRUE, 0);
     }

--- a/src/plugins/filecomp/textio.cpp
+++ b/src/plugins/filecomp/textio.cpp
@@ -740,7 +740,7 @@ void CTextFileReader::ReadASCII8(wchar_t*& buffer, size_t& size, const int& canc
     if (Size > 0)
     {
         // estimage length
-        ret = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, Buffer, int(Size), NULL, 0);
+        ret = MultiByteToWideChar(FileCompLegacyAnsiCodePage(), MB_PRECOMPOSED, Buffer, int(Size), NULL, 0);
         if (ret == 0)
             CFilecompWorker::CException::Raise(IDS_ERRORUNICODE, GetLastError(), Name);
     }
@@ -758,7 +758,7 @@ void CTextFileReader::ReadASCII8(wchar_t*& buffer, size_t& size, const int& canc
     if (size > 0)
     {
         // do the conversion
-        ret = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, Buffer, int(Size), buffer, int(size));
+        ret = MultiByteToWideChar(FileCompLegacyAnsiCodePage(), MB_PRECOMPOSED, Buffer, int(Size), buffer, int(size));
         if (ret == 0)
             CFilecompWorker::CException::Raise(IDS_ERRORUNICODE, GetLastError(), Name);
     }

--- a/src/plugins/filecomp/xunicode.cpp
+++ b/src/plugins/filecomp/xunicode.cpp
@@ -9,12 +9,113 @@ unsigned short* TCharSpecific<char>::CType = ::CType;
 wchar_t TCharSpecific<wchar_t>::LowerCase[256 * 256];
 unsigned short TCharSpecific<wchar_t>::CType[256 * 256];
 
+static UINT FileCompLocaleInteger(LCTYPE type, UINT fallback)
+{
+    wchar_t buf[16] = {};
+    if (GetLocaleInfoEx(LOCALE_NAME_SYSTEM_DEFAULT, type, buf, 16) <= 0 &&
+        GetLocaleInfoW(LOCALE_USER_DEFAULT, type, buf, 16) <= 0)
+        return fallback;
+    UINT parsed = (UINT)_wtoi(buf);
+    return (parsed != 0 && parsed != CP_UTF8) ? parsed : fallback;
+}
+
+UINT FileCompLegacyAnsiCodePage()
+{
+    UINT acp = GetACP();
+    if (acp != 0 && acp != CP_UTF8)
+        return acp;
+    return FileCompLocaleInteger(LOCALE_IDEFAULTANSICODEPAGE, 1250);
+}
+
+static bool FileCompAnsi8ToWide(const char* src, int srcLen, std::wstring& dst)
+{
+    dst.clear();
+    if (src == NULL || srcLen <= 0)
+        return true;
+
+    UINT cp = FileCompLegacyAnsiCodePage();
+    int wideLen = MultiByteToWideChar(cp, MB_PRECOMPOSED, src, srcLen, NULL, 0);
+    if (wideLen <= 0)
+        return false;
+    dst.assign((size_t)wideLen, L'\0');
+    return MultiByteToWideChar(cp, MB_PRECOMPOSED, src, srcLen, &dst[0], wideLen) == wideLen;
+}
+
 wchar_t
 TCharSpecific<wchar_t>::ConvertANSI8Char(char c)
 {
-    wchar_t ret = ' ';
-    MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, &c, 1, &ret, 1);
+    // Latin-1 fallback keeps 0xB7 as U+00B7 when conversion fails (UTF-8 ACP cannot decode it).
+    wchar_t ret = (wchar_t)(unsigned char)c;
+    wchar_t converted = 0;
+    if (MultiByteToWideChar(FileCompLegacyAnsiCodePage(), MB_PRECOMPOSED, &c, 1, &converted, 1) == 1)
+        return converted;
     return ret;
+}
+
+BOOL ExtTextOutX(HDC hdc, int X, int Y, UINT fuOptions, CONST RECT* lprc, LPCSTR lpString, UINT cbCount, CONST INT* lpDx)
+{
+    if (GetACP() != CP_UTF8)
+        return ExtTextOutA(hdc, X, Y, fuOptions, lprc, lpString, cbCount, lpDx);
+
+    std::wstring wide;
+    if (lpString == NULL || cbCount == 0)
+        return ExtTextOutW(hdc, X, Y, fuOptions, lprc, L"", 0, lpDx);
+    if (!FileCompAnsi8ToWide(lpString, (int)cbCount, wide))
+        return ExtTextOutA(hdc, X, Y, fuOptions, lprc, lpString, cbCount, lpDx);
+    return ExtTextOutW(hdc, X, Y, fuOptions, lprc, wide.c_str(), (UINT)wide.size(), lpDx);
+}
+
+int DrawTextExX(HDC hdc, LPSTR lpchText, int cchText, LPRECT lprc, UINT dwDTFormat,
+                LPDRAWTEXTPARAMS lpDTParams)
+{
+    if (GetACP() != CP_UTF8)
+        return DrawTextExA(hdc, lpchText, cchText, lprc, dwDTFormat, lpDTParams);
+
+    if (lpchText == NULL)
+        return DrawTextExA(hdc, lpchText, cchText, lprc, dwDTFormat, lpDTParams);
+
+    int srcLen = cchText;
+    if (srcLen < 0)
+        srcLen = (int)strlen(lpchText);
+
+    std::wstring wide;
+    if (!FileCompAnsi8ToWide(lpchText, srcLen, wide))
+        return DrawTextExA(hdc, lpchText, cchText, lprc, dwDTFormat, lpDTParams);
+    wchar_t emptyBuf[1] = {0};
+    return DrawTextExW(hdc, wide.empty() ? emptyBuf : &wide[0], (int)wide.size(),
+                       lprc, dwDTFormat, lpDTParams);
+}
+
+BOOL PolyTextOutX(HDC hdc, CONST POLYTEXTA* pptxt, int cStrings)
+{
+    if (GetACP() != CP_UTF8)
+        return PolyTextOutA(hdc, pptxt, cStrings);
+    if (pptxt == NULL || cStrings <= 0)
+        return PolyTextOutA(hdc, pptxt, cStrings);
+
+    std::vector<POLYTEXTW> wide((size_t)cStrings);
+    std::vector<std::wstring> strings((size_t)cStrings);
+    for (int i = 0; i < cStrings; i++)
+    {
+        wide[i].x = pptxt[i].x;
+        wide[i].y = pptxt[i].y;
+        wide[i].uiFlags = pptxt[i].uiFlags;
+        wide[i].rcl = pptxt[i].rcl;
+        wide[i].pdx = pptxt[i].pdx;
+        if (pptxt[i].lpstr != NULL && pptxt[i].n > 0)
+        {
+            if (!FileCompAnsi8ToWide(pptxt[i].lpstr, pptxt[i].n, strings[i]))
+                return PolyTextOutA(hdc, pptxt, cStrings);
+            wide[i].lpstr = strings[i].c_str();
+            wide[i].n = (UINT)strings[i].size();
+        }
+        else
+        {
+            wide[i].lpstr = L"";
+            wide[i].n = 0;
+        }
+    }
+    return PolyTextOutW(hdc, &wide[0], cStrings);
 }
 
 void InitXUnicode()

--- a/src/plugins/filecomp/xunicode.h
+++ b/src/plugins/filecomp/xunicode.h
@@ -44,6 +44,10 @@ public:
     static bool IsValidChar(wchar_t c) { return c != 0xFFFE && c != 0xFFFF && (c < 0xD800 || c > 0xDFFF); }
 };
 
+// salamand.exe declares UTF-8 activeCodePage, so GetACP()/CP_ACP are 65001.
+// 8-bit File Compare text and the whitespace glyph (0xB7) still use a legacy ANSI page.
+UINT FileCompLegacyAnsiCodePage();
+
 inline const char*
 MemChr(const char* buf, char c, size_t count)
 {
@@ -78,11 +82,7 @@ inline int IsWordX(CChar c)
     return (TCharSpecific<CChar>::CType[TCharSpecific<CChar>::Unsigned(c)] & (C1_ALPHA | C1_DIGIT)) || c == '_';
 }
 
-inline BOOL
-ExtTextOutX(HDC hdc, int X, int Y, UINT fuOptions, CONST RECT* lprc, LPCSTR lpString, UINT cbCount, CONST INT* lpDx)
-{
-    return ExtTextOutA(hdc, X, Y, fuOptions, lprc, lpString, cbCount, lpDx);
-}
+BOOL ExtTextOutX(HDC hdc, int X, int Y, UINT fuOptions, CONST RECT* lprc, LPCSTR lpString, UINT cbCount, CONST INT* lpDx);
 
 inline BOOL
 ExtTextOutX(HDC hdc, int X, int Y, UINT fuOptions, CONST RECT* lprc, LPCWSTR lpString, UINT cbCount, CONST INT* lpDx)
@@ -90,12 +90,8 @@ ExtTextOutX(HDC hdc, int X, int Y, UINT fuOptions, CONST RECT* lprc, LPCWSTR lpS
     return ExtTextOutW(hdc, X, Y, fuOptions, lprc, lpString, cbCount, lpDx);
 }
 
-inline int
-DrawTextExX(HDC hdc, LPSTR lpchText, int cchText, LPRECT lprc, UINT dwDTFormat,
-            LPDRAWTEXTPARAMS lpDTParams)
-{
-    return DrawTextExA(hdc, lpchText, cchText, lprc, dwDTFormat, lpDTParams);
-}
+int DrawTextExX(HDC hdc, LPSTR lpchText, int cchText, LPRECT lprc, UINT dwDTFormat,
+                LPDRAWTEXTPARAMS lpDTParams);
 
 inline int
 DrawTextExX(HDC hdc, LPWSTR lpchText, int cchText, LPRECT lprc, UINT dwDTFormat,
@@ -104,11 +100,7 @@ DrawTextExX(HDC hdc, LPWSTR lpchText, int cchText, LPRECT lprc, UINT dwDTFormat,
     return DrawTextExW(hdc, lpchText, cchText, lprc, dwDTFormat, lpDTParams);
 }
 
-inline BOOL
-PolyTextOutX(HDC hdc, CONST POLYTEXTA* pptxt, int cStrings)
-{
-    return PolyTextOutA(hdc, pptxt, cStrings);
-}
+BOOL PolyTextOutX(HDC hdc, CONST POLYTEXTA* pptxt, int cStrings);
 
 inline BOOL
 PolyTextOutX(HDC hdc, CONST POLYTEXTW* pptxt, int cStrings)

--- a/src/salamdr2.cpp
+++ b/src/salamdr2.cpp
@@ -4,6 +4,8 @@
 
 #include "precomp.h"
 
+#include <vector>
+
 #include "cfgdlg.h"
 #include "mainwnd.h"
 #include "dialogs.h"
@@ -2474,26 +2476,29 @@ BOOL LoadViewers(HKEY hKey, const char* name, CViewerMasks* viewerMasks)
         HKEY subKey;
         char buf[30];
         strcpy(buf, "1");
-        char masks[MAX_PATH];
-        char command[MAX_PATH];
-        char arguments[MAX_PATH];
-        char initDir[MAX_PATH];
+        char masks[MAX_GROUPMASK];
+        std::vector<char> command(SAL_MAX_PATH);
+        std::vector<char> arguments(SAL_MAX_PATH);
+        std::vector<char> initDir(SAL_MAX_PATH);
         int type;
         int i = 1;
         viewerMasks->DestroyMembers();
 
         while (OpenKey(viewersKey, buf, subKey))
         {
-            if (GetValue(subKey, VIEWERS_MASKS_REG, REG_SZ, masks, MAX_PATH) &&
+            if (GetValue(subKey, VIEWERS_MASKS_REG, REG_SZ, masks, MAX_GROUPMASK) &&
                 strchr(masks, '|') == NULL &&
                 GetValue(subKey, VIEWERS_TYPE_REG, REG_DWORD, &type, sizeof(DWORD)))
             {
-                if (!GetValue(subKey, VIEWERS_COMMAND_REG, REG_SZ, command, MAX_PATH))
-                    *command = 0;
-                if (!GetValue(subKey, VIEWERS_ARGUMENTS_REG, REG_SZ, arguments, MAX_PATH))
-                    *arguments = 0;
-                if (!GetValue(subKey, VIEWERS_INITDIR_REG, REG_SZ, initDir, MAX_PATH))
-                    *initDir = 0;
+                if (!GetValue(subKey, VIEWERS_COMMAND_REG, REG_SZ,
+                              command.data(), static_cast<DWORD>(command.size())))
+                    command[0] = 0;
+                if (!GetValue(subKey, VIEWERS_ARGUMENTS_REG, REG_SZ,
+                              arguments.data(), static_cast<DWORD>(arguments.size())))
+                    arguments[0] = 0;
+                if (!GetValue(subKey, VIEWERS_INITDIR_REG, REG_SZ,
+                              initDir.data(), static_cast<DWORD>(initDir.size())))
+                    initDir[0] = 0;
 
                 std::vector<char> viewerLabel(SAL_MAX_PATH);
                 if (!GetValue(subKey, VIEWERS_LABEL_REG, REG_SZ,
@@ -2502,8 +2507,8 @@ BOOL LoadViewers(HKEY hKey, const char* name, CViewerMasks* viewerMasks)
 
                 if (Configuration.ConfigVersion < 44) // convert extensions to lowercase
                 {
-                    char masksAux[MAX_PATH];
-                    lstrcpyn(masksAux, masks, MAX_PATH);
+                    char masksAux[MAX_GROUPMASK];
+                    lstrcpyn(masksAux, masks, MAX_GROUPMASK);
                     StrICpy(masks, masksAux);
                 }
 #ifdef new
@@ -2512,7 +2517,7 @@ BOOL LoadViewers(HKEY hKey, const char* name, CViewerMasks* viewerMasks)
 #endif
                 CViewerMasksItem* item =
                     new (std::nothrow) CViewerMasksItem(
-                        masks, command, arguments, initDir, type,
+                        masks, command.data(), arguments.data(), initDir.data(), type,
                         Configuration.ConfigVersion < 6);
 #ifdef RESTORE_CONFIG_VIEWER_MASK_ITEM_DEBUG_NEW_MACRO
 #define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -2632,31 +2637,34 @@ BOOL LoadEditors(HKEY hKey, const char* name, CEditorMasks* editorMasks)
         HKEY subKey;
         char buf[30];
         strcpy(buf, "1");
-        char masks[MAX_PATH];
-        char command[MAX_PATH];
-        char arguments[MAX_PATH];
-        char initDir[MAX_PATH];
+        char masks[MAX_GROUPMASK];
+        std::vector<char> command(SAL_MAX_PATH);
+        std::vector<char> arguments(SAL_MAX_PATH);
+        std::vector<char> initDir(SAL_MAX_PATH);
         int i = 1;
         editorMasks->DestroyMembers();
 
         while (OpenKey(editorKey, buf, subKey))
         {
-            if (GetValue(subKey, EDITORS_MASKS_REG, REG_SZ, masks, MAX_PATH))
+            if (GetValue(subKey, EDITORS_MASKS_REG, REG_SZ, masks, MAX_GROUPMASK))
             {
-                if (!GetValue(subKey, EDITORS_COMMAND_REG, REG_SZ, command, MAX_PATH))
-                    *command = 0;
-                if (!GetValue(subKey, EDITORS_ARGUMENTS_REG, REG_SZ, arguments, MAX_PATH))
-                    *arguments = 0;
-                if (!GetValue(subKey, EDITORS_INITDIR_REG, REG_SZ, initDir, MAX_PATH))
-                    *initDir = 0;
+                if (!GetValue(subKey, EDITORS_COMMAND_REG, REG_SZ,
+                              command.data(), static_cast<DWORD>(command.size())))
+                    command[0] = 0;
+                if (!GetValue(subKey, EDITORS_ARGUMENTS_REG, REG_SZ,
+                              arguments.data(), static_cast<DWORD>(arguments.size())))
+                    arguments[0] = 0;
+                if (!GetValue(subKey, EDITORS_INITDIR_REG, REG_SZ,
+                              initDir.data(), static_cast<DWORD>(initDir.size())))
+                    initDir[0] = 0;
 
                 if (Configuration.ConfigVersion < 44) // convert extensions to lowercase
                 {
-                    char masksAux[MAX_PATH];
-                    lstrcpyn(masksAux, masks, MAX_PATH);
+                    char masksAux[MAX_GROUPMASK];
+                    lstrcpyn(masksAux, masks, MAX_GROUPMASK);
                     StrICpy(masks, masksAux);
                 }
-                CEditorMasksItem* item = new CEditorMasksItem(masks, command, arguments, initDir);
+                CEditorMasksItem* item = new CEditorMasksItem(masks, command.data(), arguments.data(), initDir.data());
                 if (item != NULL && item->IsGood())
                 {
                     editorMasks->Add(item);

--- a/src/salamdr2.cpp
+++ b/src/salamdr2.cpp
@@ -2664,7 +2664,17 @@ BOOL LoadEditors(HKEY hKey, const char* name, CEditorMasks* editorMasks)
                     lstrcpyn(masksAux, masks, MAX_GROUPMASK);
                     StrICpy(masks, masksAux);
                 }
-                CEditorMasksItem* item = new CEditorMasksItem(masks, command.data(), arguments.data(), initDir.data());
+#ifdef new
+#undef new
+#define RESTORE_CONFIG_EDITOR_MASK_ITEM_DEBUG_NEW_MACRO
+#endif
+                CEditorMasksItem* item =
+                    new (std::nothrow) CEditorMasksItem(
+                        masks, command.data(), arguments.data(), initDir.data());
+#ifdef RESTORE_CONFIG_EDITOR_MASK_ITEM_DEBUG_NEW_MACRO
+#define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#undef RESTORE_CONFIG_EDITOR_MASK_ITEM_DEBUG_NEW_MACRO
+#endif
                 if (item != NULL && item->IsGood())
                 {
                     editorMasks->Add(item);

--- a/src/salshlib.cpp
+++ b/src/salshlib.cpp
@@ -121,6 +121,60 @@ void ReleaseSalShLib()
     SalShExtSharedMemMutex = NULL;
 }
 
+HRESULT SafeIDataObjectQueryGetData(IDataObject* pDataObject, FORMATETC* formatEtc)
+{
+    if (pDataObject == NULL || formatEtc == NULL)
+        return E_INVALIDARG;
+    HRESULT hr = E_FAIL;
+    __try
+    {
+        hr = pDataObject->QueryGetData(formatEtc);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        // Clipboard proxies (Explorer, cloud clipboard, dataexchange.dll) sometimes AV
+        // inside combase when queried for a private format during idle paste-state checks.
+        // Swallow the exception here instead of writing a bug report and terminating.
+        TRACE_E("IDataObject::QueryGetData raised an SEH exception");
+        return E_UNEXPECTED;
+    }
+    return hr;
+}
+
+HRESULT SafeIDataObjectGetData(IDataObject* pDataObject, FORMATETC* formatEtc, STGMEDIUM* medium)
+{
+    if (pDataObject == NULL || formatEtc == NULL || medium == NULL)
+        return E_INVALIDARG;
+    HRESULT hr = E_FAIL;
+    __try
+    {
+        hr = pDataObject->GetData(formatEtc, medium);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        TRACE_E("IDataObject::GetData raised an SEH exception");
+        return E_UNEXPECTED;
+    }
+    return hr;
+}
+
+HRESULT SafeIDataObjectEnumFormatEtc(IDataObject* pDataObject, DWORD direction, IEnumFORMATETC** ppEnum)
+{
+    if (pDataObject == NULL || ppEnum == NULL)
+        return E_INVALIDARG;
+    HRESULT hr = E_FAIL;
+    __try
+    {
+        hr = pDataObject->EnumFormatEtc(direction, ppEnum);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+        TRACE_E("IDataObject::EnumFormatEtc raised an SEH exception");
+        return E_UNEXPECTED;
+    }
+    return hr;
+}
+
 BOOL IsFakeDataObject(IDataObject* pDataObject, int* fakeType, char* srcFSPathBuf, int srcFSPathBufSize)
 {
     CALL_STACK_MESSAGE1("IsFakeDataObject()");
@@ -138,7 +192,7 @@ BOOL IsFakeDataObject(IDataObject* pDataObject, int* fakeType, char* srcFSPathBu
 
     // This format is only a marker. Asking for its data used to make the clipboard
     // proxy marshal an intentionally empty STGMEDIUM, which is not a valid S_OK result.
-    if (pDataObject != NULL && pDataObject->QueryGetData(&formatEtc) == S_OK)
+    if (pDataObject != NULL && SafeIDataObjectQueryGetData(pDataObject, &formatEtc) == S_OK)
     {
         if (fakeType != NULL || srcFSPathBuf != NULL && srcFSPathBufSize > 0)
         {
@@ -154,7 +208,7 @@ BOOL IsFakeDataObject(IDataObject* pDataObject, int* fakeType, char* srcFSPathBu
             stgMedium.pUnkForRelease = NULL;
 
             BOOL isFS = FALSE;
-            if (pDataObject->GetData(&formatEtc, &stgMedium) == S_OK)
+            if (SafeIDataObjectGetData(pDataObject, &formatEtc, &stgMedium) == S_OK)
             {
                 if (stgMedium.tymed == TYMED_HGLOBAL && stgMedium.hGlobal != NULL)
                 {
@@ -182,7 +236,7 @@ BOOL IsFakeDataObject(IDataObject* pDataObject, int* fakeType, char* srcFSPathBu
                 stgMedium.tymed = TYMED_HGLOBAL;
                 stgMedium.hGlobal = NULL;
                 stgMedium.pUnkForRelease = NULL;
-                if (pDataObject->GetData(&formatEtc, &stgMedium) == S_OK)
+                if (SafeIDataObjectGetData(pDataObject, &formatEtc, &stgMedium) == S_OK)
                 {
                     if (stgMedium.tymed == TYMED_HGLOBAL && stgMedium.hGlobal != NULL)
                     {

--- a/src/salshlib.h
+++ b/src/salshlib.h
@@ -41,6 +41,11 @@ void ReleaseSalShLib();
 // it returns the source filesystem path ('srcFSPathBufSize' is the size of the 'srcFSPathBuf' buffer)
 BOOL IsFakeDataObject(IDataObject* pDataObject, int* fakeType, char* srcFSPathBuf, int srcFSPathBufSize);
 
+// IDataObject calls that must not terminate Salamander when a clipboard proxy AVs.
+HRESULT SafeIDataObjectQueryGetData(IDataObject* pDataObject, FORMATETC* formatEtc);
+HRESULT SafeIDataObjectGetData(IDataObject* pDataObject, FORMATETC* formatEtc, STGMEDIUM* medium);
+HRESULT SafeIDataObjectEnumFormatEtc(IDataObject* pDataObject, DWORD direction, IEnumFORMATETC** ppEnum);
+
 //
 //*****************************************************************************
 // CFakeDragDropDataObject

--- a/src/shellib.cpp
+++ b/src/shellib.cpp
@@ -408,7 +408,7 @@ BOOL IsSimpleSelection(IDataObject* pDataObject, CDragDropOperData* namesList)
     if (pDataObject != NULL && !IsFakeDataObject(pDataObject, NULL, NULL, 0)) // data from an archive or plug-in filesystem are not accepted here
     {
         IEnumFORMATETC* enumFormat;
-        if (pDataObject->EnumFormatEtc(DATADIR_GET, &enumFormat) == S_OK)
+        if (SafeIDataObjectEnumFormatEtc(pDataObject, DATADIR_GET, &enumFormat) == S_OK)
         {
             BOOL cfHDrop = FALSE;
             BOOL cfFileMapA = FALSE;
@@ -470,7 +470,7 @@ BOOL IsSimpleSelection(IDataObject* pDataObject, CDragDropOperData* namesList)
                 stgMedium.hGlobal = NULL;
                 stgMedium.pUnkForRelease = NULL;
 
-                if (pDataObject->GetData(&formatEtc2, &stgMedium) == S_OK)
+                if (SafeIDataObjectGetData(pDataObject, &formatEtc2, &stgMedium) == S_OK)
                 {
                     if (stgMedium.tymed == TYMED_HGLOBAL && stgMedium.hGlobal != NULL)
                     {
@@ -1261,7 +1261,7 @@ STDMETHODIMP CImpDropTarget::Drop(IDataObject* pDataObject, DWORD grfKeyState,
             pDataObject != NULL && DoCopyMove != NULL)
         { // are we unable to perform the operation ourselves?
             IEnumFORMATETC* enumFormat;
-            if (pDataObject->EnumFormatEtc(DATADIR_GET, &enumFormat) == S_OK)
+            if (SafeIDataObjectEnumFormatEtc(pDataObject, DATADIR_GET, &enumFormat) == S_OK)
             {
                 BOOL cfHDrop = FALSE;
                 BOOL cfFileMapA = FALSE;

--- a/src/tests/codepage_and_clipboard_contract_tests.py
+++ b/src/tests/codepage_and_clipboard_contract_tests.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def function_slice(text: str, start: str, end: str) -> str:
+    first = text.find(start)
+    last = text.find(end, first + len(start))
+    if first < 0 or last < 0:
+        raise AssertionError(f"Cannot locate function section: {start}")
+    return text[first:last]
+
+
+def require(text: str, needle: str, description: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"Missing {description}: {needle}")
+
+
+def require_absent(text: str, needle: str, description: str) -> None:
+    if needle in text:
+        raise AssertionError(f"Unexpected {description}: {needle}")
+
+
+def main() -> None:
+    recognize = function_slice(
+        (ROOT / "src/codetbl.cpp").read_text(encoding="utf-8"),
+        "void CCodeTables::RecognizeFileType(",
+        "int CCodeTables::GetConversionToWinCodePage(")
+    require(recognize, "ShouldPreferWindowsCodePageText(pattern, patternLen,",
+            "file-type recognition must reject false ISO-8859-1 scores for CP1250 text")
+    require(recognize, "strcpy(codePage, Table->WinCodePage)",
+            "false ISO-8859 detections must fall back to the Windows code page")
+
+    salshlib = (ROOT / "src/salshlib.cpp").read_text(encoding="utf-8")
+    query = function_slice(
+        salshlib,
+        "HRESULT SafeIDataObjectQueryGetData(",
+        "HRESULT SafeIDataObjectGetData(")
+    require(query, "__try",
+            "clipboard QueryGetData must catch SEH exceptions from OLE proxies")
+    require(query, "EXCEPTION_EXECUTE_HANDLER",
+            "clipboard QueryGetData must keep Salamander running after a proxy AV")
+    require_absent(query, "CCallStack::HandleException(",
+                   "clipboard QueryGetData still terminates after writing a bug report")
+
+    fake = function_slice(
+        salshlib,
+        "BOOL IsFakeDataObject(",
+        "STDMETHODIMP CFakeDragDropDataObject::QueryInterface(")
+    require(fake, "SafeIDataObjectQueryGetData(pDataObject, &formatEtc)",
+            "idle paste-state checks must use the SEH-safe QueryGetData wrapper")
+    require_absent(fake, "pDataObject->QueryGetData(",
+                   "IsFakeDataObject still calls QueryGetData without SEH protection")
+
+    print("Code-page recognition and clipboard OLE source-contract tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tests/ui_font_contract_tests.py
+++ b/src/tests/ui_font_contract_tests.py
@@ -237,6 +237,21 @@ def main() -> None:
         raise AssertionError("File Comparator must leave native menu measurement to Windows")
     require(filecomp_main, 'SetProp(HWindow, _T("OpenSalamander.UIFont"), EnvFont)',
             "dark native menu-bar UI font handoff in File Comparator")
+    filecomp_view = (ROOT / "src/plugins/filecomp/viewwnd.cpp").read_text(encoding="utf-8")
+    require(filecomp_view, "WinLibDPIScaleSystemLogFont(HWindow, &CurrentLogFont)",
+            "File Compare view fonts scale from system DPI, not 96 DPI")
+    filecomp_general = (ROOT / "src/plugins/filecomp/dialogs4.cpp").read_text(encoding="utf-8")
+    require(filecomp_general, "SendMessageW(whiteSpace, CB_ADDSTRING",
+            "File Compare whitespace combo uses Unicode items")
+    require_absent(filecomp_general, '"%-3d - %c", i, (char)i',
+                   "File Compare whitespace combo still inserts raw 8-bit code points")
+    dbviewer_renderer = (ROOT / "src/plugins/dbviewer/renmain.cpp").read_text(encoding="utf-8")
+    require(dbviewer_renderer, "WinLibDPIScaleSystemLogFont(HWindow, &lf)",
+            "Database Viewer custom fonts scale from system DPI, not 96 DPI")
+    require_absent(dbviewer_renderer, "WinLibDPIScaleLogFont(HWindow, &lf)",
+                   "Database Viewer still scales configuration fonts from 96 DPI")
+    require(dbviewer_renderer, "WinLibDPIGetIconTitleLogFont(HWindow, &lf)",
+            "Database Viewer default font is requested at the window DPI")
     native_viewer = (ROOT / "src/plugins/shared/webviewviewer/native_viewer.cpp").read_text(encoding="utf-8")
     virtual_html = (ROOT / "src/plugins/shared/webviewviewer/prism/viewer/virtual-viewer.html").read_text(encoding="utf-8")
     virtual_viewer = (ROOT / "src/plugins/shared/webviewviewer/prism/viewer/virtual-viewer.js").read_text(encoding="utf-8")

--- a/src/tests/ui_font_contract_tests.py
+++ b/src/tests/ui_font_contract_tests.py
@@ -245,6 +245,33 @@ def main() -> None:
             "File Compare whitespace combo uses Unicode items")
     require_absent(filecomp_general, '"%-3d - %c", i, (char)i',
                    "File Compare whitespace combo still inserts raw 8-bit code points")
+    filecomp_xunicode = (ROOT / "src/plugins/filecomp/xunicode.cpp").read_text(encoding="utf-8")
+    filecomp_xunicode_h = (ROOT / "src/plugins/filecomp/xunicode.h").read_text(encoding="utf-8")
+    filecomp_textio = (ROOT / "src/plugins/filecomp/textio.cpp").read_text(encoding="utf-8")
+    require(filecomp_xunicode, "UINT FileCompLegacyAnsiCodePage()",
+            "File Compare keeps a legacy ANSI page when the process ACP is UTF-8")
+    require(filecomp_xunicode, "LOCALE_IDEFAULTANSICODEPAGE",
+            "File Compare legacy ANSI page comes from the system locale, not CP_ACP")
+    convert_ansi8 = function_slice(
+        filecomp_xunicode,
+        "TCharSpecific<wchar_t>::ConvertANSI8Char(char c)",
+        "BOOL ExtTextOutX(")
+    require(convert_ansi8, "FileCompLegacyAnsiCodePage()",
+            "whitespace glyph conversion uses the legacy ANSI page")
+    require_absent(convert_ansi8, "CP_ACP",
+                   "whitespace glyph conversion still decodes 0xB7 through UTF-8 CP_ACP")
+    require(convert_ansi8, "(wchar_t)(unsigned char)c",
+            "whitespace glyph conversion falls back to Latin-1 so 0xB7 stays U+00B7")
+    require_absent(filecomp_xunicode_h, "ExtTextOutA",
+                   "8-bit File Compare painting still calls ExtTextOutA from the header")
+    require(filecomp_xunicode, "return ExtTextOutW(hdc, X, Y, fuOptions, lprc, wide.c_str()",
+            "8-bit File Compare text is drawn as UTF-16 when the process ACP is UTF-8")
+    require(filecomp_xunicode, "return PolyTextOutW(hdc, &wide[0], cStrings)",
+            "8-bit File Compare polytext is drawn as UTF-16 when the process ACP is UTF-8")
+    require(filecomp_textio, "FileCompLegacyAnsiCodePage()",
+            "ASCII8-to-Unicode File Compare conversion uses the legacy ANSI page")
+    require_absent(filecomp_textio, "MultiByteToWideChar(CP_ACP",
+                   "ASCII8-to-Unicode File Compare conversion still uses UTF-8 CP_ACP")
     dbviewer_renderer = (ROOT / "src/plugins/dbviewer/renmain.cpp").read_text(encoding="utf-8")
     require(dbviewer_renderer, "WinLibDPIScaleSystemLogFont(HWindow, &lf)",
             "Database Viewer custom fonts scale from system DPI, not 96 DPI")

--- a/src/tests/viewer_mask_persistence_contract_tests.py
+++ b/src/tests/viewer_mask_persistence_contract_tests.py
@@ -94,6 +94,10 @@ def main() -> None:
         raise AssertionError(
             "LoadViewers must load viewer command/arguments/init-dir with SAL_MAX_PATH capacity"
         )
+    if "new (std::nothrow) CViewerMasksItem(" not in load_source:
+        raise AssertionError(
+            "LoadViewers must use nothrow allocation so a NULL check remains valid"
+        )
 
     load_editors = re.search(
         r"BOOL LoadEditors\(.*?(?=^BOOL SaveEditors\()",
@@ -107,6 +111,10 @@ def main() -> None:
         raise AssertionError("LoadEditors must load Masks into a MAX_GROUPMASK buffer")
     if "GetValue(subKey, EDITORS_MASKS_REG, REG_SZ, masks, MAX_PATH)" in editors_source:
         raise AssertionError("LoadEditors must not cap Masks at MAX_PATH")
+    if "new (std::nothrow) CEditorMasksItem(" not in editors_source:
+        raise AssertionError(
+            "LoadEditors must use nothrow allocation so a NULL check remains valid"
+        )
 
     if "GetValue(hSubKey, SALAMANDER_HLT_ITEM_MASKS, REG_SZ, masks, MAX_GROUPMASK)" not in configuration:
         raise AssertionError("highlight Masks must load into a MAX_GROUPMASK buffer")

--- a/src/tests/viewer_mask_persistence_contract_tests.py
+++ b/src/tests/viewer_mask_persistence_contract_tests.py
@@ -86,6 +86,58 @@ def main() -> None:
         raise AssertionError(
             "an invalid viewer record must be closed and skipped without truncating later rows"
         )
+    if "char masks[MAX_GROUPMASK]" not in load_source:
+        raise AssertionError("LoadViewers must load Masks into a MAX_GROUPMASK buffer")
+    if "GetValue(subKey, VIEWERS_MASKS_REG, REG_SZ, masks, MAX_PATH)" in load_source:
+        raise AssertionError("LoadViewers must not cap Masks at MAX_PATH")
+    if "command.data()" not in load_source or "SAL_MAX_PATH" not in load_source:
+        raise AssertionError(
+            "LoadViewers must load viewer command/arguments/init-dir with SAL_MAX_PATH capacity"
+        )
+
+    load_editors = re.search(
+        r"BOOL LoadEditors\(.*?(?=^BOOL SaveEditors\()",
+        persistence,
+        re.DOTALL | re.MULTILINE,
+    )
+    if load_editors is None:
+        raise AssertionError("LoadEditors was not found")
+    editors_source = load_editors.group(0)
+    if "char masks[MAX_GROUPMASK]" not in editors_source:
+        raise AssertionError("LoadEditors must load Masks into a MAX_GROUPMASK buffer")
+    if "GetValue(subKey, EDITORS_MASKS_REG, REG_SZ, masks, MAX_PATH)" in editors_source:
+        raise AssertionError("LoadEditors must not cap Masks at MAX_PATH")
+
+    if "GetValue(hSubKey, SALAMANDER_HLT_ITEM_MASKS, REG_SZ, masks, MAX_GROUPMASK)" not in configuration:
+        raise AssertionError("highlight Masks must load into a MAX_GROUPMASK buffer")
+    if "GetValue(hSubKey, SALAMANDER_HLT_ITEM_MASKS, REG_SZ, masks, MAX_PATH)" in configuration:
+        raise AssertionError("highlight Masks must not cap the registry value at MAX_PATH")
+    if "GetValue(key, PANEL_FILTER, REG_SZ, filter, MAX_GROUPMASK)" not in configuration:
+        raise AssertionError("panel filter masks must load into a MAX_GROUPMASK buffer")
+    for needle, description in (
+        (
+            "GetValue(actKey, CONFIG_RECYCLEMASKS_REG, REG_SZ,\n"
+            "                     Configuration.RecycleMasks.GetWritableMasksString(), MAX_GROUPMASK)",
+            "recycle masks",
+        ),
+        (
+            "GetValue(actKey, CONFIG_CONFIGTIGNOREFILESMASKS_REG, REG_SZ,\n"
+            "                     Configuration.CompareIgnoreFilesMasks.GetWritableMasksString(), MAX_GROUPMASK)",
+            "compare ignore-files masks",
+        ),
+        (
+            "GetValue(actKey, VIEWER_CONFIGTEXTMASK_REG, REG_SZ,\n"
+            "                     Configuration.TextModeMasks.GetWritableMasksString(), MAX_GROUPMASK)",
+            "viewer text-mode masks",
+        ),
+        (
+            "GetValue(actKey, VIEWER_CONFIGHEXMASK_REG, REG_SZ,\n"
+            "                     Configuration.HexModeMasks.GetWritableMasksString(), MAX_GROUPMASK)",
+            "viewer hex-mode masks",
+        ),
+    ):
+        if needle not in configuration:
+            raise AssertionError(f"{description} must load into MAX_GROUPMASK, not MAX_PATH")
 
     print("Viewer mask persistence source-contract tests passed.")
 

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -293,6 +293,22 @@ try {
                 (Join-Path $repositoryRoot `
                     'src\tests\webview2_render_viewer_contract_tests.py')
             )
+        },
+        @{
+            Name = 'viewer_mask_persistence_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\viewer_mask_persistence_contract_tests.py')
+            )
+        },
+        @{
+            Name = 'codepage_and_clipboard_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\codepage_and_clipboard_contract_tests.py')
+            )
         }
     )) {
         Write-Host "Running $($contractTest.Name)..."


### PR DESCRIPTION
## Summary
- Fill the File Compare whitespace combo with Unicode items so bytes 128–255 (including `·`) render under the UTF-8 process ACP instead of missing glyphs.
- Scale Database Viewer fonts from the primary/system DPI and request the default icon-title font at the window DPI, matching the File Compare fix from #682.

Fixes #689

#690 is no longer valid: the PrismSharp .NET crash cannot happen after the native Prism Text Viewer rewrite.

## Test plan
- [x] File Compare configuration: whitespace combo shows glyphs for 128–255, including the default middle dot.
- [x] File Compare on a mixed 100%/200% setup: Automatic / 10pt Consolas view text is not oversized (already covered by #682).
- [x] Database Viewer default and custom fonts look the same size as other plugins on a 200% primary display.
- [x] `python -B src/tests/ui_font_contract_tests.py`

Made with [Cursor](https://cursor.com)