### PR TITLE
Let Registry Search be aborted and keep Find from crashing on open

### DIFF
--- a/src/plugins/regedt/finddlg.cpp
+++ b/src/plugins/regedt/finddlg.cpp
@@ -39,41 +39,36 @@ void CStatusBar::SetBase(LPCWSTR text, BOOL updateInIdle)
 {
     CALL_STACK_MESSAGE_NONE
     //  CALL_STACK_MESSAGE2("CStatusBar::SetBase(, %d)", updateInIdle);
+    // Never SendMessage while holding Section: the dialog thread takes the same
+    // lock from OnEnterIdle, so a cross-thread SB_SETTEXT would deadlock and
+    // freeze Stop / WM_CLOSE for the whole search.
+    BOOL paintNow = FALSE;
     Section.Enter();
     lstrcpynW(Text, text, MAX_FULL_KEYNAME + 50);
     BaseLen = (int)wcslen(Text);
-    // do not wait for a repaint
-    if (!Dirty)
-    {
-        if (updateInIdle)
-            UpdateInIdle = TRUE;
-        else
-        {
-            Dirty = TRUE;
-            UpdateText();
-        }
-    }
+    if (updateInIdle)
+        UpdateInIdle = TRUE;
+    else
+        paintNow = TRUE;
     Section.Leave();
+    if (paintNow)
+        UpdateText();
 }
 
 void CStatusBar::Set(LPCWSTR text, BOOL updateInIdle)
 {
     CALL_STACK_MESSAGE_NONE
     //  CALL_STACK_MESSAGE2("CStatusBar::Set(, %d)", updateInIdle);
+    BOOL paintNow = FALSE;
     Section.Enter();
     lstrcpynW(Text + BaseLen, text, MAX_FULL_KEYNAME + 49 - BaseLen);
-    // do not wait for a repaint
-    if (!Dirty)
-    {
-        if (updateInIdle)
-            UpdateInIdle = TRUE;
-        else
-        {
-            Dirty = TRUE;
-            UpdateText();
-        }
-    }
+    if (updateInIdle)
+        UpdateInIdle = TRUE;
+    else
+        paintNow = TRUE;
     Section.Leave();
+    if (paintNow)
+        UpdateText();
 }
 
 void CStatusBar::UpdateParts()
@@ -94,28 +89,29 @@ void CStatusBar::UpdateParts()
 void CStatusBar::UpdateText()
 {
     CALL_STACK_MESSAGE1("CStatusBar::UpdateText()");
-    if (HWindow != NULL)
-        SendMessageW(HWindow, SB_SETTEXTW, 0, (LPARAM)Text);
+    WCHAR text[MAX_FULL_KEYNAME + 50];
+    Section.Enter();
+    lstrcpynW(text, Text, _countof(text));
     Dirty = FALSE;
+    Section.Leave();
+    if (HWindow != NULL)
+        SendMessageW(HWindow, SB_SETTEXTW, 0, (LPARAM)text);
 }
 
 void CStatusBar::OnEnterIdle()
 {
     CALL_STACK_MESSAGE_NONE
     //  CALL_STACK_MESSAGE1("CStatusBar::OnEnterIdle()");
+    BOOL paintNow = FALSE;
     Section.Enter();
-    // should we perform the update while idle?
     if (UpdateInIdle)
     {
         UpdateInIdle = FALSE;
-        // do not wait for a repaint
-        if (!Dirty)
-        {
-            Dirty = TRUE;
-            UpdateText();
-        }
+        paintNow = TRUE;
     }
     Section.Leave();
+    if (paintNow)
+        UpdateText();
 }
 
 LRESULT
@@ -1265,11 +1261,11 @@ BOOL CFindThread::ScanKeyAux(int root, LPWSTR key, BOOL& skip, BOOL& skipAllErro
     CALL_STACK_MESSAGE_NONE
     //  CALL_STACK_MESSAGE4("CFindThread::ScanKeyAux(%d, , %d, %d, , )", root, skip,
     //                           skipAllErrors);
-    // status text
+    // status text: never SendMessage from this thread; the dialog paints on idle/timer
     if ((int)(GetTickCount() - NextStatusUpdate) > 0)
     {
-        FindDialog->StatusBar->Set(key);
-        NextStatusUpdate = GetTickCount() + 1;
+        FindDialog->StatusBar->Set(key, TRUE);
+        NextStatusUpdate = GetTickCount() + 100;
     }
 
     // check for cancellation by the user
@@ -1348,9 +1344,6 @@ BOOL CFindThread::ScanKeyAux(int root, LPWSTR key, BOOL& skip, BOOL& skipAllErro
                         RegCloseKey(hKey);
                         return Error(IDS_LOWMEM);
                     }
-                    // every 100 added items ask the list view to repaint
-                    if (FindDialog->FoundVisibleCount + 100 < FindDialog->List->GetCount())
-                        PostMessage(FindDialog->HWindow, WM_USER_ADDFILE, 0, 0);
                 }
             }
             else
@@ -1430,9 +1423,6 @@ BOOL CFindThread::ScanKeyAux(int root, LPWSTR key, BOOL& skip, BOOL& skipAllErro
                     RegCloseKey(hKey);
                     return Error(IDS_LOWMEM);
                 }
-                // every 100 added items ask the list view to repaint
-                if (FindDialog->FoundVisibleCount + 100 < FindDialog->List->GetCount())
-                    PostMessage(FindDialog->HWindow, WM_USER_ADDFILE, 0, 0);
             }
 
             if (IncludeSubkeys)
@@ -1503,7 +1493,7 @@ BOOL CFindThread::ScanKey(int root, LPWSTR key, BOOL& skip, BOOL& skipAllErrors,
     //                      skipAllErrors);
     WCHAR base[50 + MAX_PREDEF_KEYNAME];
     SalPrintfW(base, 50, LoadStrW(IDS_SEARCHING), PredefinedHKeys[root].KeyName);
-    FindDialog->StatusBar->SetBase(base);
+    FindDialog->StatusBar->SetBase(base, TRUE);
     return ScanKeyAux(root, key, skip, skipAllErrors, nameBuffer, stack);
 }
 

--- a/src/plugins/regedt/finddlg.h
+++ b/src/plugins/regedt/finddlg.h
@@ -30,8 +30,10 @@ public:
     void UpdateText();
 
     // set the base to which Set appends additional text
+    // callers on a non-UI thread must pass updateInIdle = TRUE
     void SetBase(LPCWSTR text, BOOL updateInIdle = FALSE);
     // append to the base set via SetBase
+    // callers on a non-UI thread must pass updateInIdle = TRUE
     void Set(LPCWSTR text, BOOL updateInIdle = FALSE);
     // returns the complete string
     //void Get(char *buf, int bufSize);

--- a/src/plugins/regedt/finddlg2.cpp
+++ b/src/plugins/regedt/finddlg2.cpp
@@ -262,11 +262,12 @@ void CFindDialog::UpdateListViewItems()
         // tell the list view the new item count
         ListView_SetItemCountEx(List->HWindow, count, LVSICF_NOINVALIDATEALL | LVSICF_NOSCROLL);
         // if this is the first added data, select the first item in the selection
-        // and set the focus to the list view
+        // and set the focus to the list view (but not while searching: keep Stop focused)
         if (FoundVisibleCount == 0 && count > 0)
         {
             ListView_SetItemState(List->HWindow, 0,
-                                  LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED) if (GetFocus() != List->HWindow)
+                                  LVIS_FOCUSED | LVIS_SELECTED, LVIS_FOCUSED | LVIS_SELECTED);
+            if (!SearchInProgress && GetFocus() != List->HWindow)
                 SendMessage(HWindow, WM_NEXTDLGCTL, (WPARAM)List->HWindow, TRUE);
         }
 
@@ -410,7 +411,7 @@ void CFindDialog::StartSearch()
         SearchInProgress = TRUE;
         Stopped = FALSE;
         SetWindowText(GetDlgItem(HWindow, IDOK), LoadStr(IDS_STOP));
-        SetTimer(HWindow, IDT_REFRESH_LISTVIEW, 500, NULL);
+        SetTimer(HWindow, IDT_REFRESH_LISTVIEW, 100, NULL);
         //UpdateStatusText();
         EnableControls(FALSE);
     }
@@ -991,6 +992,7 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
         }
         }
+        break; // do not fall through: WM_COMMAND lParam is a control HWND, not NMHDR
     }
 
     case WM_NOTIFY:
@@ -1146,9 +1148,12 @@ CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_TIMER:
     {
-        if ((int)(GetTickCount() - NextUpdate) > 0 && List->GetCount() > FoundVisibleCount)
+        if (wParam == IDT_REFRESH_LISTVIEW)
         {
-            UpdateListViewItems();
+            if ((int)(GetTickCount() - NextUpdate) > 0 && List->GetCount() > FoundVisibleCount)
+                UpdateListViewItems();
+            if (SearchInProgress && StatusBar != NULL)
+                StatusBar->OnEnterIdle();
         }
         return TRUE;
     }

--- a/src/tests/regedt_search_stop_contract_tests.py
+++ b/src/tests/regedt_search_stop_contract_tests.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+FINDDLG = SRC / "plugins" / "regedt" / "finddlg.cpp"
+FINDDLG2 = SRC / "plugins" / "regedt" / "finddlg2.cpp"
+FINDDLG_H = SRC / "plugins" / "regedt" / "finddlg.h"
+SEARCH_HELP = SRC / "plugins" / "regedt" / "help" / "hh" / "regedt" / "dlgboxes_search.htm"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def function_body(text: str, signature: str) -> str:
+    start = text.index(signature)
+    brace = text.index("{", start)
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace : index + 1]
+    raise AssertionError("unterminated function: " + signature)
+
+
+def assert_no_paint_under_lock(func: str, name: str) -> None:
+    pos = 0
+    found_lock = False
+    while True:
+        enter = func.find("Section.Enter();", pos)
+        if enter < 0:
+            require(found_lock, name + " does not take Section")
+            return
+        found_lock = True
+        leave = func.find("Section.Leave();", enter)
+        require(leave > enter, name + " takes Section without leaving it")
+        body = func[enter:leave]
+        require("UpdateText(" not in body, name + " calls UpdateText while holding Section")
+        require("SendMessage" not in body, name + " sends a window message while holding Section")
+        pos = leave + 1
+
+
+def main() -> int:
+    finddlg = FINDDLG.read_text(encoding="utf-8")
+    finddlg2 = FINDDLG2.read_text(encoding="utf-8")
+    finddlg_h = FINDDLG_H.read_text(encoding="utf-8")
+    help_text = SEARCH_HELP.read_text(encoding="utf-8")
+
+    set_base = function_body(finddlg, "void CStatusBar::SetBase(LPCWSTR text, BOOL updateInIdle)")
+    set_text = function_body(finddlg, "void CStatusBar::Set(LPCWSTR text, BOOL updateInIdle)")
+    update_text = function_body(finddlg, "void CStatusBar::UpdateText()")
+    on_idle = function_body(finddlg, "void CStatusBar::OnEnterIdle()")
+    scan_aux = function_body(
+        finddlg,
+        "BOOL CFindThread::ScanKeyAux(int root, LPWSTR key, BOOL& skip, BOOL& skipAllErrors,",
+    )
+    scan_key = function_body(
+        finddlg,
+        "BOOL CFindThread::ScanKey(int root, LPWSTR key, BOOL& skip, BOOL& skipAllErrors,",
+    )
+    update_list = function_body(finddlg2, "void CFindDialog::UpdateListViewItems()")
+    start_search = function_body(finddlg2, "void CFindDialog::StartSearch()")
+    stop_search = function_body(finddlg2, "void CFindDialog::StopSearch()")
+    dialog_proc = function_body(finddlg2, "CFindDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)")
+
+    assert_no_paint_under_lock(set_base, "CStatusBar::SetBase")
+    assert_no_paint_under_lock(set_text, "CStatusBar::Set")
+    assert_no_paint_under_lock(update_text, "CStatusBar::UpdateText")
+    assert_no_paint_under_lock(on_idle, "CStatusBar::OnEnterIdle")
+
+    require("Section.Leave();" in update_text, "UpdateText copies the caption under Section")
+    require(
+        update_text.find("Section.Leave();") < update_text.find("SendMessageW"),
+        "UpdateText must SendMessageW only after leaving Section",
+    )
+    require("if (paintNow)" in set_base and "UpdateText();" in set_base,
+            "SetBase paints only after leaving Section")
+    require("if (paintNow)" in set_text and "UpdateText();" in set_text,
+            "Set paints only after leaving Section")
+
+    require('StatusBar->Set(key, TRUE)' in scan_aux,
+            "registry search must not SendMessage the status bar from the worker thread")
+    require("StatusBar->Set(key);" not in scan_aux,
+            "registry search still updates the status bar synchronously from the worker")
+    require("GetTickCount() + 100" in scan_aux,
+            "status-bar dirty flag is not throttled")
+    require("WM_USER_ADDFILE" not in scan_aux,
+            "search worker still floods the dialog with WM_USER_ADDFILE")
+    require("SetBase(base, TRUE)" in scan_key,
+            "ScanKey still SendMessages the status-bar base from the worker thread")
+
+    require("if (!SearchInProgress && GetFocus() != List->HWindow)" in update_list,
+            "first results must not steal focus from Stop while searching")
+    require(
+        "SetTimer(HWindow, IDT_REFRESH_LISTVIEW, 100, NULL);" in start_search,
+        "search dialog timer must stay responsive during a long registry scan",
+    )
+    require("SetEvent(CancelEvent);" in stop_search, "StopSearch must signal CancelEvent")
+    require("StatusBar->OnEnterIdle();" in dialog_proc,
+            "the search timer must paint deferred status-bar text")
+    require("case IDOK:" in dialog_proc and "StopSearch();" in dialog_proc,
+            "Find Now/Stop must abort an in-progress search")
+    require("case WM_CLOSE:" in dialog_proc,
+            "closing the search dialog must be handled")
+    close_body = dialog_proc[dialog_proc.find("case WM_CLOSE:") : dialog_proc.find("case WM_DESTROY:")]
+    require("StopSearch();" in close_body, "WM_CLOSE must abort an in-progress search")
+    require("CloseWhenSearchFinishes = TRUE;" in close_body,
+            "WM_CLOSE during search must close after the worker stops")
+    idok_body = dialog_proc[dialog_proc.find("case IDOK:") : dialog_proc.find("case IDCANCEL:")]
+    require("if (SearchInProgress)" in idok_body and "StopSearch();" in idok_body,
+            "the Stop button must call StopSearch")
+
+    command_to_notify = dialog_proc[dialog_proc.find("case WM_COMMAND:") : dialog_proc.find("case WM_NOTIFY:")].rstrip()
+    require(
+        command_to_notify.endswith("break; // do not fall through: WM_COMMAND lParam is a control HWND, not NMHDR\n    }")
+        or "break; // do not fall through" in command_to_notify[-200:],
+        "WM_COMMAND must not fall through into WM_NOTIFY (Search for combo SETFOCUS would crash)",
+    )
+
+    require("callers on a non-UI thread must pass updateInIdle = TRUE" in finddlg_h,
+            "CStatusBar documents that worker threads must not paint immediately")
+    require("replaced by the Stop button" in help_text,
+            "help still documents that search can be stopped")
+
+    print("regedt_search_stop_contract_tests: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -319,6 +319,14 @@ try {
             )
         },
         @{
+            Name = 'regedt_search_stop_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\regedt_search_stop_contract_tests.py')
+            )
+        },
+        @{
             Name = 'codepage_and_clipboard_contract_tests'
             Arguments = @(
                 '-B',


### PR DESCRIPTION
## Summary
- Fixes Registry Editor search so Stop, Esc, and closing the dialog can abort a long scan (Fixes #707). Worker-thread status-bar updates no longer `SendMessage` while holding the same lock the UI idle handler takes, which previously deadlocked the Find window.
- Stops `WM_COMMAND` from falling through into `WM_NOTIFY`, which crashed Salamander when the Search for combo received focus while opening Find.
- Adds a source-contract test covering abort, deferred status painting, and the missing `break`.

## Test plan
- [x] Open `reg:\`, press Alt+F7, click Find Now with empty options, then click Stop; search should stop and the dialog should stay usable
- [x] Repeat and close the Find window (X) during a scan; the dialog should close after the worker stops instead of freezing
- [x] Open Windows Registry Search and confirm the dialog appears without crashing
- [x] After Stop, Find Now should work again and results should remain listed

Made with [Cursor](https://cursor.com)