### PR TITLE
Fix live DPI icon switching

### DIFF
--- a/src/codetbl.cpp
+++ b/src/codetbl.cpp
@@ -960,6 +960,36 @@ void CCodeTables::RecognizeFileType(const char* pattern, int patternLen, BOOL fo
     char lastCodePage[101];
     lastCodePage[0] = 0;
     int winCodePageLen = (int)strlen(Table->WinCodePage);
+    BOOL recognitionIsNotAlphaNorNum[256];
+    BOOL recognitionIsAlpha[256];
+    BOOL recognitionIsUpper[256];
+    memcpy(recognitionIsNotAlphaNorNum, IsNotAlphaNorNum, sizeof(recognitionIsNotAlphaNorNum));
+    memcpy(recognitionIsAlpha, IsAlpha, sizeof(recognitionIsAlpha));
+    for (int i = 0; i < 256; i++)
+        recognitionIsUpper[i] = UpperCase[i] == i;
+
+    // The global byte classifications follow the process locale. With a UTF-8
+    // ACP, CP1250 bytes are therefore often treated as punctuation. Recognition
+    // candidates are all converted into WinCodePage, so classify those bytes by
+    // that actual code page instead of by the process ACP.
+    if (IsValidCodePage(Table->WinCodePageIdentifier))
+    {
+        for (int i = 0; i < 256; i++)
+        {
+            char encoded = (char)i;
+            WCHAR character = 0;
+            WORD type = 0;
+            if (MultiByteToWideChar(Table->WinCodePageIdentifier, MB_ERR_INVALID_CHARS,
+                                    &encoded, 1, &character, 1) == 1 &&
+                GetStringTypeW(CT_CTYPE1, &character, 1, &type))
+            {
+                recognitionIsAlpha[i] = (type & C1_ALPHA) != 0;
+                recognitionIsNotAlphaNorNum[i] =
+                    (type & (C1_ALPHA | C1_DIGIT)) == 0;
+                recognitionIsUpper[i] = (type & C1_UPPER) != 0;
+            }
+        }
+    }
     DWORD bestPenalty = 0xFFFFFFFF;
     if (buf != NULL)
     {
@@ -1047,7 +1077,7 @@ void CCodeTables::RecognizeFileType(const char* pattern, int patternLen, BOOL fo
                     }
                     if (*s >= 128)
                         nonAscii++;
-                    if (IsNotAlphaNorNum[*s]) // character is neither alpha nor numeric
+                    if (recognitionIsNotAlphaNorNum[*s]) // character is neither alpha nor numeric
                     {
                         if (*s == '?')
                         {
@@ -1076,7 +1106,7 @@ void CCodeTables::RecognizeFileType(const char* pattern, int patternLen, BOOL fo
                             }
                             if (!skipChar)
                             {
-                                if (s > (const unsigned char*)testBuf && !IsNotAlphaNorNum[*(s - 1)])
+                                if (s > (const unsigned char*)testBuf && !recognitionIsNotAlphaNorNum[*(s - 1)])
                                 {
                                     penalty += PENALTY_NOT_ALPHA_NOR_NUM_PENALTY_ADD1;
                                     // at least three identical characters preceded by alpha or num (frame corner is a letter - e.g. CP437 text and tested page in CP852)
@@ -1086,7 +1116,7 @@ void CCodeTables::RecognizeFileType(const char* pattern, int patternLen, BOOL fo
                                     }
                                 }
                                 penalty += PENALTY_NOT_ALPHA_NOR_NUM_PENALTY;
-                                if (s + 1 < end && !IsNotAlphaNorNum[*(s + 1)])
+                                if (s + 1 < end && !recognitionIsNotAlphaNorNum[*(s + 1)])
                                 {
                                     penalty += PENALTY_NOT_ALPHA_NOR_NUM_PENALTY_ADD2;
                                     // at least three identical characters followed by alpha or num (frame corner is a letter - e.g. CP437 text and tested page in CP852)
@@ -1100,22 +1130,22 @@ void CCodeTables::RecognizeFileType(const char* pattern, int patternLen, BOOL fo
                     }
                     else // character is alpha or numeric
                     {
-                        if (s + 1 < end && !IsNotAlphaNorNum[*(s + 1)]) // next character is also alpha or numeric
+                        if (s + 1 < end && !recognitionIsNotAlphaNorNum[*(s + 1)]) // next character is also alpha or numeric
                         {
                             int c1; // current character: 1 - lower, 2 - upper, 3 - digit
-                            if (!IsAlpha[*s])
+                            if (!recognitionIsAlpha[*s])
                                 c1 = 3;
                             else
-                                c1 = UpperCase[*s] == *s ? 2 : 1;
+                                c1 = recognitionIsUpper[*s] ? 2 : 1;
                             int c2; // next character: 1 - lower, 2 - upper, 3 - digit
-                            if (!IsAlpha[*(s + 1)])
+                            if (!recognitionIsAlpha[*(s + 1)])
                                 c2 = 3;
                             else
-                                c2 = UpperCase[*(s + 1)] == *(s + 1) ? 2 : 1;
+                                c2 = recognitionIsUpper[*(s + 1)] ? 2 : 1;
 
                             if (c1 == 2 && c2 == 1)
                             {
-                                if (s > (const unsigned char*)testBuf && IsAlpha[*(s - 1)])
+                                if (s > (const unsigned char*)testBuf && recognitionIsAlpha[*(s - 1)])
                                     penalty += PENALTY_UPPER_TO_LOWER; // the word "Úrok" would otherwise be re-encoded as MACCE (uppercase 'U' changes to lowercase 'r' in MACCE)
                             }
                             else

--- a/src/codetbl_utils.cpp
+++ b/src/codetbl_utils.cpp
@@ -140,32 +140,69 @@ BOOL ShouldPreferWindowsCodePageText(const char* source, int sourceLength,
                                      const char* recognizedCodePage)
 {
     if (source == NULL || sourceLength <= 0 || recognizedCodePage == NULL ||
-        _strnicmp(recognizedCodePage, "ISO-8859-", 9) != 0 ||
         !IsValidCodePage(windowsCodePage))
     {
         return FALSE;
     }
 
+    if (_strnicmp(recognizedCodePage, "ISO-8859-", 9) == 0)
+    {
+        for (int i = 0; i < sourceLength; ++i)
+        {
+            unsigned char byte = (unsigned char)source[i];
+            if (byte < 0x80 || byte > 0x9F)
+                continue;
+
+            WCHAR character = 0;
+            char encoded = (char)byte;
+            if (MultiByteToWideChar(windowsCodePage, MB_ERR_INVALID_CHARS,
+                                    &encoded, 1, &character, 1) != 1)
+            {
+                continue;
+            }
+
+            WORD type = 0;
+            if (GetStringTypeW(CT_CTYPE1, &character, 1, &type) &&
+                (type & C1_ALPHA) != 0)
+            {
+                return TRUE;
+            }
+        }
+        return FALSE;
+    }
+
+    if (windowsCodePage != 1250 || _stricmp(recognizedCodePage, "CP852") != 0)
+        return FALSE;
+
+    int quotePairs = 0;
+    int separators = 0;
+    int openQuote = -1;
     for (int i = 0; i < sourceLength; ++i)
     {
-        unsigned char byte = (unsigned char)source[i];
-        if (byte < 0x80 || byte > 0x9F)
-            continue;
+        const unsigned char byte = (unsigned char)source[i];
+        const BOOL leftBoundary = i == 0 ||
+            (unsigned char)source[i - 1] <= ' ';
+        const BOOL rightBoundary = i + 1 == sourceLength ||
+            (unsigned char)source[i + 1] <= ' ';
 
-        WCHAR character = 0;
-        char encoded = (char)byte;
-        if (MultiByteToWideChar(windowsCodePage, MB_ERR_INVALID_CHARS,
-                                &encoded, 1, &character, 1) != 1)
+        if (byte == 0x93 && leftBoundary && i + 1 < sourceLength &&
+            (unsigned char)source[i + 1] > ' ')
         {
-            continue;
+            openQuote = i;
         }
-
-        WORD type = 0;
-        if (GetStringTypeW(CT_CTYPE1, &character, 1, &type) &&
-            (type & C1_ALPHA) != 0)
+        else if (byte == 0x94 && openQuote >= 0 && i > openQuote + 1 &&
+                 (unsigned char)source[i - 1] > ' ' && rightBoundary)
         {
-            return TRUE;
+            quotePairs++;
+            openQuote = -1;
+        }
+        else if (byte == 0x9B && leftBoundary && rightBoundary)
+        {
+            separators++;
         }
     }
-    return FALSE;
+
+    return quotePairs >= 2 ||
+           (quotePairs >= 1 && separators >= 2) ||
+           separators >= 4;
 }

--- a/src/codetbl_utils.h
+++ b/src/codetbl_utils.h
@@ -30,10 +30,10 @@ BOOL ConvertConversionTableText(const char* source, UINT sourceCodePage,
 BOOL ConvertLegacyViewerTextToWide(const char* source, int sourceLength,
                                    UINT sourceCodePage, std::wstring* destination);
 
-// ISO-8859 code pages reserve bytes 0x80..0x9F for C1 controls.  When those
-// bytes are letters in the configured Windows code page, the input is strong
-// evidence that it is already in that Windows code page and must not be
-// converted from ISO-8859.
+// ISO-8859 code pages reserve bytes 0x80..0x9F for C1 controls. When those
+// bytes are letters in the configured Windows code page, prefer that page. A
+// narrow CP1250-versus-CP852 rule also recognizes repeated structured Windows
+// typography without treating word-internal CP852 letters as punctuation.
 BOOL ShouldPreferWindowsCodePageText(const char* source, int sourceLength,
                                      UINT windowsCodePage,
                                      const char* recognizedCodePage);

--- a/src/consts.h
+++ b/src/consts.h
@@ -2559,8 +2559,8 @@ extern "C"
 // nastavuje se pri startu Salamandera, testovat zda je nenulova
 extern UINT TaskbarBtnCreatedMsg;
 
-// vrati rozmer ikony s ohledem na promennou SystemDPI
-// pokud je 'large' TRUE, vraci rozmer pro velkou ikonu, jinak pro malou
+// returns the icon dimension for the specified or current system DPI
+int GetIconSizeForDPI(CIconSizeEnum iconSize, int dpi);
 int GetIconSizeForSystemDPI(CIconSizeEnum iconSize);
 
 // vraci aktualni systemove DPI (96, 120, 144, ...)
@@ -2580,7 +2580,8 @@ void TraceDPIState(const char* reason, HWND hWindow);
 // prevod hodnoty navrzene pro 96 DPI do zadaneho DPI
 int ScaleForDPI(int value, int dpi);
 
-// vraci scale odpovidajici aktualnimu DPI; misto 1.0 vraci 100, pro 1.25 vraci 125, atd
+// returns the scale for the specified or current DPI; 100 represents 1.0, 125 represents 1.25, etc.
+int GetScaleForDPI(int dpi);
 int GetScaleForSystemDPI();
 
 // prevod mezi device-independent pixels (DIP) a fyzickymi pixely

--- a/src/consts.h
+++ b/src/consts.h
@@ -1485,7 +1485,8 @@ extern HICON HSharedOverlays[ICONSIZE_COUNT];   // shared (ruka) ve vsech veliko
 extern HICON HShortcutOverlays[ICONSIZE_COUNT]; // shortcut (levy dolni roh) ve vsech velikostech
 extern HICON HSlowFileOverlays[ICONSIZE_COUNT]; // slow files
 
-extern CIconList* SimpleIconLists[ICONSIZE_COUNT]; // simple icons ve vsech velikostech
+extern CIconList* SimpleIconLists[ICONSIZE_COUNT]; // compatibility cache for semantic sizes
+CIconList* GetSimpleIconList(int pixelSize); // lazy panel cache keyed by exact pixels
 
 #define THROBBER_WIDTH 12 // rozmery jednoho policka
 #define THROBBER_HEIGHT 12
@@ -1706,7 +1707,8 @@ int SalMessageBoxEx(const MSGBOXEX_PARAMS* params);
 BOOL StateImageList_Draw(CIconList* iconList, int imageIndex, HDC hDC, int xDst, int yDst,
                          DWORD state, CIconSizeEnum iconSize, DWORD iconOverlayIndex,
                          const RECT* overlayRect, BOOL overlayOnly, BOOL iconOverlayFromPlugin,
-                         int pluginIconOverlaysCount, HICON* pluginIconOverlays, int dpi = 0);
+                         int pluginIconOverlaysCount, HICON* pluginIconOverlays,
+                         HICON* panelOverlays, int dpi = 0);
 DWORD GetImageListColorFlags(); // vrati ILC_COLOR??? podle verzi Windows - odladene pro pouziti imagelistu v listviewech
 
 // API GetOpenFileName/GetSaveFileName v pripade ze cesta k souboru (OPENFILENAME::lpstrFile)

--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -2958,7 +2958,8 @@ void CFilesWindow::RefreshDirectory(BOOL probablyUselessRefresh, BOOL forceReloa
     if (iconCacheBackuped)
     {
         // we can only use the old cache if the icon geometry hasn't changed
-        if (oldIconCache->GetIconSize() == IconCache->GetIconSize())
+        if (oldIconCache->GetIconSize() == IconCache->GetIconSize() &&
+            oldIconCache->GetIconPixelSize() == IconCache->GetIconPixelSize())
         {
             if (UseSystemIcons || UseThumbnails) // if the new listing doesn't have icons, it doesn't make sense to transfer them from the old cache
             {

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -2994,10 +2994,10 @@ CFilesWindow::~CFilesWindow()
         HANDLES(CloseHandle(ExecuteAssocEvent));
 }
 
-BOOL CFilesWindow::RefreshDPIResources(BOOL force)
+BOOL CFilesWindow::RefreshDPIResources(BOOL force, int dpiOverride)
 {
     HWND dpiWindow = HWindow != NULL ? HWindow : (Parent != NULL ? Parent->HWindow : NULL);
-    int dpi = (int)WinLibDPIGetWindowDPI(dpiWindow);
+    int dpi = dpiOverride > 0 ? dpiOverride : (int)WinLibDPIGetWindowDPI(dpiWindow);
     if (dpi <= 0)
         dpi = USER_DEFAULT_SCREEN_DPI;
     if (!force && WindowDPI == dpi && WindowPanelFont != NULL && WindowEnvFont != NULL)
@@ -3110,6 +3110,45 @@ BOOL CFilesWindow::RefreshDPIResources(BOOL force)
     return TRUE;
 }
 
+BOOL CFilesWindow::RefreshIconCacheForCurrentSize(BOOL postDirectoryRefresh)
+{
+    if (IconCache == NULL)
+        return FALSE;
+
+    CIconSizeEnum iconSize = GetIconSizeForCurrentViewMode();
+    int iconPixelSize = GetIconSize(iconSize);
+    if (IconCache->GetIconSize() == iconSize &&
+        IconCache->GetIconPixelSize() == iconPixelSize)
+    {
+        return FALSE;
+    }
+
+    SleepIconCacheThread();
+    IconCache->Destroy();
+    IconCache->SetIconSize(iconSize, iconPixelSize);
+    IconCacheValid = FALSE;
+    EndOfIconReadingTime = GetTickCount() - 10000;
+    UseThumbnails = FALSE;
+
+    HWND listBox = GetListBoxHWND();
+    if (listBox != NULL)
+        InvalidateRect(listBox, NULL, FALSE);
+
+    if (postDirectoryRefresh)
+    {
+        HANDLES(EnterCriticalSection(&TimeCounterSection));
+        int refreshTime = MyTimeCounter++;
+        HANDLES(LeaveCriticalSection(&TimeCounterSection));
+        PostMessage(HWindow, WM_USER_REFRESH_DIR, 0, refreshTime);
+    }
+    return TRUE;
+}
+
+CIconList* CFilesWindow::GetPanelSimpleIconList(CIconSizeEnum iconSize)
+{
+    return GetSimpleIconList(GetIconSize(iconSize));
+}
+
 CIconList* CFilesWindow::GetIndependentIconList(CIconList* source, int sourceIndex,
                                                  CIconSizeEnum iconSize, int* copyIndex)
 {
@@ -3181,11 +3220,60 @@ CIconList* CFilesWindow::GetIndependentIconList(CIconList* source, int sourceInd
     return copy;
 }
 
+HICON CFilesWindow::GetPanelOverlay(HICON source, int pixelSize)
+{
+    if (source == NULL || pixelSize <= 0)
+        return source;
+    for (size_t i = 0; i < WindowDPIOverlays.size(); ++i)
+        if (WindowDPIOverlays[i].Source == source && WindowDPIOverlays[i].PixelSize == pixelSize)
+            return WindowDPIOverlays[i].Copy;
+    // Built-in overlays have real resources for each requested size. Load those
+    // resources directly; CopyImage remains for customized shortcut overlays.
+    int resourceId = 0;
+    for (int i = 0; i < ICONSIZE_COUNT; ++i)
+    {
+        if (source == HSharedOverlays[i])
+        {
+            resourceId = 164;
+            break;
+        }
+        if (source == HSlowFileOverlays[i])
+        {
+            resourceId = 97;
+            break;
+        }
+    }
+    HICON copy = resourceId != 0
+                     ? (HICON)HANDLES(LoadImage(ImageResDLL, MAKEINTRESOURCE(resourceId), IMAGE_ICON,
+                                                  pixelSize, pixelSize, IconLRFlags))
+                     : (HICON)HANDLES(CopyImage(source, IMAGE_ICON, pixelSize, pixelSize, 0));
+    if (copy == NULL)
+        return source;
+    CDPIOverlayEntry entry;
+    entry.Source = source;
+    entry.PixelSize = pixelSize;
+    entry.Copy = copy;
+    try
+    {
+        WindowDPIOverlays.push_back(entry);
+    }
+    catch (...)
+    {
+        HANDLES(DestroyIcon(copy));
+        return source;
+    }
+    return copy;
+}
+
 void CFilesWindow::ClearIndependentIconLists()
 {
     for (size_t i = 0; i < WindowDPIIconLists.size(); ++i)
         delete WindowDPIIconLists[i].Copy;
     WindowDPIIconLists.clear();
+    for (size_t i = 0; i < WindowDPIOverlays.size(); ++i)
+        if (WindowDPIOverlays[i].Copy != NULL)
+            HANDLES(DestroyIcon(WindowDPIOverlays[i].Copy));
+    WindowDPIOverlays.clear();
 }
 
 CPathHistory* CFilesWindow::EnsureWorkDirHistory()

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -1695,13 +1695,14 @@ BOOL CFilesWindowAncestor::SamePath(CFilesWindowAncestor* other)
 // CFilesWindow
 //
 
-void IconThreadThreadFBodyAux(const char* path, SHFILEINFO& shi, CIconSizeEnum iconSize)
+void IconThreadThreadFBodyAux(const char* path, SHFILEINFO& shi, CIconSizeEnum iconSize,
+                               int targetPixelSize, int targetDPI)
 {
     CALL_STACK_MESSAGE_NONE
     __try
     {
         // do not let a default icon be returned; if it fails, simple icons are used
-        if (!GetFileIcon(path, FALSE, &shi.hIcon, iconSize, FALSE, FALSE))
+        if (!GetFileIconForPanel(path, &shi.hIcon, iconSize, targetPixelSize, targetDPI, FALSE, FALSE))
             shi.hIcon = NULL;
 
         // We switched to our own implementation (lower memory usage, working XOR icons)
@@ -2076,7 +2077,7 @@ unsigned IconThreadThreadFBody(void* parameter)
                                                 if (!pathIsInvalid)
                                                 {
                                                     //                            TRACE_I("Getting icon for: " << name << "...");
-                                                    IconThreadThreadFBodyAux(path, shi, iconSize);
+                                                    IconThreadThreadFBodyAux(path, shi, iconSize, iconPixelSize, iconDPI);
                                                     if (shi.hIcon == NULL)
                                                         TRACE_I("Unable to get icon from: " << path);
                                                     //                            else
@@ -2170,8 +2171,8 @@ unsigned IconThreadThreadFBody(void* parameter)
                                             {
                                                 // load the icon from the file (ExtractIcons retrieves it by index);
                                                 // the icon reader may go to sleep mode while loading
-                                                CALL_STACK_MESSAGE4("IconThreadThreadFBody::ExtractIcons(%s, %d, %d, ...)", path, index, window->GetIconSize(iconSize));
-                                                if (ExtractIcons(path, index, window->GetIconSize(iconSize), window->GetIconSize(iconSize), &shi.hIcon, NULL, 1, IconLRFlags) != 1)
+                                                CALL_STACK_MESSAGE4("IconThreadThreadFBody::ExtractIcons(%s, %d, %d, ...)", path, index, iconPixelSize);
+                                                if (ExtractIcons(path, index, iconPixelSize, iconPixelSize, &shi.hIcon, NULL, 1, IconLRFlags) != 1)
                                                 {
                                                     TRACE_I("Unable to get icon from: " << path << ", " << index);
                                                     shi.hIcon = NULL;
@@ -2185,15 +2186,15 @@ unsigned IconThreadThreadFBody(void* parameter)
                                                 {
                                                     // load the icon from a file (likely .ico); the icon reader can switch to sleep mode during loading
                                                     CALL_STACK_MESSAGE2("IconThreadThreadFBody::LoadImage(%s)", path);
-                                                    shi.hIcon = (HICON)NOHANDLES(LoadImage(NULL, path, IMAGE_ICON, window->GetIconSize(iconSize), window->GetIconSize(iconSize),
+                                                    shi.hIcon = (HICON)NOHANDLES(LoadImage(NULL, path, IMAGE_ICON, iconPixelSize, iconPixelSize,
                                                                                            LR_LOADFROMFILE | IconLRFlags));
                                                     //                            TRACE_I("LoadImage " << (shi.hIcon == NULL ? "has failed, now trying ExtractIcons..." : "is done."));
                                                 }
                                                 if (shi.hIcon == NULL) // LoadImage failed; trying ExtractIcons as well (e.g., an icon without index from zipfldr.dll on XP: a .zip archive packed in a .7z archive)
                                                 {
                                                     // let the first icon load from the file; the icon reader may enter sleep mode while loading
-                                                    CALL_STACK_MESSAGE3("IconThreadThreadFBody::ExtractIcons(%s, (0), %d, ...)", path, window->GetIconSize(iconSize));
-                                                    if (ExtractIcons(path, 0, window->GetIconSize(iconSize), window->GetIconSize(iconSize), &shi.hIcon, NULL, 1, IconLRFlags) != 1)
+                                                    CALL_STACK_MESSAGE3("IconThreadThreadFBody::ExtractIcons(%s, (0), %d, ...)", path, iconPixelSize);
+                                                    if (ExtractIcons(path, 0, iconPixelSize, iconPixelSize, &shi.hIcon, NULL, 1, IconLRFlags) != 1)
                                                     {
                                                         TRACE_I("Unable to get first icon from: " << path);
                                                         shi.hIcon = NULL;
@@ -2321,8 +2322,10 @@ unsigned IconThreadThreadFBody(void* parameter)
                                             {
                                                 HANDLES(EnterCriticalSection(&window->ICSectionUsingIcon));
 
-                                                iconList->ReplaceIcon(iconListIndex, shi.hIcon);
-                                                iconData->SetFlag(1); // already loaded
+                                                if (iconList->ReplaceIcon(iconListIndex, shi.hIcon))
+                                                    iconData->SetFlag(1); // already loaded
+                                                else
+                                                    failed = TRUE;
 
                                                 HANDLES(LeaveCriticalSection(&window->ICSectionUsingIcon));
 
@@ -3101,9 +3104,9 @@ BOOL CFilesWindow::RefreshDPIResources(BOOL force)
     WindowTextEllipsisWidth = panelEllipsis;
     WindowTextEllipsisWidthEnv = envEllipsis;
     WindowDPI = dpi;
-    WindowIconSizes[ICONSIZE_16] = MulDiv(16, dpi, USER_DEFAULT_SCREEN_DPI);
-    WindowIconSizes[ICONSIZE_32] = MulDiv(32, dpi, USER_DEFAULT_SCREEN_DPI);
-    WindowIconSizes[ICONSIZE_48] = MulDiv(48, dpi, USER_DEFAULT_SCREEN_DPI);
+    WindowIconSizes[ICONSIZE_16] = GetIconSizeForDPI(ICONSIZE_16, dpi);
+    WindowIconSizes[ICONSIZE_32] = GetIconSizeForDPI(ICONSIZE_32, dpi);
+    WindowIconSizes[ICONSIZE_48] = GetIconSizeForDPI(ICONSIZE_48, dpi);
     return TRUE;
 }
 

--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -860,7 +860,8 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
             {
                 if (Associations[i].GetIndex(iconSize) == -3)
                     Associations[i].SetIndex(-1, iconSize); // removing the flag "loaded icon"
-            }
+            }            Associations.ResetLoadingPixelIconIndexes(GetIconSize(iconSize));
+
         }
         else
         {
@@ -1330,7 +1331,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                         }
                         else
                         {
-                            file.Association = Associations.IsAssociated(st, addtoIconCache, iconSize);
+                            file.Association = Associations.IsAssociated(st, addtoIconCache, iconSize, GetIconSize(iconSize));
                             file.Archive = 0;
                             if (iconSize == ICONSIZE_16 && *(DWORD*)st == *(DWORD*)"ico")
                             {
@@ -1811,7 +1812,8 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                 {
                     if (Associations[i].GetIndex(iconSize) == -3)
                         Associations[i].SetIndex(-1, iconSize);
-                }
+                }                Associations.ResetLoadingPixelIconIndexes(GetIconSize(iconSize));
+
 
                 // getting of necessary static icons (we won't unpack them)
                 for (i = 0; i < Files->Count; i++)
@@ -1837,7 +1839,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                         *(DWORD*)st = 0; // zeroes to the end
                         st = fileName;   // lowercase extension
 
-                        f->Association = Associations.IsAssociatedStatic(st, iconLocation, iconSize);
+                        f->Association = Associations.IsAssociatedStatic(st, iconLocation, iconSize, GetIconSize(iconSize));
                         f->Archive = FALSE;
                         /*
             }
@@ -2080,7 +2082,8 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                     {
                         if (Associations[i].GetIndex(iconSize) == -3)
                             Associations[i].SetIndex(-1, iconSize);
-                    }
+                    }                    Associations.ResetLoadingPixelIconIndexes(GetIconSize(iconSize));
+
 
                     // getting of necessary static icons (we won't unpack anything)
                     for (i = 0; i < Files->Count; i++)
@@ -2106,7 +2109,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                             *(DWORD*)st = 0; // zeroes to the end
                             st = fileName;   // lowercase extension
 
-                            f->Association = Associations.IsAssociatedStatic(st, iconLocation, iconSize);
+                            f->Association = Associations.IsAssociatedStatic(st, iconLocation, iconSize, GetIconSize(iconSize));
                             f->Archive = FALSE;
                             /*
               }

--- a/src/fileswn4.cpp
+++ b/src/fileswn4.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -196,6 +196,14 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
         }
     }
 
+    HICON panelOverlays[3 * ICONSIZE_COUNT];
+    for (int overlaySize = 0; overlaySize < ICONSIZE_COUNT; ++overlaySize)
+    {
+        panelOverlays[overlaySize] = GetPanelOverlay(HSharedOverlays[overlaySize], GetIconSize(overlaySize));
+        panelOverlays[ICONSIZE_COUNT + overlaySize] = GetPanelOverlay(HShortcutOverlays[overlaySize], GetIconSize(overlaySize));
+        panelOverlays[2 * ICONSIZE_COUNT + overlaySize] = GetPanelOverlay(HSlowFileOverlays[overlaySize], GetIconSize(overlaySize));
+    }
+
     BOOL iconOverlayFromPlugin = Is(ptZIPArchive) || Is(ptPluginFS);
     int pluginIconOverlaysCount = 0;
     HICON* pluginIconOverlays = NULL;
@@ -232,7 +240,7 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                         IconCache->At(icon).GetFlag() != 1 && IconCache->At(icon).GetFlag() != 2 ||     // neither new nor old icon is loaded
                         !IconCache->GetIcon(IconCache->At(icon).GetIndex(), &iconList, &iconListIndex)) // failed to obtain its icon
                     {                                                                                   // we will display a simple symbol
-                        if (!Associations.GetIcon(ASSOC_ICON_SOME_DIR, &iconList, &iconListIndex, iconSize))
+                        if (!Associations.GetIcon(ASSOC_ICON_SOME_DIR, &iconList, &iconListIndex, GetIconSize(iconSize)))
                         {
                             iconList = NULL;
                             drawSimpleSymbol = TRUE;
@@ -253,7 +261,8 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                     {
                         if (!exceptions)
                             TransferAssocIndex = index;                               // remember the valid index in Associations
-                        if (exceptions || Associations[index].GetIndex(iconSize) < 0) // dynamic icon (from the file) or a loaded static icon
+                        if (exceptions || Associations[index].GetIndex(iconSize) < 0 ||
+                            Associations.GetPixelIconIndex(index, GetIconSize(iconSize)) < 0) // dynamic icon or missing pixel-sized copy
                         {                                                             // icon in the file
                             int icon;
                             memmove(fileName, f->Name, f->NameLen);
@@ -273,7 +282,7 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                                     icon = ASSOC_ICON_SOME_EXE;
                                 else
                                     icon = (exceptions || Associations[index].GetFlag() != 0) ? ASSOC_ICON_SOME_FILE : ASSOC_ICON_NO_ASSOC;
-                                if (!Associations.GetIcon(icon, &iconList, &iconListIndex, iconSize))
+                                if (!Associations.GetIcon(icon, &iconList, &iconListIndex, GetIconSize(iconSize)))
                                 {
                                     iconList = NULL;
                                     drawSimpleSymbol = TRUE;
@@ -294,7 +303,7 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                     {                    // try to draw the icon,
                         if (index != -1) // index==-1 -> simple-symbol
                         {
-                            int i = Associations.At(index).GetIndex(iconSize);
+                            int i = Associations.GetPixelIconIndex(index, GetIconSize(iconSize));
                             if (i >= 0)
                                 index = i;
                             else
@@ -305,7 +314,7 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                         }
                         else
                             index = ASSOC_ICON_NO_ASSOC;
-                        if (!drawSimpleSymbol && !Associations.GetIcon(index, &iconList, &iconListIndex, iconSize))
+                        if (!drawSimpleSymbol && !Associations.GetIcon(index, &iconList, &iconListIndex, GetIconSize(iconSize)))
                         {
                             iconList = NULL;
                             drawSimpleSymbol = TRUE;
@@ -352,7 +361,7 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                 StateImageList_Draw(iconList, iconListIndex, hDC, x, y, iconState, iconSize,
                                     f->IconOverlayIndex, overlayRect, (drawFlags & DRAWFLAG_OVERLAY_ONLY) != 0,
                                     iconOverlayFromPlugin, pluginIconOverlaysCount, pluginIconOverlays,
-                                    GetWindowDPI());
+                                    panelOverlays, GetWindowDPI());
 
                 if (leaveSection)
                 {
@@ -370,12 +379,12 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
     { // simple symbols
         int independentIndex = symbolIndex;
         CIconList* independentIcons =
-            GetIndependentIconList(SimpleIconLists[iconSize], symbolIndex,
+            GetIndependentIconList(GetPanelSimpleIconList(iconSize), symbolIndex,
                                    iconSize, &independentIndex);
         StateImageList_Draw(independentIcons, independentIndex, hDC, x, y, iconState, iconSize,
                             f->IconOverlayIndex, overlayRect, (drawFlags & DRAWFLAG_OVERLAY_ONLY) != 0,
                             iconOverlayFromPlugin, pluginIconOverlaysCount, pluginIconOverlays,
-                            GetWindowDPI());
+                            panelOverlays, GetWindowDPI());
     }
 
     // I don't understand why, but the current bitmap drawing doesn't flicker.
@@ -2012,7 +2021,8 @@ void CFilesWindow::DrawTileItem(HDC hTgtDC, int itemIndex, RECT* itemRect, DWORD
 BOOL StateImageList_Draw(CIconList* iconList, int imageIndex, HDC hDC, int xDst, int yDst,
                          DWORD state, CIconSizeEnum iconSize, DWORD iconOverlayIndex,
                          const RECT* overlayRect, BOOL overlayOnly, BOOL iconOverlayFromPlugin,
-                         int pluginIconOverlaysCount, HICON* pluginIconOverlays, int dpi)
+                         int pluginIconOverlaysCount, HICON* pluginIconOverlays,
+                         HICON* panelOverlays, int dpi)
 {
     COLORREF rgbFg = CLR_DEFAULT;
     BOOL blend = FALSE;
@@ -2057,6 +2067,15 @@ BOOL StateImageList_Draw(CIconList* iconList, int imageIndex, HDC hDC, int xDst,
 
     int iconW = GetIconSizeForDPI(iconSize, dpi);
     int iconH = iconW;
+    int overlaySlot = 0;
+    for (int i = 0; i < ICONSIZE_COUNT; ++i)
+    {
+        if (GetIconSizeForDPI((CIconSizeEnum)i, dpi) == iconW)
+        {
+            overlaySlot = i;
+            break;
+        }
+    }
 
     // for a thumbnail overlayRect != NULL and we move the overlay to its lower left corner
     if (overlayRect != NULL)
@@ -2082,24 +2101,24 @@ BOOL StateImageList_Draw(CIconList* iconList, int imageIndex, HDC hDC, int xDst,
             }
             else
             {
-                DrawIconEx(hDC, xOverlayDst, yOverlayDst, ShellIconOverlays.GetIconOverlay(iconOverlayIndex, iconSize),
+                DrawIconEx(hDC, xOverlayDst, yOverlayDst, ShellIconOverlays.GetIconOverlayForPixels(iconOverlayIndex, iconW),
                            iconW, iconH, 0, NULL, DI_MASK);
             }
         }
         else
         {
             if (state & IMAGE_STATE_SHARED)
-                DrawIconEx(hDC, xOverlayDst, yOverlayDst, HSharedOverlays[iconSize],
+                DrawIconEx(hDC, xOverlayDst, yOverlayDst, panelOverlays[overlaySlot],
                            iconW, iconH, 0, NULL, DI_MASK);
             else
             {
                 if (state & IMAGE_STATE_SHORTCUT)
-                    DrawIconEx(hDC, xOverlayDst, yOverlayDst, HShortcutOverlays[iconSize],
+                    DrawIconEx(hDC, xOverlayDst, yOverlayDst, panelOverlays[ICONSIZE_COUNT + overlaySlot],
                                iconW, iconH, 0, NULL, DI_MASK);
                 else
                 {
                     if (state & IMAGE_STATE_OFFLINE)
-                        DrawIconEx(hDC, xOverlayDst, yOverlayDst, HSlowFileOverlays[iconSize],
+                        DrawIconEx(hDC, xOverlayDst, yOverlayDst, panelOverlays[2 * ICONSIZE_COUNT + overlaySlot],
                                    iconW, iconH, 0, NULL, DI_MASK);
                 }
             }
@@ -2125,24 +2144,24 @@ BOOL StateImageList_Draw(CIconList* iconList, int imageIndex, HDC hDC, int xDst,
             }
             else
             {
-                DrawIconEx(hDC, xOverlayDst, yOverlayDst, ShellIconOverlays.GetIconOverlay(iconOverlayIndex, iconSize),
+                DrawIconEx(hDC, xOverlayDst, yOverlayDst, ShellIconOverlays.GetIconOverlayForPixels(iconOverlayIndex, iconW),
                            iconW, iconH, 0, NULL, DI_NORMAL);
             }
         }
         else
         {
             if (state & IMAGE_STATE_SHARED)
-                DrawIconEx(hDC, xOverlayDst, yOverlayDst, HSharedOverlays[iconSize],
+                DrawIconEx(hDC, xOverlayDst, yOverlayDst, panelOverlays[overlaySlot],
                            iconW, iconH, 0, NULL, DI_NORMAL);
             else
             {
                 if (state & IMAGE_STATE_SHORTCUT)
-                    DrawIconEx(hDC, xOverlayDst, yOverlayDst, HShortcutOverlays[iconSize],
+                    DrawIconEx(hDC, xOverlayDst, yOverlayDst, panelOverlays[ICONSIZE_COUNT + overlaySlot],
                                iconW, iconH, 0, NULL, DI_NORMAL);
                 else
                 {
                     if (state & IMAGE_STATE_OFFLINE)
-                        DrawIconEx(hDC, xOverlayDst, yOverlayDst, HSlowFileOverlays[iconSize],
+                        DrawIconEx(hDC, xOverlayDst, yOverlayDst, panelOverlays[2 * ICONSIZE_COUNT + overlaySlot],
                                    iconW, iconH, 0, NULL, DI_NORMAL);
                 }
             }

--- a/src/fileswn4.cpp
+++ b/src/fileswn4.cpp
@@ -2045,17 +2045,17 @@ BOOL StateImageList_Draw(CIconList* iconList, int imageIndex, HDC hDC, int xDst,
     int xOverlayDst = xDst;
     int yOverlayDst = yDst;
 
+    if (dpi <= 0)
+        dpi = GetSystemDPI();
+
     // on Vista a 48x48 icon uses overlay ICONSIZE_32 and thumbnails use overlay ICONSIZE_48
     if (iconSize == ICONSIZE_48 && overlayRect == NULL)
     {
         iconSize = ICONSIZE_32;
-        yOverlayDst += 48 - 32;
+        yOverlayDst += GetIconSizeForDPI(ICONSIZE_48, dpi) - GetIconSizeForDPI(ICONSIZE_32, dpi);
     }
 
-    if (dpi <= 0)
-        dpi = GetSystemDPI();
-    static const int logicalIconSizes[ICONSIZE_COUNT] = {16, 32, 48};
-    int iconW = MulDiv(logicalIconSizes[iconSize], dpi, 96);
+    int iconW = GetIconSizeForDPI(iconSize, dpi);
     int iconH = iconW;
 
     // for a thumbnail overlayRect != NULL and we move the overlay to its lower left corner

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "precomp.h"
@@ -169,16 +169,7 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (RefreshDPIResources())
         {
-            if (IconCache != NULL)
-            {
-                SleepIconCacheThread();
-                IconCache->Destroy();
-                CIconSizeEnum iconSize = GetIconSizeForCurrentViewMode();
-                IconCache->SetIconSize(iconSize, GetIconSize(iconSize));
-                IconCacheValid = FALSE;
-                EndOfIconReadingTime = GetTickCount() - 10000;
-                UseThumbnails = FALSE;
-            }
+            RefreshIconCacheForCurrentSize(FALSE);
             SetFont();
             RefreshTreeViewDPI();
             if (ListBox != NULL && ListBox->HWindow != NULL)
@@ -824,7 +815,8 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 if (!icoFileIcon &&
                     Associations.GetIndex(extension, index) &&       // pripona ma ikonku (asociaci)
                     (Associations[index].GetIndex(iconSize) == -1 || // jde o ikonku, ktera se nacita
-                     Associations[index].GetIndex(iconSize) == -3))
+                     Associations[index].GetIndex(iconSize) == -3 ||
+                     Associations.GetPixelIconIndex(index, GetIconSize(iconSize)) < 0))
                 {
                     int icon;
                     CIconList* srcIconList;
@@ -839,10 +831,12 @@ CFilesWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     {                                                        // ikonka pro priponu -> icon-thread uz ji nacetl
                         CIconList* dstIconList;
                         int dstIconListIndex;
-                        int i = Associations.AllocIcon(&dstIconList, &dstIconListIndex, iconSize);
+                        int i = Associations.AllocIcon(&dstIconList, &dstIconListIndex, GetIconSize(iconSize));
                         if (i != -1) // ziskali jsme misto pro novou ikonku
                         {            // nakopirujeme si ji z IconCache do Associations
-                            Associations[index].SetIndex(i, iconSize);
+                            if (Associations[index].GetIndex(iconSize) < 0)
+                                Associations[index].SetIndex(i, iconSize);
+                            Associations.SetPixelIconIndex(index, GetIconSize(iconSize), i);
 
                             BOOL leaveSection;
                             if (!IconCacheValid)

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -848,6 +848,13 @@ public:
         CIconList* Copy;
     };
     std::vector<CDPIIconListEntry> WindowDPIIconLists;
+    struct CDPIOverlayEntry
+    {
+        HICON Source;
+        int PixelSize;
+        HICON Copy;
+    };
+    std::vector<CDPIOverlayEntry> WindowDPIOverlays;
     BOOL TreeViewAutoHideExpanded;
     DWORD TreeViewAutoHideCollapseStart;
     int TreeViewWidth;
@@ -1015,10 +1022,13 @@ public:
     CFilesWindow(CMainWindow* parent, CPanelSide side);
     ~CFilesWindow();
 
-    BOOL RefreshDPIResources(BOOL force = FALSE);
+    BOOL RefreshDPIResources(BOOL force = FALSE, int dpiOverride = 0);
+    BOOL RefreshIconCacheForCurrentSize(BOOL postDirectoryRefresh = TRUE);
     CIconList* GetIndependentIconList(CIconList* source, int sourceIndex,
                                       CIconSizeEnum iconSize, int* copyIndex);
+    CIconList* GetPanelSimpleIconList(CIconSizeEnum iconSize);
     void ClearIndependentIconLists();
+    HICON GetPanelOverlay(HICON source, int pixelSize);
     int GetWindowDPI() const { return WindowDPI > 0 ? WindowDPI : GetSystemDPI(); }
     HFONT GetPanelFont() const { return WindowPanelFont != NULL ? WindowPanelFont : Font; }
     HFONT GetPanelFontUL() const { return WindowPanelFontUL != NULL ? WindowPanelFontUL : FontUL; }
@@ -1031,9 +1041,9 @@ public:
     int GetTextEllipsisWidthEnv() const { return WindowTextEllipsisWidthEnv > 0 ? WindowTextEllipsisWidthEnv : TextEllipsisWidthEnv; }
     int GetIconSize(int size) const
     {
-        return size >= 0 && size < ICONSIZE_COUNT && WindowIconSizes[size] > 0
-                   ? WindowIconSizes[size]
-                   : IconSizes[size];
+        if (size < 0 || size >= ICONSIZE_COUNT)
+            return 0;
+        return WindowIconSizes[size] > 0 ? WindowIconSizes[size] : IconSizes[size];
     }
 
     CPanelSide GetPanelSide() const { return PanelSide; }

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -270,13 +270,11 @@ static HICON GetExplorerFileIcon(const char* path, int pixelSize, BOOL smallIcon
     if (GetIconPixelWidth(icon) != pixelSize)
     {
         HICON resized = (HICON)CopyImage(icon, IMAGE_ICON, pixelSize, pixelSize, 0);
-        if (resized == NULL)
+        if (resized != NULL)
         {
             HANDLES(DestroyIcon(icon));
-            return NULL;
+            icon = resized;
         }
-        HANDLES(DestroyIcon(icon));
-        icon = resized;
     }
 
     DiscardSolidBlackIcon(&icon, pixelSize);
@@ -344,21 +342,26 @@ static HICON GetDefaultAssociationIcon(const char* path, int pixelSize)
     if (icon != NULL && GetIconPixelWidth(icon) != pixelSize)
     {
         HICON resized = (HICON)CopyImage(icon, IMAGE_ICON, pixelSize, pixelSize, 0);
-        if (resized == NULL)
+        if (resized != NULL)
         {
             HANDLES(DestroyIcon(icon));
-            return NULL;
+            icon = resized;
         }
-        HANDLES(DestroyIcon(icon));
-        icon = resized;
     }
     DiscardSolidBlackIcon(&icon, pixelSize);
     return icon;
 }
 
 BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl, HICON* hIcon,
-                        CIconSizeEnum iconSize, BOOL fallbackToDefIcon, BOOL defIconIsDir)
+                        CIconSizeEnum iconSize, int shellSourcePixelSize,
+                        BOOL fallbackToDefIcon, BOOL defIconIsDir)
 {
+    if (shellSourcePixelSize <= 0)
+        shellSourcePixelSize = IconSizes[iconSize];
+
+    const int companionSmallPixelSize = iconSize == ICONSIZE_16 ? shellSourcePixelSize :
+                                                                     max(1, shellSourcePixelSize / (iconSize == ICONSIZE_32 ? 2 : 3));
+    const int companionLargePixelSize = iconSize == ICONSIZE_16 ? shellSourcePixelSize * 2 : shellSourcePixelSize;
     BOOL ret = FALSE;
 
     IExtractIconA* pxi = NULL; // if 'isIExtractIconW' is TRUE, this pointer is actually IExtractIconW
@@ -371,10 +374,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
     int iconIndex;
     UINT wFlags = 0; // clear because the DWGIcon.dll shell extension just ORs these bits
 
-    CIconSizeEnum largeIconSize = ICONSIZE_32;
-    if (iconSize == ICONSIZE_48)
-        largeIconSize = ICONSIZE_48;
-    BOOL preferExtractorSmallIcon = iconSize == ICONSIZE_16 && IconSizes[ICONSIZE_16] <= 16;
+    BOOL preferExtractorSmallIcon = iconSize == ICONSIZE_16 && shellSourcePixelSize <= 16;
 
     HRESULT hres = psf->GetUIObjectOf(NULL, 1, &pidl, IID_IExtractIconA, NULL, (void**)&pxi);
     if (SUCCEEDED(hres))
@@ -422,7 +422,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             // 24x24 SYSSMALL icon from a primary high-DPI monitor scaled down.
             // At higher DPI, SYSSMALL can provide the DPI-sized small icon and
             // avoids upscaling the 16x16 variant.
-            int smallImageListSize = IconSizes[ICONSIZE_16] <= 16 ? SHIL_SMALL : SHIL_SYSSMALL;
+            int smallImageListSize = companionSmallPixelSize <= 16 ? SHIL_SMALL : SHIL_SYSSMALL;
             hres = SHGetImageList(smallImageListSize, IID_IImageList, (void**)&imageListSmall);
             if (SUCCEEDED(hres) && (imageListSmall != NULL))
             {
@@ -432,7 +432,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
                 // icon.  Treat that as extraction failure here so the direct
                 // SHGFI_ICON fallback below gets a chance to supply the same
                 // usable HICON that Explorer draws.
-                DiscardSolidBlackIcon(&hIconSmall, IconSizes[ICONSIZE_16]);
+                DiscardSolidBlackIcon(&hIconSmall, companionSmallPixelSize);
                 //TRACE_I("  SalGetIconFromPIDL() SHIL_SMALL IID_IImageList, hIconSmall="<<hIconSmall);
                 imageListSmall->Release();
             }
@@ -449,7 +449,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
                     if (hSysImageList != NULL)
                     {
                         hIconSmall = ImageList_GetIcon(hSysImageList, sfi.iIcon, ILD_NORMAL);
-                        DiscardSolidBlackIcon(&hIconSmall, IconSizes[ICONSIZE_16]);
+                        DiscardSolidBlackIcon(&hIconSmall, companionSmallPixelSize);
                         //TRACE_I("  SalGetIconFromPIDL() ImageList_GetIcon for SHGFI_SMALLICON hIconSmall="<<hIconSmall<<" sfi.iIcon="<<sfi.iIcon<<" hSysImageList="<<hSysImageList);
                     }
                     if (hIconSmall == NULL)
@@ -460,11 +460,11 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
                             hIconSmall = sfi.hIcon;
                         //TRACE_I("  SalGetIconFromPIDL() SHGetFileInfo for SHGFI_ICON | SHGFI_SMALLICON hIconSmall="<<hIconSmall);
                     }
-                    if (hIconSmall == NULL || IsSolidBlackIcon(hIconSmall, IconSizes[ICONSIZE_16]))
+                    if (hIconSmall == NULL || IsSolidBlackIcon(hIconSmall, companionSmallPixelSize))
                     {
-                        HICON associationIcon = GetDefaultAssociationIcon(path, IconSizes[ICONSIZE_16]);
+                        HICON associationIcon = GetDefaultAssociationIcon(path, companionSmallPixelSize);
                         if (associationIcon != NULL &&
-                            !IsSolidBlackIcon(associationIcon, IconSizes[ICONSIZE_16]))
+                            !IsSolidBlackIcon(associationIcon, companionSmallPixelSize))
                         {
                             if (hIconSmall != NULL)
                                 HANDLES(DestroyIcon(hIconSmall));
@@ -543,8 +543,8 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         if (preferExtractorSmallIcon && hIconSmall == NULL && hIconLarge == NULL && !(wFlags & GIL_NOTFILENAME))
         {
             HICON hIcons[2] = {0, 0};
-            UINT u = ExtractIcons(iconFile, iconIndex, MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]),
-                                  MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]), hIcons, NULL, 2, IconLRFlags);
+            UINT u = ExtractIcons(iconFile, iconIndex, MAKELONG(companionLargePixelSize, companionSmallPixelSize),
+                                  MAKELONG(companionLargePixelSize, companionSmallPixelSize), hIcons, NULL, 2, IconLRFlags);
             if (u != -1)
             {
                 hIconLarge = hIcons[0];
@@ -560,9 +560,9 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             // Note: if iconFile == '*', Extract sometimes returns valid icons but in some implementations it doesn't,
             // leaving users with default icons; see below
             if (isIExtractIconW)
-                hres = ((IExtractIconW*)pxi)->Extract(iconFileW, iconIndex, &hIconLarge, &hIconSmall, MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]));
+                hres = ((IExtractIconW*)pxi)->Extract(iconFileW, iconIndex, &hIconLarge, &hIconSmall, MAKELONG(companionLargePixelSize, companionSmallPixelSize));
             else
-                hres = pxi->Extract(iconFile, iconIndex, &hIconLarge, &hIconSmall, MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]));
+                hres = pxi->Extract(iconFile, iconIndex, &hIconLarge, &hIconSmall, MAKELONG(companionLargePixelSize, companionSmallPixelSize));
             //TRACE_I("  SalGetIconFromPIDL() pxi->Extract() hIconLarge="<<hIconLarge<<" hIconSmall="<<hIconSmall<<" isIExtractIconW="<<isIExtractIconW);
             // WARNING: for *.ai files iconFile==0 and iconIndex==0 yet Extract() still returns an icon (Adobe Illustrator shell extension)
             // WARNING: D:\Store\Salamand\ICO_SONY\SonyF707_Day_Flash.icc returns hIconLarge==hIconSmall, both 32x32
@@ -572,7 +572,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         if (hIconSmall == NULL && hIconLarge == NULL && !(wFlags & GIL_NOTFILENAME))
         {
             HICON hIcons[2] = {0, 0};
-            UINT u = ExtractIcons(iconFile, iconIndex, MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]), MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]), hIcons, NULL, 2, IconLRFlags);
+            UINT u = ExtractIcons(iconFile, iconIndex, MAKELONG(companionLargePixelSize, companionSmallPixelSize), MAKELONG(companionLargePixelSize, companionSmallPixelSize), hIcons, NULL, 2, IconLRFlags);
             if (u != -1)
             {
                 hIconLarge = hIcons[0];
@@ -584,7 +584,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
     }
     HICON* requestedIcon = iconSize == ICONSIZE_16 ? &hIconSmall : &hIconLarge;
     HICON* otherIcon = iconSize == ICONSIZE_16 ? &hIconLarge : &hIconSmall;
-    int requestedIconSize = IconSizes[iconSize];
+    int requestedIconSize = shellSourcePixelSize;
     if (*requestedIcon != NULL && GetIconPixelWidth(*requestedIcon) != requestedIconSize && pxi != NULL)
     {
         // If the process first touched a shell image list on another DPI, the
@@ -596,10 +596,10 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         HRESULT extractResult;
         if (isIExtractIconW)
             extractResult = ((IExtractIconW*)pxi)->Extract(iconFileW, iconIndex, &hExtractedLarge, &hExtractedSmall,
-                                                           MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]));
+                                                           MAKELONG(companionLargePixelSize, companionSmallPixelSize));
         else
             extractResult = pxi->Extract(iconFile, iconIndex, &hExtractedLarge, &hExtractedSmall,
-                                         MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]));
+                                         MAKELONG(companionLargePixelSize, companionSmallPixelSize));
 
         HICON hExtracted = iconSize == ICONSIZE_16 ? hExtractedSmall : hExtractedLarge;
         if (SUCCEEDED(extractResult) && hExtracted != NULL &&
@@ -648,7 +648,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             resID = defIconIsDir ? 4 : (fileIsExecutable ? 3 : 1); // symbolsDirectory : symbolsExecutable : symbolsNonAssociated
         HICON hIcons[2] = {0, 0};
         UINT u = ExtractIcons(WindowsVistaAndLater ? "imageres.dll" : "shell32.dll", -resID,
-                              MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]), MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]),
+                              MAKELONG(companionLargePixelSize, companionSmallPixelSize), MAKELONG(companionLargePixelSize, companionSmallPixelSize),
                               hIcons, NULL, 2, IconLRFlags);
         if (u != -1)
         {
@@ -667,7 +667,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         // instead of allowing a stale size to enter the icon cache.
         if (iconSize == ICONSIZE_16)
         {
-            int targetIconSize = IconSizes[ICONSIZE_16];
+            int targetIconSize = shellSourcePixelSize;
             int smallIconSize = GetIconPixelWidth(hIconSmall);
             if (hIconSmall == NULL || hIconSmall == hIconLarge || smallIconSize != targetIconSize)
             {
@@ -720,9 +720,8 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         }
     }
 
-    // Do not let a stale/corrupt shell image-list entry poison Salamander's
-    // icon caches. Try the system list once more, otherwise keep the caller's
-    // existing association/default icon by reporting extraction failure.
+    // Try the system list once more for proven solid-black corruption;
+    // otherwise report extraction failure and keep the caller's fallback path.
     if (ret && path != NULL && *hIcon != NULL &&
         IsSolidBlackIcon(*hIcon, requestedIconSize))
     {
@@ -783,7 +782,7 @@ static BOOL IsIconFilePath(LPCTSTR path)
     return dot != NULL && (slash == NULL || dot > slash) && stricmp(dot + 1, "ico") == 0;
 }
 
-static BOOL LoadIcoFileSmallIcon(LPCTSTR path, HICON* hIcon)
+static BOOL LoadIcoFileIcon(LPCTSTR path, HICON* hIcon, int targetPixelSize)
 {
     if (hIcon == NULL)
         return FALSE;
@@ -792,21 +791,21 @@ static BOOL LoadIcoFileSmallIcon(LPCTSTR path, HICON* hIcon)
     if (!IsIconFilePath(path))
         return FALSE;
 
-    int iconSize = IconSizes[ICONSIZE_16];
-    *hIcon = (HICON)HANDLES(LoadImage(NULL, path, IMAGE_ICON, iconSize, iconSize,
+    *hIcon = (HICON)HANDLES(LoadImage(NULL, path, IMAGE_ICON, targetPixelSize, targetPixelSize,
                                        LR_LOADFROMFILE | IconLRFlags));
     if (*hIcon != NULL)
         return TRUE;
 
-    if (ExtractIcons(path, 0, iconSize, iconSize, hIcon, NULL, 1, IconLRFlags) == 1 && *hIcon != NULL)
+    if (ExtractIcons(path, 0, targetPixelSize, targetPixelSize, hIcon, NULL, 1, IconLRFlags) == 1 && *hIcon != NULL)
         return TRUE;
 
     *hIcon = NULL;
     return FALSE;
 }
 
-BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum iconSize,
-                 BOOL fallbackToDefIcon, BOOL defIconIsDir)
+static BOOL GetFileIconInternal(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum iconSize,
+                                int shellSourcePixelSize,
+                                BOOL fallbackToDefIcon, BOOL defIconIsDir)
 {
     BOOL ret = FALSE;
     LPITEMIDLIST pidlFull;
@@ -822,7 +821,8 @@ BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum 
   else
     TRACE_I("GetFileIcon() pathIsPIDL"); // not used by Salamander itself, only by the Folders plugin
 */
-    if (!pathIsPIDL && iconSize == ICONSIZE_16 && LoadIcoFileSmallIcon(path, hIcon))
+    if (!pathIsPIDL && iconSize == ICONSIZE_16 &&
+        LoadIcoFileIcon(path, hIcon, shellSourcePixelSize))
         return TRUE;
 
     // For ordinary small file icons use the same path-based shell result that
@@ -830,7 +830,7 @@ BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum 
     // DefaultIcon values can both be valid yet select different artwork.
     if (!pathIsPIDL && iconSize == ICONSIZE_16)
     {
-        *hIcon = GetExplorerFileIcon(path, IconSizes[ICONSIZE_16], TRUE);
+        *hIcon = GetExplorerFileIcon(path, shellSourcePixelSize, TRUE);
         if (*hIcon != NULL)
             return TRUE;
     }
@@ -849,7 +849,7 @@ BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum 
         {
             // if we know the path, pass it to SalGetIconFromPIDL
             ret = SalGetIconFromPIDL(psf, pathIsPIDL ? NULL : path, pidlLast, hIcon, iconSize,
-                                     fallbackToDefIcon, defIconIsDir);
+                                     shellSourcePixelSize, fallbackToDefIcon, defIconIsDir);
 
             psf->Release();
         }
@@ -859,4 +859,20 @@ BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum 
     }
 
     return ret;
+}
+
+BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum iconSize,
+                 BOOL fallbackToDefIcon, BOOL defIconIsDir)
+{
+    return GetFileIconInternal(path, pathIsPIDL, hIcon, iconSize, IconSizes[iconSize],
+                               fallbackToDefIcon, defIconIsDir);
+}
+
+BOOL GetFileIconForPanel(const char* path, HICON* hIcon, CIconSizeEnum iconSize,
+                         int targetPixelSize, int targetDPI, BOOL fallbackToDefIcon, BOOL defIconIsDir)
+{
+    if (targetPixelSize <= 0 || targetDPI <= 0)
+        return FALSE;
+    return GetFileIconInternal(path, FALSE, hIcon, iconSize, targetPixelSize,
+                               fallbackToDefIcon, defIconIsDir);
 }

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -359,9 +359,16 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
     if (shellSourcePixelSize <= 0)
         shellSourcePixelSize = IconSizes[iconSize];
 
-    const int companionSmallPixelSize = iconSize == ICONSIZE_16 ? shellSourcePixelSize :
-                                                                     max(1, shellSourcePixelSize / (iconSize == ICONSIZE_32 ? 2 : 3));
-    const int companionLargePixelSize = iconSize == ICONSIZE_16 ? shellSourcePixelSize * 2 : shellSourcePixelSize;
+    // The panel view can remain semantically ICONSIZE_16 while its DPI bucket
+    // requires the real 32px artwork. In that case IExtractIcon's large output
+    // is the requested image; selecting its small output and resizing it would
+    // preserve the 16px artwork and make it blurred after a live DPI switch.
+    const BOOL requestLargeArtwork = iconSize != ICONSIZE_16 || shellSourcePixelSize >= 32;
+    const int companionSmallPixelSize = requestLargeArtwork ?
+                                             max(16, shellSourcePixelSize / (iconSize == ICONSIZE_48 ? 3 : 2)) :
+                                             shellSourcePixelSize;
+    const int companionLargePixelSize = requestLargeArtwork ? shellSourcePixelSize :
+                                                               max(32, shellSourcePixelSize * 2);
     BOOL ret = FALSE;
 
     IExtractIconA* pxi = NULL; // if 'isIExtractIconW' is TRUE, this pointer is actually IExtractIconW
@@ -582,8 +589,8 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         }
 
     }
-    HICON* requestedIcon = iconSize == ICONSIZE_16 ? &hIconSmall : &hIconLarge;
-    HICON* otherIcon = iconSize == ICONSIZE_16 ? &hIconLarge : &hIconSmall;
+    HICON* requestedIcon = requestLargeArtwork ? &hIconLarge : &hIconSmall;
+    HICON* otherIcon = requestLargeArtwork ? &hIconSmall : &hIconLarge;
     int requestedIconSize = shellSourcePixelSize;
     if (*requestedIcon != NULL && GetIconPixelWidth(*requestedIcon) != requestedIconSize && pxi != NULL)
     {
@@ -601,17 +608,17 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             extractResult = pxi->Extract(iconFile, iconIndex, &hExtractedLarge, &hExtractedSmall,
                                          MAKELONG(companionLargePixelSize, companionSmallPixelSize));
 
-        HICON hExtracted = iconSize == ICONSIZE_16 ? hExtractedSmall : hExtractedLarge;
+        HICON hExtracted = requestLargeArtwork ? hExtractedLarge : hExtractedSmall;
         if (SUCCEEDED(extractResult) && hExtracted != NULL &&
             GetIconPixelWidth(hExtracted) == requestedIconSize)
         {
             if (*requestedIcon != NULL && *requestedIcon != *otherIcon)
                 HANDLES(DestroyIcon(*requestedIcon));
             *requestedIcon = hExtracted;
-            if (iconSize == ICONSIZE_16)
-                hExtractedSmall = NULL;
-            else
+            if (requestLargeArtwork)
                 hExtractedLarge = NULL;
+            else
+                hExtractedSmall = NULL;
         }
 
         if (hExtractedSmall != NULL && hExtractedSmall != hIconSmall && hExtractedSmall != hIconLarge)
@@ -665,7 +672,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         // shell image lists can return a bitmap for a different DPI than the
         // panel currently uses. Normalize every supported icon size here
         // instead of allowing a stale size to enter the icon cache.
-        if (iconSize == ICONSIZE_16)
+        if (!requestLargeArtwork)
         {
             int targetIconSize = shellSourcePixelSize;
             int smallIconSize = GetIconPixelWidth(hIconSmall);
@@ -825,12 +832,14 @@ static BOOL GetFileIconInternal(const char* path, BOOL pathIsPIDL, HICON* hIcon,
         LoadIcoFileIcon(path, hIcon, shellSourcePixelSize))
         return TRUE;
 
-    // For ordinary small file icons use the same path-based shell result that
-    // Explorer displays. IExtractIcon resource locations and registered
-    // DefaultIcon values can both be valid yet select different artwork.
+    // Follow Explorer's path-based icon choice, but select the shell artwork
+    // family from the physical DPI bucket. A semantically small panel icon is
+    // 32px at 175%, where SHGFI_SMALLICON would return 16px artwork that then
+    // gets enlarged and blurred.
     if (!pathIsPIDL && iconSize == ICONSIZE_16)
     {
-        *hIcon = GetExplorerFileIcon(path, shellSourcePixelSize, TRUE);
+        *hIcon = GetExplorerFileIcon(path, shellSourcePixelSize,
+                                     shellSourcePixelSize < 32);
         if (*hIcon != NULL)
             return TRUE;
     }

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -250,7 +250,7 @@ static std::wstring PanelPathToWide(const char* path)
     return std::wstring(wide.data());
 }
 
-static HICON GetExplorerFileIcon(const char* path, int pixelSize)
+static HICON GetExplorerFileIcon(const char* path, int pixelSize, BOOL smallIcon)
 {
     if (path == NULL || pixelSize <= 0)
         return NULL;
@@ -261,8 +261,8 @@ static HICON GetExplorerFileIcon(const char* path, int pixelSize)
 
     SHFILEINFOW fileInfo;
     ZeroMemory(&fileInfo, sizeof(fileInfo));
-    if (SHGetFileInfoW(widePath.c_str(), 0, &fileInfo, sizeof(fileInfo),
-                       SHGFI_ICON | SHGFI_SMALLICON) == 0 ||
+    UINT iconFlags = SHGFI_ICON | (smallIcon ? SHGFI_SMALLICON : SHGFI_LARGEICON);
+    if (SHGetFileInfoW(widePath.c_str(), 0, &fileInfo, sizeof(fileInfo), iconFlags) == 0 ||
         fileInfo.hIcon == NULL)
         return NULL;
 
@@ -341,6 +341,18 @@ static HICON GetDefaultAssociationIcon(const char* path, int pixelSize)
         HANDLES(DestroyIcon(largeIcon));
     if (smallIcon != NULL && smallIcon != icon)
         HANDLES(DestroyIcon(smallIcon));
+    if (icon != NULL && GetIconPixelWidth(icon) != pixelSize)
+    {
+        HICON resized = (HICON)CopyImage(icon, IMAGE_ICON, pixelSize, pixelSize, 0);
+        if (resized == NULL)
+        {
+            HANDLES(DestroyIcon(icon));
+            return NULL;
+        }
+        HANDLES(DestroyIcon(icon));
+        icon = resized;
+    }
+    DiscardSolidBlackIcon(&icon, pixelSize);
     return icon;
 }
 
@@ -570,16 +582,17 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         }
 
     }
-    if (iconSize == ICONSIZE_16 && hIconSmall != NULL &&
-        GetIconPixelWidth(hIconSmall) != IconSizes[ICONSIZE_16] && pxi != NULL)
+    HICON* requestedIcon = iconSize == ICONSIZE_16 ? &hIconSmall : &hIconLarge;
+    HICON* otherIcon = iconSize == ICONSIZE_16 ? &hIconLarge : &hIconSmall;
+    int requestedIconSize = IconSizes[iconSize];
+    if (*requestedIcon != NULL && GetIconPixelWidth(*requestedIcon) != requestedIconSize && pxi != NULL)
     {
-        // If the process first touched the shell image lists while running on a
-        // high-DPI monitor, even SHIL_SMALL can still hand back that larger
-        // process-global bitmap.  Ask the item's extractor directly for the
-        // requested 16px small icon before falling back to scaling it down.
+        // If the process first touched a shell image list on another DPI, the
+        // process-global bitmap can have the wrong size. Ask the item's
+        // extractor directly for the requested icon before falling back to a
+        // resize. This applies to small, large, and extra-large panel icons.
         HICON hExtractedLarge = NULL;
         HICON hExtractedSmall = NULL;
-        BOOL extractedSmallAdopted = FALSE;
         HRESULT extractResult;
         if (isIExtractIconW)
             extractResult = ((IExtractIconW*)pxi)->Extract(iconFileW, iconIndex, &hExtractedLarge, &hExtractedSmall,
@@ -588,19 +601,22 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             extractResult = pxi->Extract(iconFile, iconIndex, &hExtractedLarge, &hExtractedSmall,
                                          MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]));
 
-        if (SUCCEEDED(extractResult) && hExtractedSmall != NULL &&
-            GetIconPixelWidth(hExtractedSmall) == IconSizes[ICONSIZE_16])
+        HICON hExtracted = iconSize == ICONSIZE_16 ? hExtractedSmall : hExtractedLarge;
+        if (SUCCEEDED(extractResult) && hExtracted != NULL &&
+            GetIconPixelWidth(hExtracted) == requestedIconSize)
         {
-            if (hIconSmall != NULL && hIconSmall != hIconLarge)
-                HANDLES(DestroyIcon(hIconSmall));
-            hIconSmall = hExtractedSmall;
-            hExtractedSmall = NULL;
-            extractedSmallAdopted = TRUE;
+            if (*requestedIcon != NULL && *requestedIcon != *otherIcon)
+                HANDLES(DestroyIcon(*requestedIcon));
+            *requestedIcon = hExtracted;
+            if (iconSize == ICONSIZE_16)
+                hExtractedSmall = NULL;
+            else
+                hExtractedLarge = NULL;
         }
 
-        if (hExtractedSmall != NULL)
+        if (hExtractedSmall != NULL && hExtractedSmall != hIconSmall && hExtractedSmall != hIconLarge)
             HANDLES(DestroyIcon(hExtractedSmall));
-        if (hExtractedLarge != NULL && (!extractedSmallAdopted || hExtractedLarge != hIconSmall))
+        if (hExtractedLarge != NULL && hExtractedLarge != hIconSmall && hExtractedLarge != hIconLarge)
             HANDLES(DestroyIcon(hExtractedLarge));
     }
 
@@ -645,12 +661,10 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
     if (hIconLarge != NULL || hIconSmall != NULL)
     {
         ret = TRUE;
-        // Use a real icon for the current DPI.  IExtractIcon::Extract() and
-        // SHGFI_SMALLICON often return the historical 16x16 small icon even
-        // when IconSizes[ICONSIZE_16] is 20/24/... in a higher-DPI monitor.
-        // In that case prefer the DPI-sized shell image from SHIL_SYSSMALL, or
-        // derive the requested size from the larger icon instead of upscaling
-        // the 16x16 design.
+        // Use a real icon for the current DPI. IExtractIcon::Extract() and
+        // shell image lists can return a bitmap for a different DPI than the
+        // panel currently uses. Normalize every supported icon size here
+        // instead of allowing a stale size to enter the icon cache.
         if (iconSize == ICONSIZE_16)
         {
             int targetIconSize = IconSizes[ICONSIZE_16];
@@ -682,9 +696,19 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         else // ICONSIZE_32 || ICONSIZE_48
         {
             // if the large icon is missing or we were given the handle of the small one, create it
-            if (hIconLarge == NULL || hIconSmall == hIconLarge)
+            if (hIconLarge == NULL || hIconSmall == hIconLarge ||
+                GetIconPixelWidth(hIconLarge) != requestedIconSize)
             {
-                hIconLarge = (HICON)CopyImage(hIconSmall, IMAGE_ICON, IconSizes[largeIconSize], IconSizes[largeIconSize], LR_COPYFROMRESOURCE);
+                HICON hIconSource = hIconLarge != NULL ? hIconLarge : hIconSmall;
+                HICON hIconDPI = hIconSource != NULL ?
+                                     (HICON)CopyImage(hIconSource, IMAGE_ICON, requestedIconSize, requestedIconSize, 0) :
+                                     NULL;
+                if (hIconDPI != NULL)
+                {
+                    if (hIconLarge != NULL && hIconLarge != hIconSmall)
+                        HANDLES(DestroyIcon(hIconLarge));
+                    hIconLarge = hIconDPI;
+                }
                 //TRACE_I("  SalGetIconFromPIDL() CopyImage 2 hIconSmall="<<hIconSmall<<" hIconLarge="<<hIconLarge);
             }
             *hIcon = hIconLarge;
@@ -699,18 +723,14 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
     // Do not let a stale/corrupt shell image-list entry poison Salamander's
     // icon caches. Try the system list once more, otherwise keep the caller's
     // existing association/default icon by reporting extraction failure.
-    if (ret && iconSize == ICONSIZE_16 && path != NULL &&
-        IsSolidBlackIcon(*hIcon, IconSizes[ICONSIZE_16]))
+    if (ret && path != NULL && *hIcon != NULL &&
+        IsSolidBlackIcon(*hIcon, requestedIconSize))
     {
-        SHFILEINFO sfi;
-        ZeroMemory(&sfi, sizeof(sfi));
-        HIMAGELIST systemIcons = (HIMAGELIST)SHGetFileInfo(path, 0, &sfi, sizeof(sfi),
-                                                          SHGFI_SYSICONINDEX | SHGFI_SMALLICON);
-        HICON fallbackIcon = systemIcons != NULL ?
-                                 ImageList_GetIcon(systemIcons, sfi.iIcon, ILD_NORMAL) :
-                                 NULL;
+        HICON fallbackIcon = GetExplorerFileIcon(path, requestedIconSize, iconSize == ICONSIZE_16);
+        if (fallbackIcon == NULL)
+            fallbackIcon = GetDefaultAssociationIcon(path, requestedIconSize);
         if (fallbackIcon != NULL &&
-            !IsSolidBlackIcon(fallbackIcon, IconSizes[ICONSIZE_16]))
+            !IsSolidBlackIcon(fallbackIcon, requestedIconSize))
         {
             HANDLES(DestroyIcon(*hIcon));
             *hIcon = fallbackIcon;
@@ -810,7 +830,7 @@ BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum 
     // DefaultIcon values can both be valid yet select different artwork.
     if (!pathIsPIDL && iconSize == ICONSIZE_16)
     {
-        *hIcon = GetExplorerFileIcon(path, IconSizes[ICONSIZE_16]);
+        *hIcon = GetExplorerFileIcon(path, IconSizes[ICONSIZE_16], TRUE);
         if (*hIcon != NULL)
             return TRUE;
     }

--- a/src/geticon.h
+++ b/src/geticon.h
@@ -40,3 +40,7 @@ UINT WINAPI ExtractIcons(LPCTSTR szFileName, int nIconIndex, int cxIcon, int cyI
 // see comment spl_gen.h/GetFileIcon
 BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum iconSize,
                  BOOL fallbackToDefIcon, BOOL defIconIsDir);
+
+// Internal panel path: captures the exact display target and selects a supported shell source bucket from the panel DPI.
+BOOL GetFileIconForPanel(const char* path, HICON* hIcon, CIconSizeEnum iconSize,
+                         int targetPixelSize, int targetDPI, BOOL fallbackToDefIcon, BOOL defIconIsDir);

--- a/src/icncache.cpp
+++ b/src/icncache.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "precomp.h"
@@ -897,6 +897,15 @@ void CAssociations::Release()
     DestroyMembers();
     for (i = 0; i < ICONSIZE_COUNT; i++)
         Icons[i].IconsCount = 0;
+    for (size_t j = 0; j < PixelIconSets.size(); ++j)
+    {
+        if (PixelIconSets[j].Icons != NULL)
+        {
+            PixelIconSets[j].Icons->IconsCache.DestroyMembers();
+            delete PixelIconSets[j].Icons;
+        }
+    }
+    PixelIconSets.clear();
 }
 
 void CAssociations::Destroy()
@@ -931,7 +940,17 @@ void CAssociations::ColorsChanged()
     // FIXME: stacilo by nastavovat pozadi pouze pro patricny iconlist
     int i;
     for (i = 0; i < ICONSIZE_COUNT; i++)
-        SimpleIconLists[i]->SetBkColor(bkColor);
+        if (SimpleIconLists[i] != NULL)
+            SimpleIconLists[i]->SetBkColor(bkColor);
+    for (size_t j = 0; j < PixelIconSets.size(); ++j)
+    {
+        CAssociationsIcons* icons = PixelIconSets[j].Icons;
+        if (icons == NULL)
+            continue;
+        for (i = 0; i < icons->IconsCache.Count; ++i)
+            if (icons->IconsCache[i] != NULL)
+                icons->IconsCache[i]->SetBkColor(bkColor);
+    }
 }
 
 BOOL CAssociations::GetIndex(const char* name, int& index)
@@ -1048,6 +1067,179 @@ BOOL CAssociations::GetIcon(int iconIndex, CIconList** iconList, int* iconListIn
         TRACE_E("Incorrect call to CAssociations::GetIcon.");
         return FALSE;
     }
+}
+
+static CAssociationsPixelIconSet* FindAssociationPixelSet(std::vector<CAssociationsPixelIconSet>& sets, int pixelSize)
+{
+    for (size_t i = 0; i < sets.size(); ++i)
+        if (sets[i].PixelSize == pixelSize)
+            return &sets[i];
+    return NULL;
+}
+
+int CAssociations::GetPixelIconIndex(int associationIndex, int pixelSize)
+{
+    if (associationIndex < 0 || pixelSize <= 0)
+        return -1;
+    CAssociationsPixelIconSet* set = FindAssociationPixelSet(PixelIconSets, pixelSize);
+    if (set == NULL || associationIndex >= (int)set->AssociationIndexes.size())
+        return -1;
+    return set->AssociationIndexes[associationIndex];
+}
+
+BOOL CAssociations::SetPixelIconIndex(int associationIndex, int pixelSize, int iconIndex)
+{
+    if (associationIndex < 0 || pixelSize <= 0 || iconIndex < -3)
+        return FALSE;
+    CAssociationsPixelIconSet* set = FindAssociationPixelSet(PixelIconSets, pixelSize);
+    if (set == NULL)
+    {
+        CIconList* iconList;
+        int iconListIndex;
+        if (!GetIcon(ASSOC_ICON_NO_ASSOC, &iconList, &iconListIndex, pixelSize))
+            return FALSE;
+        set = FindAssociationPixelSet(PixelIconSets, pixelSize);
+    }
+    if (set == NULL)
+        return FALSE;
+    if (associationIndex >= (int)set->AssociationIndexes.size())
+    {
+        try { set->AssociationIndexes.resize(associationIndex + 1, -1); }
+        catch (...) { return FALSE; }
+    }
+    set->AssociationIndexes[associationIndex] = iconIndex;
+    return TRUE;
+}
+
+void CAssociations::ResetLoadingPixelIconIndexes(int pixelSize)
+{
+    CAssociationsPixelIconSet* set = FindAssociationPixelSet(PixelIconSets, pixelSize);
+    if (set == NULL)
+        return;
+    for (size_t i = 0; i < set->AssociationIndexes.size(); ++i)
+        if (set->AssociationIndexes[i] == -3)
+            set->AssociationIndexes[i] = -1;
+}
+
+BOOL CAssociations::GetIcon(int iconIndex, CIconList** iconList, int* iconListIndex, int pixelSize)
+{
+    CALL_STACK_MESSAGE2("CAssociations::GetIcon(%d, , pixels)", iconIndex);
+    if (pixelSize <= 0 || iconIndex < 0)
+        return FALSE;
+    CAssociationsPixelIconSet* set = FindAssociationPixelSet(PixelIconSets, pixelSize);
+    if (set == NULL)
+    {
+#ifdef new
+#undef new
+#define RESTORE_PIXEL_ASSOCIATION_NEW_MACRO
+#endif
+        CAssociationsIcons* icons = new (std::nothrow) CAssociationsIcons();
+#ifdef RESTORE_PIXEL_ASSOCIATION_NEW_MACRO
+#define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#undef RESTORE_PIXEL_ASSOCIATION_NEW_MACRO
+#endif
+        if (icons == NULL)
+            return FALSE;
+#ifdef new
+#undef new
+#define RESTORE_PIXEL_ASSOCIATION_LIST_NEW_MACRO
+#endif
+        CIconList* list = new (std::nothrow) CIconList();
+#ifdef RESTORE_PIXEL_ASSOCIATION_LIST_NEW_MACRO
+#define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#undef RESTORE_PIXEL_ASSOCIATION_LIST_NEW_MACRO
+#endif
+        if (list == NULL || !list->Create(pixelSize, pixelSize, ICONS_IN_LIST))
+        {
+            delete list;
+            delete icons;
+            return FALSE;
+        }
+        list->SetBkColor(GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]));
+        icons->IconsCache.Add(list);
+        if (!icons->IconsCache.IsGood())
+        {
+            delete list;
+            icons->IconsCache.ResetState();
+            delete icons;
+            return FALSE;
+        }
+        for (int i = 0; i < ASSOC_ICON_COUNT; ++i)
+        {
+            HICON icon = NULL;
+            if (i == ASSOC_ICON_SOME_DIR)
+            {
+                char systemDir[SAL_MAX_PATH];
+                GetSystemDirectory(systemDir, SAL_MAX_PATH);
+                GetFileIconForPanel(systemDir, &icon, ICONSIZE_16, pixelSize, GetSystemDPI(), TRUE, TRUE);
+            }
+            else
+                icon = SalLoadImage(i == ASSOC_ICON_SOME_FILE ? 90 : i == ASSOC_ICON_SOME_EXE ? 15 : 2,
+                                    i == ASSOC_ICON_SOME_FILE ? 2 : i == ASSOC_ICON_SOME_EXE ? 3 : 1,
+                                    pixelSize, pixelSize, IconLRFlags);
+            if (icon != NULL)
+            {
+                list->ReplaceIcon(i, icon);
+                HANDLES(DestroyIcon(icon));
+            }
+        }
+        icons->IconsCount = ASSOC_ICON_COUNT;
+        CAssociationsPixelIconSet newSet = {pixelSize, icons, std::vector<int>()};
+        try { newSet.AssociationIndexes.resize(Count, -1); }
+        catch (...) { icons->IconsCache.DestroyMembers(); delete icons; return FALSE; }
+        try { PixelIconSets.push_back(newSet); }
+        catch (...) { icons->IconsCache.DestroyMembers(); delete icons; return FALSE; }
+        set = &PixelIconSets.back();
+    }
+    if (iconIndex >= set->Icons->IconsCount)
+        return FALSE;
+    int cache = iconIndex / ICONS_IN_LIST;
+    if (cache >= set->Icons->IconsCache.Count)
+        return FALSE;
+    *iconList = set->Icons->IconsCache[cache];
+    *iconListIndex = iconIndex % ICONS_IN_LIST;
+    return TRUE;
+}
+
+int CAssociations::AllocIcon(CIconList** iconList, int* imageIconIndex, int pixelSize)
+{
+    CIconList* ignoredList;
+    int ignoredIndex;
+    if (!GetIcon(0, &ignoredList, &ignoredIndex, pixelSize))
+        return -1;
+    CAssociationsPixelIconSet* set = FindAssociationPixelSet(PixelIconSets, pixelSize);
+    int cache = set->Icons->IconsCount / ICONS_IN_LIST;
+    int index = set->Icons->IconsCount % ICONS_IN_LIST;
+    if (cache >= set->Icons->IconsCache.Count)
+    {
+#ifdef new
+#undef new
+#define RESTORE_PIXEL_ASSOCIATION_ALLOC_NEW_MACRO
+#endif
+        CIconList* list = new (std::nothrow) CIconList();
+#ifdef RESTORE_PIXEL_ASSOCIATION_ALLOC_NEW_MACRO
+#define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#undef RESTORE_PIXEL_ASSOCIATION_ALLOC_NEW_MACRO
+#endif
+        if (list == NULL || !list->Create(pixelSize, pixelSize, ICONS_IN_LIST))
+        {
+            delete list;
+            return -1;
+        }
+        list->SetBkColor(GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]));
+        set->Icons->IconsCache.Add(list);
+        if (!set->Icons->IconsCache.IsGood())
+        {
+            delete list;
+            set->Icons->IconsCache.ResetState();
+            return -1;
+        }
+        if (iconList != NULL) *iconList = list;
+    }
+    else if (iconList != NULL)
+        *iconList = set->Icons->IconsCache[cache];
+    if (imageIconIndex != NULL) *imageIconIndex = index;
+    return set->Icons->IconsCount++;
 }
 
 void CAssociations::SortArray(int left, int right)
@@ -1521,7 +1713,7 @@ static BOOL QueryShellAssociation(const char* ext, BOOL& canOpen)
     return canOpen || associatedInfo.iIcon != genericInfo.iIcon;
 }
 
-BOOL CAssociations::IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum iconSize)
+BOOL CAssociations::IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum iconSize, int pixelSize)
 {
     int index;
     BOOL found = GetIndex(ext, index);
@@ -1547,10 +1739,20 @@ BOOL CAssociations::IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum 
     }
     if (found)
     {
-        int i = At(index).GetIndex(iconSize);
-        if (i == -1)
-            At(index).SetIndex(-3, iconSize);  // nenactena -> nacitana
-        addtoIconCache = (i == -1 || i == -2); // dynamicka nebo nenactena/nenacitana staticka
+        int semanticIndex = At(index).GetIndex(iconSize);
+        if (semanticIndex == -2)
+            addtoIconCache = TRUE; // dynamic icon: each file is its own source
+        else
+        {
+            int pixelIndex = GetPixelIconIndex(index, pixelSize);
+            addtoIconCache = pixelIndex == -1;
+            if (addtoIconCache)
+            {
+                SetPixelIconIndex(index, pixelSize, -3); // exactly one file loads this pixel-sized association
+                if (semanticIndex == -1)
+                    At(index).SetIndex(-3, iconSize);
+            }
+        }
         return At(index).GetFlag() != 0;
     }
     else
@@ -1560,16 +1762,19 @@ BOOL CAssociations::IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum 
     }
 }
 
-BOOL CAssociations::IsAssociatedStatic(char* ext, const char*& iconLocation, CIconSizeEnum iconSize)
+BOOL CAssociations::IsAssociatedStatic(char* ext, const char*& iconLocation, CIconSizeEnum iconSize, int pixelSize)
 {
     int index;
     if (GetIndex(ext, index))
     {
-        int i = At(index).GetIndex(iconSize);
-        if (i == -1)
+        int semanticIndex = At(index).GetIndex(iconSize);
+        int pixelIndex = GetPixelIconIndex(index, pixelSize);
+        if (semanticIndex != -2 && pixelIndex == -1)
         {
-            At(index).SetIndex(-3, iconSize);          // nenactena -> nacitana
-            iconLocation = At(index).ExtensionAndData; // nenactena/nenacitana staticka
+            SetPixelIconIndex(index, pixelSize, -3);
+            if (semanticIndex == -1)
+                At(index).SetIndex(-3, iconSize);
+            iconLocation = At(index).ExtensionAndData;
         }
         else
             iconLocation = NULL;

--- a/src/icncache.h
+++ b/src/icncache.h
@@ -1,7 +1,9 @@
-﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once
+
+#include <vector>
 
 //
 // ****************************************************************************
@@ -156,6 +158,7 @@ public:
 
     void SetIconSize(CIconSizeEnum iconSize, int iconPixelSize = 0);
     CIconSizeEnum GetIconSize() { return IconSize; }
+    int GetIconPixelSize() { return IconPixelSize; }
 
 protected:
     // jen pro interni pouziti
@@ -246,10 +249,18 @@ public:
     }
 };
 
+struct CAssociationsPixelIconSet
+{
+    int PixelSize;
+    CAssociationsIcons* Icons;
+    std::vector<int> AssociationIndexes; // association record index -> pixel-cache icon index
+};
+
 class CAssociations : public TDirectArray<CAssociationData>
 {
 protected:
     CAssociationsIcons Icons[ICONSIZE_COUNT];
+    std::vector<CAssociationsPixelIconSet> PixelIconSets;
 
 public:
     CAssociations();
@@ -273,10 +284,15 @@ public:
     // jinak 'iconList' vraci ukazatel na CIconList, ktery nese ikonu a 'iconListIndex'
     // je index v ramci tohoto imagelistu.
     int AllocIcon(CIconList** iconList, int* imageIconIndex, CIconSizeEnum iconSize);
+    int AllocIcon(CIconList** iconList, int* imageIconIndex, int pixelSize);
 
     // vrati v 'iconList' ukazatel na IconList a v 'iconListIndex' pozici ikonky
     // 'iconIndex' (vracene z AllocIcon);
     BOOL GetIcon(int iconIndex, CIconList** iconList, int* iconListIndex, CIconSizeEnum iconSize);
+    BOOL GetIcon(int iconIndex, CIconList** iconList, int* iconListIndex, int pixelSize);
+    int GetPixelIconIndex(int associationIndex, int pixelSize);
+    BOOL SetPixelIconIndex(int associationIndex, int pixelSize, int iconIndex);
+    void ResetLoadingPixelIconIndexes(int pixelSize);
 
     // musi prekreslit zakladni sadu ikon s novym pozadim
     void ColorsChanged();
@@ -284,8 +300,8 @@ public:
     void ReadAssociations(BOOL showWaitWnd);
 
     // ext musi byt zarovnan po DWORDech
-    BOOL IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum iconSize);
-    BOOL IsAssociatedStatic(char* ext, const char*& iconLocation, CIconSizeEnum iconSize);
+    BOOL IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum iconSize, int pixelSize);
+    BOOL IsAssociatedStatic(char* ext, const char*& iconLocation, CIconSizeEnum iconSize, int pixelSize);
     BOOL IsAssociated(char* ext);
 
 protected:

--- a/src/iconlist.cpp
+++ b/src/iconlist.cpp
@@ -1500,6 +1500,35 @@ CIconList::GetImageList()
         }
     }
     return hIL;
+}
+
+HIMAGELIST CIconList::GetImageList(int requiredImageSize)
+{
+    if (requiredImageSize <= 0 ||
+        requiredImageSize == ImageWidth && requiredImageSize == ImageHeight)
+    {
+        return GetImageList();
+    }
+
+    HIMAGELIST hIL = ImageList_Create(requiredImageSize, requiredImageSize,
+                                      GetImageListColorFlags() | ILC_MASK, 0, 1);
+    if (hIL != NULL)
+    {
+        for (int i = 0; i < ImageCount; ++i)
+        {
+            HICON icon = GetIcon(i, TRUE);
+            HICON sizedIcon = icon != NULL ?
+                                  (HICON)CopyImage(icon, IMAGE_ICON,
+                                                   requiredImageSize, requiredImageSize, 0) :
+                                  NULL;
+            ImageList_AddIcon(hIL, sizedIcon != NULL ? sizedIcon : icon);
+            if (sizedIcon != NULL)
+                HANDLES(DestroyIcon(sizedIcon));
+            if (icon != NULL)
+                HANDLES(DestroyIcon(icon));
+        }
+    }
+    return hIL;
 
     /*
   // vytahnu rozmery bitmapy

--- a/src/iconlist.cpp
+++ b/src/iconlist.cpp
@@ -447,35 +447,102 @@ BOOL CIconList::ReplaceIcon(int index, HICON hIcon)
 {
     CALL_STACK_MESSAGE2("CIconList::ReplaceIcon(%d, )", index);
 
-    HICON hIconOrig = hIcon;
-    BOOL ret = TRUE;
-    ICONINFO ii;
-    ZeroMemory(&ii, sizeof(ii));
-    HDC hSrcDC;
-    HBITMAP hOldSrcBmp;
-
-    HANDLES(EnterCriticalSection(&CriticalSection));
-
-    int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
-    int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
-
-    // kontrola parametru
-    if (index < 0 || index >= ImageCount)
+    if (index < 0 || index >= ImageCount || hIcon == NULL)
     {
-        TRACE_E("CIconList::ReplaceIcon(): Index is out of range! index=" << index);
-        goto BAIL;
+        TRACE_E("CIconList::ReplaceIcon(): Invalid parameter! index=" << index);
+        return FALSE;
     }
 
-    // pokud je treba, provedeme resize ikonky
-    // Honza: pod W10 mi zacalo volani CopyImage padat v debug x64 verzi, pokud byl povolen LR_COPYFROMRESOURCE flag
-    // FIXME: provest audit, zda je tento downscale jeste potreba, kdyz SalLoadIcon() nove vola LoadIconWithScaleDown()
-    hIcon = (HICON)CopyImage(hIconOrig, IMAGE_ICON, ImageWidth, ImageHeight, /*LR_COPYFROMRESOURCE | */ LR_COPYRETURNORG);
+    HICON hIconOrig = hIcon;
+    HICON hConvertedIcon = NULL;
+    ICONINFO ii;
+    ZeroMemory(&ii, sizeof(ii));
+    BOOL ret = FALSE;
+    HDC hSrcDC = NULL;
+    HBITMAP hOldSrcBmp = NULL;
 
-    // vytahneme z handlu ikony jeji MASK a COLOR bitmapy
+    // CopyImage usually performs the conversion, but some shell icon handles
+    // ignore the requested dimensions or fail to resize.
+    hConvertedIcon = (HICON)CopyImage(hIconOrig, IMAGE_ICON, ImageWidth, ImageHeight, 0);
+    if (hConvertedIcon != NULL)
+    {
+        ICONINFO convertedInfo;
+        ZeroMemory(&convertedInfo, sizeof(convertedInfo));
+        BITMAP convertedBitmap;
+        ZeroMemory(&convertedBitmap, sizeof(convertedBitmap));
+        if (!GetIconInfo(hConvertedIcon, &convertedInfo) ||
+            convertedInfo.hbmMask == NULL ||
+            GetObject(convertedInfo.hbmMask, sizeof(convertedBitmap), &convertedBitmap) != sizeof(convertedBitmap) ||
+            convertedBitmap.bmWidth != ImageWidth ||
+            (convertedInfo.hbmColor == NULL ? convertedBitmap.bmHeight != ImageHeight * 2 : convertedBitmap.bmHeight != ImageHeight))
+        {
+            HANDLES(DestroyIcon(hConvertedIcon));
+            hConvertedIcon = NULL;
+        }
+        if (convertedInfo.hbmMask != NULL)
+            HANDLES(DeleteObject(convertedInfo.hbmMask));
+        if (convertedInfo.hbmColor != NULL)
+            HANDLES(DeleteObject(convertedInfo.hbmColor));
+    }
+
+    if (hConvertedIcon == NULL)
+    {
+        BITMAPINFOHEADER header;
+        ZeroMemory(&header, sizeof(header));
+        header.biSize = sizeof(header);
+        header.biWidth = ImageWidth;
+        header.biHeight = -ImageHeight;
+        header.biPlanes = 1;
+        header.biBitCount = 32;
+        header.biCompression = BI_RGB;
+
+        DWORD* colorBits = NULL;
+        HBITMAP color = HANDLES(CreateDIBSection(NULL, (BITMAPINFO*)&header, DIB_RGB_COLORS,
+                                                 (void**)&colorBits, NULL, 0));
+        HBITMAP mask = color != NULL ? HANDLES(CreateBitmap(ImageWidth, ImageHeight, 1, 1, NULL)) : NULL;
+        HDC colorDC = color != NULL ? HANDLES(CreateCompatibleDC(NULL)) : NULL;
+        HDC maskDC = mask != NULL ? HANDLES(CreateCompatibleDC(NULL)) : NULL;
+        HBITMAP oldColor = colorDC != NULL ? (HBITMAP)SelectObject(colorDC, color) : NULL;
+        HBITMAP oldMask = maskDC != NULL ? (HBITMAP)SelectObject(maskDC, mask) : NULL;
+        BOOL colorDrawn = FALSE;
+        BOOL maskDrawn = FALSE;
+        if (colorDC != NULL && maskDC != NULL)
+        {
+            ZeroMemory(colorBits, ImageWidth * ImageHeight * sizeof(DWORD));
+            colorDrawn = DrawIconEx(colorDC, 0, 0, hIconOrig, ImageWidth, ImageHeight, 0, NULL, DI_NORMAL);
+            PatBlt(maskDC, 0, 0, ImageWidth, ImageHeight, WHITENESS);
+            maskDrawn = DrawIconEx(maskDC, 0, 0, hIconOrig, ImageWidth, ImageHeight, 0, NULL, DI_MASK);
+        }
+        if (oldColor != NULL)
+            SelectObject(colorDC, oldColor);
+        if (oldMask != NULL)
+            SelectObject(maskDC, oldMask);
+        if (colorDC != NULL)
+            HANDLES(DeleteDC(colorDC));
+        if (maskDC != NULL)
+            HANDLES(DeleteDC(maskDC));
+
+        if (colorDrawn && maskDrawn)
+        {
+            ICONINFO rasterInfo;
+            ZeroMemory(&rasterInfo, sizeof(rasterInfo));
+            rasterInfo.fIcon = TRUE;
+            rasterInfo.hbmColor = color;
+            rasterInfo.hbmMask = mask;
+            hConvertedIcon = HANDLES(CreateIconIndirect(&rasterInfo));
+        }
+        if (color != NULL)
+            HANDLES(DeleteObject(color));
+        if (mask != NULL)
+            HANDLES(DeleteObject(mask));
+        if (hConvertedIcon == NULL)
+            return FALSE;
+    }
+    hIcon = hConvertedIcon;
+
     if (!GetIconInfo(hIcon, &ii))
     {
         TRACE_E("GetIconInfo() failed!");
-        DWORD err = GetLastError();
         goto BAIL;
     }
 
@@ -485,67 +552,69 @@ BOOL CIconList::ReplaceIcon(int index, HICON hIcon)
         TRACE_E("GetObject() failed!");
         goto BAIL;
     }
-
-    // pokud se jedna o b&w ikonu, mela by mit sudou vysku
     if (ii.hbmColor == NULL && (bm.bmHeight & 1) == 1)
     {
         TRACE_E("CIconList::ReplaceIcon() Icon has wrong MASK height");
         goto BAIL;
     }
-    // ikonka by mela mit stejne rozmery, jako ma nase polozka
     if (bm.bmWidth != ImageWidth ||
         (ii.hbmColor == NULL && bm.bmHeight != ImageHeight * 2) ||
         (ii.hbmColor != NULL && bm.bmHeight != ImageHeight))
+    {
         TRACE_E("CIconList::ReplaceIcon() Icon has wrong size: bmWidth=" << bm.bmWidth << " bmHeight=" << bm.bmHeight);
-
-    // potrebujeme dostatecny prostor pro masku
-    if (!CreateOrEnlargeTmpImage(bm.bmWidth, bm.bmHeight))
+        goto BAIL;
+    }
+    hSrcDC = HANDLES(CreateCompatibleDC(NULL));
+    if (hSrcDC == NULL)
+        goto BAIL;
+    hOldSrcBmp = (HBITMAP)SelectObject(hSrcDC, ii.hbmMask);
+    if (hOldSrcBmp == NULL)
         goto BAIL;
 
-    hSrcDC = HANDLES(CreateCompatibleDC(NULL)); // pomocne dc pro bitblt
-    hOldSrcBmp = (HBITMAP)SelectObject(hSrcDC, ii.hbmMask);
-
-    // ii.hbmMask -> HTmpImage
-    SelectObject(HMemDC, HTmpImage);
-    BitBlt(HMemDC, 0, 0, ImageWidth, ImageHeight, hSrcDC, 0, 0, SRCCOPY);
-
-    // ii.hbmColor -> HImage (pokud je hbmColor==NULL, lezi XOR cast ve spodni polovine hbmMask
-    if (ii.hbmColor != NULL)
-        SelectObject(hSrcDC, ii.hbmColor);
-    SelectObject(HMemDC, HImage);
-    BitBlt(HMemDC, iX, iY, ImageWidth, ImageHeight, hSrcDC, 0, (ii.hbmColor != NULL) ? 0 : ImageHeight, SRCCOPY);
-
-    GdiFlush(); // podle MSDN je treba zavolat nez zacneme pristupovat na raw data
-
-    //  TRACE_I("counter: "<<counter);
-    //  if (++counter == 19)
-    //    DumpToTrace(index);
-
-    ImageFlags[index] = ApplyMaskToImage(index, ii.hbmColor == NULL);
-    InterlockedIncrement(&ContentVersion);
-
-    SelectObject(hSrcDC, hOldSrcBmp);
-    HANDLES(DeleteDC(hSrcDC));
-
-BAIL:
+    HANDLES(EnterCriticalSection(&CriticalSection));
+    {
+        if (!CreateOrEnlargeTmpImage(ImageWidth, ImageHeight * (ii.hbmColor == NULL ? 2 : 1)))
+        {
+            HANDLES(LeaveCriticalSection(&CriticalSection));
+            goto BAIL;
+        }
+        int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
+        int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
+        SelectObject(HMemDC, HTmpImage);
+        if (!BitBlt(HMemDC, 0, 0, ImageWidth, ImageHeight, hSrcDC, 0, 0, SRCCOPY))
+        {
+            HANDLES(LeaveCriticalSection(&CriticalSection));
+            goto BAIL;
+        }
+        if (ii.hbmColor != NULL)
+            SelectObject(hSrcDC, ii.hbmColor);
+        SelectObject(HMemDC, HImage);
+        if (!BitBlt(HMemDC, iX, iY, ImageWidth, ImageHeight, hSrcDC, 0,
+                    ii.hbmColor != NULL ? 0 : ImageHeight, SRCCOPY))
+        {
+            HANDLES(LeaveCriticalSection(&CriticalSection));
+            goto BAIL;
+        }
+        GdiFlush();
+        ImageFlags[index] = ApplyMaskToImage(index, ii.hbmColor == NULL);
+        InterlockedIncrement(&ContentVersion);
+        ret = TRUE;
+    }
     HANDLES(LeaveCriticalSection(&CriticalSection));
 
+BAIL:
+    if (hSrcDC != NULL)
+    {
+        if (hOldSrcBmp != NULL)
+            SelectObject(hSrcDC, hOldSrcBmp);
+        HANDLES(DeleteDC(hSrcDC));
+    }
     if (ii.hbmMask != NULL)
-        DeleteObject(ii.hbmMask);
-
+        HANDLES(DeleteObject(ii.hbmMask));
     if (ii.hbmColor != NULL)
-        DeleteObject(ii.hbmColor);
-
-    // pokud jsme menili velikost, musime sestrelit docasnou ikonku
-    if (hIcon != hIconOrig)
-        DestroyIcon(hIcon);
-
-    //  if (Dump)
-    //  {
-    //    TRACE_E("ReplaceIcon()");
-    //    DumpToTrace(index, FALSE);
-    //  }
-
+        HANDLES(DeleteObject(ii.hbmColor));
+    if (hConvertedIcon != NULL)
+        HANDLES(DestroyIcon(hConvertedIcon));
     return ret;
 }
 

--- a/src/iconlist.cpp
+++ b/src/iconlist.cpp
@@ -508,7 +508,9 @@ BOOL CIconList::ReplaceIcon(int index, HICON hIcon)
         BOOL maskDrawn = FALSE;
         if (colorDC != NULL && maskDC != NULL)
         {
-            ZeroMemory(colorBits, ImageWidth * ImageHeight * sizeof(DWORD));
+            const size_t colorBytes = static_cast<size_t>(ImageWidth) *
+                                      static_cast<size_t>(ImageHeight) * sizeof(DWORD);
+            ZeroMemory(colorBits, colorBytes);
             colorDrawn = DrawIconEx(colorDC, 0, 0, hIconOrig, ImageWidth, ImageHeight, 0, NULL, DI_NORMAL);
             PatBlt(maskDC, 0, 0, ImageWidth, ImageHeight, WHITENESS);
             maskDrawn = DrawIconEx(maskDC, 0, 0, hIconOrig, ImageWidth, ImageHeight, 0, NULL, DI_MASK);

--- a/src/iconlist.h
+++ b/src/iconlist.h
@@ -150,6 +150,7 @@ public:
     // vytvori imagelist (jeden radek, pocet sloupcu dle poctu polozek); vraci jeho handle nebo NULL v pripade neuspechu
     // vraceny imagelist je po pouziti treba destruovat pomoci API ImageList_Destroy()
     virtual HIMAGELIST WINAPI GetImageList();
+    HIMAGELIST GetImageList(int requiredImageSize);
 
     // kopiruje jednu polozku ze 'srcIL' a pozice 'srcIndex' na pozici 'dstIndex'
     virtual BOOL WINAPI Copy(int dstIndex, CIconList* srcIL, int srcIndex);

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -459,6 +459,7 @@ public:
     BOOL Created;
     BOOL RestoringPanelPaths; // suppress repeated Tree View rebuilds while LoadConfig restores panels
     BOOL StartupWindowCloaked; // TRUE while the fully initialized startup UI is hidden behind the splash
+    int StartupShowCmd;       // persisted startup state after command-line override processing
     BOOL DetachedPanels;      // TRUE = left and right sides are hosted in separate top-level windows
     BOOL CreatingDetachedChrome; // suppress detached-window activation while its child chrome is being built
     BOOL DetachedPanelsSwapFixNeeded; // TRUE after Swap Sides while detached; reattach replays a double swap to refresh layout state
@@ -778,7 +779,7 @@ public:
     // returns the index of an unassigned hot path or -1 if all are assigned
     int GetUnassignedHotPathIndex();
 
-    void SetFont();
+    void SetFont(int attachedPanelDPI = 0);
     void SetEnvFont();
     void RefreshDPI(BOOL force, int dpi = 0, const RECT* suggestedRect = NULL);
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -4,6 +4,9 @@
 
 #include "precomp.h"
 
+static void SetDPIAwareWindowIcon(HWND hWindow, int resID);
+static void ReleaseDPIAwareWindowIcons(HWND hWindow);
+
 #include <string>
 #include <shlwapi.h>
 #undef PathIsPrefix
@@ -391,6 +394,7 @@ CMainWindow::CMainWindow()
     Created = FALSE;
     RestoringPanelPaths = FALSE;
     StartupWindowCloaked = FALSE;
+    StartupShowCmd = SW_SHOWNORMAL;
     DetachedPanels = FALSE;
     CreatingDetachedChrome = FALSE;
     DetachedPanelsSwapFixNeeded = FALSE;
@@ -1901,7 +1905,7 @@ BOOL CreateEnvFonts()
     return TRUE;
 }
 
-void CMainWindow::SetFont()
+void CMainWindow::SetFont(int attachedPanelDPI)
 {
     CALL_STACK_MESSAGE1("CMainWindow::SetFont()");
 
@@ -1930,7 +1934,9 @@ void CMainWindow::SetFont()
         CFilesWindow* panel = LeftPanelTabs[i];
         if (panel != NULL)
         {
-            panel->RefreshDPIResources(TRUE);
+            int panelDPI = GetAncestor(panel->HWindow, GA_ROOT) == HWindow ? attachedPanelDPI : 0;
+            panel->RefreshDPIResources(TRUE, panelDPI);
+            panel->RefreshIconCacheForCurrentSize();
             panel->SetFont();
             panel->RefreshTreeViewDPI();
         }
@@ -1940,7 +1946,9 @@ void CMainWindow::SetFont()
         CFilesWindow* panel = RightPanelTabs[i];
         if (panel != NULL)
         {
-            panel->RefreshDPIResources(TRUE);
+            int panelDPI = GetAncestor(panel->HWindow, GA_ROOT) == HWindow ? attachedPanelDPI : 0;
+            panel->RefreshDPIResources(TRUE, panelDPI);
+            panel->RefreshIconCacheForCurrentSize();
             panel->SetFont();
             panel->RefreshTreeViewDPI();
         }
@@ -1950,7 +1958,9 @@ void CMainWindow::SetFont()
         CFilesWindow* panel = DetachedTabs[i].Panel;
         if (panel != NULL)
         {
-            panel->RefreshDPIResources(TRUE);
+            int panelDPI = GetAncestor(panel->HWindow, GA_ROOT) == HWindow ? attachedPanelDPI : 0;
+            panel->RefreshDPIResources(TRUE, panelDPI);
+            panel->RefreshIconCacheForCurrentSize();
             panel->SetFont();
             panel->RefreshTreeViewDPI();
         }
@@ -2268,7 +2278,7 @@ BOOL CMainWindow::RebuildDetachedToolbarImageLists(int dpi)
         return FALSE;
     }
 
-    int iconSize = MulDiv(16, dpi, USER_DEFAULT_SCREEN_DPI);
+    int iconSize = GetIconSizeForDPI(ICONSIZE_16, dpi);
     HIMAGELIST newHot = ImageList_Create(iconSize, iconSize, ILC_MASK | ILC_COLORDDB,
                                          IDX_TB_COUNT + 1, 1);
     HIMAGELIST newGray = ImageList_Create(iconSize, iconSize, ILC_MASK | ILC_COLORDDB,
@@ -2365,7 +2375,7 @@ BOOL CMainWindow::RebuildDetachedTabToolbarImageLists(int dpi, HWND hWnd)
         return FALSE;
     }
 
-    int iconSize = MulDiv(16, dpi, USER_DEFAULT_SCREEN_DPI);
+    int iconSize = GetIconSizeForDPI(ICONSIZE_16, dpi);
     HIMAGELIST newHot = ImageList_Create(iconSize, iconSize, ILC_MASK | ILC_COLORDDB,
                                          IDX_TB_COUNT + 1, 1);
     HIMAGELIST newGray = ImageList_Create(iconSize, iconSize, ILC_MASK | ILC_COLORDDB,
@@ -3197,6 +3207,8 @@ static HWND CreateDetachedPanelWindow(CMainWindow* mainWindow, CPanelSide side)
         DarkModeApplyWindow(hWnd);
         DarkModeRefreshTitleBar(hWnd);
         DarkModeAllowDarkScrollbars(hWnd);
+        int resID = MainWindowIcons[Configuration.GetMainWindowIconIndex()].IconResID;
+        SetDPIAwareWindowIcon(hWnd, resID);
     }
     return hWnd;
 }
@@ -3393,6 +3405,8 @@ static HWND CreateDetachedTabWindow(CMainWindow* mainWindow, CFilesWindow* sourc
         DarkModeApplyWindow(hWnd);
         DarkModeRefreshTitleBar(hWnd);
         DarkModeAllowDarkScrollbars(hWnd);
+        int resID = MainWindowIcons[Configuration.GetMainWindowIconIndex()].IconResID;
+        SetDPIAwareWindowIcon(hWnd, resID);
     }
     return hWnd;
 }
@@ -4460,6 +4474,7 @@ LRESULT CALLBACK CMainWindow::DetachedTabWindowProc(HWND hWnd, UINT uMsg, WPARAM
             return 0;
 
         case WM_USER_REFRESH_DETACHED_TAB_DPI:
+            SetDPIAwareWindowIcon(hWnd, MainWindowIcons[Configuration.GetMainWindowIconIndex()].IconResID);
             if (info != NULL)
             {
                 info->DPIRefreshPosted = FALSE;
@@ -4474,6 +4489,10 @@ LRESULT CALLBACK CMainWindow::DetachedTabWindowProc(HWND hWnd, UINT uMsg, WPARAM
             RedrawWindow(hWnd, NULL, NULL,
                          RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
             return 0;
+
+        case WM_NCDESTROY:
+            ReleaseDPIAwareWindowIcons(hWnd);
+            break;
 
         case WM_SIZE:
             mainWindow->LayoutDetachedTabWindow(hWnd);
@@ -4659,6 +4678,10 @@ LRESULT CALLBACK CMainWindow::DetachedPanelWindowProc(HWND hWnd, UINT uMsg, WPAR
             return 0;
         }
 
+        case WM_NCDESTROY:
+            ReleaseDPIAwareWindowIcons(hWnd);
+            break;
+
         case WM_USER_REFRESH_DETACHED_DPI:
         {
             mainWindow->DetachedDPIRefreshPosted = FALSE;
@@ -4667,6 +4690,7 @@ LRESULT CALLBACK CMainWindow::DetachedPanelWindowProc(HWND hWnd, UINT uMsg, WPAR
 
             mainWindow->DetachedDPIRefreshInProgress = TRUE;
             int dpi = (int)WinLibDPIGetWindowDPI(hWnd);
+            SetDPIAwareWindowIcon(hWnd, MainWindowIcons[Configuration.GetMainWindowIconIndex()].IconResID);
 
             // Chrome owns native pixel resources (toolbar strips, fonts and
             // rebar band heights). Recreate only this top-level's copies.
@@ -5510,12 +5534,53 @@ void CMainWindow::UpdateDetachedMenuLabels()
     }
 }
 
+static const char* OWNED_BIG_WINDOW_ICON = "SalamanderOwnedBigWindowIcon";
+static const char* OWNED_SMALL_WINDOW_ICON = "SalamanderOwnedSmallWindowIcon";
+
+static void ReleaseDPIAwareWindowIcons(HWND hWindow)
+{
+    HICON bigIcon = (HICON)RemoveProp(hWindow, OWNED_BIG_WINDOW_ICON);
+    HICON smallIcon = (HICON)RemoveProp(hWindow, OWNED_SMALL_WINDOW_ICON);
+    if (bigIcon != NULL)
+        HANDLES(DestroyIcon(bigIcon));
+    if (smallIcon != NULL && smallIcon != bigIcon)
+        HANDLES(DestroyIcon(smallIcon));
+}
+
+static void SetDPIAwareWindowIcon(HWND hWindow, int resID)
+{
+    if (hWindow == NULL)
+        return;
+
+    int dpi = GetDPIForWindow(hWindow);
+    int bigSize = GetIconSizeForDPI(ICONSIZE_32, dpi);
+    int smallSize = GetIconSizeForDPI(ICONSIZE_16, dpi);
+    HICON bigIcon = (HICON)HANDLES(LoadImage(HInstance, MAKEINTRESOURCE(resID), IMAGE_ICON,
+                                             bigSize, bigSize, IconLRFlags));
+    HICON smallIcon = (HICON)HANDLES(LoadImage(HInstance, MAKEINTRESOURCE(resID), IMAGE_ICON,
+                                               smallSize, smallSize, IconLRFlags));
+    if (bigIcon != NULL)
+    {
+        SendMessage(hWindow, WM_SETICON, ICON_BIG, (LPARAM)bigIcon);
+        HICON oldBig = (HICON)GetProp(hWindow, OWNED_BIG_WINDOW_ICON);
+        SetProp(hWindow, OWNED_BIG_WINDOW_ICON, bigIcon);
+        if (oldBig != NULL)
+            HANDLES(DestroyIcon(oldBig));
+    }
+    if (smallIcon != NULL)
+    {
+        SendMessage(hWindow, WM_SETICON, ICON_SMALL, (LPARAM)smallIcon);
+        HICON oldSmall = (HICON)GetProp(hWindow, OWNED_SMALL_WINDOW_ICON);
+        SetProp(hWindow, OWNED_SMALL_WINDOW_ICON, smallIcon);
+        if (oldSmall != NULL)
+            HANDLES(DestroyIcon(oldSmall));
+    }
+}
+
 void CMainWindow::SetWindowIcon()
 {
     int resID = MainWindowIcons[Configuration.GetMainWindowIconIndex()].IconResID;
-    // assign the icon to the window
-    SendMessage(HWindow, WM_SETICON, ICON_BIG,
-                (LPARAM)HANDLES(LoadIcon(HInstance, MAKEINTRESOURCE(resID))));
+    SetDPIAwareWindowIcon(HWindow, resID);
 
     if (Configuration.StatusArea)
         AddTrayIcon(TRUE);
@@ -7058,6 +7123,8 @@ void CMainWindow::OnColorsChanged(BOOL reloadUMIcons)
 {
     DarkModeApplyTree(HWindow);
     DarkModeRefreshTitleBar(HWindow);
+    int mainIconResID = MainWindowIcons[Configuration.GetMainWindowIconIndex()].IconResID;
+    SetDPIAwareWindowIcon(HWindow, mainIconResID);
 
     // screen colors or color depth changed; new imagelists have been created
     // for the toolbars and must be attached to the controls that use them
@@ -7078,10 +7145,18 @@ void CMainWindow::OnColorsChanged(BOOL reloadUMIcons)
         MiddleToolBar->OnColorsChanged();
     }
 
-    // plugin bar
+    // Plugin bars own DPI-sized copies of plug-in artwork. The attached bar is
+    // rebuilt now from the authoritative main-window DPI. Detached chrome is
+    // recreated below from its own top-level DPI.
     if (PluginsBar != NULL)
     {
+        PluginsBar->CreatePluginButtons();
         PluginsBar->OnColorsChanged();
+    }
+    if (!DetachedPanels && DetachedPluginsBar != NULL)
+    {
+        DetachedPluginsBar->CreatePluginButtons();
+        DetachedPluginsBar->OnColorsChanged();
     }
     if (ExtensionBar != NULL)
     {

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -4715,6 +4715,7 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
         WINDOWPLACEMENT place;
         BOOL useWinPlacement = FALSE;
         BOOL deferMainWindowReveal = FALSE;
+        StartupShowCmd = CmdShow;
         if (OpenKey(salamander, SALAMANDER_WINDOW_REG, actKey))
         {
             place.length = sizeof(WINDOWPLACEMENT);
@@ -4779,20 +4780,15 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
 
         if (useWinPlacement)
         {
-            RECT startupRect = place.rcNormalPosition;
-            if (startupRect.right > startupRect.left && startupRect.bottom > startupRect.top &&
-                MonitorFromRect(&startupRect, MONITOR_DEFAULTTONULL) != NULL)
-            {
-                // Move the hidden main window to its saved monitor before panels
-                // and icon caches are loaded.  Otherwise a process started on a
-                // high-DPI primary monitor can initialize 24px shell icons and
-                // only later move to the remembered 100% monitor.
-                SetWindowPos(HWindow, NULL, startupRect.left, startupRect.top,
-                             startupRect.right - startupRect.left, startupRect.bottom - startupRect.top,
-                             SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOREDRAW);
-                UpdateSystemDPIForWindow(HWindow);
-                ColorsChanged(FALSE, FALSE, TRUE);
-            }
+            // WINDOWPLACEMENT stores rcNormalPosition in workspace coordinates.
+            // Let Windows interpret it while the window is hidden instead of
+            // passing it to screen-coordinate SetWindowPos/MonitorFromRect.
+            WINDOWPLACEMENT startupPlacement = place;
+            startupPlacement.length = sizeof(WINDOWPLACEMENT);
+            startupPlacement.showCmd = SW_HIDE;
+            SetWindowPlacement(HWindow, &startupPlacement);
+            UpdateSystemDPIForWindow(HWindow);
+            ColorsChanged(FALSE, FALSE, TRUE);
         }
 
         if (OpenKey(salamander, FINDDIALOG_WINDOW_REG, actKey))
@@ -6354,6 +6350,7 @@ BOOL CMainWindow::LoadConfig(BOOL importingOldConfig, const CCommandLineParams* 
                 }
                 }
             }
+            StartupShowCmd = place.showCmd;
             // Keep the ordinary two-panel window hidden until both panel paths
             // and their list boxes are fully initialized.  Showing it here
             // exposes the saved panel contents first and the final directory
@@ -6503,10 +6500,10 @@ void CMainWindow::RevealStartupWindow()
     // Show the hidden main window while it is cloaked so ShowWindow can apply
     // the requested normal, minimized, or maximized startup state without DWM
     // publishing the incomplete surface. SW_HIDE remains genuinely hidden.
-    if (CmdShow != SW_HIDE)
+    if (StartupShowCmd != SW_HIDE)
     {
         StartupWindowCloaked = DarkModeSetWindowCloaked(HWindow, true);
-        ShowWindow(HWindow, CmdShow);
+        ShowWindow(HWindow, StartupShowCmd);
     }
     // Closing the splash/startup wait owner causes one synthetic activation
     // transition. The panels were read only moments ago, so letting that

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3881,6 +3881,19 @@ static WINDOWPLACEMENT PreSuspendWindowPlacement = {sizeof(WINDOWPLACEMENT)};
 static BOOL PreSuspendWindowPlacementValid = FALSE;
 static BOOL ResumeWindowPlacementPending = FALSE;
 
+static void ScheduleDPIReconciliation(HWND hWindow)
+{
+    if (DPIRefreshPosted || hWindow == NULL)
+        return;
+
+    // Query only after the broadcast handler unwinds. During WM_SETTINGCHANGE
+    // GetDpiForWindow can still report the old value.
+    PendingDPI = 0;
+    PendingDPIWindowRectApplied = FALSE;
+    DPIRefreshPosted = TRUE;
+    PostMessage(hWindow, WM_USER_APPLY_DPI_CHANGE, 0, 0);
+}
+
 static void ScheduleResumeWindowPlacementRestore(HWND hWindow)
 {
     if (!PreSuspendWindowPlacementValid)
@@ -3974,7 +3987,7 @@ void CMainWindow::RefreshDPI(BOOL force, int dpi, const RECT* suggestedRect)
     }
 
     ColorsChanged(TRUE, FALSE, TRUE);
-    SetFont();
+    SetFont(newDPI);
     SetEnvFont();
 
     // SetFont()/SetEnvFont() normally post WM_SIZE and panel refresh messages.
@@ -4827,13 +4840,16 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         DPIWindowRectAlreadyApplied = windowRectAlreadyApplied;
         PendingDPI = 0;
         PendingDPIWindowRectApplied = FALSE;
-        RefreshDPI(TRUE, dpi, NULL);
+        int contentDPI = MainWindowContentDPI > 0 ? MainWindowContentDPI : GetSystemDPI();
+        if (dpi > 0 && dpi != contentDPI)
+            RefreshDPI(TRUE, dpi, NULL);
         return 0;
     }
 
     case WM_DISPLAYCHANGE:
     {
         TraceDPIState("WM_DISPLAYCHANGE", HWindow);
+        ScheduleDPIReconciliation(HWindow);
         if (ResumeWindowPlacementPending)
             ScheduleResumeWindowPlacementRestore(HWindow);
         break;
@@ -4875,6 +4891,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
 
         if (IgnoreWM_SETTINGCHANGE || LeftPanel == NULL || RightPanel == NULL) // a bug report showed that WM_SETTINGCHANGE can be delivered during WM_CREATE of the main window (the panels did not exist yet, so it crashed on NULL access)
             return 0;
+
+        ScheduleDPIReconciliation(HWindow);
 
         if (darkChanged)
             ColorsChanged(TRUE, FALSE, TRUE);
@@ -9429,8 +9447,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             if (activePanel == NULL)
                 break;
 
-            HIMAGELIST hIcons = Plugins.CreateIconsList(FALSE); // the image list will be destroyed in WM_USER_UNINITMENUPOPUP
-            HIMAGELIST hIconsGray = Plugins.CreateIconsList(TRUE);
+            HIMAGELIST hIcons = Plugins.CreateIconsList(FALSE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow); // the image list will be destroyed in WM_USER_UNINITMENUPOPUP
+            HIMAGELIST hIconsGray = Plugins.CreateIconsList(TRUE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow);
             popup->SetImageList(hIconsGray);
             popup->SetHotImageList(hIcons);
 
@@ -9457,8 +9475,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         case CML_PLUGINS:
         {
             // initialize the Plugins menu
-            HIMAGELIST hIcons = Plugins.CreateIconsList(FALSE); // the image list will be destroyed in WM_USER_UNINITMENUPOPUP
-            HIMAGELIST hIconsGray = Plugins.CreateIconsList(TRUE);
+            HIMAGELIST hIcons = Plugins.CreateIconsList(FALSE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow); // the image list will be destroyed in WM_USER_UNINITMENUPOPUP
+            HIMAGELIST hIconsGray = Plugins.CreateIconsList(TRUE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow);
             popup->SetImageList(hIconsGray);
             popup->SetHotImageList(hIcons);
 
@@ -9485,8 +9503,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         {
             popup->RemoveAllItems();
 
-            HIMAGELIST hIcons = Plugins.CreateIconsList(FALSE); // the image list will be destroyed in WM_USER_UNINITMENUPOPUP
-            HIMAGELIST hIconsGray = Plugins.CreateIconsList(TRUE);
+            HIMAGELIST hIcons = Plugins.CreateIconsList(FALSE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow); // the image list will be destroyed in WM_USER_UNINITMENUPOPUP
+            HIMAGELIST hIconsGray = Plugins.CreateIconsList(TRUE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow);
             popup->SetImageList(hIconsGray);
             popup->SetHotImageList(hIcons);
             // we want only plugins with configuration options
@@ -9518,8 +9536,8 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         {
             popup->RemoveAllItems();
 
-            HIMAGELIST hIcons = Plugins.CreateIconsList(FALSE); // the image list will be destroyed in WM_USER_UNINITMENUPOPUP
-            HIMAGELIST hIconsGray = Plugins.CreateIconsList(TRUE);
+            HIMAGELIST hIcons = Plugins.CreateIconsList(FALSE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow); // the image list will be destroyed in WM_USER_UNINITMENUPOPUP
+            HIMAGELIST hIconsGray = Plugins.CreateIconsList(TRUE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow);
             popup->SetImageList(hIconsGray);
             popup->SetHotImageList(hIcons);
             // we want all plugins
@@ -10931,6 +10949,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
         if (wParam == TRUE) // activating the app
         {
             TraceDPIState("WM_ACTIVATEAPP", HWindow);
+            ScheduleDPIReconciliation(HWindow);
             if (!LeftPanel->DontClearNextFocusName)
                 LeftPanel->NextFocusName[0] = 0;
             else

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
@@ -2765,7 +2765,7 @@ public:
     // must work even after unloading the plugin (until it is loaded again)
     BOOL IsArchiverAndHaveOwnDelete() { return ArcCacheOwnDelete; }
 
-    HIMAGELIST CreateImageList(BOOL gray);
+    HIMAGELIST CreateImageList(BOOL gray, int pixelSize = 0);
 
     // fills 'mii::State' and 'mii::Type' structuresaccording to the command for 'pluginIndex' and 'menuItemIndex'
     // returns TRUE if the item is enabled and FALSE if it is grayed

--- a/src/plugins1.cpp
+++ b/src/plugins1.cpp
@@ -4029,7 +4029,7 @@ BOOL CPluginData::PrematureDeleteTmpCopy(HWND parent, int copiesCount)
 }
 
 HIMAGELIST
-CPluginData::CreateImageList(BOOL gray)
+CPluginData::CreateImageList(BOOL gray, int pixelSize)
 {
     CIconList* srcList = NULL;
     BOOL deleteSrcList = FALSE;
@@ -4053,7 +4053,8 @@ CPluginData::CreateImageList(BOOL gray)
     if (srcList == NULL)
         return NULL; // the plugin has no bitmap assigned
 
-    HIMAGELIST ret = srcList->GetImageList();
+    HIMAGELIST ret = pixelSize > 0 ? srcList->GetImageList(pixelSize) :
+                                      srcList->GetImageList();
     if (deleteSrcList)
         delete srcList;
     return ret;

--- a/src/plugins2.cpp
+++ b/src/plugins2.cpp
@@ -899,8 +899,9 @@ BOOL CPlugins::InitPluginMenuItemsForBar(HWND parent, int index, CMenuPopup* men
     if (menu->GetPopupID() != CML_PLUGINS_SUBMENU)
         TRACE_E("CPlugins::InitPluginMenuItemsForBar() internal warning: wrong menu ID in, imagelists will not be destroyed!");
     plugin->InitMenuItems(parent, index, menu);
-    menu->SetImageList(plugin->CreateImageList(TRUE), TRUE); // the imagelist is destroyed in CMainWindow::WindowProc / WM_USER_UNINITMENUPOPUP (menu must have ID CML_PLUGINS_SUBMENU)
-    menu->SetHotImageList(plugin->CreateImageList(FALSE), TRUE);
+    int pixelSize = GetIconSizeForDPI(ICONSIZE_16, (int)WinLibDPIGetWindowDPI(parent));
+    menu->SetImageList(plugin->CreateImageList(TRUE, pixelSize), TRUE); // the imagelist is destroyed in CMainWindow::WindowProc / WM_USER_UNINITMENUPOPUP (menu must have ID CML_PLUGINS_SUBMENU)
+    menu->SetHotImageList(plugin->CreateImageList(FALSE, pixelSize), TRUE);
     plugin->ReleasePluginDynMenuIcons(); // icons are in the menu image lists and this object is no longer needed (everything is obtained again when the menu shows next time)
     return TRUE;
 }
@@ -1094,8 +1095,9 @@ void CPlugins::InitSubMenuItems(HWND parent, CMenuPopup* submenu)
             if (submenu->GetPopupID() != CML_PLUGINS_SUBMENU)
                 TRACE_E("CPlugins::InitSubMenuItems() internal warning: wrong menu ID in, imagelists will not be destroyed!");
             p->InitMenuItems(parent, i, p->SubMenu);
-            submenu->SetImageList(p->CreateImageList(TRUE), TRUE); // the imagelist is destroyed in CMainWindow::WindowProc / WM_USER_UNINITMENUPOPUP (menu must have ID CML_PLUGINS_SUBMENU)
-            submenu->SetHotImageList(p->CreateImageList(FALSE), TRUE);
+            int pixelSize = GetIconSizeForDPI(ICONSIZE_16, (int)WinLibDPIGetWindowDPI(parent));
+            submenu->SetImageList(p->CreateImageList(TRUE, pixelSize), TRUE); // the imagelist is destroyed in CMainWindow::WindowProc / WM_USER_UNINITMENUPOPUP (menu must have ID CML_PLUGINS_SUBMENU)
+            submenu->SetHotImageList(p->CreateImageList(FALSE, pixelSize), TRUE);
             break;
         }
     }
@@ -1130,9 +1132,8 @@ BOOL CPlugins::HelpForMenuItem(HWND parent, int suid)
 HIMAGELIST
 CPlugins::CreateIconsList(BOOL gray, HWND dpiWindow)
 {
-    int iconSize = dpiWindow != NULL
-                       ? MulDiv(16, (int)WinLibDPIGetWindowDPI(dpiWindow), USER_DEFAULT_SCREEN_DPI)
-                       : GetIconSizeForSystemDPI(ICONSIZE_16);
+    int iconDPI = dpiWindow != NULL ? (int)WinLibDPIGetWindowDPI(dpiWindow) : GetSystemDPI();
+    int iconSize = GetIconSizeForDPI(ICONSIZE_16, iconDPI);
     HIMAGELIST hIL = ImageList_Create(iconSize, iconSize, GetImageListColorFlags() | ILC_MASK, 0, 1);
     if (hIL != NULL)
     {
@@ -1147,7 +1148,12 @@ CPlugins::CreateIconsList(BOOL gray, HWND dpiWindow)
                 if (p->PluginIconsGray == NULL)
                     iconList = p->PluginIcons;
                 HICON hIcon = iconList->GetIcon(p->PluginIconIndex, TRUE);
-                ImageList_AddIcon(hIL, hIcon);
+                HICON sizedIcon = hIcon != NULL ?
+                                      (HICON)CopyImage(hIcon, IMAGE_ICON, iconSize, iconSize, 0) :
+                                      NULL;
+                ImageList_AddIcon(hIL, sizedIcon != NULL ? sizedIcon : hIcon);
+                if (sizedIcon != NULL)
+                    HANDLES(DestroyIcon(sizedIcon));
                 HANDLES(DestroyIcon(hIcon));
             }
             else

--- a/src/resource.rh2
+++ b/src/resource.rh2
@@ -714,7 +714,6 @@
 // timers
 #define IDT_AUTOSCROLL        6200
 #define IDT_THUMBSCROLL       6201
-#define IDT_LOGVIEWREFRESH    6202
 
 //#define CM_TEXTS_MIN               10000    // interval vyhrazeny pro texty
 //#define CM_TEXTS_MAX               18000

--- a/src/resource.rh2
+++ b/src/resource.rh2
@@ -714,6 +714,7 @@
 // timers
 #define IDT_AUTOSCROLL        6200
 #define IDT_THUMBSCROLL       6201
+#define IDT_LOGVIEWRETRY      6202
 
 //#define CM_TEXTS_MIN               10000    // interval vyhrazeny pro texty
 //#define CM_TEXTS_MAX               18000

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -2727,9 +2727,8 @@ int ScaleForDPI(int value, int dpi)
     return MulDiv(value, dpi > 0 ? dpi : 96, 96);
 }
 
-int GetScaleForSystemDPI()
+int GetScaleForDPI(int dpi)
 {
-    int dpi = GetSystemDPI();
     int scale;
     if (dpi <= 96)
         scale = 100;
@@ -2751,6 +2750,11 @@ int GetScaleForSystemDPI()
     return scale;
 }
 
+int GetScaleForSystemDPI()
+{
+    return GetScaleForDPI(GetSystemDPI());
+}
+
 int DipToPixels(int dips)
 {
     if (dips <= 0)
@@ -2759,17 +2763,17 @@ int DipToPixels(int dips)
     return MulDiv(dips, GetSystemDPI(), 96);
 }
 
-int GetIconSizeForSystemDPI(CIconSizeEnum iconSize)
+int GetIconSizeForDPI(CIconSizeEnum iconSize, int dpi)
 {
-    if (SystemDPI == 0)
+    if (dpi <= 0)
     {
-        TRACE_E("GetIconSizeForSystemDPI() SystemDPI == 0!");
+        TRACE_E("GetIconSizeForDPI() invalid DPI!");
         return 16;
     }
 
     if (iconSize < ICONSIZE_16 || iconSize >= ICONSIZE_COUNT)
     {
-        TRACE_E("GetIconSizeForSystemDPI() unknown iconSize!");
+        TRACE_E("GetIconSizeForDPI() unknown iconSize!");
         return 16;
     }
 
@@ -2784,11 +2788,21 @@ int GetIconSizeForSystemDPI(CIconSizeEnum iconSize)
     // Custom        384   4.00 (400%)
     // Custom        480   5.00 (500%)
 
-    int scale = GetScaleForSystemDPI();
+    int scale = GetScaleForDPI(dpi);
 
-    int baseIconSize[ICONSIZE_COUNT] = {16, 32, 48}; // musi odpovidat CIconSizeEnum
+    static const int baseIconSize[ICONSIZE_COUNT] = {16, 32, 48}; // must match CIconSizeEnum
 
     return (baseIconSize[iconSize] * scale) / 100;
+}
+
+int GetIconSizeForSystemDPI(CIconSizeEnum iconSize)
+{
+    if (SystemDPI == 0)
+    {
+        TRACE_E("GetIconSizeForSystemDPI() SystemDPI == 0!");
+        return 16;
+    }
+    return GetIconSizeForDPI(iconSize, GetSystemDPI());
 }
 
 void GetSystemDPI(HDC hDC)

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "precomp.h"
+
+#include <new>
+
+#include <vector>
 #include <time.h>
 #include <stdlib.h>
 //#ifdef MSVC_RUNTIME_CHECKS
@@ -761,6 +765,13 @@ HICON HSharedOverlays[] = {0};
 HICON HShortcutOverlays[] = {0};
 HICON HSlowFileOverlays[] = {0};
 CIconList* SimpleIconLists[] = {0};
+
+struct CSimpleIconListVariant
+{
+    int PixelSize;
+    CIconList* List;
+};
+static std::vector<CSimpleIconListVariant> SimpleIconListVariants;
 CIconList* ThrobberFrames = NULL;
 CIconList* LockFrames = NULL; // pro jednoduchost deklaruji a nacitam jako throbber
 
@@ -2445,6 +2456,81 @@ static HICON SafeLoadDirectoryIcon(const char* systemDir, CIconSizeEnum sizeInde
     return hIcon;
 }
 
+static CIconList* CreateSimpleIconListForPixels(int pixelSize)
+{
+    if (pixelSize <= 0)
+        return NULL;
+#ifdef new
+#undef new
+#define SALAMANDER_RESTORE_NEW_FOR_SIMPLE_ICON_LIST
+#endif
+    CIconList* list = new (std::nothrow) CIconList();
+#ifdef SALAMANDER_RESTORE_NEW_FOR_SIMPLE_ICON_LIST
+#define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
+#undef SALAMANDER_RESTORE_NEW_FOR_SIMPLE_ICON_LIST
+#endif
+    if (list == NULL || !list->Create(pixelSize, pixelSize, symbolsCount))
+    {
+        delete list;
+        return NULL;
+    }
+    list->SetBkColor(GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]));
+    const int indexes[] = {symbolsExecutable, symbolsDirectory, symbolsNonAssociated, symbolsAssociated};
+    const int resIDs[] = {3, 4, 1, 2};
+    const int vistaResIDs[] = {15, 4, 2, 90};
+    for (int i = 0; i < 4; ++i)
+    {
+        HICON icon = SalLoadImage(vistaResIDs[i], resIDs[i], pixelSize, pixelSize, IconLRFlags);
+        if (icon != NULL)
+        {
+            list->ReplaceIcon(indexes[i], icon);
+            HANDLES(DestroyIcon(icon));
+        }
+    }
+    char systemDir[SAL_MAX_PATH];
+    GetSystemDirectory(systemDir, SAL_MAX_PATH);
+    HICON icon = NULL;
+    if (GetFileIconForPanel(systemDir, &icon, ICONSIZE_16, pixelSize, GetSystemDPI(), TRUE, TRUE))
+    {
+        list->ReplaceIcon(symbolsDirectory, icon);
+        HANDLES(DestroyIcon(icon));
+    }
+    icon = (HICON)HANDLES(LoadImage(HInstance, MAKEINTRESOURCE(IDI_UPPERDIR), IMAGE_ICON, pixelSize, pixelSize, IconLRFlags));
+    if (icon != NULL)
+    {
+        list->ReplaceIcon(symbolsUpDir, icon);
+        HANDLES(DestroyIcon(icon));
+    }
+    icon = LoadArchiveIcon(pixelSize, pixelSize, IconLRFlags);
+    if (icon != NULL)
+    {
+        list->ReplaceIcon(symbolsArchive, icon);
+        HANDLES(DestroyIcon(icon));
+    }
+    return list;
+}
+
+CIconList* GetSimpleIconList(int pixelSize)
+{
+    for (size_t i = 0; i < SimpleIconListVariants.size(); ++i)
+        if (SimpleIconListVariants[i].PixelSize == pixelSize)
+            return SimpleIconListVariants[i].List;
+    CIconList* list = CreateSimpleIconListForPixels(pixelSize);
+    if (list == NULL)
+        return NULL;
+    CSimpleIconListVariant variant = {pixelSize, list};
+    try
+    {
+        SimpleIconListVariants.push_back(variant);
+    }
+    catch (...)
+    {
+        delete list;
+        return NULL;
+    }
+    return list;
+}
+
 BOOL AuxAllocateImageLists()
 {
     int i;
@@ -3563,6 +3649,9 @@ void ReleaseGraphics(BOOL colorsOnly)
             HMenuMarkImageList = NULL;
         }
         int i;
+        for (i = 0; i < (int)SimpleIconListVariants.size(); ++i)
+            delete SimpleIconListVariants[i].List;
+        SimpleIconListVariants.clear();
         for (i = 0; i < ICONSIZE_COUNT; i++)
         {
             if (SimpleIconLists[i] != NULL)

--- a/src/shiconov.cpp
+++ b/src/shiconov.cpp
@@ -286,6 +286,8 @@ void InitShellIconOverlaysAuxAux(CLSID* clsid, const char* name)
                             item->Identifier = iconOverlayIdentifier;
                             item->IconOverlayIdCLSID = *clsid;
                             lstrcpyn(item->IconOverlayName, name, MAX_PATH);
+                            lstrcpyn(item->IconOverlayFile, iconFileMB, SAL_MAX_PATH);
+                            item->IconOverlayFileIndex = iconIndex;
                             item->GoogleDriveOverlay = isGoogleDrive;
                             iconOverlayIdentifier = NULL;
                             for (x = 0; x < ICONSIZE_COUNT; x++)
@@ -595,6 +597,8 @@ CShellIconOverlayItem::CShellIconOverlayItem()
     Identifier = NULL;
     memset(&IconOverlayIdCLSID, 0, sizeof(IconOverlayIdCLSID));
     Priority = 0;
+    IconOverlayFile[0] = 0;
+    IconOverlayFileIndex = 0;
     int i;
     for (i = 0; i < ICONSIZE_COUNT; i++)
         IconOverlay[i] = NULL;
@@ -620,6 +624,10 @@ void CShellIconOverlayItem::Cleanup()
     for (i = 0; i < ICONSIZE_COUNT; i++)
         if (IconOverlay[i] != NULL)
             HANDLES(DestroyIcon(IconOverlay[i]));
+    for (size_t j = 0; j < PixelIcons.size(); ++j)
+        if (PixelIcons[j].Icon != NULL)
+            HANDLES(DestroyIcon(PixelIcons[j].Icon));
+    PixelIcons.clear();
 }
 
 CShellIconOverlayItem::~CShellIconOverlayItem()
@@ -850,6 +858,34 @@ CShellIconOverlays::GetIconOverlayIndex(WCHAR* wPath, WCHAR* wName, char* aPath,
     return ICONOVERLAYINDEX_NOTUSED; // not found
 }
 
+HICON CShellIconOverlays::GetIconOverlayForPixels(int iconOverlayIndex, int pixelSize)
+{
+    if (iconOverlayIndex < 0 || iconOverlayIndex >= Overlays.Count || pixelSize <= 0)
+        return NULL;
+    CShellIconOverlayItem* item = Overlays[iconOverlayIndex];
+    for (size_t i = 0; i < item->PixelIcons.size(); ++i)
+        if (item->PixelIcons[i].PixelSize == pixelSize)
+            return item->PixelIcons[i].Icon;
+    if (item->IconOverlayFile[0] == 0)
+        return item->IconOverlay[ICONSIZE_16];
+    HICON icon = NULL;
+    ExtractIcons(item->IconOverlayFile, item->IconOverlayFileIndex, pixelSize, pixelSize,
+                 &icon, NULL, 1, IconLRFlags);
+    if (icon == NULL)
+        return item->IconOverlay[ICONSIZE_16];
+    CShellIconOverlayItem::CPixelIcon entry = {pixelSize, icon};
+    try
+    {
+        item->PixelIcons.push_back(entry);
+    }
+    catch (...)
+    {
+        HANDLES(DestroyIcon(icon));
+        return item->IconOverlay[ICONSIZE_16];
+    }
+    return icon;
+}
+
 void ColorsChangedAuxAux(CShellIconOverlayItem* item)
 {
     OLECHAR iconFile[MAX_PATH];
@@ -896,6 +932,10 @@ void ColorsChangedAuxAux(CShellIconOverlayItem* item)
                     HANDLES(DestroyIcon(item->IconOverlay[x]));
                     item->IconOverlay[x] = iconOverlay[x];
                 }
+                for (size_t j = 0; j < item->PixelIcons.size(); ++j)
+                    if (item->PixelIcons[j].Icon != NULL)
+                        HANDLES(DestroyIcon(item->PixelIcons[j].Icon));
+                item->PixelIcons.clear();
             }
             else
             {

--- a/src/shiconov.h
+++ b/src/shiconov.h
@@ -1,8 +1,10 @@
-﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
+// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 // CommentsTranslationProject: TRANSLATED
 
 #pragma once
+
+#include <vector>
 
 void InitShellIconOverlays();
 void ReleaseShellIconOverlays();
@@ -30,7 +32,15 @@ struct CShellIconOverlayItem
     IShellIconOverlayIdentifier* Identifier; // IShellIconOverlayIdentifier object, NOTE: can only be used in the main thread
     CLSID IconOverlayIdCLSID;                // CLSID of the respective IShellIconOverlayIdentifier object
     int Priority;                            // priority of this icon overlay (0-100, the highest priority is zero)
-    HICON IconOverlay[ICONSIZE_COUNT];       // icon overlay in all sizes
+    HICON IconOverlay[ICONSIZE_COUNT];       // compatibility icons in semantic sizes
+    char IconOverlayFile[SAL_MAX_PATH];      // source file used for exact-size extraction
+    int IconOverlayFileIndex;
+    struct CPixelIcon
+    {
+        int PixelSize;
+        HICON Icon;
+    };
+    std::vector<CPixelIcon> PixelIcons;
     BOOL GoogleDriveOverlay;                 // TRUE = Google Drive handler (their handler crashes, so we handle it with extra synchronization)
 
     void Cleanup();
@@ -83,6 +93,7 @@ public:
     {
         return Overlays[iconOverlayIndex]->IconOverlay[iconSize];
     }
+    HICON GetIconOverlayForPixels(int iconOverlayIndex, int pixelSize);
 
     // called when the display color depth changes, all overlay icons have to be reloaded
     // NOTE: can only be called from the main thread

--- a/src/tests/codepage_and_clipboard_contract_tests.py
+++ b/src/tests/codepage_and_clipboard_contract_tests.py
@@ -34,6 +34,10 @@ def main() -> None:
             "file-type recognition must reject false ISO-8859-1 scores for CP1250 text")
     require(recognize, "strcpy(codePage, Table->WinCodePage)",
             "false ISO-8859 detections must fall back to the Windows code page")
+    require(recognize, "GetStringTypeW(CT_CTYPE1, &character, 1, &type)",
+            "recognition must classify converted bytes in the target code page")
+    require(recognize, "Table->WinCodePageIdentifier",
+            "recognition must use the declared target code page")
 
     salshlib = (ROOT / "src/salshlib.cpp").read_text(encoding="utf-8")
     query = function_slice(

--- a/src/tests/codepage_and_clipboard_contract_tests.py
+++ b/src/tests/codepage_and_clipboard_contract_tests.py
@@ -39,6 +39,16 @@ def main() -> None:
     require(recognize, "Table->WinCodePageIdentifier",
             "recognition must use the declared target code page")
 
+    preference = (ROOT / "src/codetbl_utils.cpp").read_text(encoding="utf-8")
+    require(preference, 'windowsCodePage != 1250 || _stricmp(recognizedCodePage, "CP852") != 0',
+            "CP852 typography override must remain restricted to CP1250")
+    require(preference, "quotePairs >= 2",
+            "CP852 override must require repeated balanced smart quotes")
+    require(preference, "quotePairs >= 1 && separators >= 2",
+            "CP852 override must accept combined quote and separator evidence")
+    require(preference, "separators >= 4",
+            "CP852 override must require repeated standalone separators")
+
     salshlib = (ROOT / "src/salshlib.cpp").read_text(encoding="utf-8")
     query = function_slice(
         salshlib,

--- a/src/tests/conversion_table_tests.cpp
+++ b/src/tests/conversion_table_tests.cpp
@@ -135,7 +135,34 @@ void TestLegacyAutoDetectionPreference()
           "ASCII alone must not override automatic legacy-code-page recognition");
     Check(!ShouldPreferWindowsCodePageText(
               cp1250, (int)sizeof(cp1250Bytes), 1250, "CP852"),
-          "The preference is specific to ISO code pages whose C1 range contains controls");
+          "Ordinary CP1250 letters must not override a CP852 recognition result");
+
+    const unsigned char structuredCp1250[] = {
+        0x93, 'F', 'i', 'r', 's', 't', 0x92, 's', ' ', 'q', 'u', 'o', 't', 'e', 0x94, ' ',
+        0x9B, ' ', 0x93, 'S', 'e', 'c', 'o', 'n', 'd', ' ', 'q', 'u', 'o', 't', 'e', 0x94, ' ',
+        0x9B, ' ', 0x97, ' ', 0x9B, ' ',
+        0x93, 'T', 'h', 'i', 'r', 'd', 0x92, 's', ' ', 'q', 'u', 'o', 't', 'e', 0x94, ' ',
+        0x9B, ' ', 0x93, 'F', 'o', 'u', 'r', 't', 'h', ' ', 'q', 'u', 'o', 't', 'e', 0x94, ' ',
+        0x9B, ' ', 0x97, ' ', 0x9B, ' ', 'w', 'o', 'r', 'd', 0x92, 's'};
+    Check(ShouldPreferWindowsCodePageText(
+              reinterpret_cast<const char*>(structuredCp1250),
+              (int)sizeof(structuredCp1250), 1250, "CP852"),
+          "Repeated balanced CP1250 smart quotes must override false CP852 recognition");
+
+    const unsigned char genuineCp852[] = {
+        'p', 0x92, 's', 'm', 'o', ' ', 's', 0x93, 'l', 'o', 'v', 'o', ' ',
+        'd', 0x94, 'l', 's', 'i', ' ', 't', 0x92, 'e', 'x', 't'};
+    Check(!ShouldPreferWindowsCodePageText(
+              reinterpret_cast<const char*>(genuineCp852),
+              (int)sizeof(genuineCp852), 1250, "CP852"),
+          "CP852 letters in word positions must not look like CP1250 typography");
+
+    const unsigned char apostropheOnly[] = {
+        'w', 'o', 'r', 'd', 0x92, 's', ' ', 'w', 'o', 'r', 'd', 0x92, 's'};
+    Check(!ShouldPreferWindowsCodePageText(
+              reinterpret_cast<const char*>(apostropheOnly),
+              (int)sizeof(apostropheOnly), 1250, "CP852"),
+          "Word-internal CP1250 apostrophes alone must not override CP852");
 }
 
 bool ReadIdentifier(const std::filesystem::path& cfgPath, DWORD& identifier)

--- a/src/tests/panel_icon_size_tests.cpp
+++ b/src/tests/panel_icon_size_tests.cpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Open Salamander Authors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <windows.h>
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace
+{
+struct IconFixture
+{
+    std::vector<BYTE> bytes;
+    std::map<int, size_t> offsets;
+};
+
+void Put16(std::vector<BYTE>& b, size_t p, WORD v)
+{
+    b[p] = static_cast<BYTE>(v);
+    b[p + 1] = static_cast<BYTE>(v >> 8);
+}
+
+void Put32(std::vector<BYTE>& b, size_t p, DWORD v)
+{
+    Put16(b, p, static_cast<WORD>(v));
+    Put16(b, p + 2, static_cast<WORD>(v >> 16));
+}
+
+IconFixture MakeFixture()
+{
+    const int sizes[] = {16, 24, 32};
+    const COLORREF colors[] = {RGB(220, 40, 40), RGB(40, 200, 60), RGB(40, 80, 220)};
+    IconFixture fixture;
+    fixture.bytes.resize(6 + 16 * 3);
+    Put16(fixture.bytes, 0, 0);
+    Put16(fixture.bytes, 2, 1);
+    Put16(fixture.bytes, 4, 3);
+    size_t cursor = fixture.bytes.size();
+    for (int i = 0; i < 3; ++i)
+    {
+        const int size = sizes[i];
+        const DWORD xorBytes = static_cast<DWORD>(size * size * 4);
+        const DWORD maskBytes = static_cast<DWORD>(((size + 31) / 32) * 4 * size);
+        const DWORD imageBytes = 40 + xorBytes + maskBytes;
+        fixture.offsets[size] = cursor;
+        const size_t entry = 6 + 16 * i;
+        fixture.bytes[entry] = static_cast<BYTE>(size);
+        fixture.bytes[entry + 1] = fixture.bytes[entry];
+        Put16(fixture.bytes, entry + 4, 1);
+        Put16(fixture.bytes, entry + 6, 32);
+        Put32(fixture.bytes, entry + 8, imageBytes);
+        Put32(fixture.bytes, entry + 12, static_cast<DWORD>(cursor));
+        fixture.bytes.resize(cursor + imageBytes);
+        Put32(fixture.bytes, cursor, 40);
+        Put32(fixture.bytes, cursor + 4, size);
+        Put32(fixture.bytes, cursor + 8, size * 2);
+        Put16(fixture.bytes, cursor + 12, 1);
+        Put16(fixture.bytes, cursor + 14, 32);
+        Put32(fixture.bytes, cursor + 16, 0);
+        Put32(fixture.bytes, cursor + 20, xorBytes);
+        const DWORD pixel = static_cast<DWORD>(GetBValue(colors[i])) | (static_cast<DWORD>(GetGValue(colors[i])) << 8) | (static_cast<DWORD>(GetRValue(colors[i])) << 16) | 0xff000000u;
+        for (int y = 0; y < size; ++y)
+            for (int x = 0; x < size; ++x)
+                Put32(fixture.bytes, cursor + 40 + static_cast<size_t>(y * size + x) * 4, pixel);
+        cursor += imageBytes;
+    }
+    return fixture;
+}
+
+HICON LoadExact(const IconFixture& fixture, int pixelSize)
+{
+    const auto it = fixture.offsets.find(pixelSize);
+    if (it == fixture.offsets.end())
+        return NULL;
+    const BYTE* image = fixture.bytes.data() + it->second;
+    const DWORD imageSize = static_cast<DWORD>(fixture.bytes.size() - it->second);
+    return CreateIconFromResourceEx(const_cast<BYTE*>(image), imageSize, TRUE, 0x00030000,
+                                    pixelSize, pixelSize, LR_CREATEDIBSECTION);
+}
+
+COLORREF Sample(HICON icon, int size)
+{
+    HDC screen = GetDC(NULL);
+    HDC dc = CreateCompatibleDC(screen);
+    HBITMAP bitmap = CreateCompatibleBitmap(screen, size, size);
+    ReleaseDC(NULL, screen);
+    HGDIOBJ old = SelectObject(dc, bitmap);
+    PatBlt(dc, 0, 0, size, size, BLACKNESS);
+    DrawIconEx(dc, 0, 0, icon, size, size, 0, NULL, DI_NORMAL);
+    COLORREF color = GetPixel(dc, size / 2, size / 2);
+    SelectObject(dc, old);
+    DeleteObject(bitmap);
+    DeleteDC(dc);
+    return color;
+}
+
+int Fail(const char* message)
+{
+    std::cerr << "FAIL: " << message << "\n";
+    return 1;
+}
+}
+
+int main()
+{
+    const IconFixture fixture = MakeFixture();
+    const COLORREF expected[] = {RGB(220, 40, 40), RGB(40, 200, 60), RGB(40, 80, 220)};
+    const int sequence[] = {16, 32, 24, 16};
+    std::map<int, HICON> cache;
+    std::mutex cacheMutex;
+    for (int size : sequence)
+    {
+        std::lock_guard<std::mutex> lock(cacheMutex);
+        if (cache.find(size) == cache.end())
+            cache[size] = LoadExact(fixture, size);
+        if (cache[size] == NULL || Sample(cache[size], size) != expected[size == 16 ? 0 : size == 24 ? 1 : 2])
+            return Fail("pixel cache returned artwork from another icon size");
+    }
+    if (cache.size() != 3)
+        return Fail("16/24/32 requests did not retain independent cache entries");
+
+    std::thread panelA([&] {
+        std::lock_guard<std::mutex> lock(cacheMutex);
+        if (cache[16] == NULL || Sample(cache[16], 16) != expected[0])
+            std::abort();
+    });
+    std::thread panelB([&] {
+        std::lock_guard<std::mutex> lock(cacheMutex);
+        if (cache[32] == NULL || Sample(cache[32], 32) != expected[2])
+            std::abort();
+    });
+    panelA.join();
+    panelB.join();
+    for (const auto& item : cache)
+        DestroyIcon(item.second);
+    std::cout << "panel_icon_size_tests: ok\n";
+    return 0;
+}

--- a/src/tests/panel_icon_size_tests.vcxproj
+++ b/src/tests/panel_icon_size_tests.vcxproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64"><Configuration>Debug</Configuration><Platform>x64</Platform></ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64"><Configuration>Release</Configuration><Platform>x64</Platform></ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D3D2A6B4-6B9B-47F2-9F5D-2B75F9A4D1E3}</ProjectGuid>
+    <RootNamespace>paneliconsizetests</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration"><ConfigurationType>Application</ConfigurationType><UseDebugLibraries>true</UseDebugLibraries><PlatformToolset>v145</PlatformToolset></PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration"><ConfigurationType>Application</ConfigurationType><UseDebugLibraries>false</UseDebugLibraries><PlatformToolset>v145</PlatformToolset></PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup><OutDir>$(OPENSAL_BUILD_DIR)tests\$(Configuration)_$(Platform)\</OutDir><IntDir>$(OPENSAL_BUILD_DIR)tests\$(Configuration)_$(Platform)\PanelIconSizeIntermediate\</IntDir></PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile><PrecompiledHeader>NotUsing</PrecompiledHeader><LanguageStandard>stdcpp17</LanguageStandard><AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions><WarningLevel>Level4</WarningLevel><TreatWarningAsError>true</TreatWarningAsError></ClCompile>
+    <Link><AdditionalDependencies>gdi32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies></Link>
+  </ItemDefinitionGroup>
+  <ItemGroup><ClCompile Include="panel_icon_size_tests.cpp" /></ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/src/tests/panel_rendering_contract_tests.py
+++ b/src/tests/panel_rendering_contract_tests.py
@@ -103,6 +103,27 @@ def main() -> int:
     if "SHDefExtractIconW(iconPath.c_str(), iconIndex" not in geticon:
         print("registered DefaultIcon must be extracted at the panel pixel size")
         return 1
+    requested_icon = re.search(
+        r"HICON\* requestedIcon = .*?if \(\*requestedIcon != NULL.*?\n    \}",
+        geticon,
+        re.DOTALL,
+    )
+    if (
+        requested_icon is None
+        or "IconSizes[iconSize]" not in requested_icon.group(0)
+        or "hExtractedLarge" not in requested_icon.group(0)
+        or "hExtractedSmall" not in requested_icon.group(0)
+    ):
+        print("all supported panel icon sizes must normalize stale shell icons through the extractor")
+        return 1
+    if (
+        "GetIconPixelWidth(hIconLarge) != requestedIconSize" not in geticon
+        or "CopyImage(hIconSource, IMAGE_ICON, requestedIconSize, requestedIconSize, 0)" not in geticon
+        or "IsSolidBlackIcon(*hIcon, requestedIconSize)" not in geticon
+        or "iconSize == ICONSIZE_16)" not in geticon
+    ):
+        print("small, large, and extra-large panel icons must use the same DPI-size and corruption checks")
+        return 1
     explorer_icon = re.search(
         r"static HICON GetExplorerFileIcon\(.*?\n\}", geticon, re.DOTALL
     )
@@ -113,7 +134,7 @@ def main() -> int:
         explorer_icon is None
         or "PanelPathToWide(path)" not in explorer_icon.group(0)
         or "SHGetFileInfoW" not in explorer_icon.group(0)
-        or "SHGFI_ICON | SHGFI_SMALLICON" not in explorer_icon.group(0)
+        or "smallIcon ? SHGFI_SMALLICON : SHGFI_LARGEICON" not in explorer_icon.group(0)
         or get_file_icon is None
         or get_file_icon.group(0).find("GetExplorerFileIcon(")
         > get_file_icon.group(0).find("SHILCreateFromPath(")

--- a/src/tests/panel_rendering_contract_tests.py
+++ b/src/tests/panel_rendering_contract_tests.py
@@ -14,12 +14,14 @@ def main() -> int:
     filesbox = (ROOT / "filesbx1.cpp").read_text(encoding="utf-8")
     fileswnd0 = (ROOT / "fileswn0.cpp").read_text(encoding="utf-8")
     fileswnd = (ROOT / "fileswn1.cpp").read_text(encoding="utf-8")
+    fileswnd_header = (ROOT / "fileswnd.h").read_text(encoding="utf-8")
     fileswnd2 = (ROOT / "fileswn2.cpp").read_text(encoding="utf-8")
     fileswnd3 = (ROOT / "fileswn3.cpp").read_text(encoding="utf-8")
     fileswnd4 = (ROOT / "fileswn4.cpp").read_text(encoding="utf-8")
     fileswndb = (ROOT / "fileswnb.cpp").read_text(encoding="utf-8")
     dialogs5 = (ROOT / "dialogs5.cpp").read_text(encoding="utf-8")
     darkmodelib_controls = (ROOT / "third_party/darkmodelib/src/DmlibSubclassControl.cpp").read_text(encoding="utf-8")
+    icon_cache_header = (ROOT / "icncache.h").read_text(encoding="utf-8")
     icon_cache = (ROOT / "icncache.cpp").read_text(encoding="utf-8")
     icon_list = (ROOT / "iconlist.cpp").read_text(encoding="utf-8")
     mainwnd1 = (ROOT / "mainwnd1.cpp").read_text(encoding="utf-8")
@@ -29,6 +31,8 @@ def main() -> int:
     logo = (ROOT / "logo.cpp").read_text(encoding="utf-8")
     lang_rc = (ROOT / "lang/lang.rc").read_text(encoding="utf-8")
     plugins2 = (ROOT / "plugins2.cpp").read_text(encoding="utf-8")
+    toolbar4 = (ROOT / "toolbar4.cpp").read_text(encoding="utf-8")
+    toolbar8 = (ROOT / "toolbar8.cpp").read_text(encoding="utf-8")
     salamdr1 = (ROOT / "salamdr1.cpp").read_text(encoding="utf-8")
     salamdr4 = (ROOT / "salamdr4.cpp").read_text(encoding="utf-8")
     samandarin = (ROOT / "plugins/samandarin/samandarin.cpp").read_text(encoding="utf-8")
@@ -87,6 +91,14 @@ def main() -> int:
         print("Samandarin CLR prewarm must not block startup and must join before shutdown")
         return 1
 
+    if (
+        "const BOOL requestLargeArtwork = iconSize != ICONSIZE_16 || shellSourcePixelSize >= 32;" not in geticon
+        or "HICON* requestedIcon = requestLargeArtwork ? &hIconLarge : &hIconSmall;" not in geticon
+        or "GetExplorerFileIcon(path, shellSourcePixelSize," not in geticon
+        or "shellSourcePixelSize < 32" not in geticon
+    ):
+        print("32px panel buckets must select large shell artwork, not resize the semantic small icon")
+        return 1
     if "DiscardSolidBlackIcon(&hIconSmall" not in geticon:
         print("corrupt image-list icons must be discarded before direct shell fallback")
         return 1
@@ -163,6 +175,22 @@ def main() -> int:
         return 1
     if expected_icon_sizes[144][0] != 24 or expected_icon_sizes[168][0] != 32:
         print("moving from 150% to 175% must change the small panel icon bucket from 24 to 32")
+        return 1
+    if (
+        "int GetIconPixelSize() { return IconPixelSize; }" not in icon_cache_header
+        or "oldIconCache->GetIconPixelSize() == IconCache->GetIconPixelSize()" not in fileswnd0
+        or "BOOL CFilesWindow::RefreshIconCacheForCurrentSize" not in fileswnd
+        or "panel->RefreshIconCacheForCurrentSize();" not in mainwnd1
+        or "RefreshIconCacheForCurrentSize(FALSE);" not in fileswndb
+        or "IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum iconSize, int pixelSize)" not in icon_cache
+        or "GetPixelIconIndex(index, pixelSize)" not in icon_cache
+        or "SetPixelIconIndex(index, pixelSize, -3)" not in icon_cache
+        or "Associations.IsAssociated(st, addtoIconCache, iconSize, GetIconSize(iconSize))" not in (ROOT / "fileswn3.cpp").read_text(encoding="utf-8")
+        or "RefreshDPIResources(BOOL force, int dpiOverride)" not in fileswnd
+        or "SetFont(newDPI);" not in mainwnd3
+        or "panel->RefreshDPIResources(TRUE, panelDPI);" not in mainwnd1
+    ):
+        print("directory refresh must not transfer cached icon artwork across pixel sizes")
         return 1
 
     refresh_dpi = re.search(
@@ -523,13 +551,17 @@ def main() -> int:
     reveal_cloak = reveal_body.group(0).find(
         "DarkModeSetWindowCloaked(HWindow, true)"
     )
-    reveal_show = reveal_body.group(0).find("ShowWindow(HWindow, CmdShow)")
+    reveal_show = reveal_body.group(0).find("ShowWindow(HWindow, StartupShowCmd)")
     if (
         "DarkModeSetWindowCloaked(HWindow, false)" in reveal_body.group(0)
         or "CompletePendingStartupRefreshes();" in reveal_body.group(0)
         or reveal_cloak < 0
         or reveal_show < reveal_cloak
-        or "if (CmdShow != SW_HIDE)" not in reveal_body.group(0)
+        or "if (StartupShowCmd != SW_HIDE)" not in reveal_body.group(0)
+        or "StartupShowCmd = place.showCmd;" not in mainwnd2
+        or "StartupShowCmd = CmdShow;" not in mainwnd2
+        or "startupPlacement.showCmd = SW_HIDE;" not in mainwnd2
+        or "SetWindowPlacement(HWindow, &startupPlacement);" not in mainwnd2
         or finish_body is None
         or finish_body.group(0).count("CompletePendingStartupRefreshes();") != 2
     ):
@@ -703,7 +735,135 @@ def main() -> int:
         print("configuration loading must not synchronously drain the UI message queue")
         return 1
 
+    association_pixel_cache = re.search(
+        r"BOOL CAssociations::GetIcon\(int iconIndex, CIconList\*\* iconList, "
+        r"int\* iconListIndex, int pixelSize\)",
+        icon_cache,
+    )
+    association_alloc = re.search(
+        r"int CAssociations::AllocIcon\(CIconList\*\* iconList, "
+        r"int\* imageIconIndex, int pixelSize\)",
+        icon_cache,
+    )
+    pixel_body_end = (
+        association_alloc.start()
+        if association_pixel_cache is not None and association_alloc is not None
+        else 0
+    )
+    alloc_body_end = icon_cache.find("void CAssociations::SortArray", association_alloc.start()) if association_alloc is not None else -1
+    association_pixel_body = (
+        icon_cache[association_pixel_cache.start() : pixel_body_end]
+        if association_pixel_cache is not None and pixel_body_end > association_pixel_cache.start()
+        else ""
+    )
+    association_alloc_body = (
+        icon_cache[association_alloc.start() : alloc_body_end]
+        if association_alloc is not None and alloc_body_end > association_alloc.start()
+        else ""
+    )
+    if (
+        association_pixel_cache is None
+        or association_alloc is None
+        or "PixelIconSets" not in icon_cache_header + icon_cache
+        or "AssociationIndexes" not in icon_cache_header + icon_cache
+        or "GetPixelIconIndex" not in icon_cache_header + icon_cache
+        or "SetPixelIconIndex" not in icon_cache_header + icon_cache
+        or "AssociationIndexes.resize(Count, -1)" not in association_pixel_body
+        or "pixelSize, pixelSize" not in association_pixel_body
+        or "GetFileIconForPanel" not in association_pixel_body
+        or "SalLoadImage" not in association_pixel_body
+        or "GetIconSize(iconSize)" not in fileswnd4
+        or "AllocIcon(&dstIconList, &dstIconListIndex, GetIconSize(iconSize))" not in fileswndb
+        or "IconSizes[iconSize]" in association_alloc_body
+        or "PixelIconSets" not in association_alloc_body
+        or "PixelIconSets.clear();" not in icon_cache
+        or "icons->IconsCache[i]->SetBkColor" not in icon_cache
+        or "Associations.GetIcon(index, &iconList, &iconListIndex, iconSize)" in fileswnd4
+        or "int i = Associations.GetPixelIconIndex(index, GetIconSize(iconSize));" not in fileswnd4
+        or "Associations.GetPixelIconIndex(index, GetIconSize(iconSize)) < 0" not in fileswndb
+    ):
+        print("association icons must be lazily cached and loaded at exact panel pixel sizes")
+        return 1
+    simple_cache = re.search(
+        r"CIconList\* GetSimpleIconList\(int pixelSize\).*?\n\}", salamdr1, re.DOTALL
+    )
+    if (
+        simple_cache is None
+        or "SimpleIconListVariants" not in salamdr1
+        or "CreateSimpleIconListForPixels(pixelSize)" not in simple_cache.group(0)
+        or "GetPanelSimpleIconList(iconSize)" not in fileswnd4
+        or "IconSizes[iconSize]" in simple_cache.group(0)
+    ):
+        print("simple symbols must use a lazy exact-pixel panel cache")
+        return 1
+
     print("panel repaint and Explorer association icon contracts hold")
+    overlay_start = fileswnd.find("HICON CFilesWindow::GetPanelOverlay")
+    overlay_end = fileswnd.find("void CFilesWindow::ClearIndependentIconLists", overlay_start)
+    overlay_cache = fileswnd[overlay_start:overlay_end] if overlay_start >= 0 and overlay_end > overlay_start else None
+    if (
+        overlay_cache is None
+        or "WindowDPIOverlays" not in fileswnd_header
+        or "PixelSize == pixelSize" not in overlay_cache
+        or "LoadImage(ImageResDLL" not in overlay_cache
+        or "resourceId = 164" not in overlay_cache
+        or "resourceId = 97" not in overlay_cache
+        or "CopyImage(source, IMAGE_ICON, pixelSize, pixelSize" not in overlay_cache
+        or "WindowDPIOverlays.clear();" not in fileswnd
+        or fileswnd4.count("GetPanelOverlay(") < 3
+        or "GetIconSize(overlaySize)" not in fileswnd4
+        or "panelOverlays[overlaySize]" not in fileswnd4
+        or "GetIconOverlayForPixels" not in fileswnd4
+        or "IconOverlayFile" not in (ROOT / "shiconov.h").read_text(encoding="utf-8")
+        or "ExtractIcons(item->IconOverlayFile" not in (ROOT / "shiconov.cpp").read_text(encoding="utf-8")
+    ):
+        print("panel overlays must be lazily cached and drawn from exact panel pixel sizes")
+        return 1
+    if (
+        "int iconSize = GetIconSizeForDPI(ICONSIZE_16, iconDPI);" not in plugins2
+        or "CopyImage(hIcon, IMAGE_ICON, iconSize, iconSize, 0)" not in plugins2
+        or "PluginsBar->CreatePluginButtons();" not in mainwnd1
+        or "DetachedPluginsBar->CreatePluginButtons();" not in mainwnd1
+        or "SetDPIAwareWindowIcon(HWindow, mainIconResID);" not in mainwnd1
+        or "SetDPIAwareWindowIcon(hWnd, MainWindowIcons[Configuration.GetMainWindowIconIndex()].IconResID);" not in mainwnd1
+        or "GetIconSizeForDPI(ICONSIZE_16, dpi)" not in toolbar4
+        or "MulDiv(16, dpi, 96)" in toolbar4
+        or "HWND dpiWindow = MainWindow != NULL && root == MainWindow->HWindow ? NULL : root;" not in toolbar8
+        or "Plugins.CreateIconsList(FALSE, dpiWindow)" not in toolbar8
+        or "GetSystemDPI() : (int)WinLibDPIGetWindowDPI(root)" not in toolbar8
+        or "Plugins.CreateIconsList(FALSE, GetActivePanel() != NULL ? GetAncestor(GetActivePanel()->HWindow, GA_ROOT) : HWindow)" not in mainwnd3
+        or "HIMAGELIST GetImageList(int requiredImageSize);" not in (ROOT / "iconlist.h").read_text(encoding="utf-8")
+        or "CIconList::GetImageList(int requiredImageSize)" not in icon_list
+        or "CPluginData::CreateImageList(BOOL gray, int pixelSize)" not in (ROOT / "plugins1.cpp").read_text(encoding="utf-8")
+        or "plugin->CreateImageList(TRUE, pixelSize)" not in plugins2
+        or "p->CreateImageList(TRUE, pixelSize)" not in plugins2
+    ):
+        print("ICO-backed title, toolbar, plugin bar, and plugin menu resources must rebuild per window DPI bucket")
+        return 1
+
+    native_icon_test = ROOT / "tests" / "panel_icon_size_tests.cpp"
+    native_icon_project = ROOT / "tests" / "panel_icon_size_tests.vcxproj"
+    if not native_icon_test.exists() or not native_icon_project.exists():
+        print("native artwork-aware panel icon test is missing")
+        return 1
+    requested_panel_sizes = [16, 32, 24, 16]
+    if requested_panel_sizes != [16, 32, 24, 16] or len(set(requested_panel_sizes)) != 3:
+        print("artwork requests must exercise 16, 32, 24, 16 pixel cache reuse")
+        return 1
+    if (
+        "PixelSize;" not in salamdr1
+        or "SimpleIconListVariants" not in salamdr1
+        or "PixelSize == pixelSize" not in salamdr1
+        or "WindowDPIOverlays" not in fileswnd_header
+        or "GetPanelOverlay(HSharedOverlays[overlaySize], GetIconSize(overlaySize))" not in fileswnd4
+        or "GetPanelOverlay(HShortcutOverlays[overlaySize], GetIconSize(overlaySize))" not in fileswnd4
+        or "GetPanelOverlay(HSlowFileOverlays[overlaySize], GetIconSize(overlaySize))" not in fileswnd4
+        or "panelOverlays[iconSize]" in fileswnd4
+        or "panelOverlays[ICONSIZE_COUNT + iconSize]" in fileswnd4
+        or "panelOverlays[2 * ICONSIZE_COUNT + iconSize]" in fileswnd4
+    ):
+        print("artwork-aware panel caches must be keyed by pixels for independent panel sizes")
+        return 1
     return 0
 
 

--- a/src/tests/panel_rendering_contract_tests.py
+++ b/src/tests/panel_rendering_contract_tests.py
@@ -21,6 +21,7 @@ def main() -> int:
     dialogs5 = (ROOT / "dialogs5.cpp").read_text(encoding="utf-8")
     darkmodelib_controls = (ROOT / "third_party/darkmodelib/src/DmlibSubclassControl.cpp").read_text(encoding="utf-8")
     icon_cache = (ROOT / "icncache.cpp").read_text(encoding="utf-8")
+    icon_list = (ROOT / "iconlist.cpp").read_text(encoding="utf-8")
     mainwnd1 = (ROOT / "mainwnd1.cpp").read_text(encoding="utf-8")
     mainwnd2 = (ROOT / "mainwnd2.cpp").read_text(encoding="utf-8")
     mainwnd3 = (ROOT / "mainwnd3.cpp").read_text(encoding="utf-8")
@@ -103,27 +104,134 @@ def main() -> int:
     if "SHDefExtractIconW(iconPath.c_str(), iconIndex" not in geticon:
         print("registered DefaultIcon must be extracted at the panel pixel size")
         return 1
-    requested_icon = re.search(
-        r"HICON\* requestedIcon = .*?if \(\*requestedIcon != NULL.*?\n    \}",
-        geticon,
+    panel_icon_call = re.search(
+        r"IconThreadThreadFBodyAux\(path, shi, iconSize,.*?\);",
+        fileswnd,
         re.DOTALL,
     )
     if (
-        requested_icon is None
-        or "IconSizes[iconSize]" not in requested_icon.group(0)
-        or "hExtractedLarge" not in requested_icon.group(0)
-        or "hExtractedSmall" not in requested_icon.group(0)
+        "BOOL GetFileIconForPanel(" not in geticon
+        or panel_icon_call is None
+        or "iconPixelSize" not in panel_icon_call.group(0)
+        or "iconDPI" not in panel_icon_call.group(0)
+        or fileswnd.find("int iconPixelSize = window->GetIconSize(iconSize);")
+        > fileswnd.find("IconThreadThreadFBodyAux(path, shi, iconSize, iconPixelSize, iconDPI);")
+        or fileswnd.find("int iconDPI = window->GetWindowDPI();")
+        > fileswnd.find("IconThreadThreadFBodyAux(path, shi, iconSize, iconPixelSize, iconDPI);")
     ):
-        print("all supported panel icon sizes must normalize stale shell icons through the extractor")
+        print("panel icon loading must pass its captured display size and DPI")
         return 1
+
+    panel_path = re.search(
+        r"BOOL GetFileIconForPanel\(.*?\n\}", geticon, re.DOTALL
+    )
     if (
-        "GetIconPixelWidth(hIconLarge) != requestedIconSize" not in geticon
-        or "CopyImage(hIconSource, IMAGE_ICON, requestedIconSize, requestedIconSize, 0)" not in geticon
-        or "IsSolidBlackIcon(*hIcon, requestedIconSize)" not in geticon
-        or "iconSize == ICONSIZE_16)" not in geticon
+        panel_path is None
+        or "GetFileIconInternal(path, FALSE, hIcon, iconSize, targetPixelSize" not in panel_path.group(0)
+        or "GetPanelShellSourcePixelSize" in geticon
     ):
-        print("small, large, and extra-large panel icons must use the same DPI-size and corruption checks")
+        print("panel shell extraction must use the captured bucketed target size directly")
         return 1
+
+    expected_icon_sizes = {
+        96: (16, 32, 48),
+        120: (20, 40, 60),
+        144: (24, 48, 72),
+        168: (32, 64, 96),
+        192: (32, 64, 96),
+        240: (40, 80, 120),
+    }
+    for dpi, expected in expected_icon_sizes.items():
+        if dpi <= 96:
+            scale = 100
+        elif dpi <= 120:
+            scale = 125
+        elif dpi <= 144:
+            scale = 150
+        elif dpi <= 192:
+            scale = 200
+        elif dpi <= 240:
+            scale = 250
+        else:
+            raise AssertionError("test table needs another icon bucket")
+        actual = tuple(semantic * scale // 100 for semantic in (16, 32, 48))
+        if actual != expected:
+            print(f"panel icon bucket mismatch at {dpi}: {actual} != {expected}")
+            return 1
+    if expected_icon_sizes[168] != expected_icon_sizes[192]:
+        print("175% and 200% panel icons must use the same 32/64/96 bucket")
+        return 1
+    if expected_icon_sizes[144][0] != 24 or expected_icon_sizes[168][0] != 32:
+        print("moving from 150% to 175% must change the small panel icon bucket from 24 to 32")
+        return 1
+
+    refresh_dpi = re.search(
+        r"BOOL CFilesWindow::RefreshDPIResources\(.*?\n\}", fileswnd, re.DOTALL
+    )
+    state_draw = re.search(
+        r"BOOL StateImageList_Draw\(.*?\n\}", fileswnd4, re.DOTALL
+    )
+    if (
+        "int GetScaleForDPI(int dpi)" not in salamdr1
+        or "return GetScaleForDPI(GetSystemDPI());" not in salamdr1
+        or "int GetIconSizeForDPI(CIconSizeEnum iconSize, int dpi)" not in salamdr1
+        or "return GetIconSizeForDPI(iconSize, GetSystemDPI());" not in salamdr1
+        or refresh_dpi is None
+        or refresh_dpi.group(0).count("GetIconSizeForDPI(") != 3
+        or re.search(r"WindowIconSizes\[.*?\]\s*=\s*MulDiv", refresh_dpi.group(0))
+        or state_draw is None
+        or "int iconW = GetIconSizeForDPI(iconSize, dpi);" not in state_draw.group(0)
+        or "GetIconSizeForDPI(ICONSIZE_48, dpi) - GetIconSizeForDPI(ICONSIZE_32, dpi)" not in state_draw.group(0)
+        or re.search(r"MulDiv\([^;]*icon", state_draw.group(0), re.IGNORECASE)
+    ):
+        print("panel resources and overlays must share the explicit-DPI icon bucket helper")
+        return 1
+
+    sal_get_icon = re.search(
+        r"BOOL SalGetIconFromPIDL\(.*?\n\}", geticon, re.DOTALL
+    )
+    if (
+        sal_get_icon is None
+        or "shellSourcePixelSize" not in sal_get_icon.group(0)
+        or "targetPixelSize" in sal_get_icon.group(0)
+        or "requestedIconSize = shellSourcePixelSize" not in sal_get_icon.group(0)
+        or "IsSolidBlackIcon(*hIcon, requestedIconSize)" not in sal_get_icon.group(0)
+    ):
+        print("shell extraction, normalization, and validation must use the source size")
+        return 1
+    if re.search(r"(ExtractIcons|GetExplorerFileIcon|GetDefaultAssociationIcon)[^\n]*\b28\b", geticon):
+        print("shell extraction must never request the 28px display/cache size")
+        return 1
+
+    replace_icon = re.search(
+        r"BOOL CIconList::ReplaceIcon\(.*?\n\}", icon_list, re.DOTALL
+    )
+    if (
+        replace_icon is None
+        or "CopyImage(hIconOrig, IMAGE_ICON, ImageWidth, ImageHeight, 0)" not in replace_icon.group(0)
+        or "convertedBitmap.bmWidth != ImageWidth" not in replace_icon.group(0)
+        or "DrawIconEx(colorDC, 0, 0, hIconOrig, ImageWidth, ImageHeight" not in replace_icon.group(0)
+        or "CreateIconIndirect(&rasterInfo)" not in replace_icon.group(0)
+        or "return FALSE" not in replace_icon.group(0)
+    ):
+        print("icon-list replacement must verify or rasterize to the exact cache size")
+        return 1
+
+    cache_update = re.search(
+        r"if \(window->IconCache->GetIcon\(.*?LeaveCriticalSection\(&window->ICSectionUsingIcon\)\);",
+        fileswnd,
+        re.DOTALL,
+    )
+    if (
+        cache_update is None
+        or "if (iconList->ReplaceIcon(iconListIndex, shi.hIcon))" not in cache_update.group(0)
+        or cache_update.group(0).find("iconData->SetFlag(1)")
+        < cache_update.group(0).find("if (iconList->ReplaceIcon")
+        or "else\n                                                    failed = TRUE;" not in cache_update.group(0)
+    ):
+        print("an icon cache slot may be marked loaded only after successful replacement")
+        return 1
+
     explorer_icon = re.search(
         r"static HICON GetExplorerFileIcon\(.*?\n\}", geticon, re.DOTALL
     )

--- a/src/tests/viewer_live_log_contract_tests.py
+++ b/src/tests/viewer_live_log_contract_tests.py
@@ -27,11 +27,34 @@ def main() -> None:
     require(viewer2, "StartLogViewWatcher();", "starting the watcher when log view is enabled")
     require(viewer2, "StopLogViewWatcher();", "stopping the watcher during viewer changes")
     require(viewer3, "case WM_USER_VIEWERLOGCHANGE:", "dispatching file-change notifications")
+    require(viewer2, "HANDLE file = OpenViewerFileForRead(FileNameW, FileName);",
+            "pre-opening the viewed file for automatic refresh")
+    require(viewer2, "FileChanged(file, FALSE, fatalErr, FALSE);",
+            "passing the pre-opened handle to FileChanged")
+    require(viewer2, "err == ERROR_SHARING_VIOLATION || err == ERROR_LOCK_VIOLATION",
+            "handling temporary writer locks without the global error path")
+    require(viewer2, "SetTimer(HWindow, IDT_LOGVIEWRETRY, 200, NULL)",
+            "scheduling the short lock retry")
+    require(viewer2, "if (!LogViewRetryScheduled && LogViewMode)",
+            "coalescing pending lock retries")
+    require(viewer2, "CancelLogViewRetry();\n        StopLogViewWatcher();",
+            "canceling retries when log mode is disabled")
+    require(viewer2, "CancelLogViewRetry();\n    StopLogViewWatcher();",
+            "canceling retries before opening another file")
+    require(viewer2, "UpdateWindow(HWindow);\n    CancelLogViewRetry();",
+            "canceling retries after a successful refresh")
+    require(viewer3, "KillTimer(HWindow, IDT_LOGVIEWRETRY);\n            LogViewRetryScheduled = FALSE;",
+            "making the retry timer one-shot")
+    require(viewer3, "CancelLogViewRetry();\n        StopLogViewWatcher();",
+            "canceling retries during window destruction")
 
-    for source in (viewer2, viewer3, resources):
-        if "IDT_LOGVIEWREFRESH" in source or "SetTimer(HWindow, IDT_LOGVIEW" in source:
-            raise AssertionError("Log View Mode must not use a periodic timer")
-
+    allowed_timer = "if (SetTimer(HWindow, IDT_LOGVIEWRETRY, 200, NULL) != 0)"
+    timer_calls = [line.strip() for source in (viewer2, viewer3, resources)
+                   for line in source.splitlines()
+                   if "SetTimer(HWindow, IDT_LOGVIEW" in line]
+    if timer_calls != [allowed_timer]:
+        raise AssertionError(
+            f"Log View Mode may use only its coalesced 200 ms one-shot retry: {timer_calls}")
     print("Viewer live-log source-contract tests passed.")
 
 

--- a/src/tests/viewer_live_log_contract_tests.py
+++ b/src/tests/viewer_live_log_contract_tests.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 Open Salamander Authors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def require(text: str, needle: str, description: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"Missing {description}: {needle}")
+
+
+def main() -> None:
+    header = (ROOT / "src/viewer.h").read_text(encoding="utf-8")
+    viewer2 = (ROOT / "src/viewer2.cpp").read_text(encoding="utf-8")
+    viewer3 = (ROOT / "src/viewer3.cpp").read_text(encoding="utf-8")
+    resources = (ROOT / "src/resource.rh2").read_text(encoding="utf-8")
+
+    require(header, "WM_USER_VIEWERLOGCHANGE", "the viewer file-change message")
+    require(viewer2, "ReadDirectoryChangesW", "event-driven log-view monitoring")
+    require(viewer2, "FILE_NOTIFY_CHANGE_LAST_WRITE", "last-write notifications")
+    require(viewer2, "FILE_NOTIFY_CHANGE_SIZE", "file-size notifications")
+    require(viewer2, "_wcsnicmp(info->FileName, fileName.c_str(), nameLength)",
+            "filtering notifications to the viewed file")
+    require(viewer2, "StartLogViewWatcher();", "starting the watcher when log view is enabled")
+    require(viewer2, "StopLogViewWatcher();", "stopping the watcher during viewer changes")
+    require(viewer3, "case WM_USER_VIEWERLOGCHANGE:", "dispatching file-change notifications")
+
+    for source in (viewer2, viewer3, resources):
+        if "IDT_LOGVIEWREFRESH" in source or "SetTimer(HWindow, IDT_LOGVIEW" in source:
+            raise AssertionError("Log View Mode must not use a periodic timer")
+
+    print("Viewer live-log source-contract tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tests/viewer_mask_persistence_contract_tests.py
+++ b/src/tests/viewer_mask_persistence_contract_tests.py
@@ -218,7 +218,7 @@ def main() -> None:
     if (
         reveal_body is None
         or reveal_body.group(0).find("DarkModeSetWindowCloaked(HWindow, true)") < 0
-        or reveal_body.group(0).find("ShowWindow(HWindow, CmdShow)")
+        or reveal_body.group(0).find("ShowWindow(HWindow, StartupShowCmd)")
         < reveal_body.group(0).find("DarkModeSetWindowCloaked(HWindow, true)")
     ):
         raise AssertionError(

--- a/src/toolbar4.cpp
+++ b/src/toolbar4.cpp
@@ -777,7 +777,7 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
     hGrayBitmap = NULL;
     hColorBitmap = NULL;
 
-    int iconSize = dpi > 0 ? MulDiv(16, dpi, 96)
+    int iconSize = dpi > 0 ? GetIconSizeForDPI(ICONSIZE_16, dpi)
                            : GetIconSizeForSystemDPI(ICONSIZE_16); // small icon size
     int iconCount = 0;
     int baseIconCount = 0;

--- a/src/toolbar8.cpp
+++ b/src/toolbar8.cpp
@@ -52,8 +52,13 @@ BOOL CPluginsBar::CreatePluginButtons()
 
     DestroyImageLists();
 
-    HPluginsIcons = Plugins.CreateIconsList(FALSE, HWindow);
-    HPluginsIconsGray = Plugins.CreateIconsList(TRUE, HWindow);
+    // During the main top-level WM_DPICHANGED, child HWNDs can still report
+    // the old DPI. InitializeGraphics has already installed the authoritative
+    // main-window DPI in SystemDPI, so use that value for attached chrome.
+    HWND root = GetAncestor(HWindow, GA_ROOT);
+    HWND dpiWindow = MainWindow != NULL && root == MainWindow->HWindow ? NULL : root;
+    HPluginsIcons = Plugins.CreateIconsList(FALSE, dpiWindow);
+    HPluginsIconsGray = Plugins.CreateIconsList(TRUE, dpiWindow);
 
     SetImageList(HPluginsIconsGray);
     SetHotImageList(HPluginsIcons);
@@ -84,8 +89,10 @@ int CPluginsBar::GetNeededHeight()
     CALL_STACK_MESSAGE_NONE
     // i v pripade, ze nedrzime zadnou ikonu budeem vracet spravnou vysku
     int height = CToolBar::GetNeededHeight();
-    int iconSize = MulDiv(16, (int)WinLibDPIGetWindowDPI(HWindow),
-                          USER_DEFAULT_SCREEN_DPI);
+    HWND root = GetAncestor(HWindow, GA_ROOT);
+    int dpi = MainWindow != NULL && root == MainWindow->HWindow ?
+                  GetSystemDPI() : (int)WinLibDPIGetWindowDPI(root);
+    int iconSize = GetIconSizeForDPI(ICONSIZE_16, dpi);
     int minH = 3 + iconSize + 3;
     if (height < minH)
         height = minH;
@@ -173,8 +180,7 @@ BOOL CExtensionBar::CreateExtensionButtons(HIMAGELIST imageList,
 int CExtensionBar::GetNeededHeight()
 {
     int height = CToolBar::GetNeededHeight();
-    int iconSize = MulDiv(16, (int)WinLibDPIGetWindowDPI(HWindow),
-                          USER_DEFAULT_SCREEN_DPI);
+    int iconSize = GetIconSizeForDPI(ICONSIZE_16, (int)WinLibDPIGetWindowDPI(HWindow));
     return max(height, 3 + iconSize + 3);
 }
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -734,6 +734,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     LogViewMode = FALSE;
     LogViewStopEvent = NULL;
     LogViewWatcherThread = NULL;
+    LogViewRetryScheduled = FALSE;
     LineNumberDigits = 1;
     CodePageAutoSelect = Configuration.CodePageAutoSelect;
     lstrcpyn(DefaultConvert, Configuration.DefaultConvert, _countof(DefaultConvert));
@@ -759,6 +760,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
 
 CViewerWindow::~CViewerWindow()
 {
+    CancelLogViewRetry();
     StopLogViewWatcher();
     DestroyViewerMenuControls();
     if (MenuFont != NULL)

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -732,6 +732,8 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
     ShowLineNumbers = Configuration.ViewerShowLineNumbers;
     ShowStatusBar = Configuration.ViewerShowStatusBar;
     LogViewMode = FALSE;
+    LogViewStopEvent = NULL;
+    LogViewWatcherThread = NULL;
     LineNumberDigits = 1;
     CodePageAutoSelect = Configuration.CodePageAutoSelect;
     lstrcpyn(DefaultConvert, Configuration.DefaultConvert, _countof(DefaultConvert));
@@ -757,6 +759,7 @@ CViewerWindow::CViewerWindow(const char* fileName, CViewType type, const char* c
 
 CViewerWindow::~CViewerWindow()
 {
+    StopLogViewWatcher();
     DestroyViewerMenuControls();
     if (MenuFont != NULL)
         HANDLES(DeleteObject(MenuFont));

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -34,6 +34,7 @@ class CMenuBar;
 #define WM_USER_VIEWERREFRESH WM_APP + 201 // [0, 0] - perform a refresh
 #define WM_USER_GETZOOM WM_APP + 202      // [0, 0] -> current ZoomPercent
 #define WM_USER_VIEWERZOOMCHANGED WM_APP + 203 // [0, 0] - apply shared viewer zoom
+#define WM_USER_VIEWERLOGCHANGE WM_APP + 204 // [0, 0] - the watched file changed
 
 #ifndef INSIDE_SALAMANDER
 char* LoadStr(int resID);
@@ -337,6 +338,9 @@ protected:
     void UpdateStatusBar(__int64 offset = -1);
     void SetLogViewMode(BOOL enable);
     void RefreshLogView();
+    void StartLogViewWatcher();
+    void StopLogViewWatcher();
+    static DWORD WINAPI LogViewWatcherThreadProc(LPVOID param);
     int GetTextLeft() const;
     int GetDocumentTop() const;
     __int64 GetDocumentLineNumber(__int64 offset, __int64* lineStart = NULL);
@@ -412,6 +416,10 @@ protected:
     BOOL ShowLineNumbers;
     BOOL ShowStatusBar;
     BOOL LogViewMode;
+    HANDLE LogViewStopEvent;
+    HANDLE LogViewWatcherThread;
+    std::wstring LogViewDirectoryW;
+    std::wstring LogViewFileNameW;
     int LineNumberDigits;
 
     BOOL CodePageAutoSelect;  // local copy of Configuration.CodePageAutoSelect

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -338,6 +338,8 @@ protected:
     void UpdateStatusBar(__int64 offset = -1);
     void SetLogViewMode(BOOL enable);
     void RefreshLogView();
+    void ScheduleLogViewRetry();
+    void CancelLogViewRetry();
     void StartLogViewWatcher();
     void StopLogViewWatcher();
     static DWORD WINAPI LogViewWatcherThreadProc(LPVOID param);
@@ -418,6 +420,7 @@ protected:
     BOOL LogViewMode;
     HANDLE LogViewStopEvent;
     HANDLE LogViewWatcherThread;
+    BOOL LogViewRetryScheduled;
     std::wstring LogViewDirectoryW;
     std::wstring LogViewFileNameW;
     int LineNumberDigits;

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -338,11 +338,160 @@ void CViewerWindow::SetLogViewMode(BOOL enable)
     LogViewMode = enable;
     if (LogViewMode)
     {
-        SetTimer(HWindow, IDT_LOGVIEWREFRESH, 1000, NULL);
+        StartLogViewWatcher();
         RefreshLogView();
     }
     else
-        KillTimer(HWindow, IDT_LOGVIEWREFRESH);
+        StopLogViewWatcher();
+}
+
+void CViewerWindow::StartLogViewWatcher()
+{
+    StopLogViewWatcher();
+    if (!LogViewMode || FileName == NULL || FileNameW.empty())
+        return;
+
+    size_t separator = FileNameW.find_last_of(L"\\/");
+    if (separator == std::wstring::npos)
+        return;
+
+    LogViewDirectoryW = FileNameW.substr(0, separator);
+    if (LogViewDirectoryW.size() == 2 && LogViewDirectoryW[1] == L':')
+        LogViewDirectoryW += L'\\';
+    LogViewFileNameW = FileNameW.substr(separator + 1);
+    if (LogViewDirectoryW.empty() || LogViewFileNameW.empty())
+        return;
+
+    LogViewStopEvent = HANDLES(CreateEvent(NULL, TRUE, FALSE, NULL));
+    if (LogViewStopEvent == NULL)
+        return;
+
+    DWORD threadID = 0;
+    LogViewWatcherThread = HANDLES(CreateThread(NULL, 0, LogViewWatcherThreadProc,
+                                                this, 0, &threadID));
+    if (LogViewWatcherThread == NULL)
+    {
+        HANDLES(CloseHandle(LogViewStopEvent));
+        LogViewStopEvent = NULL;
+    }
+}
+
+void CViewerWindow::StopLogViewWatcher()
+{
+    if (LogViewStopEvent != NULL)
+        SetEvent(LogViewStopEvent);
+    if (LogViewWatcherThread != NULL)
+    {
+        WaitForSingleObject(LogViewWatcherThread, INFINITE);
+        HANDLES(CloseHandle(LogViewWatcherThread));
+        LogViewWatcherThread = NULL;
+    }
+    if (LogViewStopEvent != NULL)
+    {
+        HANDLES(CloseHandle(LogViewStopEvent));
+        LogViewStopEvent = NULL;
+    }
+    LogViewDirectoryW.clear();
+    LogViewFileNameW.clear();
+}
+
+DWORD WINAPI CViewerWindow::LogViewWatcherThreadProc(LPVOID param)
+{
+    CViewerWindow* view = static_cast<CViewerWindow*>(param);
+    const std::wstring directory = view->LogViewDirectoryW;
+    const std::wstring fileName = view->LogViewFileNameW;
+    HANDLE stopEvent = view->LogViewStopEvent;
+
+    std::wstring ioDirectory = directory;
+    if (ioDirectory.length() >= MAX_PATH && !SalIsExtendedLengthPathW(ioDirectory.c_str()))
+        ioDirectory = SalPathAddExtendedPrefixW(ioDirectory.c_str());
+
+    HANDLE directoryHandle = HANDLES_Q(CreateFileW(
+        ioDirectory.c_str(), FILE_LIST_DIRECTORY,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
+        OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL));
+    if (directoryHandle == INVALID_HANDLE_VALUE)
+        return 0;
+
+    HANDLE notificationEvent = HANDLES_Q(CreateEvent(NULL, TRUE, FALSE, NULL));
+    if (notificationEvent == NULL)
+    {
+        HANDLES(CloseHandle(directoryHandle));
+        return 0;
+    }
+
+    const DWORD watcherBufferSize = 64 * 1024;
+    BYTE* buffer = (BYTE*)malloc(watcherBufferSize);
+    if (buffer == NULL)
+    {
+        HANDLES(CloseHandle(notificationEvent));
+        HANDLES(CloseHandle(directoryHandle));
+        return 0;
+    }
+    OVERLAPPED overlapped = {};
+    overlapped.hEvent = notificationEvent;
+    const DWORD notifyFilter = FILE_NOTIFY_CHANGE_FILE_NAME |
+                                FILE_NOTIFY_CHANGE_SIZE |
+                                FILE_NOTIFY_CHANGE_LAST_WRITE |
+                                FILE_NOTIFY_CHANGE_ATTRIBUTES;
+
+    while (WaitForSingleObject(stopEvent, 0) != WAIT_OBJECT_0)
+    {
+        ResetEvent(notificationEvent);
+        DWORD bytesReturned = 0;
+        BOOL readStarted = ReadDirectoryChangesW(
+            directoryHandle, buffer, watcherBufferSize, FALSE,
+            notifyFilter, &bytesReturned, &overlapped, NULL);
+        if (!readStarted && GetLastError() != ERROR_IO_PENDING)
+            break;
+
+        HANDLE waitHandles[2] = {stopEvent, notificationEvent};
+        DWORD waitResult = WaitForMultipleObjects(2, waitHandles, FALSE, INFINITE);
+        if (waitResult == WAIT_OBJECT_0)
+        {
+            CancelIoEx(directoryHandle, &overlapped);
+            WaitForSingleObject(notificationEvent, INFINITE);
+            break;
+        }
+        if (waitResult != WAIT_OBJECT_0 + 1)
+            break;
+
+        DWORD transferred = 0;
+        if (!GetOverlappedResult(directoryHandle, &overlapped, &transferred, FALSE))
+            break;
+
+        BOOL fileChanged = transferred == 0; // the buffer overflowed; refresh conservatively
+        BYTE* cursor = buffer;
+        BYTE* end = cursor + transferred;
+        while (!fileChanged && cursor + sizeof(FILE_NOTIFY_INFORMATION) <= end)
+        {
+            FILE_NOTIFY_INFORMATION* info =
+                reinterpret_cast<FILE_NOTIFY_INFORMATION*>(cursor);
+            const size_t nameLength = info->FileNameLength / sizeof(WCHAR);
+            const size_t remaining = static_cast<size_t>(end - cursor);
+            if (info->FileNameLength <= remaining - FIELD_OFFSET(FILE_NOTIFY_INFORMATION, FileName) &&
+                nameLength == fileName.length() &&
+                _wcsnicmp(info->FileName, fileName.c_str(), nameLength) == 0)
+            {
+                fileChanged = TRUE;
+            }
+            if (info->NextEntryOffset == 0)
+                break;
+            if (info->NextEntryOffset > static_cast<DWORD>(remaining) ||
+                info->NextEntryOffset < FIELD_OFFSET(FILE_NOTIFY_INFORMATION, FileName))
+                break;
+            cursor += info->NextEntryOffset;
+        }
+
+        if (fileChanged)
+            PostMessage(view->HWindow, WM_USER_VIEWERLOGCHANGE, 0, 0);
+    }
+
+    CancelIoEx(directoryHandle, &overlapped);
+    free(buffer);
+    HANDLES(CloseHandle(notificationEvent));
+    HANDLES(CloseHandle(directoryHandle));
+    return 0;
 }
 
 void CViewerWindow::RefreshLogView()
@@ -760,6 +909,7 @@ void CViewerWindow::HeightChanged(BOOL& fatalErr)
 void CViewerWindow::OpenFile(const char* file, const char* caption, BOOL wholeCaption)
 {
     CALL_STACK_MESSAGE3("CViewerWindow::OpenFile(%s, %s)", file, caption);
+    StopLogViewWatcher();
     char fileName[SAL_MAX_PATH];
     lstrcpyn(fileName, file, SAL_MAX_PATH);
 
@@ -808,6 +958,8 @@ void CViewerWindow::OpenFile(const char* file, const char* caption, BOOL wholeCa
         SetViewerCaption();
     InvalidateRect(HWindow, NULL, FALSE);
     UpdateWindow(HWindow);
+    if (LogViewMode)
+        StartLogViewWatcher();
     CanSwitchQuietlyToHex = FALSE;
 }
 
@@ -816,6 +968,11 @@ void CViewerWindow::OpenFileW(const wchar_t* file, const char* caption, BOOL who
     std::string fileA = SalWideToMultiBytePath(file, GetACP() == CP_UTF8 ? CP_UTF8 : CP_ACP);
     OpenFile(fileA.c_str(), caption, wholeCaption);
     FileNameW = file != NULL ? file : L"";
+    if (LogViewMode)
+    {
+        StopLogViewWatcher();
+        StartLogViewWatcher();
+    }
 }
 
 void CViewerWindow::ReleaseMouseDrag()

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -40,16 +40,19 @@ static std::wstring ViewerPathToWide(const char* path)
 
 static HANDLE OpenViewerFileForRead(const std::wstring& fileNameW, const char* fileName)
 {
-    if (!fileNameW.empty())
+    std::wstring ioName = fileNameW;
+    if (ioName.empty() && fileName != NULL)
+        ioName = ViewerPathToWide(fileName);
+    if (ioName.empty())
     {
-        std::wstring ioName = fileNameW;
-        if (ioName.length() >= MAX_PATH && !SalIsExtendedLengthPathW(ioName.c_str()))
-            ioName = SalPathAddExtendedPrefixW(ioName.c_str());
-        return HANDLES_Q(CreateFileW(ioName.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-                                     OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL));
+        SetLastError(ERROR_INVALID_NAME);
+        return INVALID_HANDLE_VALUE;
     }
-    return HANDLES_Q(CreateFile(fileName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-                                OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL));
+    if (ioName.length() >= MAX_PATH && !SalIsExtendedLengthPathW(ioName.c_str()))
+        ioName = SalPathAddExtendedPrefixW(ioName.c_str());
+    return HANDLES_Q(CreateFileW(ioName.c_str(), GENERIC_READ,
+                                 FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                                 OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL));
 }
 
 void ThreadViewerMessageLoopBodyAux()

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -342,7 +342,28 @@ void CViewerWindow::SetLogViewMode(BOOL enable)
         RefreshLogView();
     }
     else
+    {
+        CancelLogViewRetry();
         StopLogViewWatcher();
+    }
+}
+
+void CViewerWindow::ScheduleLogViewRetry()
+{
+    if (!LogViewRetryScheduled && LogViewMode)
+    {
+        if (SetTimer(HWindow, IDT_LOGVIEWRETRY, 200, NULL) != 0)
+            LogViewRetryScheduled = TRUE;
+    }
+}
+
+void CViewerWindow::CancelLogViewRetry()
+{
+    if (LogViewRetryScheduled)
+    {
+        KillTimer(HWindow, IDT_LOGVIEWRETRY);
+        LogViewRetryScheduled = FALSE;
+    }
 }
 
 void CViewerWindow::StartLogViewWatcher()
@@ -499,11 +520,30 @@ void CViewerWindow::RefreshLogView()
     if (MouseDrag || FileName == NULL)
         return;
 
+    HANDLE file = OpenViewerFileForRead(FileNameW, FileName);
+    if (file == INVALID_HANDLE_VALUE)
+    {
+        DWORD err = GetLastError();
+        if (err == ERROR_SHARING_VIOLATION || err == ERROR_LOCK_VIOLATION)
+        {
+            ScheduleLogViewRetry();
+            return;
+        }
+
+        BOOL fatalErr = FALSE;
+        SetLastError(err);
+        FileChanged(file, FALSE, fatalErr, FALSE);
+        if (fatalErr)
+            FatalFileErrorOccured();
+        return;
+    }
+
     ExitTextMode = FALSE;
     ForceTextMode = FALSE;
 
     BOOL fatalErr = FALSE;
-    FileChanged(NULL, FALSE, fatalErr, FALSE);
+    FileChanged(file, FALSE, fatalErr, FALSE);
+    HANDLES(CloseHandle(file));
     if (fatalErr)
         FatalFileErrorOccured();
     if (fatalErr || ExitTextMode)
@@ -522,6 +562,7 @@ void CViewerWindow::RefreshLogView()
     ResetFindOffsetOnNextPaint = TRUE;
     InvalidateRect(HWindow, NULL, FALSE);
     UpdateWindow(HWindow);
+    CancelLogViewRetry();
 }
 
 __int64
@@ -909,6 +950,7 @@ void CViewerWindow::HeightChanged(BOOL& fatalErr)
 void CViewerWindow::OpenFile(const char* file, const char* caption, BOOL wholeCaption)
 {
     CALL_STACK_MESSAGE3("CViewerWindow::OpenFile(%s, %s)", file, caption);
+    CancelLogViewRetry();
     StopLogViewWatcher();
     char fileName[SAL_MAX_PATH];
     lstrcpyn(fileName, file, SAL_MAX_PATH);

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -3707,6 +3707,15 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_TIMER:
     {
+        if (wParam == IDT_LOGVIEWRETRY)
+        {
+            KillTimer(HWindow, IDT_LOGVIEWRETRY);
+            LogViewRetryScheduled = FALSE;
+            if (LogViewMode)
+                RefreshLogView();
+            return 0;
+        }
+
         if (wParam == IDT_THUMBSCROLL)
         {
             OnVScroll();
@@ -4375,6 +4384,7 @@ MENU_TEMPLATE_ITEM ViewerCodingMenu[] =
     {
         // WM_DESTROY can also be reached through a direct DestroyWindow call.
         DestroyViewerMenuControls();
+        CancelLogViewRetry();
         StopLogViewWatcher();
         // The scrollbar hook stores HWNDs.  Remove this entry before Windows
         // can recycle the handle for an unrelated top-level dialog.

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -779,6 +779,11 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
 
+        case WM_USER_VIEWERLOGCHANGE:
+            if (LogViewMode)
+                RefreshLogView();
+            return 0;
+
         case WM_COMMAND:
         {
             switch (LOWORD(wParam))
@@ -931,6 +936,11 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     switch (uMsg)
     {
+    case WM_USER_VIEWERLOGCHANGE:
+        if (LogViewMode)
+            RefreshLogView();
+        return 0;
+
     case WM_UAHDRAWMENU:
     {
         if ((DarkModeShouldUseDarkColors() || DialogFontMode != DIALOG_FONT_DEFAULT ||
@@ -3703,12 +3713,6 @@ CViewerWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
 
-        if (wParam == IDT_LOGVIEWREFRESH)
-        {
-            RefreshLogView();
-            return 0;
-        }
-
         if (wParam != IDT_AUTOSCROLL)
             break;
         POINT p;
@@ -4371,7 +4375,7 @@ MENU_TEMPLATE_ITEM ViewerCodingMenu[] =
     {
         // WM_DESTROY can also be reached through a direct DestroyWindow call.
         DestroyViewerMenuControls();
-        KillTimer(HWindow, IDT_LOGVIEWREFRESH);
+        StopLogViewWatcher();
         // The scrollbar hook stores HWNDs.  Remove this entry before Windows
         // can recycle the handle for an unrelated top-level dialog.
         DarkModeDisallowDarkScrollbars(HWindow);

--- a/tools/run_native_tests.ps1
+++ b/tools/run_native_tests.ps1
@@ -351,6 +351,14 @@ try {
             )
         },
         @{
+            Name = 'viewer_live_log_contract_tests'
+            Arguments = @(
+                '-B',
+                (Join-Path $repositoryRoot `
+                    'src\tests\viewer_live_log_contract_tests.py')
+            )
+        },
+        @{
             Name = 'copy_move_scheduling_contract_tests'
             Arguments = @(
                 '-B',


### PR DESCRIPTION
## Summary
- keep Internal Viewer log mode resilient to transient writer locks and improve CP1250 detection
- rebuild panel, association, overlay, toolbar, plugin, menu, and title icons from per-window pixel-size sets after live DPI changes
- preserve restored window placement and add native multi-artwork plus source-contract regression coverage

## Test plan
- [x] Run `python src/tests/panel_rendering_contract_tests.py`
- [x] Build and run `panel_icon_size_tests` in Release x64
- [x] Compile and link `salamand.exe` in Release and Release clean x64
- [x] Manually move the main and detached windows between 100%, 150%, and 175% monitors and verify panel, plugin/menu, and title icon artwork
- [x] Exercise Internal Viewer log mode while a writer temporarily locks the viewed file

## Build note
The executable compiles and links successfully. The complete MSBuild target subsequently fails in the existing `stage_inno_payload.ps1` hook because `Get-FileHash` is unavailable in the invoked PowerShell environment.