### PR TITLE
Let Ctrl+PgDown open archives by content regardless of extension

### DIFF
--- a/help/src/hh/salamand/basicwork_openarchive.htm
+++ b/help/src/hh/salamand/basicwork_openarchive.htm
@@ -15,8 +15,12 @@
 <h1>Opening Archive Files</h1>
 
 <p>You can simply open and browse <a href="glossary_a.htm">archive files</a> in panels
-as if they were normal directories. Just focus archive file and press the Enter key or
-double-click mouse on archive file. Also see
+as if they were normal directories. Just focus an archive file (a type listed in
+Configuration/Archives Associations in Panels) and press the Enter key or
+double-click mouse on the archive file. To open a file as an archive regardless of
+its extension (including self-extracting .exe files and Office Open XML packages such as
+.docx), focus the file and press Ctrl+Page Down. Enter and double-click keep the associated
+application and never fall back to browsing the file as an archive. Also see
 <a href="navigating_changedir.htm">Changing Directory</a> for other ways of opening
 (changing directory to) archive file, mainly: Commands/Change Directory (Shift+F7)
 and Edit/Paste (Ctrl+V).</p>

--- a/help/src/hh/salamand/navigating_changedir.htm
+++ b/help/src/hh/salamand/navigating_changedir.htm
@@ -41,6 +41,15 @@ the <a href="windows_dirline.htm">Directory Line</a>.
 </tr>
 
 <tr>
+<td>Enter Focused File as Archive</td>
+<td>Ctrl+Page Down</td>
+<td>Opens the focused disk file as an archive by content, even when the extension is missing,
+wrong, or used by an associated application (for example a self-extracting .exe or a .docx
+package). Enter and double-click keep the associated action and do not fall back to browsing
+the file as an archive.</td>
+</tr>
+
+<tr>
 <td>Back (in directories history)</td>
 <td>Alt+Left Arrow</td>
 <td>Changes the current directory to the previous directory (the directory which

--- a/help/src/hh/salamand/shortcuts_keyboard.htm
+++ b/help/src/hh/salamand/shortcuts_keyboard.htm
@@ -183,7 +183,7 @@ of this help (see Contents tab).</p>
 <tr><td>Shift+Page Down</td><td>Select (if focused item was unselected when Shift was pressed) or unselect
         all items from focused item to the item down one page and go down one page</td></tr>
 <tr><td>Ctrl+Page Up</td><td>Go to the parent directory</td></tr>
-<tr><td>Ctrl+Page Down</td><td>Go to focused directory or archive</td></tr>
+<tr><td>Ctrl+Page Down</td><td>Go to focused directory, or enter focused file as an archive (by content, regardless of extension)</td></tr>
 
 <tr><td style="background: #ffffff"></td><td style="background: #ffffff"></td></tr>
 

--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -12,6 +12,7 @@
 #include "stswnd.h"
 #include "filesbox.h"
 #include "zip.h"
+#include "pack.h"
 #include "shellib.h"
 #include "toolbar.h"
 #include "common/widepath.h"
@@ -309,14 +310,65 @@ void CFilesWindow::CtrlPageDnOrEnter(WPARAM key)
         else
         {
             int index = GetCaretIndex();
-            if (key != VK_NEXT || index >= 0 && index < Dirs->Count || // Enter or directory or
+            if (key == VK_NEXT && Is(ptDisk) &&
                 index >= Dirs->Count && index < Files->Count + Dirs->Count &&
-                    (Files->At(index - Dirs->Count).Archive || IsNethoodFS())) // an archive file or a file in the Nethood FS (it has servers listed as files and Entire Network as a directory, so the panel is sorted correctly -> Ctrl+PageDown must also open servers and their shares, because they are "directories")
+                !Files->At(index - Dirs->Count).Archive && !IsNethoodFS())
+            {
+                TryEnterFileAsArchive(index);
+            }
+            else if (key != VK_NEXT || index >= 0 && index < Dirs->Count || // Enter or directory or
+                     index >= Dirs->Count && index < Files->Count + Dirs->Count &&
+                         (Files->At(index - Dirs->Count).Archive || IsNethoodFS())) // an archive file or a file in the Nethood FS (it has servers listed as files and Entire Network as a directory, so the panel is sorted correctly -> Ctrl+PageDown must also open servers and their shares, because they are "directories")
             {
                 Execute(index);
             }
         }
     }
+}
+
+void CFilesWindow::TryEnterFileAsArchive(int index)
+{
+    CALL_STACK_MESSAGE2("CFilesWindow::TryEnterFileAsArchive(%d)", index);
+    if (!Is(ptDisk) || index < Dirs->Count || index >= Files->Count + Dirs->Count)
+        return;
+
+    BeginStopRefresh();
+    if (CheckPath(FALSE) != ERROR_SUCCESS)
+    {
+        RefreshDirectory();
+        EndStopRefresh();
+        return;
+    }
+
+    CFileData* file = &Files->At(index - Dirs->Count);
+    char fullName[SAL_MAX_PATH];
+    lstrcpyn(fullName, GetPath(), SAL_MAX_PATH);
+    if (!SalPathAppend(fullName, file->Name, SAL_MAX_PATH))
+    {
+        SalMessageBox(HWindow, LoadStr(IDS_TOOLONGNAME), LoadStr(IDS_ERRORCHANGINGDIR),
+                      MB_OK | MB_ICONEXCLAMATION);
+        EndStopRefresh();
+        return;
+    }
+
+    CPluginData* plugin = PackProbeArchivePlugin(fullName, this);
+    if (plugin == NULL)
+    {
+        SalMessageBox(HWindow, LoadStr(IDS_FILEISNOTARCHIVE), LoadStr(IDS_ERRORCHANGINGDIR),
+                      MB_OK | MB_ICONEXCLAMATION);
+        EndStopRefresh();
+        return;
+    }
+
+    std::string savedPath(GetPath());
+    int topIndex = ListBox->GetTopIndex();
+    BOOL noChange;
+    if (ChangePathToArchive(fullName, "", -1, NULL, FALSE, &noChange, TRUE, NULL, FALSE, FALSE, FALSE, plugin))
+        TopIndexMem.Push(savedPath.c_str(), topIndex);
+    else if (!noChange)
+        TopIndexMem.Clear();
+    UpdateWindow(HWindow);
+    EndStopRefresh();
 }
 
 void CFilesWindow::CtrlPageUpOrBackspace()

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -3164,7 +3164,7 @@ BOOL CFilesWindow::ChangePathToArchive(const char* archive, const char* archiveP
                                        int suggestedTopIndex, const char* suggestedFocusName,
                                        BOOL forceUpdate, BOOL* noChange, BOOL refreshListBox,
                                        int* failReason, BOOL isRefresh, BOOL canFocusFileName,
-                                       BOOL isHistory)
+                                       BOOL isHistory, CPluginData* forcedPlugin)
 {
     if (!isRefresh && !ConfirmUnlockTabForPathChange())
         return FALSE;
@@ -3288,7 +3288,14 @@ BOOL CFilesWindow::ChangePathToArchive(const char* archive, const char* archiveP
                 goto ERROR_1;
             }
 
-            if (PackerFormatConfig.PackIsArchive(archive)) // is it an archive?
+            CPluginData* pluginForOpen = forcedPlugin;
+            if (pluginForOpen == NULL && PackerFormatConfig.PackIsArchive(archive) == 0 &&
+                Is(ptZIPArchive) && StrICmp(GetZIPArchive(), archive) == 0)
+            {
+                pluginForOpen = GetPluginDataForPluginIface();
+            }
+
+            if (PackerFormatConfig.PackIsArchive(archive) || pluginForOpen != NULL) // is it an archive?
             {
                 // retrieve file info (does it exist?, size, date & time)
                 DWORD err2 = NO_ERROR;
@@ -3323,7 +3330,7 @@ BOOL CFilesWindow::ChangePathToArchive(const char* archive, const char* archiveP
                 CPluginData* plugin = NULL;
                 if (!nullFile)
                     CreateSafeWaitWindow(LoadStr(IDS_LISTINGARCHIVE), NULL, 2000, FALSE, MainWindow->HWindow);
-                if (nullFile || PackList(this, archive, *newArchiveDir, pluginData, plugin))
+                if (nullFile || PackList(this, archive, *newArchiveDir, pluginData, plugin, pluginForOpen))
                 {
                     // free the cache so it does not linger in the object
                     newArchiveDir->FreeAddCache();

--- a/src/fileswn5.cpp
+++ b/src/fileswn5.cpp
@@ -1814,20 +1814,24 @@ void CFilesWindow::ViewFile(char* name, BOOL altView, DWORD handlerID, int enumF
                     BOOL arcCacheOwnDelete = FALSE;
                     CPluginInterfaceAbstract* plugin = NULL; // != NULL if the plugin handles its own deletion
                     int format = PackerFormatConfig.PackIsArchive(GetZIPArchive());
+                    CPluginData* archivePlugin = NULL;
                     if (format != 0) // a supported archive was found
                     {
                         format--;
                         int index = PackerFormatConfig.GetUnpackerIndex(format);
                         if (index < 0) // view: is the processing internal (plugin)?
                         {
-                            CPluginData* data = Plugins.Get(-index - 1);
-                            if (data != NULL)
-                            {
-                                data->GetCacheInfo(arcCacheTmpPath, &arcCacheOwnDelete, &arcCacheCacheCopies);
-                                if (arcCacheOwnDelete)
-                                    plugin = data->GetPluginInterface()->GetInterface();
-                            }
+                            archivePlugin = Plugins.Get(-index - 1);
                         }
+                    }
+                    else
+                        archivePlugin = PackGetPluginForArchiveFile(GetZIPArchive(), this);
+
+                    if (archivePlugin != NULL)
+                    {
+                        archivePlugin->GetCacheInfo(arcCacheTmpPath, &arcCacheOwnDelete, &arcCacheCacheCopies);
+                        if (arcCacheOwnDelete)
+                            plugin = archivePlugin->GetPluginInterface()->GetInterface();
                     }
 
                     // besides itself, compare the file with all the others and look for a case-sensitive identical name;

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1246,7 +1246,8 @@ public:
     BOOL ChangePathToArchive(const char* archive, const char* archivePath, int suggestedTopIndex = -1,
                              const char* suggestedFocusName = NULL, BOOL forceUpdate = FALSE,
                              BOOL* noChange = NULL, BOOL refreshListBox = TRUE, int* failReason = NULL,
-                             BOOL isRefresh = FALSE, BOOL canFocusFileName = FALSE, BOOL isHistory = FALSE);
+                             BOOL isRefresh = FALSE, BOOL canFocusFileName = FALSE, BOOL isHistory = FALSE,
+                             CPluginData* forcedPlugin = NULL);
     // change path to the plug-in FS;
     // if suggestedTopIndex != -1 the top index will be set;
     // if suggestedFocusName != NULL and present in the new list, it will be focused;
@@ -1678,6 +1679,7 @@ public:
 
     void CtrlPageDnOrEnter(WPARAM key);
     void CtrlPageUpOrBackspace();
+    void TryEnterFileAsArchive(int index);
 
     // attempts to open the focused file as a shortcut, extract its target
     // and focus that target in the panel 'panel'

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -1973,6 +1973,7 @@ STRINGTABLE
  IDS_DIALOGFONT_RESTART, "UI font changes do not take effect until Open Salamander is restarted."
  IDS_FONTDESCRIPTION_PANEL, "panel font"
  IDS_FONTDESCRIPTION_UI, "UI font"
+ IDS_FILEISNOTARCHIVE, "The selected file is not a supported archive."
  
  IDS_TASKLISTLINE, "PID=%d, started on %s, %s%s"
  IDS_TASKLISTCURLINE, ", current process"

--- a/src/pack.h
+++ b/src/pack.h
@@ -720,7 +720,14 @@ void PackSetErrorHandler(BOOL (*handler)(HWND parent, const WORD errNum, ...));
 
 // determine the contents of the archive
 BOOL PackList(CFilesWindow* panel, const char* archiveFileName, CSalamanderDirectory& dir,
-              CPluginDataInterfaceAbstract*& pluginData, CPluginData*& plugin);
+              CPluginDataInterfaceAbstract*& pluginData, CPluginData*& plugin,
+              CPluginData* forcedPlugin = NULL);
+
+// Quiet content probe: ask panel-archiver plugins whether they can open this file.
+CPluginData* PackProbeArchivePlugin(const char* archiveFileName, CFilesWindow* panel);
+
+// Plugin assigned by extension, or the plugin already listing this archive in the panel.
+CPluginData* PackGetPluginForArchiveFile(const char* archiveFileName, CFilesWindow* panel);
 
 // extract the selected files from the archive (calls UniversalUncompress)
 BOOL PackUncompress(HWND parent, CFilesWindow* panel, const char* archiveFileName,

--- a/src/pack1.cpp
+++ b/src/pack1.cpp
@@ -565,6 +565,71 @@ BOOL PackScanLine(char* buffer, CSalamanderDirectory& dir, const int index,
 
 //
 // ****************************************************************************
+static BOOL IsSevenZipArchiverPlugin(const CPluginData* plugin)
+{
+    if (plugin == NULL || plugin->DLLName == NULL)
+        return FALSE;
+    const char* name = plugin->DLLName;
+    const char* slash = strrchr(name, '\\');
+    if (slash != NULL)
+        name = slash + 1;
+    const char* slash2 = strrchr(name, '/');
+    if (slash2 != NULL)
+        name = slash2 + 1;
+    return StrICmp(name, "7zip.spl") == 0;
+}
+
+CPluginData* PackGetPluginForArchiveFile(const char* archiveFileName, CFilesWindow* panel)
+{
+    int format = PackerFormatConfig.PackIsArchive(archiveFileName);
+    if (format != 0)
+    {
+        format--;
+        int index = PackerFormatConfig.GetUnpackerIndex(format);
+        if (index < 0)
+        {
+            CPluginData* plugin = Plugins.Get(-index - 1);
+            if (plugin != NULL && plugin->SupportPanelView)
+                return plugin;
+        }
+        return NULL;
+    }
+    if (panel != NULL && panel->Is(ptZIPArchive) &&
+        StrICmp(panel->GetZIPArchive(), archiveFileName) == 0)
+    {
+        CPluginData* plugin = panel->GetPluginDataForPluginIface();
+        if (plugin != NULL && plugin->SupportPanelView)
+            return plugin;
+    }
+    return NULL;
+}
+
+CPluginData* PackProbeArchivePlugin(const char* archiveFileName, CFilesWindow* panel)
+{
+    CPluginData* preferred = PackGetPluginForArchiveFile(archiveFileName, panel);
+    if (preferred != NULL && preferred->CanOpenArchive(archiveFileName))
+        return preferred;
+
+    CPluginData* sevenZip = NULL;
+    int i;
+    for (i = 0; i < Plugins.GetCount(); i++)
+    {
+        CPluginData* plugin = Plugins.Get(i);
+        if (plugin == NULL || !plugin->SupportPanelView || plugin == preferred)
+            continue;
+        if (IsSevenZipArchiverPlugin(plugin))
+        {
+            sevenZip = plugin;
+            continue;
+        }
+        if (plugin->CanOpenArchive(archiveFileName))
+            return plugin;
+    }
+    if (sevenZip != NULL && sevenZip->CanOpenArchive(archiveFileName))
+        return sevenZip;
+    return NULL;
+}
+
 // BOOL PackList(CFilesWindow *panel, const char *archiveFileName, CSalamanderDirectory &dir,
 //               CPluginDataInterfaceAbstract *&pluginData, CPluginData *&plugin)
 //
@@ -579,7 +644,8 @@ BOOL PackScanLine(char* buffer, CSalamanderDirectory& dir, const int index,
 //        plugin is the plug-in record that performed ListArchive
 
 BOOL PackList(CFilesWindow* panel, const char* archiveFileName, CSalamanderDirectory& dir,
-              CPluginDataInterfaceAbstract*& pluginData, CPluginData*& plugin)
+              CPluginDataInterfaceAbstract*& pluginData, CPluginData*& plugin,
+              CPluginData* forcedPlugin)
 {
     CALL_STACK_MESSAGE2("PackList(, %s, , ,)", archiveFileName);
     // clean up just in case
@@ -589,11 +655,26 @@ BOOL PackList(CFilesWindow* panel, const char* archiveFileName, CSalamanderDirec
 
     FirstError = TRUE;
 
+    if (forcedPlugin != NULL)
+    {
+        if (!forcedPlugin->SupportPanelView)
+            return (*PackErrorHandlerPtr)(NULL, IDS_PACKERR_ARCNAME_UNSUP);
+        plugin = forcedPlugin;
+        return plugin->ListArchive(panel, archiveFileName, dir, pluginData);
+    }
+
     // find the correct one according to the table
     int format = PackerFormatConfig.PackIsArchive(archiveFileName);
-    // Supported archive not found - error
     if (format == 0)
+    {
+        CPluginData* stored = PackGetPluginForArchiveFile(archiveFileName, panel);
+        if (stored != NULL)
+        {
+            plugin = stored;
+            return plugin->ListArchive(panel, archiveFileName, dir, pluginData);
+        }
         return (*PackErrorHandlerPtr)(NULL, IDS_PACKERR_ARCNAME_UNSUP);
+    }
 
     format--;
     int index = PackerFormatConfig.GetUnpackerIndex(format);
@@ -1361,9 +1442,13 @@ BOOL PackUncompress(HWND parent, CFilesWindow* panel, const char* archiveFileNam
     CALL_STACK_MESSAGE4("PackUncompress(, , %s, , %s, %s, ,)", archiveFileName, targetDir, archiveRoot);
     // find the correct one according to the table
     int format = PackerFormatConfig.PackIsArchive(archiveFileName);
-    // Supported archive not found - error
     if (format == 0)
-        return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_ARCNAME_UNSUP);
+    {
+        CPluginData* stored = PackGetPluginForArchiveFile(archiveFileName, panel);
+        if (stored == NULL || !stored->SupportPanelView)
+            return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_ARCNAME_UNSUP);
+        return stored->UnpackArchive(panel, archiveFileName, pluginData, targetDir, archiveRoot, nextName, param);
+    }
 
     format--;
     int index = PackerFormatConfig.GetUnpackerIndex(format);
@@ -1778,9 +1863,14 @@ BOOL PackUnpackOneFile(CFilesWindow* panel, const char* archiveFileName,
 
     // find the correct one according to the table
     int format = PackerFormatConfig.PackIsArchive(archiveFileName);
-    // No supported archive found - error
     if (format == 0)
-        return (*PackErrorHandlerPtr)(NULL, IDS_PACKERR_ARCNAME_UNSUP);
+    {
+        CPluginData* stored = PackGetPluginForArchiveFile(archiveFileName, panel);
+        if (stored == NULL || !stored->SupportPanelView)
+            return (*PackErrorHandlerPtr)(NULL, IDS_PACKERR_ARCNAME_UNSUP);
+        return stored->UnpackOneFile(panel, archiveFileName, pluginData, nameInArchive,
+                                     fileData, targetDir, newFileName, renamingNotSupported);
+    }
 
     format--;
     int index = PackerFormatConfig.GetUnpackerIndex(format);

--- a/src/pack2.cpp
+++ b/src/pack2.cpp
@@ -135,9 +135,15 @@ BOOL PackCompress(HWND parent, CFilesWindow* panel, const char* archiveFileName,
                         archiveRoot, move, sourceDir);
     // find the correct one according to the table
     int format = PackerFormatConfig.PackIsArchive(archiveFileName);
-    // Did not find a supported archive - error
+    // Did not find a supported archive - fall back to the plugin already listing this file
     if (format == 0)
-        return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_ARCNAME_UNSUP);
+    {
+        CPluginData* stored = PackGetPluginForArchiveFile(archiveFileName, panel);
+        if (stored == NULL || !stored->SupportPanelEdit)
+            return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_ARCNAME_UNSUP);
+        return stored->PackToArchive(panel, archiveFileName, archiveRoot, move,
+                                     sourceDir, nextName, param);
+    }
 
     format--;
     if (!PackerFormatConfig.GetUsePacker(format))
@@ -650,9 +656,15 @@ BOOL PackDelFromArc(HWND parent, CFilesWindow* panel, const char* archiveFileNam
 
     // find the correct one according to the table
     int format = PackerFormatConfig.PackIsArchive(archiveFileName);
-    // Did not find a supported archive - error
+    // Did not find a supported archive - fall back to the plugin already listing this file
     if (format == 0)
-        return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_ARCNAME_UNSUP);
+    {
+        CPluginData* stored = PackGetPluginForArchiveFile(archiveFileName, panel);
+        if (stored == NULL || !stored->SupportPanelEdit)
+            return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_ARCNAME_UNSUP);
+        return stored->DeleteFromArchive(panel, archiveFileName, pluginData, archiveRoot,
+                                         nextName, param);
+    }
 
     format--;
     if (!PackerFormatConfig.GetUsePacker(format))

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -140,6 +140,14 @@ public:
         return r;
     }
 
+    BOOL CanOpenArchive(const char* fileName)
+    {
+        EnterPlugin();
+        BOOL r = Interface->CanOpenArchive(fileName);
+        LeavePlugin();
+        return r;
+    }
+
     // ********************************************************************************
     // WARNING: lower thread priority before executing plug-in operations!
     // ********************************************************************************
@@ -2702,6 +2710,9 @@ public:
 
     // plugin call: CanCloseArchive
     BOOL CanCloseArchive(CFilesWindow* panel, const char* archiveFileName, BOOL force);
+
+    // plugin call: CanOpenArchive (quiet content probe; FALSE for plugins older than SAL_SDK_VER_CANOPENARCHIVE)
+    BOOL CanOpenArchive(const char* name);
 
     // plugin call: CanViewFile
     BOOL CanViewFile(const char* name);

--- a/src/plugins/7zip/7zclient.cpp
+++ b/src/plugins/7zip/7zclient.cpp
@@ -11,6 +11,7 @@
 #include "open.h"
 #include "7zthreads.h"
 #include "FStreams.h"
+#include "arcprobe.h"
 
 #include "7zip.rh"
 #include "7zip.rh2"
@@ -158,8 +159,8 @@ BOOL C7zClient::GetArchiveFormat(const char* fileName, GUID* classID)
     *classID = CLSID_CFormat7z;
 
     const char* ext = strrchr(fileName, '.');
-    if (ext == NULL || *++ext == 0)
-        return TRUE;
+    if (ext == NULL || *++ext == 0 || _stricmp(ext, "exe") == 0)
+        return FALSE;
 
     TCHAR dllPath[SAL_MAX_PATH];
     if (!GetModuleFileName(DLLInstance, dllPath, SAL_MAX_PATH))
@@ -197,7 +198,7 @@ BOOL C7zClient::GetArchiveFormat(const char* fileName, GUID* classID)
         }
     }
 
-    return TRUE;
+    return FALSE;
 }
 
 BOOL C7zClient::OpenArchiveWithFormat(const char* fileName, const GUID* classID, IInArchive** archive, UString& password, BOOL quiet /* = FALSE*/)
@@ -229,12 +230,41 @@ BOOL C7zClient::OpenArchiveWithFormat(const char* fileName, const GUID* classID,
     return TRUE;
 }
 
+BOOL C7zClient::Find7zFamilySignature(const char* fileName, GUID* classID)
+{
+    static const unsigned char k7z[] = {0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C};
+    static const unsigned char kXz[] = {0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00};
+    if (ArchiveProbeScan(fileName, k7z, sizeof(k7z), 8 * 1024 * 1024, 0))
+    {
+        *classID = CLSID_CFormat7z;
+        return TRUE;
+    }
+    if (ArchiveProbeScan(fileName, kXz, sizeof(kXz), 8, 0))
+    {
+        static const CLSID CLSID_CFormatXz = {0x23170F69, 0x40C1, 0x278A, {0x10, 0x00, 0x00, 0x01, 0x10, 0x0C, 0x00, 0x00}};
+        *classID = CLSID_CFormatXz;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL C7zClient::CanOpenByContent(const char* fileName)
+{
+    GUID dummy;
+    return Find7zFamilySignature(fileName, &dummy);
+}
+
 BOOL C7zClient::OpenArchive(const char* fileName, IInArchive** archive, UString& password, BOOL quiet /* = FALSE*/)
 {
     GUID classID;
-    if (!GetArchiveFormat(fileName, &classID))
-        return FALSE;
-    return OpenArchiveWithFormat(fileName, &classID, archive, password, quiet);
+    BOOL haveExtFormat = GetArchiveFormat(fileName, &classID);
+    if (haveExtFormat && OpenArchiveWithFormat(fileName, &classID, archive, password, quiet))
+        return TRUE;
+    if (Find7zFamilySignature(fileName, &classID))
+        return OpenArchiveWithFormat(fileName, &classID, archive, password, quiet);
+    if (!haveExtFormat)
+        return Error(IDS_UNSUPPORTED_ARCHIVE, quiet, fileName);
+    return FALSE;
 }
 
 BOOL C7zClient::ListArchive(const char* fileName, CSalamanderDirectoryAbstract* dir, CPluginDataInterface*& pluginData, UString& password)

--- a/src/plugins/7zip/7zclient.h
+++ b/src/plugins/7zip/7zclient.h
@@ -108,6 +108,7 @@ public:
     ~C7zClient();
 
     BOOL ListArchive(const char* fileName, CSalamanderDirectoryAbstract* dir, CPluginDataInterface*& pluginData, UString& password);
+    BOOL CanOpenByContent(const char* fileName);
 
     int Decompress(CSalamanderForOperationsAbstract* salamander, const char* archiveName, const char* outDir,
                    TIndirectArray<CArchiveItemInfo>* itemList, UString& password, BOOL silentDelete = FALSE);
@@ -123,6 +124,7 @@ public:
 protected:
     BOOL OpenArchive(const char* fileName, IInArchive** archive, UString& password, BOOL quiet = FALSE);
     BOOL OpenArchiveWithFormat(const char* fileName, const GUID* classID, IInArchive** archive, UString& password, BOOL quiet = FALSE);
+    BOOL Find7zFamilySignature(const char* fileName, GUID* classID);
 
     BOOL FillItemData(IInArchive* archive, UINT32 index, C7zClient::CItemData* itemData);
     BOOL AddFileDir(IInArchive* archive, UINT32 idx,

--- a/src/plugins/7zip/7zip.cpp
+++ b/src/plugins/7zip/7zip.cpp
@@ -209,7 +209,9 @@ int ConfigVersion = 0;
 // 4: added registration for all formats handled by the bundled 7-Zip engine.
 // 5: split panel archiver registration per extension so associations are not grouped under another plugin.
 // 6: force registration of formats added after the original .7z-only plugin.
-#define CURRENT_CONFIG_VERSION 6
+// 7: remove document-like Office/OpenDocument/EPUB/XPI types from panel
+//    archiver and custom unpacker lists so Enter opens the associated app.
+#define CURRENT_CONFIG_VERSION 7
 const char* CONFIG_VERSION = "Version";
 
 CConfig Config;
@@ -694,18 +696,25 @@ void CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamand
     //  salamander->AddViewer("*.7z", FALSE); // default (plugin install), otherwise Salamander ignores it
 
     static const char* const panelArchiverExtensionGroups[] = {
-        "7z;xz;txz;bz2;bzip2;tbz2;tbz;gz;gzip;tgz;tpz;tar;ova;zip;z01;zipx;jar;xpi;odt;ods;docx;xlsx;epub;wim;swm;esd",
+        "7z;xz;txz;bz2;bzip2;tbz2;tbz;gz;gzip;tgz;tpz;tar;ova;zip;z01;zipx;jar;wim;swm;esd",
         "apm;apfs;ar;a;deb;udeb;lib;arj;cab;chm;chi;chq;chw;hxs;hxi;hxr;hxq;hxw;lit;cpio;cramfs;dmg;img;ext;ext2;ext3;ext4;fat;gpt;hfs;hfsx;ihex;iso;lzh;lha;lzma;mbr",
-        "msi;msp;doc;xls;ppt;nsis;ntfs;qcow;qcow2;qcow2c;rar;r00;rpm;squashfs;udf;scap;uefi;uefif;vdi;vhd;vhdx;vmdk;xar;z;taz"};
+        "msi;msp;nsis;ntfs;qcow;qcow2;qcow2c;rar;r00;rpm;squashfs;udf;scap;uefi;uefif;vdi;vhd;vhdx;vmdk;xar;z;taz"};
     for (unsigned i = 0; i < sizeof(panelArchiverExtensionGroups) / sizeof(panelArchiverExtensionGroups[0]); i++)
         salamander->AddPanelArchiver(panelArchiverExtensionGroups[i], TRUE, FALSE);
 
     salamander->AddCustomPacker("7-Zip (Plugin)", "7z", ConfigVersion < 1);
-    salamander->AddCustomUnpacker("7-Zip (Plugin)", "*.7z;*.xz;*.txz;*.bz2;*.bzip2;*.tbz2;*.tbz;*.gz;*.gzip;*.tgz;*.tpz;*.tar;*.ova;*.zip;*.z01;*.zipx;*.jar;*.xpi;*.odt;*.ods;*.docx;*.xlsx;*.epub;*.wim;*.swm;*.esd;*.apm;*.apfs;*.ar;*.a;*.deb;*.udeb;*.lib;*.arj;*.cab;*.chm;*.chi;*.chq;*.chw;*.hxs;*.hxi;*.hxr;*.hxq;*.hxw;*.lit;*.cpio;*.cramfs;*.dmg;*.img;*.ext;*.ext2;*.ext3;*.ext4;*.fat;*.gpt;*.hfs;*.hfsx;*.ihex;*.iso;*.lzh;*.lha;*.lzma;*.mbr;*.msi;*.msp;*.doc;*.xls;*.ppt;*.nsis;*.ntfs;*.qcow;*.qcow2;*.qcow2c;*.rar;*.r00;*.rpm;*.squashfs;*.udf;*.scap;*.uefi;*.uefif;*.vdi;*.vhd;*.vhdx;*.vmdk;*.xar;*.z;*.taz", ConfigVersion < 6);
+    salamander->AddCustomUnpacker("7-Zip (Plugin)", "*.7z;*.xz;*.txz;*.bz2;*.bzip2;*.tbz2;*.tbz;*.gz;*.gzip;*.tgz;*.tpz;*.tar;*.ova;*.zip;*.z01;*.zipx;*.jar;*.wim;*.swm;*.esd;*.apm;*.apfs;*.ar;*.a;*.deb;*.udeb;*.lib;*.arj;*.cab;*.chm;*.chi;*.chq;*.chw;*.hxs;*.hxi;*.hxr;*.hxq;*.hxw;*.lit;*.cpio;*.cramfs;*.dmg;*.img;*.ext;*.ext2;*.ext3;*.ext4;*.fat;*.gpt;*.hfs;*.hfsx;*.ihex;*.iso;*.lzh;*.lha;*.lzma;*.mbr;*.msi;*.msp;*.nsis;*.ntfs;*.qcow;*.qcow2;*.qcow2c;*.rar;*.r00;*.rpm;*.squashfs;*.udf;*.scap;*.uefi;*.uefif;*.vdi;*.vhd;*.vhdx;*.vmdk;*.xar;*.z;*.taz", ConfigVersion < 7);
 
     // UPGRADE SECTION
     // Panel archiver extensions are registered above in bounded groups.  This also upgrades
     // older configurations without creating one overlong registry value or one row per extension.
+    if (ConfigVersion < 7) // remove document-like types from panel archiver associations
+    {
+        static const char* const removedDocumentExts[] = {
+            "doc", "docx", "xls", "xlsx", "ppt", "pptx", "odt", "ods", "odp", "odg", "epub", "xpi"};
+        for (unsigned i = 0; i < sizeof(removedDocumentExts) / sizeof(removedDocumentExts[0]); i++)
+            salamander->ForceRemovePanelArchiver(removedDocumentExts[i]);
+    }
 
     /* used by the export_mnu.py script, which generates salmenu.mnu for the Translator
    keep it synchronized with the calls to salamander->AddMenuItem() below...
@@ -800,6 +809,13 @@ BOOL CPluginInterfaceForArchiver::Init()
     CALL_STACK_MESSAGE1("CPluginInterfaceForArchiver::Init()");
 
     return TRUE;
+}
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    C7zClient client;
+    return client.CanOpenByContent(fileName);
 }
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander,

--- a/src/plugins/7zip/7zip.h
+++ b/src/plugins/7zip/7zip.h
@@ -73,6 +73,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     // plugin-specific methods
 public:

--- a/src/plugins/demoplug/archiver.cpp
+++ b/src/plugins/demoplug/archiver.cpp
@@ -91,6 +91,12 @@ CArcPluginDataInterface::ColumnWidthWasChanged(BOOL leftPanel, const CColumn* co
 }
 
 BOOL WINAPI
+CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    return FALSE;
+}
+
+BOOL WINAPI
 CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                          CSalamanderDirectoryAbstract* dir,
                                          CPluginDataInterfaceAbstract*& pluginData)

--- a/src/plugins/demoplug/demoplug.h
+++ b/src/plugins/demoplug/demoplug.h
@@ -192,6 +192,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies);
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile);
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount);
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 };
 
 class CPluginInterfaceForViewer : public CPluginInterfaceForViewerAbstract

--- a/src/plugins/diskdir/diskdir.cpp
+++ b/src/plugins/diskdir/diskdir.cpp
@@ -444,6 +444,12 @@ CPluginInterfaceForArchiverAbstract* WINAPI CDiskDirPlugin::GetInterfaceForArchi
     return &ArchiverInterface;
 }
 
+BOOL WINAPI CDiskDirArchiver::CanOpenArchive(const char* fileName)
+{
+    // Listing catalogs are too generic to claim from a content probe.
+    return FALSE;
+}
+
 BOOL WINAPI CDiskDirArchiver::ListArchive(CSalamanderForOperationsAbstract*,
                                           const char* fileName,
                                           CSalamanderDirectoryAbstract* dir,

--- a/src/plugins/diskdir/diskdir.h
+++ b/src/plugins/diskdir/diskdir.h
@@ -34,6 +34,7 @@ public:
     BOOL WINAPI GetCacheInfo(char*, BOOL*, BOOL*) override { return FALSE; }
     void WINAPI DeleteTmpCopy(const char*, BOOL) override {}
     BOOL WINAPI PrematureDeleteTmpCopy(HWND, int) override { return FALSE; }
+    BOOL WINAPI CanOpenArchive(const char* fileName) override;
 };
 
 class CDiskDirPlugin : public CPluginInterfaceAbstract

--- a/src/plugins/pak/spl/pak.cpp
+++ b/src/plugins/pak/spl/pak.cpp
@@ -11,6 +11,7 @@
 #include "pak.rh2"
 #include "lang\lang.rh"
 #include "pak.h"
+#include "arcprobe.h"
 
 // ****************************************************************************
 
@@ -247,6 +248,13 @@ CPluginInterface::GetInterfaceForMenuExt()
 //
 // CPluginInterfaceForArchiver
 //
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kPack[] = {'P', 'A', 'C', 'K'};
+    return ArchiveProbeScan(fileName, kPack, sizeof(kPack), 8, 0);
+}
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                               CSalamanderDirectoryAbstract* dir,

--- a/src/plugins/pak/spl/pak.h
+++ b/src/plugins/pak/spl/pak.h
@@ -75,6 +75,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     /*void InitPlugin(CSalamanderForOperationsAbstract * salamander, CPakIfaceAbstract * pakIFace,
                     const char * pakFileName);*/

--- a/src/plugins/serviceexplorer/archiver.cpp
+++ b/src/plugins/serviceexplorer/archiver.cpp
@@ -1,6 +1,6 @@
 #include "precomp.h"
 
-// spolecny interface pro pluginova data archivatoru
+// shared interface for archiver plugin data
 CArcPluginDataInterface ArcPluginDataInterface;
 
 // ****************************************************************************
@@ -18,6 +18,11 @@ void WINAPI CArcPluginDataInterface::ColumnFixedWidthShouldChange(BOOL leftPanel
 void WINAPI CArcPluginDataInterface::ColumnWidthWasChanged(BOOL leftPanel, const CColumn *column, int newWidth)
 {
 
+}
+
+BOOL WINAPI CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    return FALSE;
 }
 
 BOOL WINAPI CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract *salamander, const char *fileName,

--- a/src/plugins/serviceexplorer/plugin.h
+++ b/src/plugins/serviceexplorer/plugin.h
@@ -136,6 +136,7 @@ class CPluginInterfaceForArchiver: public CPluginInterfaceForArchiverAbstract
     virtual BOOL WINAPI GetCacheInfo(char *tempPath, BOOL *ownDelete, BOOL *cacheCopies);
     virtual void WINAPI DeleteTmpCopy(const char *fileName, BOOL firstFile);
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount);
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 };
 
 class CPluginInterfaceForViewer: public CPluginInterfaceForViewerAbstract

--- a/src/plugins/shared/arcprobe.h
+++ b/src/plugins/shared/arcprobe.h
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <windows.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Quiet magic-byte helpers for CPluginInterfaceForArchiverAbstract::CanOpenArchive.
+// No UI. Uses the same char* path the archiver SDK already passes to ListArchive.
+
+inline HANDLE ArchiveProbeOpenRead(const char* fileName)
+{
+    if (fileName == NULL || fileName[0] == 0)
+        return INVALID_HANDLE_VALUE;
+
+    int n = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, fileName, -1, NULL, 0);
+    if (n <= 0)
+        n = MultiByteToWideChar(CP_ACP, 0, fileName, -1, NULL, 0);
+    if (n <= 0)
+        return INVALID_HANDLE_VALUE;
+
+    wchar_t* wide = (wchar_t*)malloc((size_t)n * sizeof(wchar_t));
+    if (wide == NULL)
+        return INVALID_HANDLE_VALUE;
+    int converted = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, fileName, -1, wide, n);
+    if (converted <= 0)
+        converted = MultiByteToWideChar(CP_ACP, 0, fileName, -1, wide, n);
+    HANDLE file = INVALID_HANDLE_VALUE;
+    if (converted > 0)
+    {
+        const wchar_t* pathToOpen = wide;
+        wchar_t* prefixed = NULL;
+        size_t wideLen = wcslen(wide);
+        if (wideLen >= MAX_PATH && wcsncmp(wide, L"\\\\?\\", 4) != 0)
+        {
+            if (wcsncmp(wide, L"\\\\", 2) == 0)
+            {
+                prefixed = (wchar_t*)malloc((wideLen + 8 + 1) * sizeof(wchar_t));
+                if (prefixed != NULL)
+                {
+                    wcscpy(prefixed, L"\\\\?\\UNC\\");
+                    wcscat(prefixed, wide + 2);
+                    pathToOpen = prefixed;
+                }
+            }
+            else
+            {
+                prefixed = (wchar_t*)malloc((wideLen + 4 + 1) * sizeof(wchar_t));
+                if (prefixed != NULL)
+                {
+                    wcscpy(prefixed, L"\\\\?\\");
+                    wcscat(prefixed, wide);
+                    pathToOpen = prefixed;
+                }
+            }
+        }
+        file = CreateFileW(pathToOpen, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                           NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        free(prefixed);
+    }
+    free(wide);
+    return file;
+}
+
+inline BOOL ArchiveProbeFindBytes(const unsigned char* data, DWORD dataLen,
+                                  const unsigned char* magic, int magicLen)
+{
+    if (data == NULL || magic == NULL || magicLen <= 0 || dataLen < (DWORD)magicLen)
+        return FALSE;
+    const DWORD last = dataLen - (DWORD)magicLen;
+    for (DWORD i = 0; i <= last; i++)
+    {
+        if (memcmp(data + i, magic, (size_t)magicLen) == 0)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+inline BOOL ArchiveProbeMatchAt(HANDLE file, ULONGLONG offset,
+                                const unsigned char* magic, int magicLen)
+{
+    if (file == INVALID_HANDLE_VALUE || magic == NULL || magicLen <= 0)
+        return FALSE;
+    LARGE_INTEGER pos;
+    pos.QuadPart = (LONGLONG)offset;
+    if (!SetFilePointerEx(file, pos, NULL, FILE_BEGIN))
+        return FALSE;
+    unsigned char buf[64];
+    if (magicLen > (int)sizeof(buf))
+        return FALSE;
+    DWORD read = 0;
+    if (!ReadFile(file, buf, (DWORD)magicLen, &read, NULL) || read != (DWORD)magicLen)
+        return FALSE;
+    return memcmp(buf, magic, (size_t)magicLen) == 0;
+}
+
+inline BOOL ArchiveProbeScan(const char* fileName, const unsigned char* magic, int magicLen,
+                             DWORD maxFromStart, DWORD maxFromEnd)
+{
+    HANDLE file = ArchiveProbeOpenRead(fileName);
+    if (file == INVALID_HANDLE_VALUE)
+        return FALSE;
+
+    LARGE_INTEGER size = {};
+    if (!GetFileSizeEx(file, &size) || size.QuadPart <= 0)
+    {
+        CloseHandle(file);
+        return FALSE;
+    }
+
+    BOOL found = FALSE;
+    if (maxFromStart > 0)
+    {
+        DWORD toRead = maxFromStart;
+        if ((ULONGLONG)size.QuadPart < toRead)
+            toRead = (DWORD)size.QuadPart;
+        unsigned char* buf = (unsigned char*)malloc(toRead);
+        if (buf != NULL)
+        {
+            LARGE_INTEGER zero = {};
+            DWORD read = 0;
+            if (SetFilePointerEx(file, zero, NULL, FILE_BEGIN) &&
+                ReadFile(file, buf, toRead, &read, NULL))
+            {
+                found = ArchiveProbeFindBytes(buf, read, magic, magicLen);
+            }
+            free(buf);
+        }
+    }
+
+    if (!found && maxFromEnd > 0)
+    {
+        DWORD toRead = maxFromEnd;
+        if ((ULONGLONG)size.QuadPart < toRead)
+            toRead = (DWORD)size.QuadPart;
+        unsigned char* buf = (unsigned char*)malloc(toRead);
+        if (buf != NULL)
+        {
+            LARGE_INTEGER pos;
+            pos.QuadPart = size.QuadPart - toRead;
+            DWORD read = 0;
+            if (SetFilePointerEx(file, pos, NULL, FILE_BEGIN) &&
+                ReadFile(file, buf, toRead, &read, NULL))
+            {
+                found = ArchiveProbeFindBytes(buf, read, magic, magicLen);
+            }
+            free(buf);
+        }
+    }
+
+    CloseHandle(file);
+    return found;
+}

--- a/src/plugins/shared/spl_arc.h
+++ b/src/plugins/shared/spl_arc.h
@@ -182,6 +182,13 @@ public:
     // POZNAMKA: behem provadeni PrematureDeleteTmpCopy je zajisteno, ze nedojde
     // k volani DeleteTmpCopy
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) = 0;
+
+    // Quiet, extension-agnostic probe used by Ctrl+PageDown to enter a file as an archive.
+    // Must not show UI (no error boxes, no password dialogs) and should only read a header
+    // or footer. Return TRUE if this plugin can later ListArchive the file (including
+    // encrypted archives of this format). Appended after PrematureDeleteTmpCopy for
+    // binary compatibility with older plugins.
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName) = 0;
 };
 
 #ifdef _MSC_VER

--- a/src/plugins/shared/spl_vers.h
+++ b/src/plugins/shared/spl_vers.h
@@ -222,8 +222,10 @@
 //   103 - 5.0
 //   104 - 5.0 per-monitor DPI window graphics
 //   105 - 5.0 Salamatrix service registry and panel-tab snapshot API
+//   106 - 5.0 CanOpenArchive on CPluginInterfaceForArchiverAbstract
 
-#define LAST_VERSION_OF_SALAMANDER 105
+#define LAST_VERSION_OF_SALAMANDER 106
+#define SAL_SDK_VER_CANOPENARCHIVE 106
 #define REQUIRE_LAST_VERSION_OF_SALAMANDER "This plugin requires Open Salamander 5.0 (" SAL_VER_PLATFORM ") or later."
 
 #endif // __SPL_VERS_H

--- a/src/plugins/tar/tardll.cpp
+++ b/src/plugins/tar/tardll.cpp
@@ -12,6 +12,7 @@
 #include "tar.rh"
 #include "tar.rh2"
 #include "lang\lang.rh"
+#include "arcprobe.h"
 
 // TODO: resolve case sensitivity
 // TODO: handle multiple files with the same name in one archive
@@ -267,6 +268,35 @@ CPluginInterface::GetInterfaceForViewer()
 //
 // ****************************************************************************
 //
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kGzip[] = {0x1F, 0x8B};
+    static const unsigned char kBzip[] = {0x42, 0x5A, 0x68}; // BZh
+    static const unsigned char kCompress[] = {0x1F, 0x9D};
+    static const unsigned char kRpm[] = {0xED, 0xAB, 0xEE, 0xDB};
+    static const unsigned char kAr[] = {'!', '<', 'a', 'r', 'c', 'h', '>'};
+    static const unsigned char kUstar[] = {'u', 's', 't', 'a', 'r'};
+    static const unsigned char kCpioBin[] = {0xC7, 0x71};
+    static const unsigned char kCpioAsc[] = {'0', '7', '0', '7', '0'};
+    if (ArchiveProbeScan(fileName, kGzip, sizeof(kGzip), 4, 0) ||
+        ArchiveProbeScan(fileName, kBzip, sizeof(kBzip), 4, 0) ||
+        ArchiveProbeScan(fileName, kCompress, sizeof(kCompress), 4, 0) ||
+        ArchiveProbeScan(fileName, kRpm, sizeof(kRpm), 8, 0) ||
+        ArchiveProbeScan(fileName, kAr, sizeof(kAr), 8, 0) ||
+        ArchiveProbeScan(fileName, kCpioBin, sizeof(kCpioBin), 8, 0) ||
+        ArchiveProbeScan(fileName, kCpioAsc, sizeof(kCpioAsc), 8, 0))
+    {
+        return TRUE;
+    }
+    HANDLE file = ArchiveProbeOpenRead(fileName);
+    if (file == INVALID_HANDLE_VALUE)
+        return FALSE;
+    BOOL isTar = ArchiveProbeMatchAt(file, 257, kUstar, sizeof(kUstar));
+    CloseHandle(file);
+    return isTar;
+}
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander,
                                               const char* fileName,

--- a/src/plugins/tar/tardll.h
+++ b/src/plugins/tar/tardll.h
@@ -44,6 +44,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 };
 
 class CPluginInterfaceForViewer : public CPluginInterfaceForViewerAbstract

--- a/src/plugins/unarj/unarjspl.cpp
+++ b/src/plugins/unarj/unarjspl.cpp
@@ -12,6 +12,7 @@
 #include "unarj.rh"
 #include "unarj.rh2"
 #include "lang\lang.rh"
+#include "arcprobe.h"
 
 // ****************************************************************************
 
@@ -200,6 +201,13 @@ ARJErrorProc(int error, BOOL flags)
 {
     CALL_STACK_MESSAGE_NONE
     return InterfaceForArchiver.ErrorProc(error, flags);
+}
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kArj[] = {0x60, 0xEA};
+    return ArchiveProbeScan(fileName, kArj, sizeof(kArj), 1024 * 1024, 0);
 }
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,

--- a/src/plugins/unarj/unarjspl.h
+++ b/src/plugins/unarj/unarjspl.h
@@ -68,6 +68,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     BOOL Error(int error, ...);
 

--- a/src/plugins/uncab/uncab.cpp
+++ b/src/plugins/uncab/uncab.cpp
@@ -12,6 +12,7 @@
 #include "uncab.rh"
 #include "uncab.rh2"
 #include "lang\lang.rh"
+#include "arcprobe.h"
 
 // The only sizes seen so far are 0x10660 & 0x17c7c
 #define SFX_BUFF_SIZE 0x18000
@@ -248,6 +249,13 @@ CPluginInterface::GetInterfaceForArchiver()
 //
 // CPluginInterfaceForArchiver
 //
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kMscf[] = {'M', 'S', 'C', 'F'};
+    return ArchiveProbeScan(fileName, kMscf, sizeof(kMscf), 1024 * 1024, 0);
+}
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                               CSalamanderDirectoryAbstract* dir,

--- a/src/plugins/uncab/uncab.h
+++ b/src/plugins/uncab/uncab.h
@@ -129,6 +129,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     BOOL Error(int error, ...);
 

--- a/src/plugins/unchm/unchm.cpp
+++ b/src/plugins/unchm/unchm.cpp
@@ -11,6 +11,7 @@
 #include "unchm.rh"
 #include "unchm.rh2"
 #include "lang\lang.rh"
+#include "arcprobe.h"
 
 // ****************************************************************************
 
@@ -244,6 +245,13 @@ BOOL CPluginInterfaceForArchiver::Init()
     CALL_STACK_MESSAGE1("CPluginInterfaceForArchiver::Init()");
 
     return TRUE;
+}
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kItsf[] = {'I', 'T', 'S', 'F'};
+    return ArchiveProbeScan(fileName, kItsf, sizeof(kItsf), 8, 0);
 }
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander,

--- a/src/plugins/unchm/unchm.h
+++ b/src/plugins/unchm/unchm.h
@@ -58,6 +58,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     // plugin-specific methods
 public:

--- a/src/plugins/unfat/unfat.cpp
+++ b/src/plugins/unfat/unfat.cpp
@@ -13,6 +13,7 @@
 
 #include "unfat.h"
 #include "fat.h"
+#include "arcprobe.h"
 
 #include "unfat.rh"
 #include "unfat.rh2"
@@ -248,6 +249,18 @@ CPluginInterface::GetInterfaceForArchiver()
 //
 // CPluginInterfaceForArchiver
 //
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kFat[] = {0x55, 0xAA};
+    HANDLE file = ArchiveProbeOpenRead(fileName);
+    if (file == INVALID_HANDLE_VALUE)
+        return FALSE;
+    BOOL found = ArchiveProbeMatchAt(file, 510, kFat, sizeof(kFat));
+    CloseHandle(file);
+    return found;
+}
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander,
                                               const char* fileName,

--- a/src/plugins/unfat/unfat.h
+++ b/src/plugins/unfat/unfat.h
@@ -58,6 +58,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 };
 
 class CPluginInterface : public CPluginInterfaceAbstract

--- a/src/plugins/uniso/uniso.cpp
+++ b/src/plugins/uniso/uniso.cpp
@@ -11,6 +11,7 @@
 #include "uniso.rh"
 #include "uniso.rh2"
 #include "lang\lang.rh"
+#include "arcprobe.h"
 
 // ****************************************************************************
 
@@ -420,6 +421,19 @@ BOOL CPluginInterfaceForArchiver::Init()
     CALL_STACK_MESSAGE1("CPluginInterfaceForArchiver::Init()");
 
     return TRUE;
+}
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kCd001[] = {'C', 'D', '0', '0', '1'};
+    HANDLE file = ArchiveProbeOpenRead(fileName);
+    if (file == INVALID_HANDLE_VALUE)
+        return FALSE;
+    BOOL found = ArchiveProbeMatchAt(file, 0x8001, kCd001, sizeof(kCd001)) ||
+                 ArchiveProbeMatchAt(file, 0x8801, kCd001, sizeof(kCd001));
+    CloseHandle(file);
+    return found;
 }
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander,

--- a/src/plugins/uniso/uniso.h
+++ b/src/plugins/uniso/uniso.h
@@ -70,6 +70,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     // plugin's own methods
 public:

--- a/src/plugins/unlha/unlha.cpp
+++ b/src/plugins/unlha/unlha.cpp
@@ -8,6 +8,7 @@
 #include "unlha.rh"
 #include "unlha.rh2"
 #include "lang\lang.rh"
+#include "arcprobe.h"
 
 // ****************************************************************************
 
@@ -135,6 +136,37 @@ CPluginInterface::GetInterfaceForArchiver()
 //
 // CPluginInterfaceForArchiver
 //
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    HANDLE file = ArchiveProbeOpenRead(fileName);
+    if (file == INVALID_HANDLE_VALUE)
+        return FALSE;
+    const DWORD toRead = 65536;
+    unsigned char* buf = (unsigned char*)malloc(toRead);
+    BOOL found = FALSE;
+    if (buf != NULL)
+    {
+        DWORD read = 0;
+        if (ReadFile(file, buf, toRead, &read, NULL) && read >= 7)
+        {
+            DWORD last = read - 5;
+            DWORD i;
+            for (i = 2; i < last; i++)
+            {
+                if (buf[i] == '-' && buf[i + 1] == 'l' && buf[i + 4] == '-')
+                {
+                    found = TRUE;
+                    break;
+                }
+            }
+        }
+        free(buf);
+    }
+    CloseHandle(file);
+    return found;
+}
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                               CSalamanderDirectoryAbstract* dir,

--- a/src/plugins/unlha/unlha.h
+++ b/src/plugins/unlha/unlha.h
@@ -55,6 +55,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     void UnpackInnerBody(FILE* f, const char* targetDir, const char* fileName, LHA_HEADER& hdr, BOOL bDir);
     BOOL MakeFilesList(TDirectArray<int>& offsets, SalEnumSelection next, void* nextParam, const char* targetDir);

--- a/src/plugins/unmime/unmime.cpp
+++ b/src/plugins/unmime/unmime.cpp
@@ -9,6 +9,7 @@
 #include "parser.h"
 #include "decoder.h"
 #include "unmime.h"
+#include "arcprobe.h"
 
 // ****************************************************************************
 
@@ -245,6 +246,17 @@ static void ShowBadBlockMessage(CStartMarker* m, BOOL bDontShow[][2])
         SalamanderGeneral->ShowMessageBox(text, LoadStr(IDS_PLUGINNAME), MSGBOX_INFO);
         bDontShow[e][m->iBadBlock - 1] = TRUE;
     }
+}
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kMime[] = {'M', 'I', 'M', 'E', '-', 'V', 'e', 'r', 's', 'i', 'o', 'n', ':'};
+    static const unsigned char kBegin[] = {'b', 'e', 'g', 'i', 'n', ' '};
+    static const unsigned char kContent[] = {'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':'};
+    return ArchiveProbeScan(fileName, kMime, sizeof(kMime), 4096, 0) ||
+           ArchiveProbeScan(fileName, kBegin, sizeof(kBegin), 256, 0) ||
+           ArchiveProbeScan(fileName, kContent, sizeof(kContent), 4096, 0);
 }
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,

--- a/src/plugins/unmime/unmime.h
+++ b/src/plugins/unmime/unmime.h
@@ -89,6 +89,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 };
 
 class CPluginInterface : public CPluginInterfaceAbstract

--- a/src/plugins/unole/unole2.cpp
+++ b/src/plugins/unole/unole2.cpp
@@ -9,6 +9,7 @@
 #include "unOLE2.rh"
 #include "unOLE2.rh2"
 #include "lang\lang.rh"
+#include "arcprobe.h"
 
 #define BUF_SIZE 65536
 
@@ -330,6 +331,13 @@ BOOL OpenStorage(const char* fileName, LPSTORAGE* ppStorage, LPMALLOC* ppIMalloc
     }
     return TRUE;
 } /* OpenStorage */
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kOle[] = {0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1};
+    return ArchiveProbeScan(fileName, kOle, sizeof(kOle), 8, 0);
+}
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                               CSalamanderDirectoryAbstract* dir,

--- a/src/plugins/unole/unole2.h
+++ b/src/plugins/unole/unole2.h
@@ -51,6 +51,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     BOOL Init();
 };

--- a/src/plugins/unrar/unrar.cpp
+++ b/src/plugins/unrar/unrar.cpp
@@ -3,6 +3,7 @@
 
 #include "precomp.h"
 #include <string>
+#include "arcprobe.h"
 
 // ****************************************************************************
 
@@ -287,6 +288,13 @@ CPluginInterface::GetInterfaceForArchiver()
 //
 // CPluginInterfaceForArchiver
 //
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kRar[] = {0x52, 0x61, 0x72, 0x21, 0x1A, 0x07}; // "Rar!\x1a\x07"
+    return ArchiveProbeScan(fileName, kRar, sizeof(kRar), 2 * 1024 * 1024, 0);
+}
 
 BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                               CSalamanderDirectoryAbstract* dir,

--- a/src/plugins/unrar/unrar.h
+++ b/src/plugins/unrar/unrar.h
@@ -180,6 +180,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 
     BOOL Error(int error, ...);
 

--- a/src/plugins/zip/main.cpp
+++ b/src/plugins/zip/main.cpp
@@ -14,6 +14,7 @@
 #include "spl_base.h"
 #include "spl_gen.h"
 #include "spl_arc.h"
+#include "arcprobe.h"
 #include "spl_menu.h"
 #include "spl_vers.h"
 #include "dbg.h"
@@ -1040,6 +1041,20 @@ BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* 
     }
     pluginData = new CPluginDataInterface();
     return TRUE;
+}
+
+BOOL CPluginInterfaceForArchiver::CanOpenArchive(const char* fileName)
+{
+    CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::CanOpenArchive(%s)", fileName);
+    static const unsigned char kLocal[] = {0x50, 0x4B, 0x03, 0x04};
+    static const unsigned char kEocd[] = {0x50, 0x4B, 0x05, 0x06};
+    static const unsigned char kZip64[] = {0x50, 0x4B, 0x06, 0x06};
+    if (ArchiveProbeScan(fileName, kLocal, sizeof(kLocal), 8, 0))
+        return TRUE;
+    // EOCD lives in the last 64 KB + 22 bytes; also covers ZIP SFX stubs.
+    if (ArchiveProbeScan(fileName, kEocd, sizeof(kEocd), 0, 65557))
+        return TRUE;
+    return ArchiveProbeScan(fileName, kZip64, sizeof(kZip64), 0, 65557);
 }
 
 BOOL CPluginInterfaceForArchiver::UnpackArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,

--- a/src/plugins/zip/zipdll.h
+++ b/src/plugins/zip/zipdll.h
@@ -68,6 +68,7 @@ public:
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) { return FALSE; }
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) {}
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) { return FALSE; }
+    virtual BOOL WINAPI CanOpenArchive(const char* fileName);
 };
 
 class CPluginInterfaceForMenuExt : public CPluginInterfaceForMenuExtAbstract

--- a/src/plugins1.cpp
+++ b/src/plugins1.cpp
@@ -3836,6 +3836,19 @@ BOOL CPluginData::CanCloseArchive(CFilesWindow* panel, const char* archiveFileNa
     return ret;
 }
 
+BOOL CPluginData::CanOpenArchive(const char* name)
+{
+    CALL_STACK_MESSAGE4("CPluginData::CanOpenArchive(%s) (%s v. %s)", name, DLLName, Version);
+    if (!SupportPanelView)
+        return FALSE;
+    // BuiltForVersion is valid only after the plugin is loaded.
+    if (!InitDLL(MainWindow->HWindow, TRUE, FALSE) || !PluginIfaceForArchiver.NotEmpty())
+        return FALSE;
+    if (BuiltForVersion < SAL_SDK_VER_CANOPENARCHIVE)
+        return FALSE;
+    return PluginIfaceForArchiver.CanOpenArchive(name);
+}
+
 BOOL CPluginData::CanViewFile(const char* name)
 {
     CALL_STACK_MESSAGE4("CPluginData::CanViewFile(%s) (%s v. %s)", name, DLLName, Version);

--- a/src/plugins2.cpp
+++ b/src/plugins2.cpp
@@ -922,6 +922,7 @@ void CPlugins::CalculateStateCache()
         if (MainWindow->GetActivePanel()->Is(ptZIPArchive))
         {
             int format = PackerFormatConfig.PackIsArchive(MainWindow->GetActivePanel()->GetZIPArchive());
+            CPluginData* archivePlugin = NULL;
             if (format != 0) // not an error
             {
                 format--;
@@ -933,6 +934,17 @@ void CPlugins::CalculateStateCache()
                     index = PackerFormatConfig.GetPackerIndex(format);
                     if (index < 0)
                         StateCache.ActivePackerIndex = -index - 1; // it's a plugin
+                }
+            }
+            else
+            {
+                archivePlugin = PackGetPluginForArchiveFile(MainWindow->GetActivePanel()->GetZIPArchive(),
+                                                           MainWindow->GetActivePanel());
+                if (archivePlugin != NULL)
+                {
+                    StateCache.ActiveUnpackerIndex = Plugins.GetIndex(archivePlugin->GetPluginInterface()->GetInterface());
+                    if (archivePlugin->SupportPanelEdit)
+                        StateCache.ActivePackerIndex = StateCache.ActiveUnpackerIndex;
                 }
             }
         }
@@ -957,6 +969,7 @@ void CPlugins::CalculateStateCache()
         if (MainWindow->GetNonActivePanel()->Is(ptZIPArchive))
         {
             int format = PackerFormatConfig.PackIsArchive(MainWindow->GetNonActivePanel()->GetZIPArchive());
+            CPluginData* archivePlugin = NULL;
             if (format != 0) // not an error
             {
                 format--;
@@ -968,6 +981,17 @@ void CPlugins::CalculateStateCache()
                     index = PackerFormatConfig.GetPackerIndex(format);
                     if (index < 0)
                         StateCache.NonactivePackerIndex = -index - 1; // it's a plugin
+                }
+            }
+            else
+            {
+                archivePlugin = PackGetPluginForArchiveFile(MainWindow->GetNonActivePanel()->GetZIPArchive(),
+                                                           MainWindow->GetNonActivePanel());
+                if (archivePlugin != NULL)
+                {
+                    StateCache.NonactiveUnpackerIndex = Plugins.GetIndex(archivePlugin->GetPluginInterface()->GetInterface());
+                    if (archivePlugin->SupportPanelEdit)
+                        StateCache.NonactivePackerIndex = StateCache.NonactiveUnpackerIndex;
                 }
             }
         }

--- a/src/tests/archive_ctrl_pgdn_contract_tests.py
+++ b/src/tests/archive_ctrl_pgdn_contract_tests.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+SPL_ARC = SRC / "plugins" / "shared" / "spl_arc.h"
+SPL_VERS = SRC / "plugins" / "shared" / "spl_vers.h"
+PLUGINS_H = SRC / "plugins.h"
+PLUGINS1 = SRC / "plugins1.cpp"
+FILESWN0 = SRC / "fileswn0.cpp"
+PACK_H = SRC / "pack.h"
+PACK1 = SRC / "pack1.cpp"
+FILESWND_H = SRC / "fileswnd.h"
+SEVEN_ZIP = SRC / "plugins" / "7zip" / "7zip.cpp"
+
+REMOVED_DOC_EXTS = (
+    "doc",
+    "docx",
+    "xls",
+    "xlsx",
+    "ppt",
+    "pptx",
+    "odt",
+    "ods",
+    "epub",
+    "xpi",
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def function_body(text: str, signature: str) -> str:
+    start = text.index(signature)
+    brace = text.index("{", start)
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace : index + 1]
+    raise AssertionError("unterminated function: " + signature)
+
+
+def split_extensions(mask):
+    parts = []
+    for raw in mask.replace("*.", "").lower().split(";"):
+        ext = raw.strip().lstrip(".")
+        if ext:
+            parts.append(ext)
+    return set(parts)
+
+
+def main() -> int:
+    spl_arc = SPL_ARC.read_text(encoding="utf-8")
+    class_match = re.search(
+        r"class CPluginInterfaceForArchiverAbstract\b.*?\{(.*)^\};",
+        spl_arc,
+        re.DOTALL | re.MULTILINE,
+    )
+    require(class_match is not None, "CPluginInterfaceForArchiverAbstract was not found")
+    methods = re.findall(r"virtual\s+\w[\w\s\*&]*\s+WINAPI\s+(\w+)\s*\(", class_match.group(1))
+    require(methods, "no WINAPI methods found on CPluginInterfaceForArchiverAbstract")
+    require(
+        methods[-1] == "CanOpenArchive",
+        "CanOpenArchive must be the last method in CPluginInterfaceForArchiverAbstract, got "
+        + methods[-1],
+    )
+    require(
+        "PrematureDeleteTmpCopy" in methods
+        and methods.index("PrematureDeleteTmpCopy") == len(methods) - 2,
+        "CanOpenArchive must be appended after PrematureDeleteTmpCopy",
+    )
+
+    spl_vers = SPL_VERS.read_text(encoding="utf-8")
+    require(
+        re.search(r"#define\s+LAST_VERSION_OF_SALAMANDER\s+106\b", spl_vers) is not None,
+        "LAST_VERSION_OF_SALAMANDER must be 106",
+    )
+    require(
+        re.search(r"#define\s+SAL_SDK_VER_CANOPENARCHIVE\s+106\b", spl_vers) is not None,
+        "SAL_SDK_VER_CANOPENARCHIVE must be 106",
+    )
+
+    plugins1 = PLUGINS1.read_text(encoding="utf-8")
+    can_open = function_body(plugins1, "BOOL CPluginData::CanOpenArchive")
+    require(
+        "BuiltForVersion < SAL_SDK_VER_CANOPENARCHIVE" in can_open,
+        "CPluginData::CanOpenArchive must gate calls on BuiltForVersion",
+    )
+    require(
+        "InitDLL(" in can_open,
+        "CPluginData::CanOpenArchive must load the plugin before reading BuiltForVersion",
+    )
+    require(
+        can_open.find("InitDLL(") < can_open.find("BuiltForVersion < SAL_SDK_VER_CANOPENARCHIVE"),
+        "BuiltForVersion gate must run after InitDLL so unloaded plugins are probed",
+    )
+
+    fileswn0 = FILESWN0.read_text(encoding="utf-8")
+    ctrl = function_body(fileswn0, "void CFilesWindow::CtrlPageDnOrEnter")
+    require(
+        "TryEnterFileAsArchive" in ctrl,
+        "Ctrl+PgDown on a non-archive disk file must call TryEnterFileAsArchive",
+    )
+    require(
+        "ExecuteAssociation" not in ctrl,
+        "CtrlPageDnOrEnter must not call ExecuteAssociation",
+    )
+    try_enter = function_body(fileswn0, "void CFilesWindow::TryEnterFileAsArchive")
+    require(
+        "ExecuteAssociation" not in try_enter,
+        "TryEnterFileAsArchive must not call ExecuteAssociation",
+    )
+    require(
+        "PackProbeArchivePlugin" in try_enter and "ChangePathToArchive" in try_enter,
+        "TryEnterFileAsArchive must probe plugins and open with ChangePathToArchive",
+    )
+    require(
+        "IDS_FILEISNOTARCHIVE" in try_enter,
+        "failed probes must show IDS_FILEISNOTARCHIVE",
+    )
+
+    pack_h = PACK_H.read_text(encoding="utf-8")
+    require(
+        re.search(
+            r"BOOL PackList\([^;]*CPluginData\*\s*forcedPlugin\s*=\s*NULL\s*\)",
+            pack_h,
+            re.DOTALL,
+        )
+        is not None,
+        "PackList must accept an optional forced plugin",
+    )
+    fileswnd_h = FILESWND_H.read_text(encoding="utf-8")
+    require(
+        re.search(
+            r"BOOL ChangePathToArchive\([^;]*CPluginData\*\s*forcedPlugin\s*=\s*NULL\s*\)",
+            fileswnd_h,
+            re.DOTALL,
+        )
+        is not None,
+        "ChangePathToArchive must accept an optional forced plugin",
+    )
+
+    pack1 = PACK1.read_text(encoding="utf-8")
+    probe = function_body(pack1, "CPluginData* PackProbeArchivePlugin")
+    require(
+        "IsSevenZipArchiverPlugin" in probe,
+        "probe order must identify the 7-Zip plugin",
+    )
+    require(
+        probe.rfind("sevenZip") > probe.find("IsSevenZipArchiverPlugin"),
+        "7-Zip must be tried last in PackProbeArchivePlugin",
+    )
+
+    seven_zip = SEVEN_ZIP.read_text(encoding="utf-8")
+    require(
+        re.search(r"#define\s+CURRENT_CONFIG_VERSION\s+7\b", seven_zip) is not None,
+        "7-Zip CURRENT_CONFIG_VERSION must be 7",
+    )
+    connect_start = seven_zip.index("void CPluginInterface::Connect")
+    connect_end = seven_zip.index("void CPluginInterface::Event", connect_start)
+    connect = seven_zip[connect_start:connect_end]
+    require(
+        "ConfigVersion < 7" in connect and "ForceRemovePanelArchiver" in connect,
+        "Connect must ForceRemovePanelArchiver on ConfigVersion < 7",
+    )
+
+    association_masks = []
+    association_masks.extend(re.findall(r'AddPanelArchiver\(\s*"([^"]*)"', connect))
+    association_masks.extend(re.findall(r'AddCustomUnpacker\(\s*"[^"]*"\s*,\s*"([^"]*)"', connect))
+    groups = re.search(
+        r"panelArchiverExtensionGroups\[\]\s*=\s*\{(.*?)\};",
+        connect,
+        re.DOTALL,
+    )
+    require(groups is not None, "panelArchiverExtensionGroups was not found")
+    association_masks.extend(re.findall(r'"([^"]*)"', groups.group(1)))
+    require(association_masks, "no 7-Zip panel/unpacker association strings found")
+    present = set()
+    for mask in association_masks:
+        present.update(split_extensions(mask))
+    leftover = [ext for ext in REMOVED_DOC_EXTS if ext in present]
+    require(
+        not leftover,
+        "7-Zip AddPanelArchiver/AddCustomUnpacker must not contain " + ", ".join(leftover),
+    )
+    for ext in REMOVED_DOC_EXTS:
+        require(
+            f'ForceRemovePanelArchiver("{ext}")' in connect
+            or f'ForceRemovePanelArchiver("{ext}");' in connect
+            or f'"{ext}"' in connect,
+            f"Connect upgrade must ForceRemovePanelArchiver {ext}",
+        )
+    removed_list = re.search(
+        r"removedDocumentExts\[\]\s*=\s*\{(.*?)\};",
+        connect,
+        re.DOTALL,
+    )
+    require(removed_list is not None, "removedDocumentExts was not found")
+    removed = set(re.findall(r'"([^"]*)"', removed_list.group(1)))
+    missing_force = [ext for ext in REMOVED_DOC_EXTS if ext not in removed]
+    require(
+        not missing_force,
+        "ForceRemovePanelArchiver list is missing " + ", ".join(missing_force),
+    )
+
+    plugins_h = PLUGINS_H.read_text(encoding="utf-8")
+    require(
+        "BOOL CanOpenArchive(const char* fileName)" in plugins_h,
+        "archiver encapsulation must wrap CanOpenArchive",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -3038,6 +3038,7 @@
 #define IDS_EXCOL_REMOVE_FAVORITE                  14423
 #define IDS_EXCOL_PLUGINS                          14424
 #define IDS_FONTDESCRIPTION_UI                      14425
+#define IDS_FILEISNOTARCHIVE                        14426
 
 #define IDS_MENU_OPT_MANAGECONFIG        13169
 

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -311,6 +311,14 @@ try {
             )
         },
         @{
+            Name = 'archive_ctrl_pgdn_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\archive_ctrl_pgdn_contract_tests.py')
+            )
+        },
+        @{
             Name = 'codepage_and_clipboard_contract_tests'
             Arguments = @(
                 '-B',


### PR DESCRIPTION
## Summary
- Ctrl+PgDown probes panel archivers with a new quiet `CanOpenArchive` SDK method (version 106) so files open as archives even with a missing, wrong, or `.exe`/Office extension. Enter and double-click keep the associated action and never run as a fallback.
- After a probe open, refresh/view/unpack/pack fall back to the plugin already listing the file, so `archive.exe` does not fail on F3 or copy.
- 7-Zip config version 7 removes Office/OpenDocument/EPUB/XPI from Archives associations in panel, so Enter opens Word/Excel/etc. while Ctrl+PgDown still browses the package.

Fixes #655

## Test plan
- [x] ASCII zip renamed to `.dat` / no extension: Ctrl+PgDown enters the archive; Enter does not
- [x] Unicode directory + Unicode name, and a Win32 long path
- [x] RAR SFX `.exe`: Ctrl+PgDown lists the archive and does not execute it
- [x] Existing config upgrade removes `doc`/`docx`/`xls`/`xlsx`/`ppt`/`pptx`/`odt`/`ods`/`epub`/`xpi` from Configuration → Archives associations in panel
- [x] `.docx` / `.xlsx` / `.pptx` / `.odt`: Enter opens the associated app; Ctrl+PgDown opens as ZIP
- [x] `.doc`: Enter opens Word; Ctrl+PgDown can open as OLE
- [x] Refresh, F3, and copy from a probed archive still work
- [x] Non-archive file shows "The selected file is not a supported archive" and stays put
- [x] `src/tests/archive_ctrl_pgdn_contract_tests.py` (via `tools/run_native_tests.ps1`)